### PR TITLE
Bump kaish-kernel to 0.8.4 (clears 0.2.0 release gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,6 @@ requests — `main` is protected by convention, not a scratchpad.
   `v*` tag. Before tagging: confirm the `kaish-kernel` pin is current (next bullet),
   re-run `docs/sandbox-probes.md` and stamp its "Last run" line, and verify
   `cargo tree -i aws-lc-rs` is empty and the musl binary is `not a dynamic executable`.
-- **Release gate — kaish bump pending.** A bug surfaced upstream right after kaish
-  `0.8.3` (the current `Cargo.toml` pin); 0.2.0 waits on the fixed release. Bump the
-  pin, adapt to any API change rather than pinning around it (per **Working here**),
-  and re-green the offline suite before cutting. Tracked in `docs/issues.md`.
+- **kaish pin.** Currently `kaish-kernel = "0.8.4"` — the release that fixed the bug
+  which surfaced just after `0.8.3`. The bump was clean (no API change); offline suite
+  green. Keep this current per the **Working here** kaish-bump discipline before cutting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85388674cd5438f7af7105613e776f3cd454f9d35925c15f836eb35728898b76"
+checksum = "5d7789b337d2dca16dbd62f5c6b52b5c59d35037200156cf78d0a3ee29d81fcc"
 dependencies = [
  "async-trait",
  "ignore",
@@ -1288,18 +1288,18 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861618aad1a9a08a7ee50ad1120f09c8102467eb3eaa159019d6afd230b707ff"
+checksum = "3b3e7a2f81430be4ab7046f7b24654fa38e9fc19ad33d6de7552b90936e8fcb1"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd794dd8d6b362aee38407092e736b9f78b422a67d5d3d2f096ddb0261c40c2"
+checksum = "478d843786658d8d8e6c51956b04eb5530a40434de613f863b222ef092f269e2"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644559df8d50d73ae6325f0835c4aab07d82b8ad45be9ae7d2564ebecd0a44ca"
+checksum = "fc465058212ca30a396eb07b4eb7d82720ccaa1a82dc92c029766bf7dda8c8af"
 dependencies = [
  "async-trait",
  "clap",
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1d62730da2995fdd0fed59aace0e8a2f127473afdc15fa6c0c8cb110db2952"
+checksum = "3e8a3f6c4f583ceaa89c8b0486db6d7982f388f34da12c5715b73fd141e8c870"
 dependencies = [
  "base64",
  "serde",
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb406969e8974e34c2f325b378c2a79d70b3cd43ffcca1e210827636323e4611"
+checksum = "a16e1f4189ba8719f8ac37dc21a21c502ce3e9c1c48aaee0a17b47e42b46939b"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # `os-integration` (trash) OFF — so those builtins are never compiled in. kaibo's
 # read-only safety is thus structural (the dangerous surface doesn't exist),
 # backed by the runtime read-only mount; see src/sandbox.rs.
-kaish-kernel = { version = "0.8.3", default-features = false, features = ["localfs"] }
+kaish-kernel = { version = "0.8.4", default-features = false, features = ["localfs"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
 async-trait = "0.1"
 anyhow = "1"

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -282,13 +282,6 @@ completes, while a pure-script spin still dies at 30s.
 
 ## P2 — Focused fixes & hardening
 
-### Bump kaish-kernel past 0.8.3 before cutting 0.2.0 (release gate)
-A bug surfaced upstream right after the `0.8.3` cut — the current `Cargo.toml` pin
-(`kaish-kernel = "0.8.3"`) — and the fix is in an imminent release. Bump the pin,
-adapt kaibo to any API change rather than pinning around it (AGENTS.md "Working
-here"), and re-green the offline suite. This gates the 0.2.0 release tag; the
-release process is documented in AGENTS.md "Pull requests & the changelog".
-
 ### Review the provider retry + failure policy (and document it)
 We don't have a stated, audited answer for what a `consult`/`explore`/`synthesize`
 call does when a provider misbehaves mid-flight: a 429/529 overload, a connection


### PR DESCRIPTION
Bumps `kaish-kernel` `0.8.3` → `0.8.4` — the fixed upstream release we were gating 0.2.0 on.

## What
- The whole kaish family (kernel/vfs/types/glob/help/tool-api) moved together to 0.8.4.
- **No API breakage** — clean build, no adaptation needed.
- Offline test suite stays green.
- TLS invariant holds: `cargo tree -i aws-lc-rs` is empty.
- Retired the release-gate entry from `docs/issues.md`; the AGENTS.md gate bullet is now a plain "keep the pin current" note. 0.2.0 is unblocked.

## Verification
- `cargo build` — clean
- `cargo test` — all suites pass (live/probe tests `#[ignore]`d as usual)
- `cargo tree -i aws-lc-rs` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)