### PR TITLE
Infer the launch cwd as the default root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ the git log. Each later release appends a new section at the top.
   and still land on the project. The scope handshake and `kaibo://config` tag the
   root as inferred. An `--allow-path` that excludes the cwd leaves no default root —
   kaibo never defaults to a path its own containment check would reject.
+- **`~` expands in `[server] root` and `allow_paths`** (config-file and `KAIBO_*`
+  env layers), matching the tilde handling key files and `[context]` paths already
+  get. Set `allow_paths = ["~/src"]` once and every project under it is in-bounds —
+  with cwd inferred as the default root, you stop thinking about `path` entirely.
+  (Previously a literal `~` was taken verbatim and failed canonicalization at startup.)
 - **Per-tool gating.** Each tool has a `--no-<tool>` flag (all on by default); an
   all-off server is refused at startup.
 - **Operator ignore files** via a `[kaish.ignore]` config stanza.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ the git log. Each later release appends a new section at the top.
   writing `config.toml`, alongside `kaibo://config` (resolved runtime state) and
   `kaibo://config/example` (annotated template) resources. Secrets are referenced by
   env-var name or key-file path, never inlined.
+- **Zero-config workspace root.** When no `--root` is set, kaibo adopts its launch
+  cwd as the inferred default root (it already scoped containment to that cwd, and
+  MCP clients start stdio servers with cwd = workspace), so a call may omit `path`
+  and still land on the project. The scope handshake and `kaibo://config` tag the
+  root as inferred. An `--allow-path` that excludes the cwd leaves no default root —
+  kaibo never defaults to a path its own containment check would reject.
 - **Per-tool gating.** Each tool has a `--no-<tool>` flag (all on by default); an
   all-off server is refused at startup.
 - **Operator ignore files** via a `[kaish.ignore]` config stanza.

--- a/docs/config.md
+++ b/docs/config.md
@@ -572,19 +572,27 @@ would then reject, so an omitted `path` there stays an error.
 ```toml
 # config.toml
 [server]
-allow_paths = ["/home/atobey/shared-libs", "/data/fixtures"]
+allow_paths = ["~/src", "/data/fixtures"]
 ```
 
 ```sh
 # env — colon-separated like PATH
-KAIBO_ALLOW_PATHS=/home/atobey/shared-libs:/data/fixtures kaibo
+KAIBO_ALLOW_PATHS=~/src:/data/fixtures kaibo
 
 # CLI — repeatable
-kaibo --allow-path /home/atobey/shared-libs --allow-path /data/fixtures
+kaibo --allow-path ~/src --allow-path /data/fixtures
 ```
 
 A non-empty CLI `--allow-path` set replaces the env/file layer entirely (same
 precedence rule as `--root`). To lift all limits: `--allow-path /`.
+
+**Set it once.** Putting your whole workspace tree in `allow_paths`
+(`["~/src"]`) means every project under it is in-bounds, and because the client's
+cwd/workspace lands inside that tree, kaibo infers it as the [default root](#path-containment)
+automatically — so you configure access once and never pass `path` per call. A
+leading `~` in `root` / `allow_paths` expands to `$HOME` (file and env layers), the
+same as key files and `[context]` paths; the CLI relies on your shell's own
+expansion. Other paths are taken as written.
 
 **When defaulting does *not* happen.** If `--allow-path` is set to a tree that does
 not contain the launch cwd and no `--root` is given, there is no default root: the

--- a/docs/config.md
+++ b/docs/config.md
@@ -543,7 +543,7 @@ per-tool `tool` spans (see Telemetry).
 
 ## Path containment
 
-**Always on.** Every tool call's `path` argument (or the server `--root` when `path`
+**Always on.** Every tool call's `path` argument (or the default root when `path`
 is omitted) is resolved — `std::fs::canonicalize` expands symlinks and collapses `..`
 — and then checked against the **allowed set**. A path that doesn't fall at-or-under
 one of the allowed trees is `invalid_params`, naming the allowed trees and the three
@@ -556,6 +556,16 @@ so the zero-config case scopes itself to the project naturally, without any oper
 action. The default isn't silent: the resolved allowed set is reported in a startup
 log line and in the `## Scope` section of the server's MCP `instructions` (visible in
 every `initialize` response), and at `kaibo://config`.
+
+**The default root** is what a call resolves to when it omits `path`: an explicit
+`--root`, or — when none is set — the launch cwd, *inferred* whenever it falls inside
+the allowed set (it always does in the zero-config case, since the cwd is the whole
+allowed set). So the common single-workspace case needs no `--root`: kaibo already
+knows the workspace from its cwd and uses it for both bounding and defaulting. The
+inferred case is labelled as such in the `## Scope` handshake and at `kaibo://config`
+(`default_root_inferred`). The one gap: an `--allow-path` that *excludes* the cwd
+leaves no default root — kaibo never defaults to a path its own containment check
+would then reject, so an omitted `path` there stays an error.
 
 **Widening the boundary:**
 
@@ -576,10 +586,12 @@ kaibo --allow-path /home/atobey/shared-libs --allow-path /data/fixtures
 A non-empty CLI `--allow-path` set replaces the env/file layer entirely (same
 precedence rule as `--root`). To lift all limits: `--allow-path /`.
 
-**Containment ≠ defaulting.** With no `--root`, an omitted `path` still errors
-("no `path` provided and the server has no default `--root`") — the launch cwd
-bounds what you *may ask about*, it never becomes what you *asked about*. The error
-is `invalid_params`, surfaced where the caller can read it.
+**When defaulting does *not* happen.** If `--allow-path` is set to a tree that does
+not contain the launch cwd and no `--root` is given, there is no default root: the
+cwd is outside the boundary, so adopting it would point the default at a path
+containment rejects. An omitted `path` then errors ("no `path` provided and the
+server has no default root …") — `invalid_params`, surfaced where the caller can read
+it. Pass an explicit `--root` (inside an allowed tree) to restore a default.
 
 **Resolution.** `resolve_root` (`src/server.rs`) returns the *canonicalized* path,
 so the kaish VFS mount target is always resolved. A nonexistent or non-directory

--- a/src/config.rs
+++ b/src/config.rs
@@ -1863,7 +1863,12 @@ pub fn default_config_path() -> Option<PathBuf> {
     })
 }
 
-/// Expand a leading `~` to `$HOME`. Leaves other paths untouched.
+/// Expand a leading `~` or `~/...` to `$HOME`. Leaves every other path untouched —
+/// in particular `~user` (no slash) is **not** expanded: kaibo never does a `getpwnam`
+/// lookup from config-parsing code, and a literal `~user` simply fails canonicalization
+/// loudly. Keep it this narrow; widening it to `~user` would pull a mutable system
+/// database into a path that feeds the containment boundary. With `$HOME` unset the
+/// input passes through verbatim (and then fails canonicalization), never silently.
 fn expand_tilde(s: &str) -> PathBuf {
     if let Some(rest) = s.strip_prefix("~/") {
         if let Some(home) = std::env::var_os("HOME") {
@@ -1881,6 +1886,30 @@ fn expand_tilde(s: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- expand_tilde ---------------------------------------------------------
+
+    /// `expand_tilde` must expand only a leading `~` / `~/...` to `$HOME`, and leave
+    /// everything else — `~user`, a mid-path `~`, absolute and relative paths —
+    /// verbatim. The non-expansion of `~user` is a security property (no getpwnam from
+    /// a path that feeds containment), so it gets its own teeth here.
+    #[test]
+    fn expand_tilde_only_touches_a_leading_home_tilde() {
+        let home = std::env::var("HOME").expect("HOME set in test env");
+        let home = home.trim_end_matches('/');
+
+        assert_eq!(expand_tilde("~/src"), PathBuf::from(format!("{home}/src")));
+        assert_eq!(expand_tilde("~"), PathBuf::from(home));
+
+        // Passthrough cases — left exactly as written.
+        for verbatim in ["~user", "~user/x", "/abs/~/x", "rel/path", "/data/fixtures"] {
+            assert_eq!(
+                expand_tilde(verbatim),
+                PathBuf::from(verbatim),
+                "{verbatim:?} must pass through unchanged"
+            );
+        }
+    }
 
     // --- built-in equivalence -------------------------------------------------
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -939,12 +939,16 @@ impl Config {
         let tools = merge_tools(server.tools.unwrap_or_default());
         let default_cast = server.cast.unwrap_or_else(|| "anthropic".to_string());
         let log = server.log.unwrap_or_else(|| "kaibo=info".to_string());
-        let root = server.root.map(PathBuf::from);
+        // Tilde-expand `root` and `allow_paths` (file *and* env layers both land here
+        // as strings), so a hand-edited `~/src` resolves to `$HOME/src` like key files
+        // and `[context]` paths already do — rather than a literal `~` that fails
+        // canonicalization at startup. Absolute/relative paths pass through unchanged.
+        let root = server.root.as_deref().map(expand_tilde);
         let allow_paths = server
             .allow_paths
             .unwrap_or_default()
-            .into_iter()
-            .map(PathBuf::from)
+            .iter()
+            .map(|s| expand_tilde(s))
             .collect();
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default());

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -15,7 +15,7 @@
 //! progressively learn more kaish — syntax, scatter, the builtin index, a single
 //! builtin's parameters — without spending a tool turn.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use kaish_kernel::help::{
@@ -261,6 +261,8 @@ pub fn kaibo_instructions_with_scope(
     schemas: &[ToolSchema],
     config: &Config,
     allowed_set: &[PathBuf],
+    default_root: Option<&Path>,
+    default_root_inferred: bool,
     usability: CastUsability,
     usable_casts: &[(String, CastUsability)],
 ) -> String {
@@ -276,8 +278,14 @@ pub fn kaibo_instructions_with_scope(
     let casts = casts_section(&config.default_cast, usable_casts);
     let reference = kaish_reference(schemas);
 
-    // Scope section: always accurate, never ambiguous.
-    let root_line = match &config.root {
+    // Scope section: always accurate, never ambiguous. Report the *effective* default
+    // root (an explicit `--root`, or the launch cwd kaibo inferred), and tag the
+    // inferred case so the caller can tell it wasn't configured by hand.
+    let root_line = match default_root {
+        Some(r) if default_root_inferred => format!(
+            "- **Default root:** `{}` (inferred from launch cwd — a call may omit `path`)",
+            r.display()
+        ),
         Some(r) => format!("- **Default root:** `{}`", r.display()),
         None => "- **Default root:** none — every call must pass a `path` argument.".to_string(),
     };
@@ -429,6 +437,8 @@ mod tests {
             &[],
             &config,
             &[PathBuf::from("/tmp")],
+            None,
+            false,
             CastUsability::Unconfigured,
             &[],
         );
@@ -471,6 +481,8 @@ mod tests {
                 &[],
                 &config,
                 &[PathBuf::from("/tmp")],
+                None,
+                false,
                 usability,
                 &[],
             );
@@ -498,6 +510,8 @@ mod tests {
             &[],
             &config,
             &[PathBuf::from("/tmp")],
+            None,
+            false,
             CastUsability::Ready,
             &usable,
         );
@@ -542,6 +556,8 @@ mod tests {
             &sample_schemas_for_ordering(),
             &config,
             &[PathBuf::from("/tmp")],
+            None,
+            false,
             CastUsability::Ready,
             &usable,
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,14 +39,17 @@ struct Args {
     /// that cwd is also adopted as the inferred default root — so a call may omit
     /// `path` without configuring anything. (An --allow-path that excludes the cwd
     /// leaves no default root, since we never default to a path containment rejects.)
+    /// A leading `~` is expanded by your shell, not by kaibo; in config.toml / KAIBO_*
+    /// kaibo expands it for you.
     #[arg(long, value_name = "DIR")]
     root: Option<PathBuf>,
 
     /// Additional allowed path tree. Repeatable. A per-call `path` must resolve
     /// to at-or-under --root or one of these; use --allow-path / to lift all
     /// limits. Also settable via KAIBO_ALLOW_PATHS (colon-separated) or
-    /// [server] allow_paths in config.toml. A non-empty set of --allow-path flags
-    /// replaces the env/file layer.
+    /// [server] allow_paths in config.toml — those expand a leading `~`; on the CLI
+    /// your shell does (a quoted '~/src' arrives literal and fails canonicalization).
+    /// A non-empty set of --allow-path flags replaces the env/file layer.
     #[arg(long = "allow-path", value_name = "DIR", action = clap::ArgAction::Append)]
     allow_path: Vec<PathBuf>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,10 @@ struct Args {
     /// Default project root to explore when a call omits `path`. Also joins the
     /// containment allowed set: a call's `path` must resolve to at-or-under --root
     /// or one of the --allow-path trees. With neither flag the allowed set defaults
-    /// to the launch cwd (MCP clients start stdio servers with cwd = workspace).
+    /// to the launch cwd (MCP clients start stdio servers with cwd = workspace), and
+    /// that cwd is also adopted as the inferred default root — so a call may omit
+    /// `path` without configuring anything. (An --allow-path that excludes the cwd
+    /// leaves no default root, since we never default to a path containment rejects.)
     #[arg(long, value_name = "DIR")]
     root: Option<PathBuf>,
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -418,9 +418,14 @@ impl KaiboHandler {
                 let cwd_canon = std::fs::canonicalize(&cwd)
                     .with_context(|| format!("canonicalizing cwd {}", cwd.display()))?;
                 if allowed.is_empty() {
-                    // Zero config: the workspace is the whole boundary.
+                    // Zero config: the workspace is the whole boundary. Push it here,
+                    // *before* the guard below, so the `starts_with` check sees it and
+                    // adopts cwd as the default root in the zero-config case.
                     allowed.push(cwd_canon.clone());
                 }
+                // Mirror `resolve_root`'s containment check (step 3): only adopt cwd
+                // when it falls inside the allowed set, so we never default to a path
+                // the call-time check would reject.
                 if allowed.iter().any(|tree| cwd_canon.starts_with(tree)) {
                     (Some(cwd_canon), true)
                 } else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,7 @@
 //! stdio only — like kaish-mcp, kaibo must never bind a socket: it can read a
 //! user's filesystem, so the transport pipe is the security boundary.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
@@ -111,8 +111,9 @@ pub struct ConsultInput {
     /// The question to investigate about the project.
     pub question: String,
 
-    /// Absolute path to the project to explore. Optional only if the server was
-    /// launched with a default `--root`. Must be at-or-under an allowed tree; see
+    /// Absolute path to the project to explore. Optional when the server has a
+    /// default root — an explicit `--root`, or the launch cwd inferred when it's
+    /// inside the allowed set. Must be at-or-under an allowed tree; see
     /// `kaibo://config` for the server's current allowed set and how to widen it.
     #[serde(default)]
     pub path: Option<String>,
@@ -181,8 +182,9 @@ pub struct ExploreInput {
     /// The question to investigate about the project.
     pub question: String,
 
-    /// Absolute path to the project. Optional only if the server was launched
-    /// with a default `--root`. Must be at-or-under an allowed tree; see
+    /// Absolute path to the project. Optional when the server has a default root
+    /// — an explicit `--root`, or the launch cwd inferred when it's inside the
+    /// allowed set. Must be at-or-under an allowed tree; see
     /// `kaibo://config` for the server's current allowed set and how to widen it.
     #[serde(default)]
     pub path: Option<String>,
@@ -222,8 +224,9 @@ pub struct SynthesizeInput {
     #[serde(default)]
     pub context: Option<String>,
 
-    /// Absolute path to the project. Optional only if the server was launched
-    /// with a default `--root`. Must be at-or-under an allowed tree; see
+    /// Absolute path to the project. Optional when the server has a default root
+    /// — an explicit `--root`, or the launch cwd inferred when it's inside the
+    /// allowed set. Must be at-or-under an allowed tree; see
     /// `kaibo://config` for the server's current allowed set and how to widen it.
     #[serde(default)]
     pub path: Option<String>,
@@ -254,8 +257,9 @@ pub struct RunKaishInput {
     /// The kaish (sh-like) script to run against the read-only project.
     pub script: String,
 
-    /// Absolute path to the project. Optional only if the server was launched
-    /// with a default `--root`. Must be at-or-under an allowed tree; see
+    /// Absolute path to the project. Optional when the server has a default root
+    /// — an explicit `--root`, or the launch cwd inferred when it's inside the
+    /// allowed set. Must be at-or-under an allowed tree; see
     /// `kaibo://config` for the server's current allowed set and how to widen it.
     /// Each call starts at this root — there is no persistent cwd across calls.
     #[serde(default)]
@@ -287,6 +291,16 @@ pub struct KaiboHandler {
     /// config.allow_paths; falls back to the canonicalized cwd when both are empty.
     /// `Arc` because rmcp clones the handler per request.
     allowed_set: Arc<Vec<PathBuf>>,
+    /// The effective default root a call uses when it omits `path` — the explicit
+    /// `--root`/config value, or the launch cwd inferred when it falls inside the
+    /// allowed set. Canonicalized. `None` only when no root was configured *and* the
+    /// cwd is outside the allowed set (an `--allow-path` that excludes the cwd), in
+    /// which case an omitted `path` stays a parameter error. `Arc` for cheap clone.
+    default_root: Arc<Option<PathBuf>>,
+    /// True when [`Self::default_root`] was inferred from the launch cwd rather than
+    /// configured explicitly. Surfaced as "(inferred from launch cwd)" in the scope
+    /// section and `kaibo://config` so the boundary stays legible.
+    default_root_inferred: bool,
 }
 
 /// Inject `casts` as a JSON-Schema `enum` on the `cast` parameter of every
@@ -366,13 +380,17 @@ impl KaiboHandler {
         // so `resolve_root`'s Path::starts_with check is sound (symlinks resolved,
         // `..` collapsed). A nonexistent path can't bound anything — loud error.
         let mut allowed: Vec<PathBuf> = Vec::new();
+        // The explicit default root, if `--root` was configured — canonicalized so it
+        // doubles as both an allowed tree and the call's default root.
+        let mut explicit_root: Option<PathBuf> = None;
         if let Some(root) = &config.root {
             let canon = std::fs::canonicalize(root)
                 .with_context(|| format!("canonicalizing --root {}", root.display()))?;
             if !canon.is_dir() {
                 anyhow::bail!("--root {} is not a directory", canon.display());
             }
-            allowed.push(canon);
+            allowed.push(canon.clone());
+            explicit_root = Some(canon);
         }
         for p in &config.allow_paths {
             let canon = std::fs::canonicalize(p)
@@ -382,16 +400,34 @@ impl KaiboHandler {
             }
             allowed.push(canon);
         }
-        // When no root and no allow_paths are given, fall back to the launch cwd.
-        // MCP clients start stdio servers with cwd = workspace, so the zero-config
-        // case scopes itself to the project naturally.
-        if allowed.is_empty() {
-            let cwd = std::env::current_dir()
-                .context("could not determine current directory for default allowed set")?;
-            let canon = std::fs::canonicalize(&cwd)
-                .with_context(|| format!("canonicalizing cwd {}", cwd.display()))?;
-            allowed.push(canon);
-        }
+
+        // Resolve the default root and the allowed-set cwd fallback together. With an
+        // explicit `--root`, that is the default root and no cwd is consulted. Without
+        // one, the launch cwd does double duty: MCP clients start stdio servers with
+        // cwd = workspace, so it is both the zero-config allowed tree *and* the natural
+        // default root — adopt it as the inferred default root whenever it falls inside
+        // the allowed set, so a call may omit `path` in the common single-workspace
+        // case. We never adopt a cwd the containment check would then reject (an
+        // `--allow-path` that excludes the cwd leaves the default root unset, and an
+        // omitted `path` stays a parameter error).
+        let (default_root, default_root_inferred): (Option<PathBuf>, bool) = match explicit_root {
+            Some(root) => (Some(root), false),
+            None => {
+                let cwd = std::env::current_dir()
+                    .context("could not determine current directory for the default root")?;
+                let cwd_canon = std::fs::canonicalize(&cwd)
+                    .with_context(|| format!("canonicalizing cwd {}", cwd.display()))?;
+                if allowed.is_empty() {
+                    // Zero config: the workspace is the whole boundary.
+                    allowed.push(cwd_canon.clone());
+                }
+                if allowed.iter().any(|tree| cwd_canon.starts_with(tree)) {
+                    (Some(cwd_canon), true)
+                } else {
+                    (None, false)
+                }
+            }
+        };
 
         // Stamp the live cast roster onto the consultation tools' `cast` param as a
         // JSON-Schema `enum`, so an agent choosing a team reads the menu off the tool
@@ -413,6 +449,8 @@ impl KaiboHandler {
             sessions,
             mcp_log_level: Arc::new(AtomicU8::new(mcp_log::rank(mcp_log::DEFAULT_LEVEL))),
             allowed_set: Arc::new(allowed),
+            default_root: Arc::new(default_root),
+            default_root_inferred,
         })
     }
 
@@ -448,11 +486,26 @@ impl KaiboHandler {
         (*self.allowed_set).clone()
     }
 
+    /// The effective default root — what a call resolves to when it omits `path`.
+    /// The explicit `--root`/config value, or the launch cwd when it was inferred
+    /// (see [`Self::default_root_inferred`]); `None` when neither applies. Exposed
+    /// for tests and the `kaibo://config` resource.
+    pub fn default_root(&self) -> Option<PathBuf> {
+        (*self.default_root).clone()
+    }
+
+    /// Whether [`Self::default_root`] was inferred from the launch cwd rather than
+    /// configured explicitly.
+    pub fn default_root_inferred(&self) -> bool {
+        self.default_root_inferred
+    }
+
     /// Resolve a call's project root with containment enforcement:
     ///
-    /// 1. Select the raw path: the explicit `path` arg, else the server's `--root`.
-    ///    An omitted `path` with no `--root` is a parameter error — not a silent
-    ///    default (containment does not change this existing behavior).
+    /// 1. Select the raw path: the explicit `path` arg, else the effective default
+    ///    root (an explicit `--root`, or the launch cwd inferred when it falls inside
+    ///    the allowed set). An omitted `path` with no default root is a parameter
+    ///    error — not a silent default.
     /// 2. Canonicalize the selected path (resolves symlinks and `..`). A path that
     ///    doesn't exist is `invalid_params` with the canonicalize error.
     /// 3. Require the canonicalized path to be at-or-under one of the allowed trees.
@@ -461,12 +514,17 @@ impl KaiboHandler {
     ///
     /// Returns the CANONICALIZED path so the kaish mount target is always resolved.
     fn resolve_root(&self, path: Option<String>) -> Result<PathBuf, McpError> {
-        // Step 1: select the raw path.
+        // Step 1: select the raw path. The default root is the explicit `--root` or
+        // the inferred launch cwd (already canonicalized and dir-checked at startup,
+        // and guaranteed inside the allowed set); the steps below re-validate it
+        // uniformly with an explicit `path`, so there is no special-casing here.
         let raw = match path {
             Some(p) => PathBuf::from(p),
-            None => self.config.root.clone().ok_or_else(|| {
+            None => (*self.default_root).clone().ok_or_else(|| {
                 McpError::invalid_params(
-                    "no `path` provided and the server has no default --root",
+                    "no `path` provided and the server has no default root \
+                     (configure one with --root, or launch kaibo with its cwd \
+                     inside the allowed set so the workspace is inferred)",
                     None,
                 )
             })?,
@@ -1022,6 +1080,8 @@ impl rmcp::ServerHandler for KaiboHandler {
                 &self.tool_schemas,
                 &self.config,
                 &self.allowed_set,
+                self.default_root.as_deref(),
+                self.default_root_inferred,
                 self.config
                     .default_cast_usability(|k| std::env::var(k).ok()),
                 &self.config.usable_casts(|k| std::env::var(k).ok()),
@@ -1074,6 +1134,8 @@ impl rmcp::ServerHandler for KaiboHandler {
             &self.tool_schemas,
             &self.config,
             &self.allowed_set,
+            self.default_root.as_deref(),
+            self.default_root_inferred,
         )
     }
 
@@ -1305,7 +1367,12 @@ fn render_resource(uri: &str, schemas: &[ToolSchema]) -> Option<String> {
 /// values. The backend struct stores sources, not secrets; this renderer reads only
 /// those source fields. If Config ever gains a resolved-key cache, do not read it here.
 /// Tests in this file assert the contract holds.
-fn render_config_resource(config: &Config, allowed_set: &[PathBuf]) -> String {
+fn render_config_resource(
+    config: &Config,
+    allowed_set: &[PathBuf],
+    default_root: Option<&Path>,
+    default_root_inferred: bool,
+) -> String {
     use serde::Serialize;
     use std::collections::BTreeMap;
 
@@ -1316,9 +1383,14 @@ fn render_config_resource(config: &Config, allowed_set: &[PathBuf]) -> String {
     struct ConfigDoc {
         /// Allowed path trees: a per-call path must be at-or-under one of these.
         allowed_paths: Vec<String>,
-        /// Default root (the --root value), if set.
+        /// The effective default root a call uses when it omits `path` — an explicit
+        /// `--root`, or the launch cwd kaibo inferred. Absent when neither applies.
         #[serde(skip_serializing_if = "Option::is_none")]
         default_root: Option<String>,
+        /// True when `default_root` was inferred from the launch cwd rather than
+        /// configured explicitly. Only meaningful when `default_root` is present.
+        #[serde(skip_serializing_if = "std::ops::Not::not")]
+        default_root_inferred: bool,
         /// Default cast name (what a call omitting `cast` gets).
         default_cast: String,
         /// Which tools are currently advertised.
@@ -1581,7 +1653,8 @@ fn render_config_resource(config: &Config, allowed_set: &[PathBuf]) -> String {
             .iter()
             .map(|p| p.display().to_string())
             .collect(),
-        default_root: config.root.as_ref().map(|p| p.display().to_string()),
+        default_root: default_root.map(|p| p.display().to_string()),
+        default_root_inferred,
         default_cast: config.default_cast.clone(),
         tools: ToolsDoc {
             consult,
@@ -1665,9 +1738,12 @@ fn read_kaibo_resource_with_config(
     schemas: &[ToolSchema],
     config: &Config,
     allowed_set: &[PathBuf],
+    default_root: Option<&Path>,
+    default_root_inferred: bool,
 ) -> Result<ReadResourceResult, McpError> {
     if uri == CONFIG_URI {
-        let body = render_config_resource(config, allowed_set);
+        let body =
+            render_config_resource(config, allowed_set, default_root, default_root_inferred);
         return Ok(ReadResourceResult {
             contents: vec![ResourceContents::text(body, uri)],
         });
@@ -2125,7 +2201,7 @@ mod tests {
         // Use the config-aware dispatch for all URIs — same path the handler takes.
         let config = Config::builtin();
         let allowed: Vec<PathBuf> = Vec::new();
-        let result = read_kaibo_resource_with_config(uri, schemas, &config, &allowed)
+        let result = read_kaibo_resource_with_config(uri, schemas, &config, &allowed, None, false)
             .expect("known uri must read");
         match &result.contents[0] {
             ResourceContents::TextResourceContents { text, .. } => text.clone(),
@@ -2165,7 +2241,9 @@ mod tests {
                 &format!("{BUILTIN_PREFIX}nope"),
                 &schemas,
                 &config,
-                &allowed
+                &allowed,
+                None,
+                false
             )
             .is_err(),
             "an unregistered builtin must be a not-found error"
@@ -2177,7 +2255,8 @@ mod tests {
         let config = Config::builtin();
         let allowed: Vec<PathBuf> = Vec::new();
         assert!(
-            read_kaibo_resource_with_config("kaibo://nope", &[], &config, &allowed).is_err(),
+            read_kaibo_resource_with_config("kaibo://nope", &[], &config, &allowed, None, false)
+                .is_err(),
             "an unknown URI must be a not-found error, not an empty success"
         );
     }
@@ -2276,7 +2355,8 @@ mod tests {
 
         let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp")];
-        let result = read_kaibo_resource_with_config(CONFIG_EXAMPLE_URI, &[], &config, &allowed)
+        let result =
+            read_kaibo_resource_with_config(CONFIG_EXAMPLE_URI, &[], &config, &allowed, None, false)
             .expect("example resource must be readable");
         let body = match &result.contents[0] {
             ResourceContents::TextResourceContents { text, .. } => text.clone(),
@@ -2323,7 +2403,7 @@ mod tests {
     fn config_resource_renders_expected_fields() {
         let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp/test-allowed")];
-        let body = render_config_resource(&config, &allowed);
+        let body = render_config_resource(&config, &allowed, None, false);
         // Structural presence checks — the resource is TOML or a document, not prose.
         for needle in [
             "allowed_paths",
@@ -2404,7 +2484,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[]);
+        let body = render_config_resource(&config, &[], None, false);
         // The header NAME is discoverable…
         assert!(
             body.contains("authorization"),
@@ -2435,7 +2515,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[]);
+        let body = render_config_resource(&config, &[], None, false);
         for needle in ["[backend_aliases]", "[cast_aliases]"] {
             assert!(body.contains(needle), "must render {needle}:\n{body}");
         }
@@ -2482,7 +2562,7 @@ mod tests {
             unsafe {
                 std::env::set_var(var_name, SENTINEL);
             }
-            let b = render_config_resource(&config, &allowed);
+            let b = render_config_resource(&config, &allowed, None, false);
             #[allow(deprecated)]
             unsafe {
                 std::env::remove_var(var_name);
@@ -2508,7 +2588,7 @@ mod tests {
         let file_path = tmp.path().to_string_lossy().to_string();
         let toml2 = format!("[backends.anthropic]\napi_key_file = \"{file_path}\"\n");
         let config2 = Config::from_toml_str(&toml2).expect("valid config");
-        let body2 = render_config_resource(&config2, &allowed);
+        let body2 = render_config_resource(&config2, &allowed, None, false);
         // The file path (source pointer) may appear, but not the file contents.
         assert!(
             !body2.contains(SENTINEL),
@@ -2523,14 +2603,14 @@ mod tests {
     fn read_kaibo_config_resource_is_readable() {
         let config = Config::builtin();
         let allowed = handler().allowed_set();
-        let body_str = render_config_resource(&config, &allowed);
+        let body_str = render_config_resource(&config, &allowed, None, false);
         // Sanity: the rendered document has something in it.
         assert!(
             !body_str.is_empty(),
             "config resource body must not be empty"
         );
         // The dispatch must not return not-found for this URI.
-        let result = read_kaibo_resource_with_config(CONFIG_URI, &[], &config, &allowed);
+        let result = read_kaibo_resource_with_config(CONFIG_URI, &[], &config, &allowed, None, false);
         assert!(
             result.is_ok(),
             "kaibo://config must be readable, got {result:?}"
@@ -2554,6 +2634,8 @@ mod tests {
             &schemas,
             &config,
             &allowed,
+            None,
+            false,
             crate::config::CastUsability::Ready,
             &[],
         );
@@ -2573,18 +2655,20 @@ mod tests {
         );
     }
 
-    /// When there is a default root, the scope section must say so rather than
-    /// saying "no default root".
+    /// When there is an explicit default root, the scope section must name it and
+    /// must NOT tag it as inferred.
     #[test]
     fn instructions_scope_section_names_default_root() {
         let schemas = sample_schemas();
-        let mut config = Config::builtin();
-        config.root = Some(std::path::PathBuf::from("/projects/myapp"));
-        let allowed = vec![std::path::PathBuf::from("/projects/myapp")];
+        let config = Config::builtin();
+        let root = std::path::PathBuf::from("/projects/myapp");
+        let allowed = vec![root.clone()];
         let text = kaibo_instructions_with_scope(
             &schemas,
             &config,
             &allowed,
+            Some(&root),
+            false,
             crate::config::CastUsability::Ready,
             &[],
         );
@@ -2592,19 +2676,51 @@ mod tests {
             text.contains("/projects/myapp"),
             "scope section must name the configured root:\n{text}"
         );
+        assert!(
+            !text.contains("inferred"),
+            "an explicit root must not be tagged inferred:\n{text}"
+        );
     }
 
-    /// When no default root is set the scope section must be honest about it.
+    /// An inferred default root (from the launch cwd) must be named *and* tagged so
+    /// the caller can tell it wasn't configured by hand.
+    #[test]
+    fn instructions_scope_section_tags_inferred_default_root() {
+        let schemas = sample_schemas();
+        let config = Config::builtin();
+        let root = std::path::PathBuf::from("/work/space");
+        let allowed = vec![root.clone()];
+        let text = kaibo_instructions_with_scope(
+            &schemas,
+            &config,
+            &allowed,
+            Some(&root),
+            true,
+            crate::config::CastUsability::Ready,
+            &[],
+        );
+        assert!(
+            text.contains("/work/space"),
+            "scope section must name the inferred root:\n{text}"
+        );
+        assert!(
+            text.to_lowercase().contains("inferred"),
+            "an inferred root must be tagged so the boundary stays legible:\n{text}"
+        );
+    }
+
+    /// When no default root applies the scope section must be honest about it.
     #[test]
     fn instructions_scope_section_states_no_default_root_when_absent() {
         let schemas = sample_schemas();
-        let mut config = Config::builtin();
-        config.root = None;
+        let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp")];
         let text = kaibo_instructions_with_scope(
             &schemas,
             &config,
             &allowed,
+            None,
+            false,
             crate::config::CastUsability::Ready,
             &[],
         );

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -910,7 +910,10 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
 /// covers `KAIBO_ROOT` / `KAIBO_ALLOW_PATHS` too.)
 #[test]
 fn tilde_expands_in_root_and_allow_paths() {
+    // Trim a trailing slash so `{home}/src` matches `PathBuf::from(HOME).join("src")`,
+    // which normalizes `/home/user/` + `src` to `/home/user/src` (no empty component).
     let home = std::env::var("HOME").expect("HOME set in test env");
+    let home = home.trim_end_matches('/');
     let toml = "[server]\n\
                 root = \"~/src/proj\"\n\
                 allow_paths = [\"~/src\", \"/data/fixtures\"]\n";
@@ -940,6 +943,44 @@ fn tilde_expands_in_root_and_allow_paths() {
             .iter()
             .any(|p| p.to_string_lossy().starts_with('~')),
         "no allow_paths entry may keep a literal leading ~, got {:?}",
+        c.allow_paths
+    );
+}
+
+/// The env layer funnels through the same expansion: `KAIBO_ROOT` and the
+/// colon-separated `KAIBO_ALLOW_PATHS` must expand a leading `~` to `$HOME`. Pins the
+/// commit's "covers env too" claim — distinct from the file-layer test — so a future
+/// refactor that expanded only the file path would be caught.
+#[test]
+fn tilde_expands_in_env_layer_root_and_allow_paths() {
+    let home = std::env::var("HOME").expect("HOME set in test env");
+    let home = home.trim_end_matches('/');
+    let env: HashMap<&str, &str> = [
+        ("KAIBO_ROOT", "~/envroot"),
+        ("KAIBO_ALLOW_PATHS", "~/a:~/b:/data/fixtures"),
+    ]
+    .into_iter()
+    .collect();
+    // No config file (built-in defaults) + the injected env layer.
+    let c = Config::load_with(None, None, |k| env.get(k).map(|s| s.to_string())).unwrap();
+
+    assert_eq!(
+        c.root.as_deref(),
+        Some(std::path::Path::new(&format!("{home}/envroot"))),
+        "~ in KAIBO_ROOT must expand to $HOME"
+    );
+    for expected in [format!("{home}/a"), format!("{home}/b")] {
+        assert!(
+            c.allow_paths
+                .contains(&std::path::PathBuf::from(&expected)),
+            "~ in KAIBO_ALLOW_PATHS must expand to {expected}, got {:?}",
+            c.allow_paths
+        );
+    }
+    assert!(
+        c.allow_paths
+            .contains(&std::path::PathBuf::from("/data/fixtures")),
+        "non-tilde KAIBO_ALLOW_PATHS entry must pass through, got {:?}",
         c.allow_paths
     );
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -902,6 +902,48 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
     );
 }
 
+/// A leading `~` in `[server] root` and `allow_paths` must expand to `$HOME` — the
+/// same tilde handling key files and `[context]` paths already get. A config file is
+/// hand-edited, so `~/src` is the natural thing to write; taking it literally would
+/// later canonicalize a bogus `~` path and refuse startup. Non-tilde paths pass
+/// through untouched. (The env layer funnels through the same conversion, so this
+/// covers `KAIBO_ROOT` / `KAIBO_ALLOW_PATHS` too.)
+#[test]
+fn tilde_expands_in_root_and_allow_paths() {
+    let home = std::env::var("HOME").expect("HOME set in test env");
+    let toml = "[server]\n\
+                root = \"~/src/proj\"\n\
+                allow_paths = [\"~/src\", \"/data/fixtures\"]\n";
+    let c = Config::from_toml_str(toml).expect("valid config");
+
+    assert_eq!(
+        c.root.as_deref(),
+        Some(std::path::Path::new(&format!("{home}/src/proj"))),
+        "~ in [server] root must expand to $HOME"
+    );
+    assert!(
+        c.allow_paths
+            .contains(&std::path::PathBuf::from(format!("{home}/src"))),
+        "~ in allow_paths must expand to $HOME, got {:?}",
+        c.allow_paths
+    );
+    // A non-tilde absolute path is left exactly as written.
+    assert!(
+        c.allow_paths
+            .contains(&std::path::PathBuf::from("/data/fixtures")),
+        "absolute allow_paths must pass through untouched, got {:?}",
+        c.allow_paths
+    );
+    // A literal `~` is never left dangling in either field.
+    assert!(
+        !c.allow_paths
+            .iter()
+            .any(|p| p.to_string_lossy().starts_with('~')),
+        "no allow_paths entry may keep a literal leading ~, got {:?}",
+        c.allow_paths
+    );
+}
+
 #[test]
 fn env_overrides_file_defaults_and_flows_into_slot_tunables() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -146,6 +146,13 @@ async fn omitted_path_with_root_set_uses_root() {
     config.allow_paths = vec![];
     let handler = KaiboHandler::new(config).expect("handler builds");
 
+    // An explicit --root is the default root, and is NOT tagged inferred — guards
+    // against the `(Some(root), false)` arm accidentally flipping to `true`.
+    assert!(
+        !handler.default_root_inferred(),
+        "an explicit --root must not be marked inferred"
+    );
+
     let out = handler
         .run_kaish(Parameters(RunKaishInput {
             script: "cat hello.txt".to_string(),
@@ -279,6 +286,35 @@ async fn omitted_path_with_allow_path_excluding_cwd_still_errors() {
         err_str.contains("path") || err_str.contains("root") || err_str.contains("parameter"),
         "omitted path must produce a parameter-flavored error, got: {err_str}"
     );
+}
+
+// --- (f3) cwd is an *ancestor* of the only allow-path: no default root --------
+
+/// When the only `--allow-path` is a *descendant* of the launch cwd (so cwd is an
+/// ancestor of the boundary, not inside it), the cwd must NOT be adopted as the
+/// default root: `cwd.starts_with(allow_path)` is false, so cwd is above the boundary
+/// and resolving to it would escape the allowed set. This pins the ancestor-vs-
+/// descendant semantic distinctly from the sibling case in (f2).
+#[tokio::test]
+async fn omitted_path_with_cwd_ancestor_of_allow_path_has_no_default_root() {
+    // Create the allow-path *inside* the crate cwd so cwd is its ancestor. (tempdir's
+    // usual /tmp location would be a sibling, exercising a different branch.)
+    let sub = tempfile::tempdir_in(".").expect("tempdir under cwd");
+    let handler = handler_with_allowed(None, &[sub.path()]);
+
+    assert!(
+        handler.default_root().is_none(),
+        "cwd as an ancestor of the allow-path is outside the boundary; no default root"
+    );
+    assert!(!handler.default_root_inferred());
+
+    handler
+        .run_kaish(Parameters(RunKaishInput {
+            script: "ls".to_string(),
+            path: None,
+        }))
+        .await
+        .expect_err("omitted path with no default root must be a parameter error");
 }
 
 // --- (h) empty-string path is rejected as invalid_params --------------------

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -205,14 +205,66 @@ async fn no_root_no_allow_paths_defaults_to_cwd() {
     );
 }
 
-// --- (f) omitted path with no root still errors as a parameter error ---------
+// --- (f) omitted path with no root infers the launch cwd as the default root --
 
-/// With no --root set, an omitted `path` is a parameter error ("not a silent
-/// default") — containment does not change this existing behavior.
+/// With no --root and no --allow-path, an omitted `path` resolves to the launch
+/// cwd: the zero-config allowed set is the cwd, so the cwd is adopted as the
+/// inferred default root and a call may omit `path` in the common single-workspace
+/// case. (MCP clients start stdio servers with cwd = workspace.)
 #[tokio::test]
-async fn omitted_path_no_root_still_errors_as_parameter_error() {
-    let config = Config::builtin(); // no root
+async fn omitted_path_zero_config_infers_cwd_as_default_root() {
+    let config = Config::builtin(); // no root, no allow_paths -> cwd inferred
     let handler = KaiboHandler::new(config).expect("handler builds");
+
+    let out = handler
+        .run_kaish(Parameters(RunKaishInput {
+            script: "ls".to_string(),
+            path: None,
+        }))
+        .await
+        .expect("omitted path with zero-config must resolve to the inferred cwd")
+        .content
+        .into_iter()
+        .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // `ls` at the crate root (the test process cwd) lists real files.
+    assert!(
+        out.contains("Cargo.toml"),
+        "inferred-cwd call should list the crate root, got: {out}"
+    );
+
+    // The handler must expose the inferred default root, and mark it inferred.
+    let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+    assert_eq!(
+        handler.default_root().as_deref(),
+        Some(cwd.as_path()),
+        "zero-config default root must be the canonicalized cwd"
+    );
+    assert!(
+        handler.default_root_inferred(),
+        "a cwd-derived default root must be marked inferred"
+    );
+}
+
+// --- (f2) an allow-path that excludes the cwd leaves no default root ----------
+
+/// When `--allow-path` is set to a tree that does NOT contain the launch cwd and
+/// no `--root` is given, the cwd is outside the boundary, so it must NOT be adopted
+/// as the default root. An omitted `path` then remains a parameter error — we never
+/// default to a root the containment check would reject.
+#[tokio::test]
+async fn omitted_path_with_allow_path_excluding_cwd_still_errors() {
+    let allowed = tempdir().unwrap(); // a tempdir, never an ancestor of the crate cwd
+    let handler = handler_with_allowed(None, &[allowed.path()]);
+
+    // No default root was inferred (cwd is outside the allow-path).
+    assert!(
+        handler.default_root().is_none(),
+        "cwd outside the allowed set must not be adopted as a default root"
+    );
+    assert!(!handler.default_root_inferred());
 
     let err = handler
         .run_kaish(Parameters(RunKaishInput {
@@ -220,10 +272,8 @@ async fn omitted_path_no_root_still_errors_as_parameter_error() {
             path: None,
         }))
         .await
-        .expect_err("omitted path with no root must be a parameter error");
+        .expect_err("omitted path with no default root must be a parameter error");
 
-    // The error must be invalid_params territory — not a containment rejection,
-    // but the existing "no path provided and no --root" error.
     let err_str = format!("{err:?}");
     assert!(
         err_str.contains("path") || err_str.contains("root") || err_str.contains("parameter"),


### PR DESCRIPTION
## Why

kaibo's containment layer already adopts the launch cwd as an allowed tree when no `--root`/`--allow-path` is set (MCP clients start stdio servers with cwd = workspace). But the **default root** — what a call resolves to when it omits `path` — stayed unset, so every `consult`/`explore`/`synthesize`/`run_kaish` call had to pass `path` explicitly even though kaibo was sitting in exactly the directory the caller meant. The convenience layer lagged the security layer. This surfaced as friction on a `/configure` run.

## What changed

- When no `--root` is configured, adopt the canonicalized cwd as the **inferred default root** — but only **when it falls inside the allowed set**. In the zero-config case the cwd *is* the whole allowed set, so it always qualifies.
- The guard is the safety: an `--allow-path` that excludes the cwd leaves the default root unset rather than pointing it at a path the containment check would reject. We never default to something we'd refuse.
- `resolve_root` re-validates the inferred root through the same canonicalize + containment path as an explicit `path` — no special-case trust.
- The boundary stays legible: the `## Scope` handshake and `kaibo://config` (`default_root_inferred`) tag the root as inferred so a reader can tell it wasn't configured by hand.

## Behavior change

This deliberately replaces the old "containment ≠ defaulting" rule (an omitted `path` used to always error without `--root`). Containment tests and `docs/config.md` are updated to the new contract.

## Tests

Failing-first tests in `tests/containment.rs`:
- `omitted_path_zero_config_infers_cwd_as_default_root` — omit `path`, land on the workspace; handler reports the inferred root.
- `omitted_path_with_allow_path_excluding_cwd_still_errors` — cwd outside the allow-path → no default root, omitted `path` still a parameter error.

Plus scope-section unit tests for the inferred-vs-explicit labelling. Full suite green; no new clippy warnings.

> Note per AGENTS.md: still wants a cross-family review pass over the diff before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)