### PR TITLE
Collapse the consultation surface to consult + oneshot, and make kaibo the legible door to an outside-family model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,23 @@ kinds of help — *consultation* (grounded, cited, read-only answers about a cod
 *capabilities* (things the team can *do* and hand back as artifacts; image generation
 today, more as `rig` grows coverage).
 
-**Consultation: one primitive, four tools.** The primitive is `run_phase`
+**Consultation: one primitive, three tools.** The primitive is `run_phase`
 (`consult.rs`): a model + preamble + an *injected toolset*, run as a bounded tool
 loop. Each consultation tool is that loop wearing different clothes:
 
-- **`consult`** — a capable model with `{run_kaish, explore′}`: it reads precise
-  spans directly and delegates broad sweeps to a cheap explorer sub-agent, then
-  answers. No rigid explorer→synth hand-off; the model chooses.
-- **`explore`** — a cheap model with `{run_kaish}` → a curated report (the seam).
-- **`synthesize`** — a capable model with `{run_kaish}` + optional caller `context`
-  → an answer (investigates directly when context is thin).
+- **`consult`** — a capable model with `{run_kaish, explore′}` + optional caller
+  `context`: it reads precise spans directly and delegates broad sweeps to a cheap
+  explorer sub-agent, then answers. No rigid explorer→synth hand-off; the model
+  chooses. Supplied context is trusted starting evidence — it investigates for
+  *more*, not to re-verify. The `explore′` sweep (`report_preamble`) lives *inside*
+  this loop now; it is not a standalone tool.
+- **`oneshot`** — a capable model with **no tools**: the caller owns the context, so
+  it's one upstream request, prompt in / answer out, no codebase access. The thin
+  counterpart to `consult` — and the door to a model outside the caller's family.
 - **`run_kaish`** — drive the read-only kaish shell directly, no model in the loop.
+
+Both model-driven tools name their cast + answering model(s) in a provenance footer
+(`with_provenance` in `server.rs`), so a cross-model study sees which model answered.
 
 **Capabilities** are a distinct, growing tool *class* — not `run_phase` loops. The
 direction is the tell: consultation and perception (`view_image`) run images and
@@ -91,7 +97,7 @@ commands.
   Two primitives — response strategy + a request log — so new cases (multi-sweep,
   model routing, error injection) are new responders, not harness changes. Inject via
   the generic seams (`run_phase`, `consult_with`, `consult_session_turn`); the public
-  `consult`/`explore`/`synthesize` build the real client behind `with_provider_client!`.
+  `consult`/`oneshot` build the real client behind `with_provider_client!`.
 - **`docs/issues.md` is the live tracker.** Skim it before new work. Delete
   entries when they ship — don't mark them done; git history is the record.
 - **`kaish-kernel` is a published crates.io dep** (pinned in `Cargo.toml`), still
@@ -169,8 +175,9 @@ How kaibo talks to LLMs — Amy's defaults, made local so any agent here inherit
   better anti-bias posture: bias lives in a report's gaps and framing, not its cited
   facts, so the cure is investigation that *extends* the context, not re-checking it.
   Keep a "the code is the only ground truth" tiebreaker for genuine conflicts (it
-  fires only when one is noticed; it doesn't send the model hunting). See the synth
-  prompts in `consult.rs` (`synthesize_preamble`, `synthesize_user_prompt`).
+  fires only when one is noticed; it doesn't send the model hunting). See the context
+  framing in `consult.rs` (`consult_preamble`, `consult_user_prompt`) — the seam that
+  absorbed the old standalone `synthesize`.
 
 ## Commit style
 
@@ -209,7 +216,7 @@ requests — `main` is protected by convention, not a scratchpad.
 - **Branch → PR → review → merge.** Non-trivial work lands on a branch and goes up
   as a PR, not direct-to-`main`. Dogfood the review: run a **cross-family** pass over
   the diff — a different model lineage than wrote it (`/code-review`, or kaibo's own
-  `consult`/`synthesize` aimed at the change) — before merge. A typo or a one-line doc
+  `consult`/`oneshot` aimed at the change) — before merge. A typo or a one-line doc
   fix can still go straight to `main`; this is judgment, not ceremony.
 - **Every user-facing change updates `CHANGELOG.md`** under the top *unreleased*
   section, in the Keep a Changelog buckets (Added / Changed / Fixed / Security / …).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,20 @@ the git log. Each later release appends a new section at the top.
 
 ### Added
 
-- **`consult`** — the headline tool: ask a question about a codebase, get a
-  grounded, cited answer. A capable model reads precise spans directly and delegates
-  broad sweeps to a cheap explorer sub-agent, then synthesizes — so your context
-  receives the answer, not the investigation transcript. Args: `question`, `path`,
-  `cast`, `session_id`, `include_report`, and per-call `explorer_model` /
-  `synth_model` (+ `_backend`) overrides.
-- **`explore`** — a fast, cheap model sweeps the project read-only and returns a
-  curated report (relevant files, line numbers, key snippets) for a stronger model
-  to reason over.
-- **`synthesize`** — a capable model answers grounded in optional caller `context`
-  (an explore report or pasted source), investigating directly when context is thin.
+- **`consult`** — the headline tool: ask a model *outside your own family* about a
+  codebase and get a grounded, cited answer. A capable model reads precise spans
+  directly and delegates broad sweeps to a cheap explorer sub-agent, then synthesizes
+  — so your context receives the answer, not the investigation transcript. Pick which
+  family answers with `cast`. Optionally seed it with `context` (a change summary or
+  pasted source), trusted as starting evidence while it investigates for more. The
+  answer carries a provenance footer naming the cast and the models that produced it.
+  Args: `question`, `context`, `path`, `cast`, `session_id`, `include_report`, and
+  per-call `explorer_model` / `synth_model` (+ `_backend`) overrides.
+- **`oneshot`** — a thin, direct second opinion from a model outside your family:
+  prompt in, answer out, no codebase access and no tools, exactly one upstream
+  request. The counterpart to `consult` for when you already own the context (you've
+  pasted what's needed, or the question is general). Pick the model with `cast`; the
+  answer carries the same provenance footer.
 - **`run_kaish`** — drive the read-only kaish shell yourself, no model in the loop:
   exit code + stdout + stderr.
 - **`generate_image`** — kaibo's first *capability* (an artifact handed back to the

--- a/README.md
+++ b/README.md
@@ -178,34 +178,32 @@ every tool off is refused at startup.
 
 ### `consult` — hybrid agent that explores and synthesizes
 
-Ask a question about a codebase; get a grounded, cited answer. A capable model drives
-a fast explorer sub-agent and can fill in any gaps using its own `run_kaish` tool.
-The models have instructions to return a synthesized report at the end, leaving the
-noise from the consultation out of your context.
+Ask a model *outside your own family* about a codebase; get a grounded, cited answer.
+A capable model drives a fast explorer sub-agent and can fill in any gaps using its own
+`run_kaish` tool. The models have instructions to return a synthesized report at the
+end, leaving the noise from the consultation out of your context. Describe what you did
+or want to know in prose — kaibo reads the real, current source itself, so you don't
+need to paste a diff; optionally seed it with `context` (a change summary or pasted
+source), which it trusts as starting evidence while investigating for more. The answer
+carries a provenance footer naming the cast and models that produced it.
 
 When an answer surprises you, pass `include_report: true` to get the explorer's raw
 findings back alongside it — the audit trail for how the consultation reached its
 conclusion. (For deeper tracing, kaibo emits per-tool OpenTelemetry spans; see
 [`docs/config.md`](docs/config.md).)
 
-*Args:* `question` (required), `path` (project dir; optional with a default `--root`),
-`cast`, `session_id`, `include_report`, and per-call `explorer_model` / `synth_model`
-(+ `_backend`) overrides.
+*Args:* `question` (required), `context` (optional seed), `path` (project dir; optional
+with a default `--root`), `cast`, `session_id`, `include_report`, and per-call
+`explorer_model` / `synth_model` (+ `_backend`) overrides.
 
-### `explore` — the fast evidence-gatherer
+### `oneshot` — a thin second opinion
 
-The explorer agent on its own: a fast, cheap model reads the project and returns a
-curated report. Its instructions ask it to include relevant files, line numbers,
-and key snippets without trying to analyze them. This saves work for the more
-expensive models.
+The counterpart to `consult` for when you already own the context: prompt in, answer
+out, no codebase access and no tools — exactly one upstream request. Use it to ask a
+model outside your family a direct question (you've pasted what's needed, or it's
+general). Pick the model with `cast`; the answer carries the same provenance footer.
 
-### `synthesize` — a second opinion
-
-A capable model answers a question, grounded in optional `context` you pass in
-(typically an `explore` report or pasted source). With context it treats it as
-primary evidence and uses the shell only to verify or fill precise gaps; without
-context it investigates directly. This is the synthesizer half of `consult`, callable
-on its own without the explorer phase.
+*Args:* `prompt` (required), `cast`, and a per-call `model` (+ `backend`) override.
 
 ### `run_kaish` — direct read-only shell
 
@@ -241,11 +239,13 @@ your agent ──stdio MCP──▶ kaibo
                        back to your agent
 ```
 
-kaibo is an agent for your agent. kaibo's consult(), explore(), and synthesize() agents have their
-own tool, `run_kaish` for working with the filesystem and transforming inputs. When using the
-consult() tool, it starts with a big model, which can delegate to the explore agent. The
-explorer/synthesis combination is meant to speed up execution and save token spend by having
-smaller and faster models do the bulk of tool calling operations before synthesis begins.
+kaibo is an agent for your agent. kaibo's consult() agent drives the read-only
+`run_kaish` shell for working with the filesystem and transforming inputs. When using the
+consult() tool, it starts with a big model, which can delegate to a fast explorer
+sub-agent. The explorer/synthesis combination is meant to speed up execution and save token
+spend by having smaller and faster models do the bulk of tool calling operations before
+synthesis begins. (oneshot() skips all of that — a single direct call when you already
+have the context.)
 
 It is written in Rust on top of [`rmcp`](https://crates.io/crates/rmcp) and
 [`rig-core`](https://crates.io/crates/rig-core). [kaish](https://crates.io/crates/kaish-kernel)

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -151,7 +151,7 @@ consult(question, root, arms, cfg, session)
 `cast = "claude"` walks the identical pipeline with boring resolution: the
 built-in single-backend cast, both arms on one backend, no media builtins.
 
-- **`explore` / `synthesize`**: one arm each, trivially.
+- **`oneshot`**: one arm (the synth slot), no tools — trivially.
 - **`run_kaish`**: shipped *without* a `cast` arg (decided at implementation
   time, overriding the draft here). It has no agent in the loop and no media
   builtins exist yet for a cast's production slots to gate; the arg lands

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -251,12 +251,12 @@ key_optional = true
 # backend in a slot is a load error naming the known backends.
 # ---------------------------------------------------------------------------
 
-# --- The payoff when you hold keys across families: a chimera — mix model FAMILIES
-#     across roles, a different lineage per job, named as one team (`cast = "chimera"`).
-#     A cheap DeepSeek explorer + a strong Claude synth give you mistakes that don't
-#     line up: cheaper AND more diverse at once. It needs at least two families,
-#     though — with one provider a clean single-family cast (like `local-only` below)
-#     is the right call, not a lesser one. ---
+# --- Advanced — a chimera: mix model FAMILIES across roles, a different lineage per
+#     job, named as one team (`cast = "chimera"`). A cheap DeepSeek explorer + a strong
+#     Claude synth give you mistakes that don't line up. It's the power-user option and
+#     wants a key per family. The common case is simpler: ONE outside family, explorer
+#     and synth both within it (the built-in `deepseek`/`gemini`/`anthropic` casts, or
+#     `local-only` below) — that single lineage already augments your own agent's. ---
 
 [casts.chimera]
 explorer = "deepseek/deepseek-v4-flash"     # cheap fast sweeps — DeepSeek family

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -22,7 +22,7 @@
 # Getting started — a fresh install has no key yet
 # ---------------------------------------------------------------------------
 # With nothing configured, kaibo starts fine and `run_kaish` works immediately —
-# the read-only shell needs no model. `consult` / `explore` / `synthesize` need a
+# the read-only shell needs no model. `consult` / `oneshot` need a
 # provider key on the default cast (`anthropic` out of the box). Give it one the
 # private way — kaibo reads the key at startup, so it never enters your chat:
 #   env:   export ANTHROPIC_API_KEY=sk-...     (or DEEPSEEK_/GEMINI_/OPENAI_…)
@@ -58,11 +58,10 @@ cast = "anthropic"
 log = "kaibo=info"
 
 # Tool gating — true advertises the tool, false drops it (the --no-<tool> flags).
-# A config with all five false is refused at startup, same as today.
+# A config with all four false is refused at startup, same as today.
 [server.tools]
 consult        = true
-explore        = true
-synthesize     = true
+oneshot        = true
 run_kaish      = true
 generate_image = true
 
@@ -335,14 +334,15 @@ synth    = "gpt/gpt-5"
 # shell contract rides the run_kaish tool regardless). File-only and operator-only
 # (a calling agent can't inject a prompt). An empty value is a loud load error.
 # Precedence per phase: slot `preamble` (per-model, above) > [prompts].<phase> >
-# built-in. The synth slot feeds both `synthesize` and `consult`, but each keeps
-# its own key, so they can diverge.
+# built-in. The synth slot feeds both `consult` and `oneshot`, but each keeps
+# its own key, so they can diverge. Phases: `explorer` (the nested explore′ sweep),
+# `consult` (the driver), `oneshot` (the thin toolless answer).
 # ---------------------------------------------------------------------------
 #
 # [prompts]
-# explorer   = "You are a security auditor. Hunt injection sinks and unsafe deserialization."
-# synthesize = "Answer concisely; lead with the file:line that settles it."
-# consult    = """
+# explorer = "You are a security auditor. Hunt injection sinks and unsafe deserialization."
+# oneshot  = "Answer concisely; you have no codebase access, so reason from what you're given."
+# consult  = """
 # You are a staff engineer reviewing this codebase.
 # Prefer architectural answers; name the file:line that carries each claim.
 # """

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -251,11 +251,12 @@ key_optional = true
 # backend in a slot is a load error naming the known backends.
 # ---------------------------------------------------------------------------
 
-# --- The reason casts exist: a chimera — mix model FAMILIES across roles, a
-#     different lineage per job, named as one team (`cast = "chimera"`). That's the
-#     whole point: two flavors of one base model give you one opinion in two voices;
-#     a cheap DeepSeek explorer + a strong Claude synth give you mistakes that don't
-#     line up. Cheaper AND more diverse at once. ---
+# --- The payoff when you hold keys across families: a chimera — mix model FAMILIES
+#     across roles, a different lineage per job, named as one team (`cast = "chimera"`).
+#     A cheap DeepSeek explorer + a strong Claude synth give you mistakes that don't
+#     line up: cheaper AND more diverse at once. It needs at least two families,
+#     though — with one provider a clean single-family cast (like `local-only` below)
+#     is the right call, not a lesser one. ---
 
 [casts.chimera]
 explorer = "deepseek/deepseek-v4-flash"     # cheap fast sweeps — DeepSeek family

--- a/docs/config.md
+++ b/docs/config.md
@@ -247,7 +247,7 @@ id — it is never parsed for a backend, so an org prefix matching a backend ali
 can't silently retarget the call); it swaps the id within the configured slot,
 dropping its pins and per-slot tunables — they described the configured model;
 the new id classifies fresh. The matching backend arg (`explorer_backend` /
-`synth_backend` on consult, `backend` on explore/synthesize) retargets the slot
+`synth_backend` on consult, `backend` on oneshot) retargets the slot
 to another backend (a call-time chimera: aliases resolve, and it works even on a
 role the cast doesn't carry). The naming rule for everything else is mechanical:
 
@@ -290,8 +290,8 @@ role the cast doesn't carry). The naming rule for everything else is mechanical:
 | project house-rules files | `context.project_files` *(list; default `["AGENTS.md"]`)* | `KAIBO_PROJECT_FILES` *(colon-separated)* | `--project-context-file FILE` *(repeatable)* |
 | user house-rules files | `context.user_files` *(list)* | `KAIBO_USER_FILES` *(colon-separated)* | `--user-context-file FILE` *(repeatable)* |
 | explorer system prompt | `prompts.explorer` *(file-only — full replace)* | — | — |
-| synthesize system prompt | `prompts.synthesize` *(file-only — full replace)* | — | — |
 | consult system prompt | `prompts.consult` *(file-only — full replace)* | — | — |
+| oneshot system prompt | `prompts.oneshot` *(file-only — full replace)* | — | — |
 
 **Two deliberate exceptions to the rule:**
 
@@ -371,7 +371,7 @@ headers = { authorization = "Bearer <token>" }     # file-only; values are secre
 What you get is the GenAI trace tree rig already produces — a tool call →
 `run_phase` per phase → `invoke_agent` → a `chat` span per model turn (with
 `gen_ai.request.model` and every `gen_ai.usage.*` token count). On top of that,
-kaibo adds the named parent spans (`consult` / `explore` / `synthesize` /
+kaibo adds the named parent spans (`consult` / `oneshot` /
 `run_kaish`) that root each trace, **and a `tool` span per tool invocation**
 (`tool_span.rs`) carrying `gen_ai.tool.name` and an ok/err `outcome` — so you can
 query *which* tool the model actually called (`run_kaish`, `view_image`, the nested
@@ -429,9 +429,8 @@ read scope is *not* widened. That's the distinction from `[server] allow_paths`
 below: `allow_paths` widens what the *model* can explore, `[context]` injects
 fixed operator text the model never navigates to.
 
-Injected into every phase that drives a model — the `consult` driver, the
-standalone `explore` and `synthesize`, *and* the nested `explore′` sweep inside
-`consult` — so the cheap explorer orients on the same `AGENTS.md`/user guidance
+Injected into the codebase-reading phases — the `consult` driver *and* its nested
+`explore′` sweep — so the cheap explorer orients on the same `AGENTS.md`/user guidance
 while it searches, not just at answer time (the block names where things live and
 what matters). Precedence is the usual per-call > CLI > env > file > built-in: a
 CLI `--project-context-file` replaces lower layers additively (the CLI can't
@@ -456,9 +455,9 @@ Prefer architectural answers; name the file:line that carries each claim.
 
 | key | replaces | runs in |
 |---|---|---|
-| `explorer` | `report_preamble` | standalone `explore` **and** the nested `explore′` sweep |
-| `synthesize` | `synthesize_preamble` | standalone `synthesize` |
+| `explorer` | `report_preamble` | the nested `explore′` sweep inside `consult` |
 | `consult` | `consult_preamble` | the `consult` driver |
+| `oneshot` | `oneshot_preamble` | the thin, toolless `oneshot` |
 
 **Full replace, by decision.** An override *is* the role framing, verbatim — kaibo
 does not re-wrap it. That's safe because the kaish operating contract (how to drive
@@ -499,11 +498,11 @@ synth    = "anthropic/claude-sonnet-4-6"   # no per-model prompt; uses [prompts]
 slot (most specific — *this* model in *this* cast) wins, the same way `effort`
 overrides the `[defaults]` effort. Set neither and the built-in runs.
 
-**One model, two synth jobs.** The synth slot's model plays *both* the standalone
-`synthesize` and the `consult` driver, so its `preamble` feeds both — but each phase
+**One model, two synth jobs.** The synth slot's model plays *both* the `consult`
+driver and the toolless `oneshot`, so its `preamble` feeds both — but each phase
 resolves under its own key, so they stay **independently overridable**: a copy today
-(both the synth slot's voice), free to diverge by setting `[prompts].synthesize` and
-`[prompts].consult` separately. `slot.preamble` = "this model's voice"; the phase
+(both the synth slot's voice), free to diverge by setting `[prompts].consult` and
+`[prompts].oneshot` separately. `slot.preamble` = "this model's voice"; the phase
 keys = "this job's framing." The explorer has one job, so no ambiguity. A per-call
 model override (a bare slot) carries no `preamble` — overriding the model doesn't
 drag the configured slot's framing along. Same loud-on-empty rule as `[prompts]`.
@@ -535,9 +534,9 @@ Size-gated, by file count:
   or point a cast that explores via `rg` at it. (`full_list_max_files = 0` is a load
   error: it would refuse every repo; disable instead.)
 
-It rides the **exploring** phases only — standalone `explore`, the `consult` driver,
-and the nested `explore′` sweep. Standalone `synthesize` works from supplied context,
-so it gets no map. Like `[context]`, the block re-sends each turn, which the size gate
+It rides the **exploring** phases only — the `consult` driver and its nested
+`explore′` sweep. The toolless `oneshot` reads no project, so it gets no map. Like
+`[context]`, the block re-sends each turn, which the size gate
 keeps bounded. Whether it actually erases the discovery turns is measurable via the
 per-tool `tool` spans (see Telemetry).
 
@@ -614,8 +613,8 @@ operator) the full picture:
 - `allowed_paths` — the canonicalized trees a per-call path must be at-or-under
 - `default_root` — the `--root` value, if set
 - `default_cast` — which cast is used when a call omits `cast`
-- `tools` — which tools are currently advertised (`consult`, `explore`,
-  `synthesize`, `run_kaish`, `generate_image`)
+- `tools` — which tools are currently advertised (`consult`, `oneshot`,
+  `run_kaish`, `generate_image`)
 - `sandbox` — exec timeout, output cap, scratch (`/` MemoryFs) cap, and any extra disabled builtins
 - `kaish.ignore` — the resolved ignore policy the file-walking builtins honor:
   `files`, `defaults`, `auto_gitignore`, `global_gitignore`, `scope`

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -15,7 +15,23 @@ Conventions:
 - Priorities: **P1** high-leverage features & robustness · **P2** focused
   fixes & hardening · **P3** infra, perf, polish · **P4** eventually.
 
-Last pass: 2026-06-13 (image-out SHIPPED, **live-verified** — kaibo's first
+Last pass: 2026-06-16 (consultation surface collapsed to **`consult` + `oneshot`**,
+offline-green — the cross-model-study finding that agents reach for the per-model pals
+over kaibo. The pals win on naming the model in the tool and offering two shapes
+(agentic + a thin oneshot); kaibo led with "a codebase" and four tools, two of which
+(`explore`, `synthesize`) were internal seams leaking onto the public surface. Fix:
+`consult` gains an optional `context` seed (absorbing `synthesize`'s trusted-evidence
+behavior; the `explore′` sweep stays internal to its loop), a new toolless `oneshot`
+(prompt in / answer out, no codebase access — the pal-shaped thin path), and `explore`/
+`synthesize` removed as public tools (with their `--no-*` flags, `[prompts]` keys, and
+config rows). Both model tools now describe themselves as the door to a model *outside
+the caller's family*, name the casts up front, and append a provenance footer (cast +
+answering models) so a study sees which model answered without opening `kaibo://config`;
+`consult` also steers "say what you did, don't paste a diff". Tests ported to the new
+seams (view_image now exercises the `consult` driver where it rides; the synthesize
+prompt tests became consult-with-context tests) + new tests pinning oneshot's empty
+toolset and the provenance footer. Lands via the `client-instructions-say-what-you-did`
+PR; cross-family review pending before merge.) 2026-06-13 (image-out SHIPPED, **live-verified** — kaibo's first
 *capability* (vs. consultation). `generate_image` (`generate_image.rs` + a `server.rs`
 handler) is a dedicated MCP tool, **not** a `run_phase` costume and **not** a kaish
 builtin: it resolves the cast's `image` slot into an `ImageGen` (`image_gen.rs`),
@@ -202,7 +218,8 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
   (explorer, synth, image, tts; `ModelRole`/`ModelSlot` in `config.rs`),
   spelled `[casts.<name>]` since the backends/casts split shipped. The `image` slot
   is now consumed by `generate_image`; `tts` stays a reserved seam pending rig
-  coverage. `explore`/`synthesize` remain the agent costumes over `run_phase`;
+  coverage. `consult`/`oneshot` are the agent costumes over `run_phase` (the old
+  `explore`/`synthesize` tools folded into them — see the surface-collapse below);
   capabilities are their own tool shapes, never new loops.
 
 **Sequencing:** (0) the backends/casts split — SHIPPED 2026-06-11. (1) vision-in —
@@ -283,7 +300,7 @@ completes, while a pure-script spin still dies at 30s.
 ## P2 — Focused fixes & hardening
 
 ### Review the provider retry + failure policy (and document it)
-We don't have a stated, audited answer for what a `consult`/`explore`/`synthesize`
+We don't have a stated, audited answer for what a `consult`/`oneshot`
 call does when a provider misbehaves mid-flight: a 429/529 overload, a connection
 reset, a partial stream, or a wedged-but-connected backend. Today the only explicit
 guard is the per-backend `request_timeout_secs` (default 900, `config.md`) that bounds
@@ -305,8 +322,9 @@ the scripted `CompletionClient` (`test_support.rs`) is the natural guard.
 ### `[context]` house rules have no size cap (and ride every turn, every phase)
 The `[context]` files are spliced into the preamble whole (`context.rs::assemble`
 → `consult.rs::with_house_rules`), the preamble is re-sent on *every* model turn,
-and the block now rides *every* phase — the driver, standalone `explore`/
-`synthesize`, and each nested `explore′` sweep. A large `AGENTS.md` +
+and the block rides every codebase-reading phase — the `consult` driver and each
+nested `explore′` sweep (the toolless `oneshot` reads no project, so it gets none).
+A large `AGENTS.md` +
 `~/.claude/CLAUDE.md` is real token cost multiplied across turns *and* sweeps. No
 truncation by design — silent truncation of operator guidance is the wrong failure
 — but a generous cap with a *loud* error (or a startup warning naming the byte
@@ -331,15 +349,16 @@ for now, but a busy server rebuilds kernels constantly. Consider a small worker
 pool, or resetting one kernel's cwd between phases instead of rebuilding. Measure
 before optimizing.
 
-### `synthesize_batch` — a tool-less, batchable synth variant (deferred from the tool-surface work)
-The standalone `synthesize` we shipped is *interactive* (`{run_kaish}`) so it can
-self-correct a bad cite — the panel was unanimous a tool-less synth is too weak.
-The strictly tool-less, non-interactive variant is still worth having for batch
-fan-out: submit → poll → read, modelled on gpal/cpal's job system. Uses the parked
-`SYNTH_ONESHOT_PREAMBLE` wording in the (now-deleted) plan. It's a **per-provider
-capability** like `thinking_params`: Gemini ✓, Anthropic ✓, DeepSeek?, `openai` ✗ —
-`None` where unsupported. Open fork when built: many-questions/one-model vs
-one-question/many-models (the diverse-opinion panel made literal).
+### `oneshot` batch — batchable fan-out of the tool-less answer (deferred)
+The tool-less, non-interactive answer shipped as the `oneshot` tool (prompt in,
+answer out, no tools — `consult.rs::oneshot`). What's still deferred is the *batch*
+shape for fan-out: submit → poll → read, modelled on gpal/cpal's job system, so a
+caller can fire many oneshots (or one question across many casts) without holding a
+synchronous call open per answer. It's a **per-provider capability** like
+`thinking_params`: Gemini ✓, Anthropic ✓, DeepSeek?, `openai` ✗ — `None` where
+unsupported. Open fork when built: many-questions/one-model vs one-question/many-models
+(the diverse-opinion panel made literal). The provenance footer oneshot already
+appends makes a batch result self-labelling.
 
 ### Provider model ids drift and live in code
 `consult.rs::default_models` hardcodes the explorer/synth ids per provider; they
@@ -461,28 +480,18 @@ mid-consult error. An MCP resource enumerating models could ride along.
 
 ## P4 — Eventually
 
-### Config-overrideable system prompts (deferred until a non-Amy user asks)
-Note: the in-tree `ModelShape` seam (P3, "Per-model request shaping") is the *same*
-resolution point this would extend — build that first; config override rides it.
-Every model-facing string is hardcoded in Rust today: the three phase preambles
-(`consult.rs` `report_preamble`/`synthesize_preamble`/`consult_preamble`, each
-interpolating `kaish_syntax_core()`), the per-call framers (`synthesize_user_prompt`,
-`consult_user_prompt`), `FINALIZE_NOTE`, and the shared cheatsheet in
-`kaish_syntax.rs` (`KAISH_SANDBOX_ADDENDUM` + the `kaish-help`-sourced contract). No
-config path reaches any of them. The seam is already there: `ConsultConfig`
-(`consult.rs`) is threaded into every phase fn, so a resolved `prompts` set could ride
-on it and replace the `&consult_preamble()` literals at the `.preamble()` call in
-`run_phase`; on the config side a `[prompts]` table would slot in exactly like
-`[defaults]`. Deferred because Amy is the only user and edits the source directly —
-build it when someone else needs it. Three forks to settle *when* asked, not now:
-- **Granularity** — server-wide `[prompts]` vs per-cast/per-slot (prompt framing is
-  model-sensitive: Gemma fixates on prohibitions where capable models don't, per the
-  positive-framing discipline, so per-slot has a real case) vs both.
-- **Replace scope** — override the role text only and keep injecting
-  `kaish_syntax_core()` (safe: can't silently drop the grounding/exit-code contract)
-  vs full-preamble raw replace vs per-field opt-in.
-- **Source** — `*_file` path (keeps `config.toml` readable, prompts as real files)
-  vs inline `"""…"""` vs both, mirroring `api_key_env`/`api_key_file`.
+### Config-overrideable system prompts — residual (the phase-preamble override shipped)
+The phase **preambles** are now config-overridable: `[prompts].<phase>` (`explorer` /
+`consult` / `oneshot`) and the per-slot `preamble` full-replace the built-in, resolved
+through `ConsultConfig.prompts` and threaded into every phase fn (`config.rs`,
+`docs/config.md`). Granularity (server-wide *and* per-slot), replace scope (full
+replace; the kaish contract still rides the `run_kaish` tool description), and source
+(inline `"""…"""`) all landed. What's *not* reachable, by design: the per-call framers
+(`consult_user_prompt`), `FINALIZE_NOTE`, and the shared cheatsheet in `kaish_syntax.rs`
+(`KAISH_SANDBOX_ADDENDUM` + the `kaish-help`-sourced contract) — the cheatsheet is the
+grounding/exit-code contract and must not be silently droppable. Only build a config
+path to the framers if a real user wants it; the remaining fork is whether a `*_file`
+source (prompts as real files) is worth it alongside the inline form.
 
 ### A secrets-manager key source (deferred)
 Custom credential paths shipped — a backend's `api_key_env` / `api_key_file`

--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -34,9 +34,10 @@ the *empirical* check on top of the *structural* guarantee.
 ## 0. The cheapest, safest probe: `run_kaish` (no model in the loop)
 
 `run_kaish` drives the read-only kaish kernel **directly** — no model, so **zero
-classifier exposure** — and it is the *exact* `KaishWorker`/VFS that `explore`,
-`consult`, and `synthesize` inject. Hammering it directly therefore covers the
+classifier exposure** — and it is the *exact* `KaishWorker`/VFS that `consult` (its
+driver and nested `explore′` sweep) injects. Hammering it directly therefore covers the
 model-driven tools too: a model can only emit kaish, which hits the same walls.
+(`oneshot` reads no project — it has no shell at all.)
 
 Run each battery below by handing the script to the `run_kaish` MCP tool (default
 `path` is the server's `--root`). Read the **stderr and the exit code together** —

--- a/src/config.rs
+++ b/src/config.rs
@@ -1021,11 +1021,8 @@ impl Config {
         if disable.consult {
             self.tools.consult = false;
         }
-        if disable.explore {
-            self.tools.explore = false;
-        }
-        if disable.synthesize {
-            self.tools.synthesize = false;
+        if disable.oneshot {
+            self.tools.oneshot = false;
         }
         if disable.run_kaish {
             self.tools.run_kaish = false;
@@ -1056,8 +1053,7 @@ impl Config {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ToolDisables {
     pub consult: bool,
-    pub explore: bool,
-    pub synthesize: bool,
+    pub oneshot: bool,
     pub run_kaish: bool,
     pub generate_image: bool,
 }
@@ -1274,12 +1270,12 @@ struct RawContext {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawPrompts {
-    /// Replaces the explorer preamble (standalone `explore` and nested `explore′`).
+    /// Replaces the explorer preamble (the nested `explore′` sweep inside `consult`).
     explorer: Option<String>,
-    /// Replaces the standalone `synthesize` preamble.
-    synthesize: Option<String>,
     /// Replaces the `consult` driver preamble.
     consult: Option<String>,
+    /// Replaces the toolless `oneshot` preamble.
+    oneshot: Option<String>,
 }
 
 /// The `[orientation]` stanza — the static repo-map injected into the exploring
@@ -1314,8 +1310,7 @@ struct RawServer {
 #[serde(deny_unknown_fields)]
 struct RawTools {
     consult: Option<bool>,
-    explore: Option<bool>,
-    synthesize: Option<bool>,
+    oneshot: Option<bool>,
     run_kaish: Option<bool>,
     generate_image: Option<bool>,
 }
@@ -1591,8 +1586,8 @@ fn merge_prompts(raw: RawPrompts) -> Result<PromptOverrides> {
     }
     Ok(PromptOverrides {
         explorer: non_empty("explorer", raw.explorer)?,
-        synthesize: non_empty("synthesize", raw.synthesize)?,
         consult: non_empty("consult", raw.consult)?,
+        oneshot: non_empty("oneshot", raw.oneshot)?,
     })
 }
 
@@ -1659,8 +1654,7 @@ fn merge_tools(raw: RawTools) -> ToolGating {
     let d = ToolGating::default();
     ToolGating {
         consult: raw.consult.unwrap_or(d.consult),
-        explore: raw.explore.unwrap_or(d.explore),
-        synthesize: raw.synthesize.unwrap_or(d.synthesize),
+        oneshot: raw.oneshot.unwrap_or(d.oneshot),
         run_kaish: raw.run_kaish.unwrap_or(d.run_kaish),
         generate_image: raw.generate_image.unwrap_or(d.generate_image),
     }
@@ -1713,11 +1707,8 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     if env_flag(get, "KAIBO_NO_CONSULT") {
         tools.consult = Some(false);
     }
-    if env_flag(get, "KAIBO_NO_EXPLORE") {
-        tools.explore = Some(false);
-    }
-    if env_flag(get, "KAIBO_NO_SYNTHESIZE") {
-        tools.synthesize = Some(false);
+    if env_flag(get, "KAIBO_NO_ONESHOT") {
+        tools.oneshot = Some(false);
     }
     if env_flag(get, "KAIBO_NO_RUN_KAISH") {
         tools.run_kaish = Some(false);

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -4,11 +4,12 @@
 //! a bounded tool loop. Every tool on the surface is that loop wearing different
 //! clothes:
 //!
-//! - [`explore`] — a cheap model · `{run_kaish}` → a curated report.
-//! - [`synthesize`] — a capable model · `{run_kaish}` · optional context → an answer.
-//! - [`consult`] — a capable model · `{run_kaish, explore′}` → a cited answer. No
-//!   rigid explorer→synth hand-off: the capable model decides when to delegate a
-//!   broad sweep to the cheap [`RunExplore`] sub-agent vs. read a span directly.
+//! - [`consult`] — a capable model · `{run_kaish, explore′}` · optional context → a
+//!   cited answer. No rigid explorer→synth hand-off: the capable model decides when
+//!   to delegate a broad sweep to the cheap [`RunExplore`] sub-agent vs. read a span
+//!   directly. The `explore′` sweep ([`report_preamble`]) is internal to this loop.
+//! - [`oneshot`] — a capable model · no tools · the caller's context → a direct
+//!   answer. The thin counterpart: one upstream request, no codebase access.
 //!
 //! Each phase arrives as a resolved [`Arm`]: its own client (type-erased — the
 //! decided plumbing fork, `docs/casts.md`), model, request params, and caps. The
@@ -52,9 +53,9 @@ use crate::view_image::ViewImage;
 /// Splice the operator's house rules (if any) onto a phase preamble. The base
 /// preamble functions stay pure (and their tests byte-for-byte stable); this is
 /// the one seam that folds in the assembled `[context]` block. Every phase that
-/// drives a model uses it — the `consult` driver, the standalone `explore` and
-/// `synthesize`, *and* the nested `explore′` sweep — so the explorer orients on
-/// the same guidance the driver does (it helps *search*, not just the answer).
+/// drives a model uses it — the `consult` driver, the toolless `oneshot`, *and* the
+/// nested `explore′` sweep — so the explorer orients on the same guidance the driver
+/// does (it helps *search*, not just the answer).
 /// `None` returns the base unchanged: a server with no `[context]` files runs
 /// exactly the historical preamble.
 ///
@@ -90,13 +91,12 @@ fn with_house_rules(base: String, house_rules: Option<&str>) -> String {
 /// orthogonal axes.
 #[derive(Debug, Clone, Default)]
 pub struct PromptOverrides {
-    /// Replaces [`report_preamble`] — the explorer, both standalone and the
-    /// nested `explore′` sweep.
+    /// Replaces [`report_preamble`] — the nested `explore′` sweep inside `consult`.
     pub explorer: Option<String>,
-    /// Replaces [`synthesize_preamble`] — the standalone `synthesize`.
-    pub synthesize: Option<String>,
     /// Replaces [`consult_preamble`] — the `consult` driver.
     pub consult: Option<String>,
+    /// Replaces [`oneshot_preamble`] — the thin, toolless `oneshot`.
+    pub oneshot: Option<String>,
 }
 
 /// Resolve one phase's full system prompt: the operator override if set, else the
@@ -576,8 +576,8 @@ where
 }
 
 /// One resolved phase arm: its own client + model + request params + caps. The
-/// unit `consult`/`explore`/`synthesize` receive — they never learn about
-/// backends or casts. The server resolves a cast's slots into arms
+/// unit `consult`/`oneshot` (and the nested `explore′`) receive — they never learn
+/// about backends or casts. The server resolves a cast's slots into arms
 /// ([`Arm::from_slot`]); tests inject any [`CompletionClient`] (the scripted
 /// offline one included) via [`Arm::new`], which is what keeps the mock harness
 /// driving the *real* loop with no network.
@@ -1070,8 +1070,8 @@ fn split_for_resume(mut history: Vec<Message>) -> (Vec<Message>, Message) {
 ///
 /// The toolset is injected via a *factory* (not a prebuilt `Vec`, and not hardcoded
 /// to `run_kaish`) so the same loop is the primitive behind every tool on the
-/// surface — `explore` ({run_kaish}), `synthesize` ({run_kaish}), and the
-/// recomposed `consult` ({run_kaish, explore′}). The factory matters because of the
+/// surface — `oneshot` ({} — no tools), the recomposed `consult`
+/// ({run_kaish, explore′}), and its nested `explore′` ({run_kaish}). The factory matters because of the
 /// turn-cap recovery below: a fresh toolset is built for the forced final turn, and
 /// `Box<dyn ToolDyn>` can't be cloned, so we rebuild rather than share. Each call
 /// spawns its own `KaishWorker`(s); the caller owns their lifetime.
@@ -1274,8 +1274,8 @@ pub struct RunExplore {
     progress: Arc<dyn ProgressSink>,
     /// The sweep's fully-resolved system prompt, computed once by `consult_tools`:
     /// the explorer override-or-default with house rules already appended. So the
-    /// nested explorer carries the same `[prompts]`/`[context]` framing as the
-    /// standalone `explore`, built once instead of per sweep.
+    /// nested explorer carries the explorer's `[prompts]`/`[context]` framing,
+    /// built once instead of per sweep.
     preamble: Arc<str>,
 }
 
@@ -1384,163 +1384,94 @@ impl Tool for RunExplore {
     }
 }
 
-/// The `explore` unit: a cheap model drives `{run_kaish}` over `root` and returns
-/// a curated report. The standalone seam behind the MCP `explore` tool — built on
-/// the one loop primitive via the resolved explorer [`Arm`].
-pub async fn explore(
-    question: &str,
-    root: impl Into<PathBuf>,
-    arm: &Arm,
-    cfg: &ConsultConfig,
-) -> Result<String> {
-    let root = root.into();
+/// The `oneshot` preamble: a thin, direct second opinion with no tools and no
+/// codebase access. The caller owns the context, so this never investigates — frame
+/// the model as a capable outside voice answering from what it was handed plus its
+/// own knowledge. Deliberately minimal: no kaish cheatsheet (there are no tools to
+/// drive) and no repo map (oneshot never reads the project).
+pub fn oneshot_preamble() -> String {
+    "You are a capable model giving a direct second opinion to another agent. Answer \
+     the question it sends from the material it provides and your own knowledge — \
+     this call has no codebase access and no tools, so the caller owns the context. \
+     Be precise and useful: reason over exactly what you were handed, and name \
+     explicitly anything you'd need that wasn't given rather than guessing it. Keep \
+     your claims grounded in the material and say where its edge is."
+        .to_string()
+}
+
+/// The `oneshot` seam: one direct completion on the resolved arm — no tools, no
+/// shell, no exploration. The thin counterpart to `consult` (prompt in, answer out)
+/// for when the caller already owns the context and just wants the model's take.
+/// Built on the one loop primitive with an empty toolset and a single turn, so it is
+/// exactly one upstream request. Orientation is never spliced (it reads no project);
+/// operator house rules still apply, like every top-level tool.
+pub async fn oneshot(prompt: &str, arm: &Arm, cfg: &ConsultConfig) -> Result<String> {
     arm.run(
         &phase_preamble(
-            cfg.prompts.explorer.as_deref(),
-            report_preamble,
-            cfg.orientation.as_deref(),
+            cfg.prompts.oneshot.as_deref(),
+            oneshot_preamble,
+            None,
             cfg.house_rules.as_deref(),
         ),
-        question.to_string(),
-        cfg.explorer_max_turns,
+        prompt.to_string(),
+        1,
         cfg.progress.as_ref(),
-        &|| phase_tools(&root, cfg, arm.caps.vision),
+        &|| Ok(Vec::new()),
     )
     .await
 }
 
-/// The single-arm phase toolset (`explore`/`synthesize`): always `run_kaish`, plus
-/// `view_image` when the arm's model is vision-capable. One [`KaishWorker`] backs
-/// both tools (shared kernel) so a vision phase doesn't spin a second kaish thread.
-fn phase_tools(root: &Path, cfg: &ConsultConfig, vision: bool) -> Result<Vec<Box<dyn ToolDyn>>> {
-    let worker = KaishWorker::spawn_with(root, cfg.sandbox.clone())?;
-    let mut tools: Vec<Box<dyn ToolDyn>> = vec![traced(RunKaish::with_progress(
-        worker.clone(),
-        cfg.progress.clone(),
-    ))];
-    if vision {
-        tools.push(traced(ViewImage::new(worker, root.to_path_buf())));
-    }
-    Ok(tools)
-}
-
-/// Build the standalone `synthesize` user prompt. Pure and offline-testable.
+/// Build the consult driver's user prompt from the question, any caller-supplied
+/// `context`, and any prior session turns. Pure and offline-testable: this framing
+/// is the whole of the context-seed and multi-turn hand-off, so it's worth pinning.
 ///
-/// With `context`, frame it as trusted starting evidence — a grounded `file:line`
-/// rarely needs re-deriving — and steer the model to reach for `run_kaish` when it
-/// needs *more* than the context gives (a span, a whole file, a detail left open),
-/// not to re-verify what's likely right (question first, then context). With no
-/// context — or whitespace-only — steer the model to investigate directly via
-/// `run_kaish` rather than guess, so the answer stays grounded either way.
-pub fn synthesize_user_prompt(question: &str, context: Option<&str>) -> String {
-    match context.map(str::trim).filter(|c| !c.is_empty()) {
-        Some(context) => format!(
-            "Question:\n{question}\n\n\
-             Context (supplied material — typically a curated explorer report or \
-             pasted source):\n{context}\n\n\
-             Answer the question, grounded in concrete `file:line` evidence. The \
-             context is your starting evidence — when it cites a `file:line`, trust \
-             it; a grounded citation rarely needs re-deriving. Reach for the \
-             `run_kaish` tool when you need more than the context gives you: a span \
-             it references but doesn't quote, a whole file or a large span when you \
-             need the full picture, a detail it left open, or anything the question \
-             asks that it didn't cover. If the code you read and the context \
-             genuinely disagree, the code wins — the code is the only ground truth. \
-             Cite concrete `file:line` for every claim."
-        ),
-        None => format!(
-            "Question:\n{question}\n\n\
-             No context was supplied. Investigate the project yourself with the \
-             `run_kaish` tool (a read-only kaish shell) and answer from what you find, \
-             citing concrete `file:line`."
-        ),
-    }
-}
-
-/// Standalone synth preamble: interactive, framing supplied context as trusted
-/// starting evidence and `run_kaish` as the way to *get more* when the context
-/// isn't enough — including whole files and large spans. Composes the shared
-/// [`kaish_syntax_core`] so the shell idioms and exit-code contract don't drift.
-pub fn synthesize_preamble() -> String {
-    let core = kaish_syntax_core();
-    format!(
-        "You answer a question about a codebase, grounded in evidence and citing \
-         concrete `file:line`. {core}\n\n\
-         You may be given CONTEXT — typically a curated explorer report (a \
-         SummaryOfFindings plus RelevantLocations, each with a `file:line`, key \
-         symbols, and a short snippet), or pasted material. \
-         Treat it as your starting evidence: when it cites a concrete `file:line`, \
-         trust it — a grounded citation rarely needs re-deriving. The `run_kaish` \
-         tool is yours to drive directly whenever the context isn't enough: fetch a \
-         span it references but doesn't quote, read a whole file or a large span when \
-         you need the full picture, chase a detail it left open, or investigate \
-         anything the question reaches that the context didn't cover. Getting more \
-         evidence when you need it is the normal move; you're never limited to what \
-         you were handed. Where the code you read and the context genuinely disagree, \
-         the code wins — the code is the only ground truth that matters. Ground every \
-         claim in a concrete `file:line`."
-    )
-}
-
-/// The standalone `synthesize` seam: a capable model answers `question`, grounded
-/// in an optional caller-supplied `context` (typically an `explore` report or
-/// pasted material), with `run_kaish` to verify or fill a precise gap. Takes the
-/// resolved synth [`Arm`] — a real outside opinion, not the cheap explorer.
-pub async fn synthesize(
-    question: &str,
-    context: Option<&str>,
-    root: impl Into<PathBuf>,
-    arm: &Arm,
-    cfg: &ConsultConfig,
-) -> Result<String> {
-    let root = root.into();
-    let user_prompt = synthesize_user_prompt(question, context);
-    arm.run(
-        &phase_preamble(
-            cfg.prompts.synthesize.as_deref(),
-            synthesize_preamble,
-            cfg.orientation.as_deref(),
-            cfg.house_rules.as_deref(),
-        ),
-        user_prompt,
-        cfg.synth_max_turns,
-        cfg.progress.as_ref(),
-        &|| phase_tools(&root, cfg, arm.caps.vision),
-    )
-    .await
-}
-
-/// Build the consult driver's user prompt from the question and any prior session
-/// turns. Pure and offline-testable: this framing is the whole of the multi-turn
-/// hand-off, so it's worth pinning in a test.
-///
-/// With **no** history this is exactly the bare question — a stateless consult is
-/// byte-for-byte unchanged. With history, prepend the prior `(question, answer)`
-/// pairs as conversation context and steer the model to re-confirm any span a prior
-/// answer cited: the exploration runs fresh every turn (we never replay the stored
-/// report — it'd be stale), so the code is the ground truth, not the old answer.
-pub fn consult_user_prompt(question: &str, history: &[QaTurn]) -> String {
-    if history.is_empty() {
+/// With **no** context and **no** history this is exactly the bare question — a
+/// stateless, unseeded consult is byte-for-byte unchanged. Supplied `context`
+/// (a diff summary, a prior report, pasted source) is framed as *trusted starting
+/// evidence*: a grounded `file:line` rarely needs re-deriving, and the steer is to
+/// investigate for *more* when the context isn't enough — the CLAUDE.md acquisition,
+/// not verification, posture. History prepends the prior `(question, answer)` pairs
+/// and steers the model to re-confirm any span a prior answer cited: the exploration
+/// runs fresh every turn (we never replay the stored report — it'd be stale), so the
+/// code is the ground truth, not the old answer.
+pub fn consult_user_prompt(question: &str, context: Option<&str>, history: &[QaTurn]) -> String {
+    let context = context.map(str::trim).filter(|c| !c.is_empty());
+    if history.is_empty() && context.is_none() {
         return question.to_string();
     }
-    let mut prompt = String::from(
-        "This is a continuing conversation about the same codebase. Earlier turns, \
-         oldest first:\n\n",
-    );
-    for (i, turn) in history.iter().enumerate() {
+    let mut prompt = String::new();
+    if !history.is_empty() {
+        prompt.push_str(
+            "This is a continuing conversation about the same codebase. Earlier turns, \
+             oldest first:\n\n",
+        );
+        for (i, turn) in history.iter().enumerate() {
+            prompt.push_str(&format!(
+                "[Turn {}]\nQ: {}\nA: {}\n\n",
+                i + 1,
+                turn.question,
+                turn.answer
+            ));
+        }
+        prompt.push_str(
+            "Use the earlier turns for context and continuity. Investigate fresh and \
+             re-confirm any `file:line` an earlier answer cited before you rely on it — \
+             the code is the ground truth, not the prior answer.\n\n",
+        );
+    }
+    if let Some(context) = context {
         prompt.push_str(&format!(
-            "[Turn {}]\nQ: {}\nA: {}\n\n",
-            i + 1,
-            turn.question,
-            turn.answer
+            "Context the caller supplied (a diff or change summary, a prior report, or \
+             pasted source):\n{context}\n\n\
+             Treat it as trusted starting evidence: when it cites a concrete \
+             `file:line`, trust it rather than re-deriving it. Reach for your tools \
+             when you need more than it gives — a span it references but doesn't quote, \
+             a whole file for the full picture, a detail it left open, or anything the \
+             question reaches that it didn't cover. Where the code you read and the \
+             context genuinely disagree, the code wins.\n\n",
         ));
     }
-    prompt.push_str(&format!(
-        "Use the earlier turns for context and continuity. Investigate fresh and \
-         re-confirm any `file:line` an earlier answer cited before you rely on it — \
-         the code is the ground truth, not the prior answer. Now answer the current \
-         question:\n\n{question}"
-    ));
+    prompt.push_str(&format!("Now answer the current question:\n\n{question}"));
     prompt
 }
 
@@ -1561,7 +1492,13 @@ pub fn consult_preamble() -> String {
          precise span yourself and confirm a detail. Build your answer from what \
          they return: quote the key snippet, name its `file:line`, and let the \
          evidence carry the claim. Where the evidence settles the question, answer \
-         it fully; where it reaches its edge, say so and name what would close the gap."
+         it fully; where it reaches its edge, say so and name what would close the gap.\n\n\
+         The caller may hand you CONTEXT — a diff or change summary, a prior report, \
+         or pasted source. Treat it as trusted starting evidence: when it cites a \
+         concrete `file:line`, trust it rather than re-deriving it, and spend your \
+         turns getting *more* than it gave — reading a span it left unquoted, a whole \
+         file for the full picture, anything the question reaches past it. Where the \
+         code you read and the context genuinely disagree, the code wins."
     )
 }
 
@@ -1582,9 +1519,8 @@ fn consult_tools(
     // pointed at the explorer arm — its own client, model, and request shape,
     // which may live on a different backend than the driver's. Bounded by
     // explorer_max_turns per sweep; no cap on how many times consult may delegate
-    // (Amy's call — watch real behavior). Its system prompt is the same explorer
-    // override-or-default + house rules the standalone `explore` resolves, built
-    // once here rather than per sweep.
+    // (Amy's call — watch real behavior). Its system prompt is the explorer
+    // override-or-default + house rules, built once here rather than per sweep.
     let explorer_preamble: Arc<str> = Arc::from(phase_preamble(
         cfg.prompts.explorer.as_deref(),
         report_preamble,
@@ -1676,6 +1612,7 @@ pub type Session<'a> = (&'a SessionStore, &'a str);
 pub(crate) async fn consult_session_turn(
     session: Option<Session<'_>>,
     question: &str,
+    context: Option<&str>,
     root: &Path,
     explorer: &Arm,
     synth: &Arm,
@@ -1685,7 +1622,7 @@ pub(crate) async fn consult_session_turn(
         Some((store, id)) => store.history(id),
         None => Vec::new(),
     };
-    let user_prompt = consult_user_prompt(question, &history);
+    let user_prompt = consult_user_prompt(question, context, &history);
 
     let out = consult_with(&user_prompt, root, explorer, synth, cfg).await?;
 
@@ -1704,6 +1641,7 @@ pub(crate) async fn consult_session_turn(
 /// the exploration, which always runs fresh. See [`consult_session_turn`].
 pub async fn consult(
     question: &str,
+    context: Option<&str>,
     root: impl Into<PathBuf>,
     explorer: &Arm,
     synth: &Arm,
@@ -1711,7 +1649,7 @@ pub async fn consult(
     session: Option<Session<'_>>,
 ) -> Result<ConsultOutput> {
     let root = root.into();
-    consult_session_turn(session, question, &root, explorer, synth, cfg).await
+    consult_session_turn(session, question, context, &root, explorer, synth, cfg).await
 }
 
 #[cfg(test)]
@@ -1788,23 +1726,31 @@ mod tests {
     /// unconditional — a server with no `[context]` runs the unchanged preamble.
     #[tokio::test]
     async fn house_rules_splice_into_the_phase_preamble_only_when_configured() {
-        const MODEL: &str = "explorer";
+        const SYNTH: &str = "capable-synth";
+        const EXPLORER: &str = "cheap-explorer";
         const MARKER: &str = "HOUSE_RULE_MARKER: prefer tabs over spaces";
 
         let dir = tempdir().unwrap();
 
-        // Configured → the marker and its framing ride in the preamble.
+        // Configured → the marker and its framing ride in the consult driver's
+        // preamble. The synth answers immediately (no sweep needed for this check).
         let client = ScriptedClient::builder()
-            .on_model(MODEL, |_req| Ok(text_response("done")))
+            .on_model(SYNTH, |_req| Ok(text_response("done")))
             .build();
         let cfg = ConsultConfig {
             house_rules: Some(Arc::from(MARKER)),
             ..ConsultConfig::default()
         };
-        explore("q", dir.path(), &arm(&client, MODEL), &cfg)
-            .await
-            .unwrap();
-        let reqs = client.requests_for(MODEL);
+        consult_with(
+            "q",
+            dir.path(),
+            &arm(&client, EXPLORER),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .unwrap();
+        let reqs = client.requests_for(SYNTH);
         let pre = reqs[0].preamble.as_deref().unwrap_or("");
         assert!(
             pre.contains(MARKER),
@@ -1814,25 +1760,31 @@ mod tests {
             pre.contains("Operator house rules"),
             "the framing header must introduce them: {pre}"
         );
-        // Still the explorer's own role framing — house rules append, not replace.
+        // Still the consult driver's own role framing — house rules append, not replace.
         assert!(
-            pre.contains("code explorer"),
+            pre.contains("You answer a question about a codebase"),
             "base preamble must remain: {pre}"
         );
 
         // Unconfigured → the same call carries the base preamble and no marker.
         let bare = ScriptedClient::builder()
-            .on_model(MODEL, |_req| Ok(text_response("done")))
+            .on_model(SYNTH, |_req| Ok(text_response("done")))
             .build();
         let cfg2 = ConsultConfig::default(); // house_rules: None
-        explore("q", dir.path(), &arm(&bare, MODEL), &cfg2)
-            .await
-            .unwrap();
-        let reqs2 = bare.requests_for(MODEL);
+        consult_with(
+            "q",
+            dir.path(),
+            &arm(&bare, EXPLORER),
+            &arm(&bare, SYNTH),
+            &cfg2,
+        )
+        .await
+        .unwrap();
+        let reqs2 = bare.requests_for(SYNTH);
         let pre2 = reqs2[0].preamble.as_deref().unwrap_or("");
         assert!(!pre2.contains(MARKER), "no [context] → no marker: {pre2}");
         assert!(
-            pre2.contains("code explorer"),
+            pre2.contains("You answer a question about a codebase"),
             "base preamble intact: {pre2}"
         );
     }
@@ -1905,28 +1857,25 @@ mod tests {
     /// operator's prose is verbatim, and the built-in role framing is *gone* (the
     /// kaish contract still rides the `run_kaish` tool, untested here). House rules
     /// still append on top — `[prompts]` and `[context]` are orthogonal axes. We
-    /// drive a single `explore` phase and read back what the model was handed.
+    /// drive a single `oneshot` phase and read back what the model was handed.
     #[tokio::test]
     async fn a_prompt_override_fully_replaces_the_preamble_and_house_rules_still_append() {
-        const MODEL: &str = "explorer";
+        const MODEL: &str = "synth";
         const CUSTOM: &str = "You are a SECURITY AUDITOR. Hunt injection sinks.";
         const HOUSE: &str = "HOUSE_RULE_MARKER: prefer tabs";
 
         let client = ScriptedClient::builder()
             .on_model(MODEL, |_req| Ok(text_response("done")))
             .build();
-        let dir = tempdir().unwrap();
         let cfg = ConsultConfig {
             prompts: PromptOverrides {
-                explorer: Some(CUSTOM.to_string()),
+                oneshot: Some(CUSTOM.to_string()),
                 ..PromptOverrides::default()
             },
             house_rules: Some(Arc::from(HOUSE)),
             ..ConsultConfig::default()
         };
-        explore("q", dir.path(), &arm(&client, MODEL), &cfg)
-            .await
-            .unwrap();
+        oneshot("q", &arm(&client, MODEL), &cfg).await.unwrap();
 
         let reqs = client.requests_for(MODEL);
         let pre = reqs[0].preamble.as_deref().unwrap_or("");
@@ -1934,7 +1883,7 @@ mod tests {
         assert!(pre.contains(CUSTOM), "override prose missing: {pre}");
         // ...the built-in framing is fully replaced (full-replace, by decision)...
         assert!(
-            !pre.contains("code explorer"),
+            !pre.contains("second opinion"),
             "override must REPLACE, not augment, the built-in: {pre}"
         );
         // ...and house rules still layer on top.
@@ -1942,7 +1891,7 @@ mod tests {
     }
 
     /// Each phase reads its *own* override key — an `explorer`-only override must
-    /// not bleed into the `synthesize` phase, which keeps its built-in. Guards the
+    /// not bleed into the `oneshot` phase, which keeps its built-in. Guards the
     /// per-phase routing in [`phase_preamble`]/[`PromptOverrides`].
     #[tokio::test]
     async fn prompt_overrides_are_per_phase() {
@@ -1952,8 +1901,7 @@ mod tests {
         let client = ScriptedClient::builder()
             .on_model(MODEL, |_req| Ok(text_response("done")))
             .build();
-        let dir = tempdir().unwrap();
-        // Only the explorer key is set; the synthesize phase must ignore it.
+        // Only the explorer key is set; the oneshot phase must ignore it.
         let cfg = ConsultConfig {
             prompts: PromptOverrides {
                 explorer: Some(CUSTOM_EXPLORER.to_string()),
@@ -1961,9 +1909,7 @@ mod tests {
             },
             ..ConsultConfig::default()
         };
-        synthesize("q", None, dir.path(), &arm(&client, MODEL), &cfg)
-            .await
-            .unwrap();
+        oneshot("q", &arm(&client, MODEL), &cfg).await.unwrap();
 
         let pre = client.requests_for(MODEL)[0]
             .preamble
@@ -1971,12 +1917,38 @@ mod tests {
             .unwrap_or_default();
         assert!(
             !pre.contains(CUSTOM_EXPLORER),
-            "the explorer override must not bleed into synthesize: {pre}"
+            "the explorer override must not bleed into oneshot: {pre}"
         );
-        // synthesize keeps its built-in framing.
+        // oneshot keeps its built-in framing.
         assert!(
-            pre.contains("You answer a question about a codebase"),
-            "synthesize keeps its built-in preamble: {pre}"
+            pre.contains("second opinion"),
+            "oneshot keeps its built-in preamble: {pre}"
+        );
+    }
+
+    /// `oneshot` is the *thin* path: it must hand the model NO tools — no `run_kaish`,
+    /// no `explore`, no `view_image`. The caller owns the context; there is no
+    /// codebase access. Pin the empty toolset so a regression that wires a shell back
+    /// in (re-collapsing oneshot into consult) fails here.
+    #[tokio::test]
+    async fn oneshot_offers_the_model_no_tools() {
+        const MODEL: &str = "synth";
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, |_req| Ok(text_response("done")))
+            .build();
+        oneshot(
+            "just answer this",
+            &arm(&client, MODEL),
+            &ConsultConfig::default(),
+        )
+        .await
+        .unwrap();
+        let reqs = client.requests_for(MODEL);
+        assert_eq!(reqs.len(), 1, "oneshot is exactly one upstream request");
+        assert!(
+            reqs[0].tool_names.is_empty(),
+            "oneshot must offer no tools, got {:?}",
+            reqs[0].tool_names
         );
     }
 
@@ -2826,6 +2798,7 @@ mod tests {
         let out1 = consult_session_turn(
             Some((&sessions, sid)),
             "Q1 what is kaish",
+            None,
             dir.path(),
             &arm(&client, "explorer"),
             &arm(&client, SYNTH),
@@ -2844,6 +2817,7 @@ mod tests {
         let out2 = consult_session_turn(
             Some((&sessions, sid)),
             "Q2 who calls it",
+            None,
             dir.path(),
             &arm(&client, "explorer"),
             &arm(&client, SYNTH),
@@ -2889,6 +2863,7 @@ mod tests {
         let result = consult_session_turn(
             Some((&sessions, sid)),
             "Q that fails",
+            None,
             dir.path(),
             &arm(&client, "explorer"),
             &arm(&client, SYNTH),
@@ -2920,6 +2895,7 @@ mod tests {
         let out = consult_session_turn(
             None,
             "lone question",
+            None,
             dir.path(),
             &arm(&client, "explorer"),
             &arm(&client, SYNTH),
@@ -2988,7 +2964,7 @@ mod tests {
             "the whole-file directive must survive: {p}"
         );
         assert!(p.contains("rg -n -B4 -A8"), "rg context-buffer idiom: {p}");
-        // The report template the synth (synthesize/consult preambles) is written
+        // The report template the consult driver preamble is written
         // against — keep the three section names in lockstep with those.
         for section in ["SummaryOfFindings", "RelevantLocations", "ExplorationTrace"] {
             assert!(p.contains(section), "missing report section {section}: {p}");
@@ -3021,23 +2997,31 @@ mod tests {
         );
     }
 
-    /// The single-arm phase toolset (`explore`/`synthesize`): `run_kaish` always,
-    /// `view_image` exactly when the arm is vision-capable. Pins the shared helper
-    /// both ways so neither phase's gate drifts.
+    /// The `consult` driver's toolset: `run_kaish` and the nested `explore′` always,
+    /// `view_image` exactly when the *synth* arm is vision-capable. Pins the gate both
+    /// ways so the driver's perception cap doesn't drift.
     #[test]
-    fn phase_tools_gates_view_image_on_the_vision_cap() {
+    fn consult_tools_gate_view_image_on_the_synth_vision_cap() {
         let dir = tempdir().unwrap();
         let cfg = ConsultConfig::default();
+        let client = ScriptedClient::builder()
+            .on_model("m", |_r| Ok(text_response("x")))
+            .build();
+        let explorer = arm(&client, "m");
+        let reports = Arc::new(Mutex::new(Vec::<String>::new()));
 
-        let blind = phase_tools(dir.path(), &cfg, false).expect("blind toolset builds");
+        let blind = consult_tools(&explorer, dir.path(), &cfg, reports.clone(), false)
+            .expect("blind toolset builds");
         let blind_names: Vec<String> = blind.iter().map(|t| t.name()).collect();
         assert!(blind_names.iter().any(|n| n == "run_kaish"));
+        assert!(blind_names.iter().any(|n| n == "explore"));
         assert!(
             !blind_names.iter().any(|n| n == "view_image"),
             "no view_image without vision, got {blind_names:?}"
         );
 
-        let seeing = phase_tools(dir.path(), &cfg, true).expect("vision toolset builds");
+        let seeing = consult_tools(&explorer, dir.path(), &cfg, reports, true)
+            .expect("vision toolset builds");
         let seeing_names: Vec<String> = seeing.iter().map(|t| t.name()).collect();
         assert!(
             seeing_names.iter().any(|n| n == "view_image"),
@@ -3306,7 +3290,7 @@ mod tests {
     #[test]
     fn empty_history_yields_the_bare_question() {
         assert_eq!(
-            consult_user_prompt("Where is the sandbox enforced?", &[]),
+            consult_user_prompt("Where is the sandbox enforced?", None, &[]),
             "Where is the sandbox enforced?"
         );
     }
@@ -3319,7 +3303,7 @@ mod tests {
             QaTurn::new("What is kaish?", "A read-only shell (src/sandbox.rs)."),
             QaTurn::new("Who calls it?", "consult drives it (src/consult.rs)."),
         ];
-        let prompt = consult_user_prompt("And explore?", &history);
+        let prompt = consult_user_prompt("And explore?", None, &history);
 
         for needle in [
             "What is kaish?",

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -1403,16 +1403,17 @@ pub fn oneshot_preamble() -> String {
 /// shell, no exploration. The thin counterpart to `consult` (prompt in, answer out)
 /// for when the caller already owns the context and just wants the model's take.
 /// Built on the one loop primitive with an empty toolset and a single turn, so it is
-/// exactly one upstream request. Orientation is never spliced (it reads no project);
-/// operator house rules still apply, like every top-level tool.
+/// exactly one upstream request. Neither orientation nor operator house rules are
+/// spliced — both are project guidance, and oneshot reads no project.
+///
+/// Safe-by-accident note: a vision synth arm carries `break_on_view_image = true`
+/// (via `Arm::rewrites_view_image`), but the empty toolset has no `view_image` tool,
+/// so the break hook can never fire and the single turn always completes cleanly. If
+/// you ever give oneshot a tool, revisit this — a live break would consume the turn
+/// and land in the turn-cap finalize path.
 pub async fn oneshot(prompt: &str, arm: &Arm, cfg: &ConsultConfig) -> Result<String> {
     arm.run(
-        &phase_preamble(
-            cfg.prompts.oneshot.as_deref(),
-            oneshot_preamble,
-            None,
-            cfg.house_rules.as_deref(),
-        ),
+        &phase_preamble(cfg.prompts.oneshot.as_deref(), oneshot_preamble, None, None),
         prompt.to_string(),
         1,
         cfg.progress.as_ref(),
@@ -1856,34 +1857,45 @@ mod tests {
     /// A `[prompts]` override **fully replaces** the built-in preamble: the
     /// operator's prose is verbatim, and the built-in role framing is *gone* (the
     /// kaish contract still rides the `run_kaish` tool, untested here). House rules
-    /// still append on top — `[prompts]` and `[context]` are orthogonal axes. We
-    /// drive a single `oneshot` phase and read back what the model was handed.
+    /// still append on top — `[prompts]` and `[context]` are orthogonal axes. Driven
+    /// on the `consult` driver, the phase that carries both an override and house
+    /// rules (oneshot reads no project, so it carries neither house rules nor a map).
     #[tokio::test]
     async fn a_prompt_override_fully_replaces_the_preamble_and_house_rules_still_append() {
-        const MODEL: &str = "synth";
+        const SYNTH: &str = "capable-synth";
+        const EXPLORER: &str = "cheap-explorer";
         const CUSTOM: &str = "You are a SECURITY AUDITOR. Hunt injection sinks.";
         const HOUSE: &str = "HOUSE_RULE_MARKER: prefer tabs";
 
         let client = ScriptedClient::builder()
-            .on_model(MODEL, |_req| Ok(text_response("done")))
+            .on_model(SYNTH, |_req| Ok(text_response("done")))
             .build();
+        let dir = tempdir().unwrap();
         let cfg = ConsultConfig {
             prompts: PromptOverrides {
-                oneshot: Some(CUSTOM.to_string()),
+                consult: Some(CUSTOM.to_string()),
                 ..PromptOverrides::default()
             },
             house_rules: Some(Arc::from(HOUSE)),
             ..ConsultConfig::default()
         };
-        oneshot("q", &arm(&client, MODEL), &cfg).await.unwrap();
+        consult_with(
+            "q",
+            dir.path(),
+            &arm(&client, EXPLORER),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .unwrap();
 
-        let reqs = client.requests_for(MODEL);
+        let reqs = client.requests_for(SYNTH);
         let pre = reqs[0].preamble.as_deref().unwrap_or("");
         // The override is verbatim...
         assert!(pre.contains(CUSTOM), "override prose missing: {pre}");
         // ...the built-in framing is fully replaced (full-replace, by decision)...
         assert!(
-            !pre.contains("second opinion"),
+            !pre.contains("You answer a question about a codebase"),
             "override must REPLACE, not augment, the built-in: {pre}"
         );
         // ...and house rules still layer on top.

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -116,11 +116,16 @@ pub fn kaibo_instructions(schemas: &[ToolSchema]) -> String {
 fn kaibo_lead() -> &'static str {
     "kaibo (解剖) — ask a question about a codebase and get a grounded, cited \
      answer. kaibo reads the project READ-ONLY through a kaish shell and never \
-     modifies files or runs external commands. Tools: `consult` (capable model, \
-     reads spans and delegates broad sweeps), `explore` (fast curated report), \
-     `synthesize` (capable model over optional context), and `run_kaish` (drive \
-     the shell directly). Each is gated independently, so a given server may \
-     advertise only some."
+     modifies files or runs external commands. It finds and reads the relevant, \
+     current code itself — point it at a project and say what you did or want to \
+     know (what you changed and why, the behavior in question); it locates the \
+     spans. You don't need to paste files or a diff: prose about your intent is \
+     worth more than a dump kaibo would just re-read from disk. Reach for \
+     `consult` first — a capable model investigates and hands back the answer, \
+     not the transcript. kaibo also exposes more focused tools (a fast \
+     `explore`, a `synthesize` seam, and `run_kaish` to drive the shell \
+     yourself), each gated independently and described in its own schema, so a \
+     given server may advertise only some."
 }
 
 /// The kaish onboarding spine — the mental model, operating contract, live builtin
@@ -389,6 +394,31 @@ mod tests {
     #[test]
     fn the_tool_description_is_the_core() {
         assert_eq!(run_kaish_tool_description(), kaish_syntax_core());
+    }
+
+    #[test]
+    fn lead_steers_callers_to_describe_intent_not_paste_a_diff() {
+        // The handshake must teach the client agent that kaibo reads the real code
+        // itself, so it should say what it did rather than dump a diff. If this
+        // framing is ever dropped, callers fall back to pasting source kaibo would
+        // only re-read from disk — catch that here.
+        let lead = kaibo_lead().to_lowercase();
+        assert!(
+            lead.contains("diff"),
+            "lead must steer callers away from pasting a diff:\n{}",
+            kaibo_lead()
+        );
+        assert!(
+            lead.contains("reads the relevant"),
+            "lead must say kaibo finds and reads the code itself:\n{}",
+            kaibo_lead()
+        );
+        // consult is the tool to reach for first; the others surface via schema.
+        assert!(
+            lead.contains("reach for `consult` first"),
+            "lead must foreground `consult` as the first reach:\n{}",
+            kaibo_lead()
+        );
     }
 
     #[test]

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -122,10 +122,10 @@ fn kaibo_lead() -> &'static str {
      spans. You don't need to paste files or a diff: prose about your intent is \
      worth more than a dump kaibo would just re-read from disk. Reach for \
      `consult` first — a capable model investigates and hands back the answer, \
-     not the transcript. kaibo also exposes more focused tools (a fast \
-     `explore`, a `synthesize` seam, and `run_kaish` to drive the shell \
-     yourself), each gated independently and described in its own schema, so a \
-     given server may advertise only some."
+     not the transcript. kaibo also exposes `oneshot` (a thin, toolless second \
+     opinion when you already own the context) and `run_kaish` (drive the \
+     read-only shell yourself), each gated independently and described in its \
+     own schema, so a given server may advertise only some."
 }
 
 /// The kaish onboarding spine — the mental model, operating contract, live builtin
@@ -183,8 +183,8 @@ fn setup_section(config: &Config) -> String {
 
     format!(
         "## Setup needed — no model provider configured\n\
-         kaibo's default cast `{cast}` has no usable API key, so `consult`, `explore`, \
-         and `synthesize` can't reach a model yet. `run_kaish` works right now — it drives \
+         kaibo's default cast `{cast}` has no usable API key, so `consult` and \
+         `oneshot` can't reach a model yet. `run_kaish` works right now — it drives \
          the read-only shell with no model in the loop — so you can browse the code while \
          you set a key.\n\n\
          Give the default cast a key. Prefer an **environment variable** or a **key file** \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //! - **Consultation** — grounded, cited answers about a codebase. A capable model
 //!   reads precise spans and delegates broad sweeps to a cheap *explorer* sub-agent,
 //!   all driving a read-only [`kaish`] kernel via `run_kaish(script)` (`cat`, `grep`,
-//!   `rg`, `find`, `jq`, pipelines, the lot). The `consult`/`explore`/`synthesize`
-//!   tools are all costumes over one primitive, [`consult::run_phase`].
+//!   `rg`, `find`, `jq`, pipelines, the lot). The `consult` and toolless `oneshot`
+//!   tools are both costumes over one primitive, [`consult::run_phase`].
 //! - **Capabilities** — things the team can *do* and hand back as artifacts. The first
 //!   is image generation ([`image_gen`], the `generate_image` tool); more (TTS/STT, …)
 //!   follow as rig grows provider coverage. A capability is its own tool shape, not a

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,13 +64,9 @@ struct Args {
     #[arg(long)]
     no_consult: bool,
 
-    /// Don't advertise the `explore` tool.
+    /// Don't advertise the `oneshot` tool.
     #[arg(long)]
-    no_explore: bool,
-
-    /// Don't advertise the `synthesize` tool.
-    #[arg(long)]
-    no_synthesize: bool,
+    no_oneshot: bool,
 
     /// Don't advertise the `run_kaish` tool.
     #[arg(long)]
@@ -121,8 +117,7 @@ async fn main() -> Result<()> {
         args.cast.clone(),
         ToolDisables {
             consult: args.no_consult,
-            explore: args.no_explore,
-            synthesize: args.no_synthesize,
+            oneshot: args.no_oneshot,
             run_kaish: args.no_run_kaish,
             generate_image: args.no_generate_image,
         },
@@ -202,7 +197,7 @@ async fn main() -> Result<()> {
     ) {
         tracing::warn!(
             cast = %config.default_cast,
-            "no API key for the default cast — consult/explore/synthesize will fail until \
+            "no API key for the default cast — consult/oneshot will fail until \
              you set a provider key (env var or key file) and reconnect; run_kaish works now. \
              See the kaibo://config/example resource."
         );

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -21,7 +21,7 @@ use std::fmt;
 /// sweeps, read zero spans, or hit its turn cap.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PhaseEvent {
-    /// A top-level tool began (`consult` / `explore` / `synthesize`).
+    /// A top-level tool began (`consult` / `oneshot`).
     PhaseStarted { phase: &'static str },
     /// The model ran a kaish script directly — a precise read.
     KaishRun { script: String },

--- a/src/server.rs
+++ b/src/server.rs
@@ -1257,14 +1257,16 @@ and where each key is sourced from.
 Anthropic / DeepSeek / Gemini I hold API keys for, and whether I run any \
 OpenAI-compatible local servers (llama.cpp, Ollama, an image server) and at what base \
 URLs. Let me tell you my providers rather than guessing them.
-3. Propose a roster that fits the providers I actually named in step 2 — don't assume \
-a chimera before you know what I can reach. If I hold keys across two or more families, \
-a chimera is the sweet spot: a cheap, fast explorer on one lineage and a stronger synth \
-on another — cheaper, and a real outside opinion where two voices' mistakes don't line \
-up. If I have just one provider, a clean single-family cast is the right answer, not a \
-fallback — get me running on what I have rather than holding out for a second key. Then \
-write the roster to `$XDG_CONFIG_HOME/kaibo/config.toml` (default \
-`~/.config/kaibo/config.toml`).
+3. Propose a roster built on a provider I actually named in step 2, then write it to \
+`$XDG_CONFIG_HOME/kaibo/config.toml` (default `~/.config/kaibo/config.toml`). The \
+default shape is a single outside family — DeepSeek, Gemini, Anthropic, or a local pair \
+— with explorer and synth both within it. That one family is already the whole win: it \
+augments my own lineage with a different house's eyes (a cheap, fast explorer and a \
+stronger synth, same family). kaibo's built-in casts are already within-family pairs, \
+so often this is just giving one of them a key rather than writing a new cast. Mixing \
+families across roles (a 'chimera' — say a DeepSeek explorer with a Claude synth) is an \
+advanced move for someone who holds several keys and asks for it; don't reach for it by \
+default.
 4. Keep secrets in the environment or a key file. A backend names an env var \
 (`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
 the secret stays outside it. Tell me which env vars to set or files to write, and let \
@@ -2173,29 +2175,28 @@ mod tests {
         }
     }
 
-    /// The chimera must be gated on actually holding multiple families, and a
-    /// single-provider setup must read as a correct outcome — not a fallback. Without
-    /// this, an eager agent jumps straight to a mixed-family roster and writes a dead
-    /// cast when the user holds one key. Pins both halves so the steer can't regress to
-    /// the old unconditional "favor a chimera".
+    /// The default roster is a within-family explorer/synth pair — one outside family
+    /// already augments the calling agent. Cross-family mixing (a chimera) is demoted to
+    /// an advanced, opt-in move, not the path the agent walks by default. Pins both so
+    /// the steer can't drift back to pushing a chimera.
     #[test]
-    fn configure_prompt_gates_the_chimera_on_having_multiple_families() {
+    fn configure_prompt_defaults_to_a_within_family_pair_not_a_chimera() {
         let result =
             kaibo_prompt_messages(CONFIGURE_PROMPT_NAME, None).expect("configure must resolve");
         let PromptMessageContent::Text { text } = &result.messages[0].content else {
             panic!("configure prompt must be a text message");
         };
         assert!(
-            text.contains("two or more families"),
-            "the chimera must be conditioned on holding multiple families; body:\n{text}"
+            text.contains("both within it"),
+            "the default must be explorer and synth within one family; body:\n{text}"
         );
         assert!(
-            text.contains("single-family"),
-            "a one-provider setup must be offered as a real answer; body:\n{text}"
+            text.contains("advanced move"),
+            "a chimera must be framed as an advanced move; body:\n{text}"
         );
         assert!(
-            text.contains("don't assume a chimera"),
-            "the prompt must tell the agent not to pre-commit to a chimera; body:\n{text}"
+            text.contains("don't reach for it by default"),
+            "the prompt must tell the agent not to default to a chimera; body:\n{text}"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1257,11 +1257,14 @@ and where each key is sourced from.
 Anthropic / DeepSeek / Gemini I hold API keys for, and whether I run any \
 OpenAI-compatible local servers (llama.cpp, Ollama, an image server) and at what base \
 URLs. Let me tell you my providers rather than guessing them.
-3. Propose a roster, then write it to `$XDG_CONFIG_HOME/kaibo/config.toml` (default \
-`~/.config/kaibo/config.toml`). Favor a cast that mixes model families across roles — \
-a cheap, fast explorer on one lineage and a stronger synth on another. That's both \
-cheaper and the whole point of an outside opinion; two flavors of one base model give \
-one voice twice.
+3. Propose a roster that fits the providers I actually named in step 2 — don't assume \
+a chimera before you know what I can reach. If I hold keys across two or more families, \
+a chimera is the sweet spot: a cheap, fast explorer on one lineage and a stronger synth \
+on another — cheaper, and a real outside opinion where two voices' mistakes don't line \
+up. If I have just one provider, a clean single-family cast is the right answer, not a \
+fallback — get me running on what I have rather than holding out for a second key. Then \
+write the roster to `$XDG_CONFIG_HOME/kaibo/config.toml` (default \
+`~/.config/kaibo/config.toml`).
 4. Keep secrets in the environment or a key file. A backend names an env var \
 (`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
 the secret stays outside it. Tell me which env vars to set or files to write, and let \
@@ -2168,6 +2171,32 @@ mod tests {
                 "configure prompt should mention {needle:?}; body:\n{text}"
             );
         }
+    }
+
+    /// The chimera must be gated on actually holding multiple families, and a
+    /// single-provider setup must read as a correct outcome — not a fallback. Without
+    /// this, an eager agent jumps straight to a mixed-family roster and writes a dead
+    /// cast when the user holds one key. Pins both halves so the steer can't regress to
+    /// the old unconditional "favor a chimera".
+    #[test]
+    fn configure_prompt_gates_the_chimera_on_having_multiple_families() {
+        let result =
+            kaibo_prompt_messages(CONFIGURE_PROMPT_NAME, None).expect("configure must resolve");
+        let PromptMessageContent::Text { text } = &result.messages[0].content else {
+            panic!("configure prompt must be a text message");
+        };
+        assert!(
+            text.contains("two or more families"),
+            "the chimera must be conditioned on holding multiple families; body:\n{text}"
+        );
+        assert!(
+            text.contains("single-family"),
+            "a one-provider setup must be offered as a real answer; body:\n{text}"
+        );
+        assert!(
+            text.contains("don't assume a chimera"),
+            "the prompt must tell the agent not to pre-commit to a chimera; body:\n{text}"
+        );
     }
 
     /// A supplied `goal` is woven into the message so the agent tailors the roster;

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,8 +17,8 @@ use rmcp::model::{
     JsonObject, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult, LoggingLevel,
     Meta, PaginatedRequestParams, ProgressNotificationParam, ProgressToken, Prompt, PromptArgument,
     PromptMessage, PromptMessageRole, ProtocolVersion, RawResource, RawResourceTemplate,
-    ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
-    SetLevelRequestParams,
+    ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities,
+    ServerInfo, SetLevelRequestParams,
 };
 use rmcp::schemars::{self, JsonSchema};
 use rmcp::service::{Peer, RequestContext};
@@ -29,7 +29,7 @@ use serde_json::json;
 use tracing::Instrument;
 
 use crate::config::{Cast, Config, ModelRole, ModelSlot};
-use crate::consult::{consult, explore, synthesize, Arm, ConsultConfig, PromptOverrides};
+use crate::consult::{consult, oneshot, Arm, ConsultConfig, PromptOverrides};
 use crate::explorer::format_output;
 use crate::generate_image::GenerateImageInput;
 use crate::image_gen::ImageGen;
@@ -65,15 +65,14 @@ const CONFIG_EXAMPLE_TOML: &str = include_str!("../docs/config.example.toml");
 
 /// Which tools to advertise. All on by default; each `--no-<tool>` flips one off.
 ///
-/// Composes to any posture: `{explore:false, synthesize:false}` ≈ the original
-/// consult-only surface; only `run_kaish` on ≈ "no code leaves the box, kaibo as a
-/// pure read-only shell". A server with *all* off is a misconfiguration — refused
-/// at startup (see `main`), not represented as a valid state here.
+/// Composes to any posture: `{oneshot:false}` ≈ the codebase-only surface; only
+/// `run_kaish` on ≈ "no code leaves the box, kaibo as a pure read-only shell". A
+/// server with *all* off is a misconfiguration — refused at startup (see `main`),
+/// not represented as a valid state here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ToolGating {
     pub consult: bool,
-    pub explore: bool,
-    pub synthesize: bool,
+    pub oneshot: bool,
     pub run_kaish: bool,
     pub generate_image: bool,
 }
@@ -82,8 +81,7 @@ impl Default for ToolGating {
     fn default() -> Self {
         Self {
             consult: true,
-            explore: true,
-            synthesize: true,
+            oneshot: true,
             run_kaish: true,
             generate_image: true,
         }
@@ -93,11 +91,7 @@ impl Default for ToolGating {
 impl ToolGating {
     /// True iff every tool is disabled — the zero-tool server we refuse to start.
     pub fn all_disabled(&self) -> bool {
-        !self.consult
-            && !self.explore
-            && !self.synthesize
-            && !self.run_kaish
-            && !self.generate_image
+        !self.consult && !self.oneshot && !self.run_kaish && !self.generate_image
     }
 }
 
@@ -113,6 +107,14 @@ pub struct ConsultInput {
     /// kaibo locates and reads the real, current code itself, so describing your
     /// intent beats pasting a diff or a file dump it would only re-read from disk.
     pub question: String,
+
+    /// Optional context to seed the investigation — a change/diff *summary*, a prior
+    /// report, or pasted source kaibo can't reach. It's treated as trusted starting
+    /// evidence: kaibo trusts a cited `file:line` rather than re-deriving it, and
+    /// spends its turns getting more where the context runs out. Prefer a prose
+    /// summary of intent over a raw diff — kaibo reads the current code itself.
+    #[serde(default)]
+    pub context: Option<String>,
 
     /// Absolute path to the project to explore. Optional when the server has a
     /// default root — an explicit `--root`, or the launch cwd inferred when it's
@@ -177,72 +179,26 @@ pub struct ConsultInput {
     pub include_report: bool,
 }
 
-/// Arguments to the `explore` tool. See [`ConsultInput`] for the
-/// `deny_unknown_fields` rationale.
+/// Arguments to the `oneshot` tool. See [`ConsultInput`] for the
+/// `deny_unknown_fields` rationale. No `path`: oneshot reads no project — it's a
+/// thin, toolless completion, so the caller owns any context the model needs.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct ExploreInput {
-    /// The question to investigate about the project.
-    pub question: String,
+pub struct OneshotInput {
+    /// The prompt to send the model. There's no codebase access on this call, so
+    /// include whatever context the answer needs (pasted source, a spec, the data) —
+    /// the model answers from this and its own knowledge, nothing else.
+    pub prompt: String,
 
-    /// Absolute path to the project. Optional when the server has a default root
-    /// — an explicit `--root`, or the launch cwd inferred when it's inside the
-    /// allowed set. Must be at-or-under an allowed tree; see
-    /// `kaibo://config` for the server's current allowed set and how to widen it.
-    #[serde(default)]
-    pub path: Option<String>,
-
-    /// Which cast (model team) runs this call; omit for the server's default.
-    /// Pick from this param's `enum` — the casts live right now; `kaibo://config`
-    /// lists every configured cast and backend, with their aliases.
+    /// Which cast (model team) runs this call; omit for the server's default. Pick
+    /// from this param's `enum` — the casts live right now; `kaibo://config` lists
+    /// every configured cast and backend, with their aliases. kaibo runs the cast's
+    /// capable (synth) model.
     #[serde(default)]
     pub cast: Option<String>,
 
-    /// Override the explorer model id. Sent verbatim — an id containing "/" is
-    /// still one id. Keeps the slot's configured backend unless `backend`
-    /// retargets it.
-    #[serde(default)]
-    pub model: Option<String>,
-
-    /// Run the model override on this backend (name or alias) instead of the
-    /// slot's configured one. Requires `model`.
-    #[serde(default)]
-    pub backend: Option<String>,
-
-    /// Max tool-loop turns for the explorer (default 50 — it's cheap, let it rip).
-    #[serde(default)]
-    pub max_turns: Option<usize>,
-}
-
-/// Arguments to the `synthesize` tool. See [`ConsultInput`] for the
-/// `deny_unknown_fields` rationale.
-#[derive(Debug, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct SynthesizeInput {
-    /// The question to answer.
-    pub question: String,
-
-    /// Optional context to ground the answer in — typically an `explore` report or
-    /// pasted source. When absent, the model investigates via `run_kaish`.
-    #[serde(default)]
-    pub context: Option<String>,
-
-    /// Absolute path to the project. Optional when the server has a default root
-    /// — an explicit `--root`, or the launch cwd inferred when it's inside the
-    /// allowed set. Must be at-or-under an allowed tree; see
-    /// `kaibo://config` for the server's current allowed set and how to widen it.
-    #[serde(default)]
-    pub path: Option<String>,
-
-    /// Which cast (model team) runs this call; omit for the server's default.
-    /// Pick from this param's `enum` — the casts live right now; `kaibo://config`
-    /// lists every configured cast and backend, with their aliases.
-    #[serde(default)]
-    pub cast: Option<String>,
-
-    /// Override the synthesizer (capable) model id. Sent verbatim — an id
-    /// containing "/" is still one id. Keeps the slot's configured backend
-    /// unless `backend` retargets it.
+    /// Override the model id. Sent verbatim — an id containing "/" is still one id.
+    /// Keeps the slot's configured backend unless `backend` retargets it.
     #[serde(default)]
     pub model: Option<String>,
 
@@ -307,8 +263,8 @@ pub struct KaiboHandler {
 }
 
 /// Inject `casts` as a JSON-Schema `enum` on the `cast` parameter of every
-/// consultation tool still in `router` (consult/explore/synthesize — the tools
-/// whose `cast` selects the explorer/synth team). This surfaces the live roster
+/// consultation tool still in `router` (consult/oneshot — the tools whose `cast`
+/// selects the answering team). This surfaces the live roster
 /// where an agent actually picks an argument value, instead of deferring it to
 /// prose the host may drop.
 ///
@@ -326,7 +282,7 @@ fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, casts: &[String]) {
         .iter()
         .map(|c| serde_json::Value::String(c.clone()))
         .collect();
-    for name in ["consult", "explore", "synthesize"] {
+    for name in ["consult", "oneshot"] {
         let Some(route) = router.map.get_mut(name) else {
             continue;
         };
@@ -365,8 +321,7 @@ impl KaiboHandler {
         // exists before dropping it — a stale name is a build-time bug we want loud.
         for (enabled, name) in [
             (gating.consult, "consult"),
-            (gating.explore, "explore"),
-            (gating.synthesize, "synthesize"),
+            (gating.oneshot, "oneshot"),
             (gating.run_kaish, "run_kaish"),
             (gating.generate_image, "generate_image"),
         ] {
@@ -609,10 +564,10 @@ impl KaiboHandler {
     /// Resolve this call's per-phase system prompts for `cast`: the per-model slot
     /// `preamble` (if set) wins over the global `[prompts].<phase>`, which wins over
     /// the built-in (resolved downstream in `consult.rs`). The synth slot's preamble
-    /// feeds *both* synth phases — standalone `synthesize` and the `consult` driver —
-    /// but through their own keys, so they stay independently overridable (a copy
-    /// today, free to diverge). `cast` is the post-override clone, so a per-call
-    /// model override (a bare slot) correctly carries no preamble.
+    /// feeds *both* capable-model tools — the `consult` driver and the toolless
+    /// `oneshot` — but through their own keys, so they stay independently overridable
+    /// (a copy today, free to diverge). `cast` is the post-override clone, so a
+    /// per-call model override (a bare slot) correctly carries no preamble.
     fn resolved_prompts(&self, cast: &Cast) -> PromptOverrides {
         let mut p = self.config.prompts.clone();
         if let Some(pre) = cast
@@ -622,8 +577,8 @@ impl KaiboHandler {
             p.explorer = Some(pre);
         }
         if let Some(pre) = cast.slot(ModelRole::Synth).and_then(|s| s.preamble.clone()) {
-            p.synthesize = Some(pre.clone());
-            p.consult = Some(pre);
+            p.consult = Some(pre.clone());
+            p.oneshot = Some(pre);
         }
         p
     }
@@ -753,26 +708,29 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Investigate a question about a codebase and return a grounded, \
-            cited answer. A capable model drives a read-only kaish shell \
-            (cat/grep/rg/find/jq/pipelines): it reads precise spans directly and \
-            delegates broad repo sweeps to a fast explorer sub-agent, then answers \
-            from what they find with concrete `file:line` citations. It finds and \
+        description = "Ask a model *outside your own family* about a codebase and get \
+            a grounded, cited answer — kaibo is the door to a second opinion from \
+            DeepSeek, Gemini, Anthropic, or a local model. Pick which one answers with \
+            `cast` (e.g. `deepseek`, `gemini`, `anthropic`; the `cast` enum lists the \
+            teams live right now, `kaibo://config` has the full set). A capable model \
+            drives a read-only kaish shell (cat/grep/rg/find/jq/pipelines): it reads \
+            precise spans directly and delegates broad repo sweeps to a fast explorer \
+            sub-agent, then answers with concrete `file:line` citations. It finds and \
             reads the relevant code itself — describe what you did or want to know \
-            (what you changed and why, the behavior in question) in prose; don't \
-            paste a diff or dump files, kaibo reads the real, current source from \
-            disk and your intent is the part it can't recover on its own. \
-            Read-only: it never modifies the project. For a multi-turn \
-            conversation, pass a stable session_id: kaibo replays that session's \
-            prior question/answer pairs as context (the exploration still runs \
-            fresh each turn). Args: question \
-            (required), path (project dir; optional if the server has a default root), \
-            cast (optional; pick from the `cast` enum of teams live right now, or \
-            see `kaibo://config`), session_id (optional; opaque conversation key), \
-            include_report (optional; attach the explorer's report as \
-            structured_content for debugging the hand-off), and optional \
-            explorer_model / synth_model overrides (a model id, sent verbatim; \
-            add explorer_backend / synth_backend to retarget the slot's backend)."
+            (what you changed and why, the behavior in question) in prose; don't paste \
+            a diff or dump files, kaibo reads the real, current source from disk and \
+            your intent is the part it can't recover on its own. Read-only: it never \
+            modifies the project. For a multi-turn conversation, pass a stable \
+            session_id: kaibo replays that session's prior question/answer pairs (the \
+            exploration still runs fresh each turn). Args: question (required), context \
+            (optional; a change summary or pasted source to seed the investigation — \
+            trusted as starting evidence), path (project dir; optional if the server \
+            has a default root), cast (optional), session_id (optional; opaque \
+            conversation key), include_report (optional; attach the explorer's report \
+            as structured_content for debugging the hand-off), and optional \
+            explorer_model / synth_model overrides (a model id, sent verbatim; add \
+            explorer_backend / synth_backend to retarget the slot's backend). For a \
+            thin answer with no codebase access, use `oneshot` instead."
     )]
     async fn consult(
         &self,
@@ -836,86 +794,50 @@ impl KaiboHandler {
             session = session.is_some(),
         );
         progress.emit(PhaseEvent::PhaseStarted { phase: "consult" });
-        let out = consult(&input.question, root, &explorer, &synth, &cfg, session)
-            .instrument(span)
-            .await
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        let out = consult(
+            &input.question,
+            input.context.as_deref(),
+            root,
+            &explorer,
+            &synth,
+            &cfg,
+            session,
+        )
+        .instrument(span)
+        .await
+        .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
         progress.emit(PhaseEvent::PhaseFinished { phase: "consult" });
 
-        Ok(consult_result(out.answer, out.report, input.include_report))
+        // Provenance: name the cast and the models that answered, so a caller (a
+        // cross-model study especially) sees which model produced this without
+        // digging into `kaibo://config`. consult runs two arms — both are named.
+        let answer = with_provenance(
+            out.answer,
+            &cast.name,
+            &[("explorer", &explorer.model), ("synth", &synth.model)],
+        );
+        Ok(consult_result(answer, out.report, input.include_report))
     }
 
     #[tool(
-        description = "Investigate a question about a codebase and return a curated \
-            report citing concrete `file:line` locations. A fast, cheap model reads \
-            the project through a read-only kaish shell (cat/grep/rg/find/pipelines) \
-            and reports what it found — relevant files, line numbers, key snippets. \
-            This is the explorer seam on its own: it gathers evidence, it does not \
-            write a polished final answer (use `consult` for that). Read-only: it \
-            never modifies the project. Args: question (required), path (project dir; \
-            optional if the server has a default root), cast (optional; the \
-            usable casts are named in the handshake and `kaibo://config`), and \
-            optional model (with optional backend) / max_turns overrides."
+        description = "Ask a model *outside your own family* a thin, direct question \
+            — prompt in, answer out, no codebase access and no tools. The counterpart \
+            to `consult`: use `oneshot` when you already own the context (you've pasted \
+            what's needed, or the question is general) and just want another model's \
+            take; use `consult` when kaibo should investigate a codebase for you. Pick \
+            which model answers with `cast` (e.g. `deepseek`, `gemini`, `anthropic`; \
+            the `cast` enum lists the teams live now, `kaibo://config` has the full \
+            set) — kaibo runs the cast's capable (synth) model. Exactly one upstream \
+            request; you are responsible for any context the model needs. Args: prompt \
+            (required), cast (optional), and an optional model (with optional backend) \
+            override."
     )]
-    async fn explore(
+    async fn oneshot(
         &self,
-        Parameters(input): Parameters<ExploreInput>,
+        Parameters(input): Parameters<OneshotInput>,
         peer: Peer<RoleServer>,
         meta: Meta,
     ) -> Result<CallToolResult, McpError> {
-        let root = self.resolve_root(input.path)?;
-        let mut cast = self.resolve_cast(input.cast)?;
-        self.apply_model_override(
-            &mut cast,
-            ModelRole::Explorer,
-            input.model.as_deref(),
-            input.backend.as_deref(),
-            "model",
-            "backend",
-        )?;
-        let arm = self.arm(&cast, ModelRole::Explorer)?;
-        let progress = progress_sink(peer, &meta);
-        let defaults = &self.config.defaults;
-        let cfg = ConsultConfig {
-            explorer_max_turns: input.max_turns.unwrap_or(defaults.explorer_max_turns),
-            synth_max_turns: defaults.synth_max_turns,
-            sandbox: self.config.sandbox.clone(),
-            progress: progress.clone(),
-            house_rules: self.house_rules(&root)?,
-            prompts: self.resolved_prompts(&cast),
-            orientation: self.orientation(&root).await?,
-        };
-
-        let span = tracing::info_span!("explore", cast = %cast.name, model = %arm.model);
-        progress.emit(PhaseEvent::PhaseStarted { phase: "explore" });
-        let report = explore(&input.question, root, &arm, &cfg)
-            .instrument(span)
-            .await
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
-        progress.emit(PhaseEvent::PhaseFinished { phase: "explore" });
-
-        Ok(CallToolResult::success(vec![Content::text(report)]))
-    }
-
-    #[tool(
-        description = "Answer a question about a codebase with a capable model, \
-            grounded in optional supplied context (typically an `explore` report or \
-            pasted source). With context, the model treats it as primary evidence and \
-            uses a read-only kaish shell to verify or fill precise gaps; without \
-            context, it investigates directly. This is the synthesizer seam on its \
-            own — a real outside opinion you can seed with material `explore` or you \
-            gathered. Read-only. Args: question (required), context (optional), path \
-            (project dir; optional with a default root), cast (optional; the \
-            usable casts are named in the handshake and `kaibo://config`), and an \
-            optional model (with optional backend) override."
-    )]
-    async fn synthesize(
-        &self,
-        Parameters(input): Parameters<SynthesizeInput>,
-        peer: Peer<RoleServer>,
-        meta: Meta,
-    ) -> Result<CallToolResult, McpError> {
-        let root = self.resolve_root(input.path)?;
         let mut cast = self.resolve_cast(input.cast)?;
         self.apply_model_override(
             &mut cast,
@@ -933,29 +855,21 @@ impl KaiboHandler {
             synth_max_turns: defaults.synth_max_turns,
             sandbox: self.config.sandbox.clone(),
             progress: progress.clone(),
-            house_rules: self.house_rules(&root)?,
+            // oneshot reads no project: no house rules, no repo map, no shell.
+            house_rules: None,
             prompts: self.resolved_prompts(&cast),
-            // synthesize works from supplied context, not exploration → no repo map.
             orientation: None,
         };
 
-        let span = tracing::info_span!(
-            "synthesize",
-            cast = %cast.name,
-            model = %arm.model,
-            with_context = input.context.is_some(),
-        );
-        progress.emit(PhaseEvent::PhaseStarted {
-            phase: "synthesize",
-        });
-        let answer = synthesize(&input.question, input.context.as_deref(), root, &arm, &cfg)
+        let span = tracing::info_span!("oneshot", cast = %cast.name, model = %arm.model);
+        progress.emit(PhaseEvent::PhaseStarted { phase: "oneshot" });
+        let answer = oneshot(&input.prompt, &arm, &cfg)
             .instrument(span)
             .await
             .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
-        progress.emit(PhaseEvent::PhaseFinished {
-            phase: "synthesize",
-        });
+        progress.emit(PhaseEvent::PhaseFinished { phase: "oneshot" });
 
+        let answer = with_provenance(answer, &cast.name, &[("model", &arm.model)]);
         Ok(CallToolResult::success(vec![Content::text(answer)]))
     }
 
@@ -1438,8 +1352,7 @@ fn render_config_resource(
     #[derive(Serialize)]
     struct ToolsDoc {
         consult: bool,
-        explore: bool,
-        synthesize: bool,
+        oneshot: bool,
         run_kaish: bool,
         generate_image: bool,
     }
@@ -1633,8 +1546,7 @@ fn render_config_resource(
     // render-or-skip decision instead of silently vanishing from the resource.
     let &ToolGating {
         consult,
-        explore,
-        synthesize,
+        oneshot,
         run_kaish,
         generate_image,
     } = &config.tools;
@@ -1676,8 +1588,7 @@ fn render_config_resource(
         default_cast: config.default_cast.clone(),
         tools: ToolsDoc {
             consult,
-            explore,
-            synthesize,
+            oneshot,
             run_kaish,
             generate_image,
         },
@@ -1760,8 +1671,7 @@ fn read_kaibo_resource_with_config(
     default_root_inferred: bool,
 ) -> Result<ReadResourceResult, McpError> {
     if uri == CONFIG_URI {
-        let body =
-            render_config_resource(config, allowed_set, default_root, default_root_inferred);
+        let body = render_config_resource(config, allowed_set, default_root, default_root_inferred);
         return Ok(ReadResourceResult {
             contents: vec![ResourceContents::text(body, uri)],
         });
@@ -1792,6 +1702,21 @@ fn consult_result(answer: String, report: String, include_report: bool) -> CallT
         result.structured_content = Some(json!({ "report": report }));
     }
     result
+}
+
+/// Append a one-line provenance footer naming the cast and the model(s) that
+/// produced `answer`. The point is legibility: a caller — a cross-model study most
+/// of all — should see *which* model answered without cross-referencing
+/// `kaibo://config`, since the answering model is the whole variable. `roles` is the
+/// labelled models for this tool (one for `oneshot`, explorer+synth for `consult`).
+/// Pure and offline-testable.
+fn with_provenance(answer: String, cast: &str, roles: &[(&str, &str)]) -> String {
+    let models = roles
+        .iter()
+        .map(|(label, model)| format!("{label} `{model}`"))
+        .collect::<Vec<_>>()
+        .join(" · ");
+    format!("{answer}\n\n———\nkaibo · cast `{cast}` · {models}")
 }
 
 /// The MCP token the client attached for progress, if any. Per the spec, progress
@@ -1903,7 +1828,7 @@ mod tests {
     #[test]
     fn consultation_tools_advertise_the_live_cast_enum() {
         let h = handler();
-        for tool in ["consult", "explore", "synthesize"] {
+        for tool in ["consult", "oneshot"] {
             let schema = h
                 .tool_router
                 .get(tool)
@@ -1947,16 +1872,16 @@ mod tests {
     }
 
     /// A per-model slot `preamble` wins over the global `[prompts].<phase>`, and the
-    /// synth slot feeds *both* synth phases (standalone `synthesize` and the consult
-    /// driver) — the "its own, even if a copy" shape: same value today, but each
-    /// arrives under its own key, free to diverge.
+    /// synth slot feeds *both* capable-model phases (the `consult` driver and the
+    /// toolless `oneshot`) — the "its own, even if a copy" shape: same value today,
+    /// but each arrives under its own key, free to diverge.
     #[test]
     fn slot_preamble_wins_over_phase_prompts_and_feeds_both_synth_phases() {
         let h = handler_from_toml(
             r#"
             [prompts]
             explorer = "EXP_PHASE"
-            synthesize = "SYN_PHASE"
+            oneshot = "ONE_PHASE"
             consult = "CON_PHASE"
 
             [casts.team]
@@ -1968,21 +1893,21 @@ mod tests {
         let p = h.resolved_prompts(&cast);
         // Slot wins over the phase prompt for the explorer...
         assert_eq!(p.explorer.as_deref(), Some("EXP_SLOT"));
-        // ...and the synth slot's voice reaches BOTH synth phases, each via its own
-        // key (a copy for now, independently addressable).
-        assert_eq!(p.synthesize.as_deref(), Some("SYNTH_SLOT"));
+        // ...and the synth slot's voice reaches BOTH capable-model phases, each via
+        // its own key (a copy for now, independently addressable).
         assert_eq!(p.consult.as_deref(), Some("SYNTH_SLOT"));
+        assert_eq!(p.oneshot.as_deref(), Some("SYNTH_SLOT"));
     }
 
     /// With no slot preambles, the global `[prompts]` is the fallback — and the two
-    /// synth phases keep *independent* keys, so standalone `synthesize` can differ
-    /// from the `consult` driver. This is the "standalone synth is its own" guarantee.
+    /// capable-model phases keep *independent* keys, so the toolless `oneshot` can
+    /// differ from the `consult` driver.
     #[test]
     fn phase_prompts_are_the_fallback_and_synth_phases_stay_independent() {
         let h = handler_from_toml(
             r#"
             [prompts]
-            synthesize = "STANDALONE_ONLY"
+            oneshot = "ONESHOT_ONLY"
             consult = "DRIVER_ONLY"
 
             [casts.team]
@@ -1993,8 +1918,8 @@ mod tests {
         let cast = h.resolve_cast(Some("team".into())).unwrap();
         let p = h.resolved_prompts(&cast);
         assert!(p.explorer.is_none(), "no explorer prompt set anywhere");
-        // The two synth phases diverge — proof they're not collapsed into one.
-        assert_eq!(p.synthesize.as_deref(), Some("STANDALONE_ONLY"));
+        // The two capable-model phases diverge — proof they're not collapsed into one.
+        assert_eq!(p.oneshot.as_deref(), Some("ONESHOT_ONLY"));
         assert_eq!(p.consult.as_deref(), Some("DRIVER_ONLY"));
     }
 
@@ -2162,11 +2087,11 @@ mod tests {
             panic!("configure prompt must be a text message");
         };
         for needle in [
-            CONFIG_EXAMPLE_URI,            // read the annotated template
-            CONFIG_URI,                    // and the resolved live state
-            "config.toml",                 // write target
-            "api_key_env",                 // keys-by-reference, not inline
-            "reconnect",                   // re-read at startup
+            CONFIG_EXAMPLE_URI, // read the annotated template
+            CONFIG_URI,         // and the resolved live state
+            "config.toml",      // write target
+            "api_key_env",      // keys-by-reference, not inline
+            "reconnect",        // re-read at startup
         ] {
             assert!(
                 text.contains(needle),
@@ -2319,6 +2244,41 @@ mod tests {
             .clone()
     }
 
+    /// Provenance footer: the answer keeps its text, and the cast plus every labelled
+    /// model is appended so a caller (a cross-model study most of all) sees which model
+    /// produced the answer without cross-referencing `kaibo://config`.
+    #[test]
+    fn provenance_footer_names_the_cast_and_every_model() {
+        let out = with_provenance(
+            "the answer".into(),
+            "gemini",
+            &[
+                ("explorer", "gemini-flash-lite-latest"),
+                ("synth", "gemini-3.5-flash"),
+            ],
+        );
+        assert!(
+            out.starts_with("the answer"),
+            "the answer is preserved: {out}"
+        );
+        assert!(out.contains("cast `gemini`"), "names the cast: {out}");
+        assert!(
+            out.contains("explorer `gemini-flash-lite-latest`"),
+            "names the explorer model: {out}"
+        );
+        assert!(
+            out.contains("synth `gemini-3.5-flash`"),
+            "names the synth model: {out}"
+        );
+
+        // The oneshot shape: a single labelled model.
+        let one = with_provenance("x".into(), "deepseek", &[("model", "deepseek-v4-pro")]);
+        assert!(
+            one.contains("cast `deepseek` · model `deepseek-v4-pro`"),
+            "{one}"
+        );
+    }
+
     /// Default path: no report requested ⇒ the answer is the whole result and no
     /// structured content rides along (a lean call, byte-for-byte its pre-flag shape).
     #[test]
@@ -2398,9 +2358,15 @@ mod tests {
 
         let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp")];
-        let result =
-            read_kaibo_resource_with_config(CONFIG_EXAMPLE_URI, &[], &config, &allowed, None, false)
-            .expect("example resource must be readable");
+        let result = read_kaibo_resource_with_config(
+            CONFIG_EXAMPLE_URI,
+            &[],
+            &config,
+            &allowed,
+            None,
+            false,
+        )
+        .expect("example resource must be readable");
         let body = match &result.contents[0] {
             ResourceContents::TextResourceContents { text, .. } => text.clone(),
             other => panic!("expected text contents, got {other:?}"),
@@ -2653,7 +2619,8 @@ mod tests {
             "config resource body must not be empty"
         );
         // The dispatch must not return not-found for this URI.
-        let result = read_kaibo_resource_with_config(CONFIG_URI, &[], &config, &allowed, None, false);
+        let result =
+            read_kaibo_resource_with_config(CONFIG_URI, &[], &config, &allowed, None, false);
         assert!(
             result.is_ok(),
             "kaibo://config must be readable, got {result:?}"

--- a/src/server.rs
+++ b/src/server.rs
@@ -108,7 +108,10 @@ impl ToolGating {
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConsultInput {
-    /// The question to investigate about the project.
+    /// The question to investigate about the project. Say what you did or want to
+    /// know in prose — what you changed and why, the behavior you're asking about.
+    /// kaibo locates and reads the real, current code itself, so describing your
+    /// intent beats pasting a diff or a file dump it would only re-read from disk.
     pub question: String,
 
     /// Absolute path to the project to explore. Optional when the server has a
@@ -754,10 +757,15 @@ impl KaiboHandler {
             cited answer. A capable model drives a read-only kaish shell \
             (cat/grep/rg/find/jq/pipelines): it reads precise spans directly and \
             delegates broad repo sweeps to a fast explorer sub-agent, then answers \
-            from what they find with concrete `file:line` citations. Read-only: it \
-            never modifies the project. For a multi-turn conversation, pass a stable \
-            session_id: kaibo replays that session's prior question/answer pairs as \
-            context (the exploration still runs fresh each turn). Args: question \
+            from what they find with concrete `file:line` citations. It finds and \
+            reads the relevant code itself — describe what you did or want to know \
+            (what you changed and why, the behavior in question) in prose; don't \
+            paste a diff or dump files, kaibo reads the real, current source from \
+            disk and your intent is the part it can't recover on its own. \
+            Read-only: it never modifies the project. For a multi-turn \
+            conversation, pass a stable session_id: kaibo replays that session's \
+            prior question/answer pairs as context (the exploration still runs \
+            fresh each turn). Args: question \
             (required), path (project dir; optional if the server has a default root), \
             cast (optional; pick from the `cast` enum of teams live right now, or \
             see `kaibo://config`), session_id (optional; opaque conversation key), \

--- a/tests/cast_param.rs
+++ b/tests/cast_param.rs
@@ -1,13 +1,13 @@
-//! The `cast` call param (docs/casts.md): the canonical selector on all three
-//! model-driven tools, exercised at the exact seam rmcp deserializes tool
-//! arguments through. The old `provider` spelling carried a transitional
-//! `#[serde(alias = "provider")]` for one cycle after the backends/casts rename;
-//! that alias is now removed, so a stale `provider` falls under
-//! `deny_unknown_fields` and becomes a loud invalid-params error — never a silent
-//! drop into the default cast (serde drops unknown fields, a textbook silent
+//! The `cast` call param (docs/casts.md): the canonical selector on the
+//! model-driven tools (`consult`, `oneshot`), exercised at the exact seam rmcp
+//! deserializes tool arguments through. The old `provider` spelling carried a
+//! transitional `#[serde(alias = "provider")]` for one cycle after the
+//! backends/casts rename; that alias is now removed, so a stale `provider` falls
+//! under `deny_unknown_fields` and becomes a loud invalid-params error — never a
+//! silent drop into the default cast (serde drops unknown fields, a textbook silent
 //! fallback). These tests pin that end state.
 
-use kaibo::server::{ConsultInput, ExploreInput, RunKaishInput, SynthesizeInput};
+use kaibo::server::{ConsultInput, OneshotInput, RunKaishInput};
 use serde_json::json;
 
 #[test]
@@ -16,13 +16,9 @@ fn cast_is_the_canonical_spelling_and_optional() {
         .expect("consult takes cast");
     assert_eq!(c.cast.as_deref(), Some("chimera"));
 
-    let e: ExploreInput = serde_json::from_value(json!({ "question": "q", "cast": "chimera" }))
-        .expect("explore takes cast");
-    assert_eq!(e.cast.as_deref(), Some("chimera"));
-
-    let s: SynthesizeInput = serde_json::from_value(json!({ "question": "q", "cast": "chimera" }))
-        .expect("synthesize takes cast");
-    assert_eq!(s.cast.as_deref(), Some("chimera"));
+    let o: OneshotInput = serde_json::from_value(json!({ "prompt": "q", "cast": "chimera" }))
+        .expect("oneshot takes cast");
+    assert_eq!(o.cast.as_deref(), Some("chimera"));
 
     // Omitting it entirely falls through to the server's default cast.
     let d: ConsultInput =
@@ -46,15 +42,14 @@ fn a_typoed_argument_is_a_loud_error_not_a_silent_default_run() {
         "the error must name the unknown field, got: {err}"
     );
 
-    // Another tool's spelling sent to the wrong tool (`max_turns` is explore's).
-    serde_json::from_value::<ConsultInput>(json!({ "question": "q", "max_turns": 5 }))
-        .expect_err("explore's max_turns spelling must not silently vanish on consult");
+    // Another tool's spelling sent to the wrong tool (`prompt` is oneshot's; consult
+    // takes `question`), so it must not silently vanish on consult.
+    serde_json::from_value::<ConsultInput>(json!({ "question": "q", "prompt": "q" }))
+        .expect_err("oneshot's prompt spelling must not silently vanish on consult");
 
-    // And the other three inputs hold the same line.
-    serde_json::from_value::<ExploreInput>(json!({ "question": "q", "sesion_id": "s" }))
-        .expect_err("explore rejects unknown fields");
-    serde_json::from_value::<SynthesizeInput>(json!({ "question": "q", "contxt": "evidence" }))
-        .expect_err("synthesize rejects unknown fields");
+    // And the other inputs hold the same line.
+    serde_json::from_value::<OneshotInput>(json!({ "prompt": "q", "sesion_id": "s" }))
+        .expect_err("oneshot rejects unknown fields");
     serde_json::from_value::<RunKaishInput>(json!({ "script": "ls", "paht": "/tmp" }))
         .expect_err("run_kaish rejects unknown fields");
 }
@@ -63,16 +58,13 @@ fn a_typoed_argument_is_a_loud_error_not_a_silent_default_run() {
 /// sending the old spelling lands on `deny_unknown_fields` and gets a loud error
 /// naming the field — never a silent fall-through to the default cast.
 #[test]
-fn a_stale_provider_arg_is_a_loud_unknown_field_on_all_three_tools() {
-    let payload = json!({ "question": "q", "provider": "gemini" });
-
-    let c = serde_json::from_value::<ConsultInput>(payload.clone());
-    let e = serde_json::from_value::<ExploreInput>(payload.clone());
-    let s = serde_json::from_value::<SynthesizeInput>(payload);
+fn a_stale_provider_arg_is_a_loud_unknown_field_on_the_model_tools() {
+    let c =
+        serde_json::from_value::<ConsultInput>(json!({ "question": "q", "provider": "gemini" }));
+    let o = serde_json::from_value::<OneshotInput>(json!({ "prompt": "q", "provider": "gemini" }));
     for (tool, res) in [
         ("consult", c.err().map(|e| e.to_string())),
-        ("explore", e.err().map(|e| e.to_string())),
-        ("synthesize", s.err().map(|e| e.to_string())),
+        ("oneshot", o.err().map(|e| e.to_string())),
     ] {
         let msg = res.unwrap_or_else(|| {
             panic!("{tool}: a stale `provider` arg must be rejected, not resolved silently")

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -864,9 +864,9 @@ fn cli_cast_wins_over_env_and_file() {
     c.apply_cli(
         Some("/tmp/proj".into()),
         Some("deepseek".to_string()),
-        // Only --no-explore was passed.
+        // Only --no-oneshot was passed.
         ToolDisables {
-            explore: true,
+            oneshot: true,
             ..Default::default()
         },
         vec![], // no --allow-path flags
@@ -875,9 +875,9 @@ fn cli_cast_wins_over_env_and_file() {
     );
     assert_eq!(c.default_cast, "deepseek", "--cast beats env and file");
     assert_eq!(c.root.as_deref(), Some(std::path::Path::new("/tmp/proj")));
-    // Only explore is dropped; the rest stay enabled.
+    // Only oneshot is dropped; the rest stay enabled.
     assert!(c.tools.consult);
-    assert!(!c.tools.explore);
+    assert!(!c.tools.oneshot);
     assert!(c.tools.run_kaish);
 }
 
@@ -971,8 +971,7 @@ fn tilde_expands_in_env_layer_root_and_allow_paths() {
     );
     for expected in [format!("{home}/a"), format!("{home}/b")] {
         assert!(
-            c.allow_paths
-                .contains(&std::path::PathBuf::from(&expected)),
+            c.allow_paths.contains(&std::path::PathBuf::from(&expected)),
             "~ in KAIBO_ALLOW_PATHS must expand to {expected}, got {:?}",
             c.allow_paths
         );
@@ -1481,7 +1480,7 @@ fn context_env_overrides_file_and_empty_opts_out() {
 fn prompts_default_to_no_overrides() {
     let c = Config::builtin();
     assert!(c.prompts.explorer.is_none());
-    assert!(c.prompts.synthesize.is_none());
+    assert!(c.prompts.oneshot.is_none());
     assert!(c.prompts.consult.is_none());
 }
 
@@ -1511,7 +1510,7 @@ fn prompts_table_sets_per_phase_overrides() {
         .unwrap()
         .contains("staff engineer"));
     // An unset phase stays None — the built-in runs.
-    assert!(c.prompts.synthesize.is_none());
+    assert!(c.prompts.oneshot.is_none());
 }
 
 /// An empty (or whitespace-only) override is a loud load error — a blank system

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex};
 
 use kaibo::config::{default_models, Config, Defaults, ModelRole, ModelSlot};
 use kaibo::consult::{
-    consult, explore, request_params, synthesize, synthesize_user_prompt, thinking_params, Arm,
-    ConsultConfig, ModelCaps, ModelShape, ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
+    consult, consult_user_prompt, oneshot, request_params, thinking_params, Arm, ConsultConfig,
+    ModelCaps, ModelShape, ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
 };
 use kaibo::credentials::{load, ProviderKind};
 use serde_json::{json, Value};
@@ -32,11 +32,32 @@ fn builtin_arm(cast: &str, role: ModelRole) -> Arm {
     arm_from(&Config::builtin(), cast, role)
 }
 
+/// A throwaway explorer arm for the driver-only `view_image` tests. `consult` needs
+/// an explorer arm to assemble its toolset, but these tests never make the driver
+/// delegate a sweep, so it is never invoked — it just has to exist. Shares the
+/// synth's scripted client under a model id the test never scripts.
+fn unused_explorer(client: &ScriptedClient) -> Arm {
+    Arm::new(
+        client.clone(),
+        "unused-explorer",
+        16384,
+        None,
+        ModelCaps {
+            vision: false,
+            tool_result_images: true,
+        },
+    )
+}
+
 #[test]
-fn synthesize_prompt_grounds_in_supplied_context() {
-    let p = synthesize_user_prompt(
+fn consult_seed_context_is_framed_as_trusted_evidence() {
+    // The seam that absorbed standalone `synthesize`: caller `context` rides the
+    // consult driver's prompt as *trusted starting evidence*, with the steer to
+    // investigate for more — not to re-verify what's likely right.
+    let p = consult_user_prompt(
         "What blocks writes?",
         Some("src/sandbox.rs:95 read-only mount"),
+        &[],
     );
 
     assert!(p.contains("What blocks writes?"), "question present");
@@ -45,25 +66,16 @@ fn synthesize_prompt_grounds_in_supplied_context() {
         "context present"
     );
     assert!(p.to_lowercase().contains("context"), "context labelled");
-    // Question framed before the supplied context.
-    let q = p.find("What blocks writes?").unwrap();
-    let c = p.find("src/sandbox.rs:95 read-only mount").unwrap();
-    assert!(q < c, "question should precede the context");
-    // Framing: a grounded citation is trusted; `run_kaish` is for *getting more*
-    // when the context isn't enough — not for re-verifying what's likely right.
-    // Pin both halves so a revert toward "verify the cited span" framing, or a
-    // revert that drops the get-more license, fails here.
-    assert!(
-        p.contains("run_kaish"),
-        "investigation tool offered even with context"
-    );
+    // Framing: a grounded citation is trusted; tools are for *getting more* when the
+    // context isn't enough — not for re-verifying. Pin both halves so a revert toward
+    // "verify the cited span", or one that drops the get-more license, fails here.
     let lower = p.to_lowercase();
     assert!(
         lower.contains("trust"),
         "a grounded citation should be trusted, got: {p}"
     );
     assert!(
-        lower.contains("more than the context")
+        lower.contains("more than it gives")
             || lower.contains("didn't cover")
             || lower.contains("left open"),
         "supplied context must steer toward fetching more, not re-verifying, got: {p}"
@@ -71,24 +83,18 @@ fn synthesize_prompt_grounds_in_supplied_context() {
 }
 
 #[test]
-fn synthesize_prompt_without_context_still_points_at_investigation() {
-    // The panel's "vacuous with empty context" worry: with no context the prompt
-    // must still drive a real investigation via run_kaish, not invite a guess.
-    let p = synthesize_user_prompt("What blocks writes?", None);
-    assert!(p.contains("What blocks writes?"));
-    assert!(
-        p.contains("run_kaish"),
-        "empty context must still steer to run_kaish, got: {p}"
+fn consult_prompt_without_context_or_history_is_the_bare_question() {
+    // No seed, no thread ⇒ the prompt is exactly the question; the investigation
+    // steer lives in the consult preamble, not this prompt. Whitespace-only context
+    // is no context — don't pretend there's evidence.
+    assert_eq!(
+        consult_user_prompt("What blocks writes?", None, &[]),
+        "What blocks writes?"
     );
-}
-
-#[test]
-fn synthesize_prompt_treats_blank_context_as_absent() {
-    // Whitespace-only context is no context — don't pretend there's evidence.
-    let p = synthesize_user_prompt("Q?", Some("  \n  "));
-    assert!(
-        p.contains("run_kaish"),
-        "blank context should behave like None, got: {p}"
+    assert_eq!(
+        consult_user_prompt("Q?", Some("  \n  "), &[]),
+        "Q?",
+        "blank context should behave like None"
     );
 }
 
@@ -596,9 +602,10 @@ fn builtin_openai_cast_is_cheap_gemma_explorer_strong_gemma_synth() {
 type Responder = Arc<
     dyn Fn(
             &rig_core::completion::CompletionRequest,
-        )
-            -> Result<rig_core::completion::CompletionResponse<()>, rig_core::completion::CompletionError>
-        + Send
+        ) -> Result<
+            rig_core::completion::CompletionResponse<()>,
+            rig_core::completion::CompletionError,
+        > + Send
         + Sync,
 >;
 
@@ -626,9 +633,10 @@ impl ScriptedClient {
     where
         F: Fn(
                 &rig_core::completion::CompletionRequest,
-            )
-                -> Result<rig_core::completion::CompletionResponse<()>, rig_core::completion::CompletionError>
-            + Send
+            ) -> Result<
+                rig_core::completion::CompletionResponse<()>,
+                rig_core::completion::CompletionError,
+            > + Send
             + Sync
             + 'static,
     {
@@ -680,7 +688,8 @@ impl rig_core::completion::CompletionModel for ScriptedModel {
     async fn completion(
         &self,
         request: rig_core::completion::CompletionRequest,
-    ) -> Result<rig_core::completion::CompletionResponse<()>, rig_core::completion::CompletionError> {
+    ) -> Result<rig_core::completion::CompletionResponse<()>, rig_core::completion::CompletionError>
+    {
         assert_eq!(
             self.id, self.client.expect_model,
             "this client serves only {:?} — the loop routed a phase to the wrong client",
@@ -719,7 +728,9 @@ impl rig_core::completion::CompletionModel for ScriptedModel {
 /// A final text answer — ends the tool loop.
 fn text_response(text: impl Into<String>) -> rig_core::completion::CompletionResponse<()> {
     rig_core::completion::CompletionResponse {
-        choice: rig_core::OneOrMany::one(rig_core::completion::message::AssistantContent::text(text)),
+        choice: rig_core::OneOrMany::one(rig_core::completion::message::AssistantContent::text(
+            text,
+        )),
         usage: rig_core::completion::Usage::new(),
         raw_response: (),
         message_id: None,
@@ -733,9 +744,9 @@ fn tool_call_response(
     args: Value,
 ) -> rig_core::completion::CompletionResponse<()> {
     rig_core::completion::CompletionResponse {
-        choice: rig_core::OneOrMany::one(rig_core::completion::message::AssistantContent::tool_call(
-            id, name, args,
-        )),
+        choice: rig_core::OneOrMany::one(
+            rig_core::completion::message::AssistantContent::tool_call(id, name, args),
+        ),
         usage: rig_core::completion::Usage::new(),
         raw_response: (),
         message_id: None,
@@ -867,6 +878,7 @@ async fn mixed_cast_consult_routes_each_phase_to_its_own_client() {
 
     let out = consult(
         "Where is target_marker defined?",
+        None,
         dir.path(),
         &explorer,
         &synth,
@@ -964,8 +976,8 @@ fn request_has_user_image(req: &rig_core::completion::CompletionRequest) -> bool
 /// the next turn — not text. The synth can only reach its answer once it has seen the
 /// image, so a green run proves the whole chain: caps → toolset assembly → VFS read
 /// through the read-only kernel → base64 envelope → rig `from_tool_output` → image in
-/// model context. The proof of the "all three phases" decision, exercised on the
-/// `synthesize` phase through its public seam.
+/// model context. The proof of the "all phases" decision, exercised on the `consult`
+/// driver (the synth arm) — where `view_image` rides now.
 #[tokio::test]
 async fn a_vision_synth_sees_an_image_through_view_image() {
     const SYNTH_MODEL: &str = "claude-sonnet-4-6";
@@ -1004,15 +1016,18 @@ async fn a_vision_synth_sees_an_image_through_view_image() {
         },
     );
 
-    let answer = synthesize(
+    let answer = consult(
         "What does the diagram show?",
         None,
         &root,
+        &unused_explorer(&synth_client),
         &synth,
         &ConsultConfig::default(),
+        None,
     )
     .await
-    .expect("vision synthesize should succeed");
+    .expect("vision consult should succeed")
+    .answer;
 
     // The only route to "DONE" runs through the image-present branch, so this single
     // assertion proves the round-trip: the model actually received the image part.
@@ -1023,7 +1038,7 @@ async fn a_vision_synth_sees_an_image_through_view_image() {
 }
 
 /// The negative: a blind synth (the default `ModelCaps { vision: false, tool_result_images: true }`) is never
-/// offered `view_image`. Pin it on the same `synthesize` seam so the gate can't
+/// offered `view_image`. Pin it on the same `consult` driver so the gate can't
 /// silently flip open for a text-only model.
 #[tokio::test]
 async fn a_blind_synth_is_not_offered_view_image() {
@@ -1049,15 +1064,17 @@ async fn a_blind_synth_is_not_offered_view_image() {
         },
     );
 
-    synthesize(
+    consult(
         "anything",
         None,
         dir.path(),
+        &unused_explorer(&synth_client),
         &synth,
         &ConsultConfig::default(),
+        None,
     )
     .await
-    .expect("blind synthesize should succeed");
+    .expect("blind consult should succeed");
     assert!(
         !synth_client.seen().is_empty(),
         "the synth client was driven"
@@ -1118,15 +1135,18 @@ async fn an_openai_vlm_sees_an_image_on_the_user_turn_channel() {
         },
     );
 
-    let answer = synthesize(
+    let answer = consult(
         "What does the diagram show?",
         None,
         &root,
+        &unused_explorer(&synth_client),
         &synth,
         &ConsultConfig::default(),
+        None,
     )
     .await
-    .expect("openai-VLM synthesize should resume after the view_image break");
+    .expect("openai-VLM consult should resume after the view_image break")
+    .answer;
 
     assert!(
         answer.contains("DONE"),
@@ -1181,15 +1201,18 @@ async fn an_openai_vlm_co_tool_call_view_image_and_run_kaish_resumes_cleanly() {
         },
     );
 
-    let answer = synthesize(
+    let answer = consult(
         "What does the diagram show?",
         None,
         &root,
+        &unused_explorer(&synth_client),
         &synth,
         &ConsultConfig::default(),
+        None,
     )
     .await
-    .expect("a co-tool-call view_image turn must resume without orphaning run_kaish");
+    .expect("a co-tool-call view_image turn must resume without orphaning run_kaish")
+    .answer;
 
     assert!(
         answer.contains("DONE"),
@@ -1232,15 +1255,15 @@ async fn secondary_local_cast_from_user_config_runs() {
     let secondary = ModelSlot::bare(glm_synth.backend.clone(), "Gemma-4-E4B-it-GGUF");
     let arm = Arm::from_slot(backend, &secondary, ModelRole::Synth, &cfg.defaults)
         .expect("secondary arm builds");
-    let answer = synthesize(
-        "In one sentence, what does kaibo's read-only sandbox prevent?",
-        Some("src/sandbox.rs builds a read-only kernel; writes and external commands are refused."),
-        env!("CARGO_MANIFEST_DIR"),
+    let answer = oneshot(
+        "Context: src/sandbox.rs builds a read-only kernel; writes and external \
+         commands are refused.\n\nIn one sentence, what does kaibo's read-only sandbox \
+         prevent?",
         &arm,
         &ConsultConfig::default(),
     )
     .await
-    .expect("secondary-cast synthesize against Lemonade should succeed");
+    .expect("secondary-cast oneshot against Lemonade should succeed");
     eprintln!("=== SECONDARY CAST ANSWER ===\n{answer}\n");
     assert!(!answer.trim().is_empty(), "expected a non-empty answer");
 }
@@ -1258,6 +1281,7 @@ async fn recomposed_consult_runs_against_local_gemma() {
 
     let out = consult(
         "How does kaibo stop the explorer from deleting real files? Name the mechanism and the file.",
+        None,
         root,
         &builtin_arm("openai", ModelRole::Explorer),
         &builtin_arm("openai", ModelRole::Synth),
@@ -1282,68 +1306,28 @@ async fn recomposed_consult_runs_against_local_gemma() {
     );
 }
 
-// The `explore` unit on its own (the seam behind the MCP `explore` tool): a cheap
-// model drives {run_kaish} and returns a curated report citing real file:line.
+// The `oneshot` seam live: a thin, toolless answer grounded only in the context the
+// caller pasted into the prompt (no codebase access, no run_kaish). The counterpart
+// to consult — consult-without-context's "investigate the real tree" path is covered
+// by `recomposed_consult_runs_against_local_gemma` above.
 #[tokio::test]
-#[ignore = "hits the local OpenAI-compatible (Gemma) server (explore only); run with --ignored while it's up"]
-async fn explore_unit_reports_from_the_real_tree() {
-    let report = explore(
-        "Which source file enforces the read-only sandbox, and name one builtin it blocks?",
-        env!("CARGO_MANIFEST_DIR"),
-        &builtin_arm("openai", ModelRole::Explorer),
+#[ignore = "hits the local OpenAI-compatible (Gemma) server (oneshot); run with --ignored while it's up"]
+async fn oneshot_answers_from_pasted_context() {
+    let arm = builtin_arm("openai", ModelRole::Synth);
+
+    let answer = oneshot(
+        "Context: src/sandbox.rs builds a read-only kernel; the LocalFs read-only \
+         mount refuses every write.\n\nIn one sentence, which file enforces kaibo's \
+         read-only sandbox?",
+        &arm,
         &ConsultConfig::default(),
     )
     .await
-    .expect("explore against local gemma should succeed");
-
-    eprintln!("=== EXPLORE REPORT ===\n{report}\n");
-    let lower = report.to_lowercase();
+    .expect("oneshot against local gemma should succeed");
+    eprintln!("=== ONESHOT ===\n{answer}\n");
     assert!(
-        lower.contains("sandbox.rs") || lower.contains("sandbox"),
-        "the report should cite the sandbox source, got: {report}"
-    );
-}
-
-// Standalone `synthesize` (the seam behind the MCP `synthesize` tool): grounded
-// from supplied context, and — the panel's worry — still useful with no context
-// because run_kaish lets it investigate rather than guess.
-#[tokio::test]
-#[ignore = "hits the local OpenAI-compatible (Gemma) server (synthesize); run with --ignored while it's up"]
-async fn synthesize_grounds_in_context_and_investigates_without_it() {
-    let root = env!("CARGO_MANIFEST_DIR");
-    let cfg = ConsultConfig::default();
-    let arm = builtin_arm("openai", ModelRole::Synth);
-
-    // With a thin context: it should answer grounded, optionally confirming via run_kaish.
-    let with_ctx = synthesize(
-        "Which file enforces the read-only sandbox?",
-        Some("src/sandbox.rs builds a read-only kernel; the LocalFs read-only mount refuses every write."),
-        root,
-        &arm,
-        &cfg,
-    )
-    .await
-    .expect("synthesize with context should succeed");
-    eprintln!("=== SYNTH (with context) ===\n{with_ctx}\n");
-    assert!(
-        with_ctx.to_lowercase().contains("sandbox"),
-        "should answer about the sandbox file, got: {with_ctx}"
-    );
-
-    // With NO context: it must still investigate via run_kaish and answer grounded.
-    let no_ctx = synthesize(
-        "Which file enforces the read-only sandbox?",
-        None,
-        root,
-        &arm,
-        &cfg,
-    )
-    .await
-    .expect("synthesize without context should still investigate and succeed");
-    eprintln!("=== SYNTH (no context) ===\n{no_ctx}\n");
-    assert!(
-        no_ctx.to_lowercase().contains("sandbox"),
-        "empty-context synth must investigate and still answer, got: {no_ctx}"
+        answer.to_lowercase().contains("sandbox"),
+        "should answer about the sandbox file from the pasted context, got: {answer}"
     );
 }
 
@@ -1358,6 +1342,7 @@ async fn two_phase_consult_via_deepseek() {
     }
     let out = consult(
         "How does kaibo stop the explorer from deleting real files? Name the mechanism and the file.",
+        None,
         env!("CARGO_MANIFEST_DIR"),
         &builtin_arm("deepseek", ModelRole::Explorer),
         &builtin_arm("deepseek", ModelRole::Synth),
@@ -1383,6 +1368,7 @@ async fn two_phase_consult_via_gemini() {
     }
     let out = consult(
         "How does kaibo stop the explorer from deleting real files? Name the mechanism and the file.",
+        None,
         env!("CARGO_MANIFEST_DIR"),
         &builtin_arm("gemini", ModelRole::Explorer),
         &builtin_arm("gemini", ModelRole::Synth),
@@ -1413,6 +1399,7 @@ async fn two_phase_consult_answers_from_the_real_tree() {
 
     let out = consult(
         "How does kaibo stop the explorer from deleting real files? Name the mechanism and the file.",
+        None,
         root,
         &builtin_arm("anthropic", ModelRole::Explorer),
         &builtin_arm("anthropic", ModelRole::Synth),
@@ -1456,6 +1443,7 @@ async fn adaptive_only_anthropic_model_round_trips() {
 
     let out = consult(
         "How does kaibo stop the explorer from deleting real files? Name the mechanism and the file.",
+        None,
         env!("CARGO_MANIFEST_DIR"),
         &explorer,
         &synth,

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -8,13 +8,7 @@ use std::process::Command;
 use kaibo::config::Config;
 use kaibo::server::{KaiboHandler, ToolGating};
 
-const ALL_TOOLS: [&str; 5] = [
-    "consult",
-    "explore",
-    "generate_image",
-    "run_kaish",
-    "synthesize",
-];
+const ALL_TOOLS: [&str; 4] = ["consult", "generate_image", "oneshot", "run_kaish"];
 
 fn advertised(gating: ToolGating) -> Vec<String> {
     let mut config = Config::builtin();
@@ -40,16 +34,9 @@ fn each_flag_removes_exactly_its_own_tool() {
             },
         ),
         (
-            "explore",
+            "oneshot",
             ToolGating {
-                explore: false,
-                ..Default::default()
-            },
-        ),
-        (
-            "synthesize",
-            ToolGating {
-                synthesize: false,
+                oneshot: false,
                 ..Default::default()
             },
         ),
@@ -88,8 +75,7 @@ fn each_flag_removes_exactly_its_own_tool() {
 fn all_disabled_is_detected() {
     let none_on = ToolGating {
         consult: false,
-        explore: false,
-        synthesize: false,
+        oneshot: false,
         run_kaish: false,
         generate_image: false,
     };
@@ -115,8 +101,7 @@ fn all_tools_disabled_refuses_to_start() {
         .env("XDG_CONFIG_HOME", empty_config.path())
         .args([
             "--no-consult",
-            "--no-explore",
-            "--no-synthesize",
+            "--no-oneshot",
             "--no-run-kaish",
             "--no-generate-image",
         ])

--- a/tests/llm_timeout.rs
+++ b/tests/llm_timeout.rs
@@ -16,7 +16,7 @@
 use std::time::{Duration, Instant};
 
 use kaibo::config::{Config, ModelRole};
-use kaibo::consult::{synthesize, Arm, ConsultConfig};
+use kaibo::consult::{oneshot, Arm, ConsultConfig};
 use tokio::net::TcpListener;
 
 /// Bind an ephemeral port and accept connections forever without ever replying —
@@ -36,7 +36,7 @@ async fn black_hole() -> (String, tokio::task::JoinHandle<()>) {
 }
 
 #[tokio::test]
-async fn synthesize_aborts_when_the_provider_never_responds() {
+async fn oneshot_aborts_when_the_provider_never_responds() {
     let (base_url, _server) = black_hole().await;
 
     // The built-in openai backend aimed at the black hole, keyless, with a short
@@ -62,10 +62,8 @@ async fn synthesize_aborts_when_the_provider_never_responds() {
     let started = Instant::now();
     let res = tokio::time::timeout(
         Duration::from_secs(20),
-        synthesize(
+        oneshot(
             "What does the sandbox prevent?",
-            Some("src/sandbox.rs builds a read-only kernel."),
-            env!("CARGO_MANIFEST_DIR"),
             &arm,
             &ConsultConfig::default(),
         ),


### PR DESCRIPTION
## Why

A cross-model study (run in a kaish session) reached for the per-model MCP pals (`consult_gemini`, `consult_deepseek`) over kaibo even with all three loaded. The pals win on two things kaibo lacked: the **model is named in the tool** (so "ask Gemini" is a 1:1 match), and they offer a **thin oneshot shape** alongside the agentic one. kaibo, meanwhile, led with "a codebase" and four tools — two of which (`explore`, `synthesize`) were internal seams leaking onto the public surface that a calling agent can't reason about reaching.

This PR reworks the client-facing instructions and the tool surface so kaibo reads as the legible **door to a model outside your own family**.

## What changed

**Instruction steers (client-facing descriptions):**
- "Say what you did, don't paste a diff" — `consult` reads the real, current source itself, so describing intent beats a diff it would re-read from disk. Applied to the handshake lead, `consult`'s description, and its `question` arg.
- `consult` is the front-door tool; the others surface through their schemas.
- The `configure` prompt now defaults to a **within-family explorer/synth pair** (one outside family already augments the calling agent) and demotes the cross-family chimera to an explicit advanced opt-in — a Claude running `configure` was jumping straight to a chimera.

**Tool-surface collapse — four tools → `consult` / `oneshot` / `run_kaish`:**
- `explore` and `synthesize` **removed** as public tools (the `explore′` sweep stays internal to the consult loop).
- `consult` gains an optional **`context`** seed, absorbing `synthesize`'s "trust the cited `file:line`, investigate for more" behavior.
- New **`oneshot`** — a thin, toolless completion (prompt in / answer out, no codebase access, one upstream request): the pal-shaped counterpart for when the caller already owns the context.
- **Provenance footer** on both model tools — cast + answering model(s) — so a cross-model study sees which model produced an answer without opening `kaibo://config`.
- Gating, CLI flags, `KAIBO_NO_*`, `[prompts]`/`[tools]` config, `inject_cast_enum`, and `kaibo://config` all updated; docs (`README`, `AGENTS.md`, `docs/{config,casts,config.example,sandbox-probes,issues}`) and the CHANGELOG follow.

## Review

Dogfooded the cross-family review through kaibo's own `consult` (cast `deepseek`): verdict "a clean redesign". It surfaced one real inconsistency (oneshot's doc claimed house rules apply while the server passed `None`) — fixed — and one latent coupling (a vision arm hands oneshot `break_on_view_image=true`, inert only because the empty toolset has no `view_image` tool) — documented. The review's own answer carried the new provenance footer, confirming the pipeline end-to-end.

## Tests

172 lib tests + integration green, zero warnings. New tests pin oneshot's empty toolset, the provenance footer, and consult-with-context framing; the `view_image` suite moved onto the consult driver (where it rides now), and the synthesize-prompt tests became consult-with-context tests. The `#[ignore]`d live probes were ported to the new seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
