### PR TITLE
Follow git worktrees of an already-allowed repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ the git log. Each later release appends a new section at the top.
   get. Set `allow_paths = ["~/src"]` once and every project under it is in-bounds —
   with cwd inferred as the default root, you stop thinking about `path` entirely.
   (Previously a literal `~` was taken verbatim and failed canonicalization at startup.)
+- **Follow git worktrees automatically.** A `path` in a linked git worktree of an
+  already-allowed repo is now reachable without an `--allow-path` — so a sibling
+  branch you check out next to the project (even one you spin up mid-session) just
+  works. kaibo resolves this by reading git's own link files, never by running git
+  (the binary still isn't in the build). Trust flows only outward from the allowed
+  repo: a forged `.git` in a foreign directory can't admit itself. The
+  `kaibo://config` `[runtime]` section shows which worktrees are currently followed.
+  Turn it off with `--no-follow-worktrees`, `KAIBO_NO_FOLLOW_WORKTREES`, or
+  `[server] follow_worktrees = false` to keep the boundary strictly static.
 - **Per-tool gating.** Each tool has a `--no-<tool>` flag (all on by default); an
   all-off server is refused at startup.
 - **Operator ignore files** via a `[kaish.ignore]` config stanza.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -50,6 +50,15 @@
 # (colon-separated env var); a non-empty CLI list replaces the env/file layer.
 # allow_paths = ["/home/atobey/shared-libs", "/data/shared"]
 
+# Follow git worktrees of an already-allowed repo (default true). When a call's
+# `path` misses the allowed set, kaibo admits it if it is a linked worktree of a
+# repo already in the set — so a sibling branch checkout (even one created
+# mid-session) is reachable without an --allow-path. Resolved by reading git's
+# link files, never by running git. The kaibo://config [runtime] section lists the
+# worktrees currently followed. Set false to keep the boundary strictly static
+# (also: --no-follow-worktrees, KAIBO_NO_FOLLOW_WORKTREES).
+# follow_worktrees = true
+
 # Default cast (by name or alias) when a call omits `cast`. The old `provider`
 # key is a load error (unknown field) — see docs/casts.md for the rename map.
 cast = "anthropic"

--- a/docs/config.md
+++ b/docs/config.md
@@ -604,6 +604,39 @@ it. Pass an explicit `--root` (inside an allowed tree) to restore a default.
 so the kaish VFS mount target is always resolved. A nonexistent or non-directory
 entry in `--root` / `--allow-path` is a loud construction error at startup.
 
+**Following git worktrees (on by default).** When a call's `path` misses the allowed
+set, kaibo doesn't reject it outright if it's a *linked git worktree of a repo
+already in the set* — it admits it. So a feature branch you check out in a sibling
+directory (`git worktree add ../proj-feature …`), even one created mid-session, is
+reachable without touching `allow_paths`. This is *narrower* than widening to the
+parent (`--allow-path ~/src` would grant read of everything under it); follow admits
+exactly the worktrees of an already-allowed repo and nothing else.
+
+kaibo resolves this by **reading git's own link files** — a worktree's `.git` file,
+the repo's `.git/worktrees/<name>/{gitdir,commondir}` — never by running `git` (the
+binary isn't in the build; see [Read-only is structural](#)). Trust flows only
+outward from the allowed repo: kaibo enumerates the worktrees the *allowed* repo's
+common git dir vouches for and admits a candidate only if it falls inside one. It
+never consults the candidate's own `.git`, so a foreign directory with a forged
+`gitdir:` pointer can't admit itself. The check runs only on the (rare)
+containment-miss path — the normal in-bounds call is untouched.
+
+Turn it off to keep the boundary strictly static:
+
+```toml
+[server]
+follow_worktrees = false
+```
+
+```sh
+KAIBO_NO_FOLLOW_WORKTREES=1 kaibo      # env
+kaibo --no-follow-worktrees            # CLI (can only disable, like --no-<tool>)
+```
+
+The worktrees currently followed are listed at `kaibo://config` under `[runtime]`
+(see below), recomputed on each read so a mid-session worktree shows up without a
+reconnect.
+
 ## kaibo://config
 
 An MCP resource at the URI `kaibo://config` (`application/toml`) exposes the server's
@@ -613,6 +646,12 @@ operator) the full picture:
 - `allowed_paths` — the canonicalized trees a per-call path must be at-or-under
 - `default_root` — the `--root` value, if set
 - `default_cast` — which cast is used when a call omits `cast`
+- `runtime` — state *computed at read time*, kept distinct from the configured
+  knobs above so a reader can tell "what kaibo discovered" from "what the operator
+  set". Currently `follow_worktrees` (the knob's effective value) and
+  `followed_worktrees` (the git worktrees admitted beyond `allowed_paths` right
+  now; recomputed each read, so a worktree added mid-session appears without a
+  reconnect)
 - `tools` — which tools are currently advertised (`consult`, `oneshot`,
   `run_kaish`, `generate_image`)
 - `sandbox` — exec timeout, output cap, scratch (`/` MemoryFs) cap, and any extra disabled builtins

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -319,6 +319,22 @@ the scripted `CompletionClient` (`test_support.rs`) is the natural guard.
 
 ## P3 — Infra, perf, polish
 
+### Expand the `kaibo://config` `[runtime]` section beyond followed worktrees
+The config resource grew a `[runtime]` table for state that's *computed at read
+time* rather than configured — currently `follow_worktrees` (the knob) and
+`followed_worktrees` (the live extra set the worktree-follow grants beyond
+`allowed_paths`, recomputed each read so a mid-session worktree shows up). The slot
+is the right home for other runtime-derived facts a caller/operator would want to
+see at a glance — candidates: which casts actually resolved a key right now (vs.
+merely configured), the resolved default root's *source* (explicit vs. inferred
+cwd) surfaced inside `[runtime]` instead of as a sibling flag, live session-store
+occupancy, or a "git repo detected at root" hint. Add these as the need shows up;
+keep the rule that `[runtime]` is *observed*, not *set* (the static knobs stay
+above it), so a reader can always tell "what kaibo discovered" from "what the
+operator chose". `RuntimeDoc` in `server.rs::render_config_resource` is the seam;
+the value is threaded in from the handler (it needs `allowed_set` / live state),
+so new fields follow that same path.
+
 ### `[context]` house rules have no size cap (and ride every turn, every phase)
 The `[context]` files are spliced into the preamble whole (`context.rs::assemble`
 → `consult.rs::with_house_rules`), the preamble is re-sent on *every* model turn,

--- a/src/config.rs
+++ b/src/config.rs
@@ -519,6 +519,13 @@ pub struct Config {
     /// `KAIBO_ALLOW_PATHS` (colon-separated), or `[server] allow_paths` in
     /// config.toml. Non-empty CLI list replaces lower layers.
     pub allow_paths: Vec<PathBuf>,
+    /// Follow git worktrees of an already-allowed repo (default `true`). When a
+    /// per-call `path` misses the static allowed set, admit it if it is a linked
+    /// worktree of a repo already in the set — resolved by reading git's link files,
+    /// never by running git (see `crate::worktree`). Set `false` (via
+    /// `--no-follow-worktrees`, `KAIBO_NO_FOLLOW_WORKTREES`, or
+    /// `[server] follow_worktrees = false`) to keep the boundary strictly static.
+    pub follow_worktrees: bool,
     /// Default cast name when a call omits `cast`.
     pub default_cast: String,
     /// `EnvFilter` directive used when `RUST_LOG` is unset.
@@ -950,6 +957,7 @@ impl Config {
             .iter()
             .map(|s| expand_tilde(s))
             .collect();
+        let follow_worktrees = server.follow_worktrees.unwrap_or(true);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default());
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;
@@ -974,6 +982,7 @@ impl Config {
         let cfg = Self {
             root,
             allow_paths,
+            follow_worktrees,
             default_cast,
             log,
             tools,
@@ -1003,17 +1012,27 @@ impl Config {
     /// Apply CLI overrides (highest precedence). Called from `main` after load.
     /// CLI can only *disable* a tool (the `--no-<tool>` flags); enabling is the job
     /// of the file/env/built-in layers. A non-empty `allow_paths` replaces lower layers.
+    // A thin positional overlay of the parsed CLI flags onto the loaded config — the
+    // knobs are inherently many and bundling them into a struct would just relocate
+    // the positionality into a literal, so we accept the arg count here.
+    #[allow(clippy::too_many_arguments)]
     pub fn apply_cli(
         &mut self,
         root: Option<PathBuf>,
         cast: Option<String>,
         disable: ToolDisables,
         allow_paths: Vec<PathBuf>,
+        disable_follow_worktrees: bool,
         project_context_files: Vec<String>,
         user_context_files: Vec<PathBuf>,
     ) {
         if let Some(root) = root {
             self.root = Some(root);
+        }
+        // Mirrors the `--no-<tool>` discipline: the CLI can only turn the follow OFF,
+        // never force it on over a `[server] follow_worktrees = false` in the file.
+        if disable_follow_worktrees {
+            self.follow_worktrees = false;
         }
         if let Some(cast) = cast {
             self.default_cast = cast;
@@ -1299,6 +1318,9 @@ struct RawServer {
     /// at-or-under `root` OR one of these. Env override: `KAIBO_ALLOW_PATHS`
     /// (colon-separated). CLI override: repeatable `--allow-path DIR`.
     allow_paths: Option<Vec<String>>,
+    /// Follow git worktrees of an already-allowed repo. Default `true`. Env:
+    /// `KAIBO_NO_FOLLOW_WORKTREES`. CLI: `--no-follow-worktrees`.
+    follow_worktrees: Option<bool>,
     /// The default cast (was `provider` before the backends/casts split; the old
     /// key is now an unknown-field load error via `deny_unknown_fields`).
     cast: Option<String>,
@@ -1696,6 +1718,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
         if !paths.is_empty() {
             server.allow_paths = Some(paths);
         }
+    }
+    if env_flag(get, "KAIBO_NO_FOLLOW_WORKTREES") {
+        server.follow_worktrees = Some(false);
     }
     if let Some(v) = get("KAIBO_CAST") {
         server.cast = Some(v);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod telemetry;
 pub mod tls;
 pub mod tool_span;
 pub mod view_image;
+pub mod worktree;
 
 /// A scripted, offline stand-in for a provider client, for driving the consult loop
 /// deterministically in unit tests. Test-only — never compiled into the binary.

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,15 @@ struct Args {
     #[arg(long = "allow-path", value_name = "DIR", action = clap::ArgAction::Append)]
     allow_path: Vec<PathBuf>,
 
+    /// Don't follow git worktrees: a per-call `path` in a linked worktree of an
+    /// already-allowed repo is rejected like any other outside path. By default
+    /// kaibo admits such worktrees (resolved by reading git's link files, never by
+    /// running git), so a sibling worktree you spin up mid-session is reachable
+    /// without an --allow-path. Also settable via KAIBO_NO_FOLLOW_WORKTREES or
+    /// [server] follow_worktrees = false.
+    #[arg(long)]
+    no_follow_worktrees: bool,
+
     /// Default cast when a call omits it (a built-in name or a cast defined in
     /// config.toml). Built-ins: anthropic | deepseek | gemini | openai (plus
     /// aliases: claude, google, local, …). Replaces the old --provider flag
@@ -122,6 +131,7 @@ async fn main() -> Result<()> {
             generate_image: args.no_generate_image,
         },
         args.allow_path.clone(),
+        args.no_follow_worktrees,
         args.project_context_file.clone(),
         args.user_context_file.clone(),
     );

--- a/src/server.rs
+++ b/src/server.rs
@@ -518,6 +518,19 @@ impl KaiboHandler {
             return Ok(canon);
         }
 
+        // Step 3b: worktree follow. A path that misses the static set is still
+        // admitted when it lives in a linked git worktree of an *already-allowed*
+        // repo — so a sibling worktree (a branch you check out next to the project,
+        // possibly mid-session) is reachable without an --allow-path. Resolved by
+        // reading git's link files, never by running git (subprocess/git are
+        // compiled out — see sandbox.rs). Trust flows only outward from the allowed
+        // repo: we enumerate the worktrees the allowed tree's own common git dir
+        // vouches for and never consult the candidate's `.git`, so a foreign dir
+        // can't forge its way in. Off when `follow_worktrees` is false.
+        if self.config.follow_worktrees && self.is_followed_worktree(&canon) {
+            return Ok(canon);
+        }
+
         // Violation: name the allowed set and the three widening knobs.
         let trees: Vec<String> = allowed.iter().map(|p| p.display().to_string()).collect();
         Err(McpError::invalid_params(
@@ -532,6 +545,50 @@ impl KaiboHandler {
             ),
             None,
         ))
+    }
+
+    /// True when `canon` falls inside a git worktree that an already-allowed repo
+    /// vouches for. The trusted side does the vouching: for each allowed tree we
+    /// resolve *its* common git dir and enumerate the worktrees that common dir
+    /// names; `canon` is admitted only if it sits inside one. We never read
+    /// `canon`'s own `.git`, so a forged pointer there can't smuggle a foreign path
+    /// in. Pure file reads on the (rare) containment-miss path — see
+    /// [`crate::worktree`].
+    fn is_followed_worktree(&self, canon: &std::path::Path) -> bool {
+        self.allowed_set.iter().any(|tree| {
+            crate::worktree::common_git_dir(tree)
+                .map(|common| {
+                    crate::worktree::vouched_worktrees(&common)
+                        .iter()
+                        .any(|wt| canon.starts_with(wt))
+                })
+                .unwrap_or(false)
+        })
+    }
+
+    /// The worktrees the follow feature currently admits *beyond* the static allowed
+    /// set — for the `kaibo://config` runtime section, so the live boundary stays
+    /// legible. Recomputed on each read (it reflects worktrees that exist now, which
+    /// can change between calls). Empty when the feature is off or nothing extra is
+    /// reachable. Deduplicated and sorted for a stable resource.
+    fn followed_worktrees(&self) -> Vec<PathBuf> {
+        if !self.config.follow_worktrees {
+            return Vec::new();
+        }
+        let mut found: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
+        for tree in self.allowed_set.iter() {
+            let Some(common) = crate::worktree::common_git_dir(tree) else {
+                continue;
+            };
+            for wt in crate::worktree::vouched_worktrees(&common) {
+                // Skip worktrees already covered by the static set — those aren't
+                // "extra"; the runtime section reports only what follow adds.
+                if !self.allowed_set.iter().any(|t| wt.starts_with(t)) {
+                    found.insert(wt);
+                }
+            }
+        }
+        found.into_iter().collect()
     }
 
     /// Assemble the operator's house rules for this call against the resolved
@@ -1056,6 +1113,9 @@ impl rmcp::ServerHandler for KaiboHandler {
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
+        // Compute the runtime-derived worktree set here (it needs the handler's
+        // allowed_set and reflects worktrees that exist *now*); the renderer is a
+        // pure function of its inputs, so it can't reach back for this itself.
         read_kaibo_resource_with_config(
             &request.uri,
             &self.tool_schemas,
@@ -1063,6 +1123,7 @@ impl rmcp::ServerHandler for KaiboHandler {
             &self.allowed_set,
             self.default_root.as_deref(),
             self.default_root_inferred,
+            self.followed_worktrees(),
         )
     }
 
@@ -1304,6 +1365,7 @@ fn render_config_resource(
     allowed_set: &[PathBuf],
     default_root: Option<&Path>,
     default_root_inferred: bool,
+    followed_worktrees: Vec<PathBuf>,
 ) -> String {
     use serde::Serialize;
     use std::collections::BTreeMap;
@@ -1325,6 +1387,10 @@ fn render_config_resource(
         default_root_inferred: bool,
         /// Default cast name (what a call omitting `cast` gets).
         default_cast: String,
+        /// Runtime-derived state — computed at read time, not configured. Distinct
+        /// from the static knobs above so a reader can tell "what kaibo discovered"
+        /// from "what the operator set".
+        runtime: RuntimeDoc,
         /// Which tools are currently advertised.
         tools: ToolsDoc,
         /// Read-only sandbox limits.
@@ -1355,6 +1421,17 @@ fn render_config_resource(
         oneshot: bool,
         run_kaish: bool,
         generate_image: bool,
+    }
+
+    /// Runtime-computed scope state. `follow_worktrees` echoes the knob;
+    /// `followed_worktrees` is the live extra set the follow feature grants beyond
+    /// `allowed_paths` right now — git worktrees of an already-allowed repo,
+    /// resolved by reading git's link files. Recomputed on each read, so a worktree
+    /// added mid-session shows up here without a reconnect.
+    #[derive(Serialize)]
+    struct RuntimeDoc {
+        follow_worktrees: bool,
+        followed_worktrees: Vec<String>,
     }
 
     #[derive(Serialize)]
@@ -1586,6 +1663,13 @@ fn render_config_resource(
         default_root: default_root.map(|p| p.display().to_string()),
         default_root_inferred,
         default_cast: config.default_cast.clone(),
+        runtime: RuntimeDoc {
+            follow_worktrees: config.follow_worktrees,
+            followed_worktrees: followed_worktrees
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+        },
         tools: ToolsDoc {
             consult,
             oneshot,
@@ -1669,9 +1753,16 @@ fn read_kaibo_resource_with_config(
     allowed_set: &[PathBuf],
     default_root: Option<&Path>,
     default_root_inferred: bool,
+    followed_worktrees: Vec<PathBuf>,
 ) -> Result<ReadResourceResult, McpError> {
     if uri == CONFIG_URI {
-        let body = render_config_resource(config, allowed_set, default_root, default_root_inferred);
+        let body = render_config_resource(
+            config,
+            allowed_set,
+            default_root,
+            default_root_inferred,
+            followed_worktrees,
+        );
         return Ok(ReadResourceResult {
             contents: vec![ResourceContents::text(body, uri)],
         });
@@ -2169,8 +2260,9 @@ mod tests {
         // Use the config-aware dispatch for all URIs — same path the handler takes.
         let config = Config::builtin();
         let allowed: Vec<PathBuf> = Vec::new();
-        let result = read_kaibo_resource_with_config(uri, schemas, &config, &allowed, None, false)
-            .expect("known uri must read");
+        let result =
+            read_kaibo_resource_with_config(uri, schemas, &config, &allowed, None, false, vec![])
+                .expect("known uri must read");
         match &result.contents[0] {
             ResourceContents::TextResourceContents { text, .. } => text.clone(),
             other => panic!("expected text contents, got {other:?}"),
@@ -2211,7 +2303,8 @@ mod tests {
                 &config,
                 &allowed,
                 None,
-                false
+                false,
+                vec![],
             )
             .is_err(),
             "an unregistered builtin must be a not-found error"
@@ -2223,8 +2316,16 @@ mod tests {
         let config = Config::builtin();
         let allowed: Vec<PathBuf> = Vec::new();
         assert!(
-            read_kaibo_resource_with_config("kaibo://nope", &[], &config, &allowed, None, false)
-                .is_err(),
+            read_kaibo_resource_with_config(
+                "kaibo://nope",
+                &[],
+                &config,
+                &allowed,
+                None,
+                false,
+                vec![]
+            )
+            .is_err(),
             "an unknown URI must be a not-found error, not an empty success"
         );
     }
@@ -2365,6 +2466,7 @@ mod tests {
             &allowed,
             None,
             false,
+            vec![],
         )
         .expect("example resource must be readable");
         let body = match &result.contents[0] {
@@ -2404,6 +2506,27 @@ mod tests {
         );
     }
 
+    /// The `[runtime]` section surfaces the live follow state: the knob, plus the
+    /// worktrees admitted *beyond* the static allowed set right now (passed in by
+    /// the handler, which computes them at read time). This keeps `kaibo://config`
+    /// honest about the real boundary — an auto-followed sibling isn't in
+    /// `allowed_paths` but is reachable, and a reader must be able to see that.
+    #[test]
+    fn config_resource_runtime_section_reports_followed_worktrees() {
+        let config = Config::builtin();
+        let allowed = vec![std::path::PathBuf::from("/tmp/the-repo")];
+        let followed = vec![std::path::PathBuf::from("/tmp/the-repo-feature")];
+        let body = render_config_resource(&config, &allowed, None, false, followed);
+        assert!(
+            body.contains("[runtime]") && body.contains("follow_worktrees = true"),
+            "runtime section must echo the follow knob:\n{body}"
+        );
+        assert!(
+            body.contains("/tmp/the-repo-feature"),
+            "runtime section must list the followed worktree:\n{body}"
+        );
+    }
+
     /// The config resource body must contain the key structural fields a calling
     /// model or operator expects: allowed paths, default_cast, gated tools,
     /// sandbox limits, backends with kind and key sources, and casts with their
@@ -2412,11 +2535,13 @@ mod tests {
     fn config_resource_renders_expected_fields() {
         let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp/test-allowed")];
-        let body = render_config_resource(&config, &allowed, None, false);
+        let body = render_config_resource(&config, &allowed, None, false, vec![]);
         // Structural presence checks — the resource is TOML or a document, not prose.
         for needle in [
             "allowed_paths",
             "default_cast",
+            "[runtime]",
+            "follow_worktrees",
             "tools",
             "sandbox",
             "defaults",
@@ -2493,7 +2618,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false);
+        let body = render_config_resource(&config, &[], None, false, vec![]);
         // The header NAME is discoverable…
         assert!(
             body.contains("authorization"),
@@ -2524,7 +2649,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false);
+        let body = render_config_resource(&config, &[], None, false, vec![]);
         for needle in ["[backend_aliases]", "[cast_aliases]"] {
             assert!(body.contains(needle), "must render {needle}:\n{body}");
         }
@@ -2571,7 +2696,7 @@ mod tests {
             unsafe {
                 std::env::set_var(var_name, SENTINEL);
             }
-            let b = render_config_resource(&config, &allowed, None, false);
+            let b = render_config_resource(&config, &allowed, None, false, vec![]);
             #[allow(deprecated)]
             unsafe {
                 std::env::remove_var(var_name);
@@ -2597,7 +2722,7 @@ mod tests {
         let file_path = tmp.path().to_string_lossy().to_string();
         let toml2 = format!("[backends.anthropic]\napi_key_file = \"{file_path}\"\n");
         let config2 = Config::from_toml_str(&toml2).expect("valid config");
-        let body2 = render_config_resource(&config2, &allowed, None, false);
+        let body2 = render_config_resource(&config2, &allowed, None, false, vec![]);
         // The file path (source pointer) may appear, but not the file contents.
         assert!(
             !body2.contains(SENTINEL),
@@ -2612,15 +2737,22 @@ mod tests {
     fn read_kaibo_config_resource_is_readable() {
         let config = Config::builtin();
         let allowed = handler().allowed_set();
-        let body_str = render_config_resource(&config, &allowed, None, false);
+        let body_str = render_config_resource(&config, &allowed, None, false, vec![]);
         // Sanity: the rendered document has something in it.
         assert!(
             !body_str.is_empty(),
             "config resource body must not be empty"
         );
         // The dispatch must not return not-found for this URI.
-        let result =
-            read_kaibo_resource_with_config(CONFIG_URI, &[], &config, &allowed, None, false);
+        let result = read_kaibo_resource_with_config(
+            CONFIG_URI,
+            &[],
+            &config,
+            &allowed,
+            None,
+            false,
+            vec![],
+        );
         assert!(
             result.is_ok(),
             "kaibo://config must be readable, got {result:?}"

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,0 +1,135 @@
+//! Follow git worktrees without running git.
+//!
+//! A `consult`/`run_kaish` `path` may point at a *linked* worktree that sits
+//! outside the configured allowed set even though it belongs to the same repo as
+//! an allowed tree (you check a branch out in a sibling dir, then ask kaibo about
+//! it). Rejecting that is toil; `--allow-path` per sibling is more toil; rooting at
+//! the parent (`~/src`) is strictly too broad. So when a path misses the static
+//! allowed set we admit it iff it is a worktree of an *already-allowed* repo.
+//!
+//! We do this WITHOUT the `git` binary — `subprocess`/`git` are compiled out of the
+//! sandbox (see `sandbox.rs`), and re-introducing them would breach the read-only
+//! invariant. We don't need them: git's worktree links are plain text files, exactly
+//! what kaibo's read-only product reads. The layout we walk:
+//!
+//! - A linked worktree's root holds a `.git` *file* (not dir):
+//!   `gitdir: <common>/worktrees/<name>`.
+//! - The repo's common git dir holds `worktrees/<name>/gitdir` (an absolute path
+//!   *back* to that worktree's `.git` file) and `worktrees/<name>/commondir`
+//!   (a relative path to the common dir).
+//! - The main worktree's `.git` *is* the common dir.
+//!
+//! **Trust flows outward from the allowed repo, never inward from the candidate.**
+//! We resolve the *allowed* tree's common dir (trusted: the operator allowed it),
+//! enumerate the worktrees that common dir itself vouches for, and admit a candidate
+//! only if it falls inside one. We never read the candidate's own `.git` to decide —
+//! that file is attacker-controllable, so a one-way "candidate points into us" pull
+//! would be spoofable (a hostile dir forging `gitdir:` to smuggle itself in). Letting
+//! only the trusted side vouch is exactly what git itself does, and it makes the
+//! spoof structurally impossible here: the candidate gets no say.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve the canonicalized git *common* dir for `start` by reading git's link
+/// files only. Walks up to the nearest ancestor holding a `.git` entry, then:
+/// a `.git` directory is itself the common dir (main worktree); a `.git` *file*
+/// points at `<common>/worktrees/<name>`, whose `commondir` resolves to the common
+/// dir (linked worktree). `None` when `start` isn't inside a resolvable working tree.
+pub fn common_git_dir(start: &Path) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        let dotgit = dir.join(".git");
+        if dotgit.is_dir() {
+            // Main worktree (or a plain repo): `.git` is the common dir.
+            return std::fs::canonicalize(&dotgit).ok();
+        }
+        if dotgit.is_file() {
+            // Linked worktree: `.git` file → the per-worktree git dir → its commondir.
+            let gitdir = read_gitdir_pointer(&dotgit)?;
+            return resolve_commondir(&gitdir);
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// The canonicalized working-tree roots a common git dir vouches for: the main
+/// worktree (the parent of a `.git` common dir) plus every linked worktree
+/// registered under `<common>/worktrees/<name>/gitdir`. These are the *only* paths
+/// the worktree-follow feature will admit beyond the static allowed set.
+pub fn vouched_worktrees(common_dir: &Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+
+    // The main worktree is the parent of a `.git`-named common dir. A bare repo's
+    // common dir isn't named `.git` and has no working tree — skip it then.
+    if common_dir.file_name().and_then(|n| n.to_str()) == Some(".git") {
+        if let Some(main) = common_dir.parent() {
+            if let Ok(canon) = std::fs::canonicalize(main) {
+                out.push(canon);
+            }
+        }
+    }
+
+    // Linked worktrees: each `worktrees/<name>/gitdir` holds the absolute path back
+    // to that worktree's `.git` file; its parent is the worktree root. This is the
+    // vouch — the trusted common dir naming where each of its worktrees lives.
+    if let Ok(entries) = std::fs::read_dir(common_dir.join("worktrees")) {
+        for entry in entries.flatten() {
+            let pointer = entry.path().join("gitdir");
+            let Some(wt_dotgit) = read_gitdir_pointer(&pointer) else {
+                continue;
+            };
+            let Some(wt_root) = wt_dotgit.parent() else {
+                continue;
+            };
+            if let Ok(canon) = std::fs::canonicalize(wt_root) {
+                out.push(canon);
+            }
+        }
+    }
+
+    out
+}
+
+/// Read a git pointer file and return the absolute path it names, canonicalization
+/// deferred to the caller (the target may be a `.git` file whose parent we want).
+/// Handles both forms git writes: a worktree-root `.git` file (`gitdir: <path>`) and
+/// a `worktrees/<name>/gitdir` file (a bare `<path>`). Relative targets resolve
+/// against the pointer file's directory, as git does.
+fn read_gitdir_pointer(pointer: &Path) -> Option<PathBuf> {
+    let text = std::fs::read_to_string(pointer).ok()?;
+    let raw = text.trim();
+    let raw = raw.strip_prefix("gitdir:").map(str::trim).unwrap_or(raw);
+    if raw.is_empty() {
+        return None;
+    }
+    let target = Path::new(raw);
+    if target.is_absolute() {
+        Some(target.to_path_buf())
+    } else {
+        // Relative to the directory holding the pointer file.
+        pointer.parent().map(|d| d.join(target))
+    }
+}
+
+/// Given a per-worktree git dir (`<common>/worktrees/<name>`), resolve the common
+/// dir via its `commondir` file (a path relative to the git dir). When there's no
+/// `commondir`, the git dir is itself the common dir. Canonicalized.
+fn resolve_commondir(gitdir: &Path) -> Option<PathBuf> {
+    let commondir_file = gitdir.join("commondir");
+    match std::fs::read_to_string(&commondir_file) {
+        Ok(text) => {
+            let rel = text.trim();
+            if rel.is_empty() {
+                return std::fs::canonicalize(gitdir).ok();
+            }
+            let target = Path::new(rel);
+            let joined = if target.is_absolute() {
+                target.to_path_buf()
+            } else {
+                gitdir.join(target)
+            };
+            std::fs::canonicalize(joined).ok()
+        }
+        Err(_) => std::fs::canonicalize(gitdir).ok(),
+    }
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -870,6 +870,7 @@ fn cli_cast_wins_over_env_and_file() {
             ..Default::default()
         },
         vec![], // no --allow-path flags
+        false,  // --no-follow-worktrees not passed
         vec![], // no --project-context-file flags
         vec![], // no --user-context-file flags
     );
@@ -891,7 +892,15 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
     // Pre-seed allow_paths as if they came from env or a config file.
     c.allow_paths = vec![std::path::PathBuf::from("/tmp/from-env")];
     // Apply CLI with no --allow-path flags (empty list).
-    c.apply_cli(None, None, ToolDisables::default(), vec![], vec![], vec![]);
+    c.apply_cli(
+        None,
+        None,
+        ToolDisables::default(),
+        vec![],
+        false,
+        vec![],
+        vec![],
+    );
     // The env/file-layer value must survive.
     assert!(
         c.allow_paths

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -507,8 +507,246 @@ fn allow_paths_cli_replaces_env_and_file() {
     c.apply_cli(None, None, kaibo::config::ToolDisables::default(), vec![
         std::path::PathBuf::from("/tmp/cli-a"),
         std::path::PathBuf::from("/tmp/cli-b"),
-    ], vec![], vec![]);
+    ], false, vec![], vec![]);
     assert_eq!(c.allow_paths.len(), 2);
     assert!(c.allow_paths.iter().any(|p| p == std::path::Path::new("/tmp/cli-a")));
     assert!(c.allow_paths.iter().any(|p| p == std::path::Path::new("/tmp/cli-b")));
+}
+
+// --- worktree follow ----------------------------------------------------------
+//
+// A path in a linked git worktree of an *already-allowed* repo is admitted even
+// though it sits outside the static allowed set — resolved by reading git's link
+// files, never by running git inside kaibo. We build authentic layouts with the
+// real `git` binary (the test harness isn't sandboxed) so we read git's actual
+// on-disk format, not our assumption of it.
+
+use std::process::Command;
+
+/// Whether a usable `git` is on PATH. The worktree-follow tests build authentic
+/// layouts with the real binary; on the rare host without git we skip them rather
+/// than panic with a confusing "git runs in the test harness" — a missing git is an
+/// environment gap, not a kaibo bug. `Command::new` returns an `Err` (not a panic)
+/// when the program isn't found, so this is safe to probe.
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Skip the calling test (with a visible note) when git is unavailable. Used at the
+/// top of every worktree-follow test so the suite stays green on a git-less host.
+macro_rules! require_git {
+    ($name:literal) => {
+        if !git_available() {
+            eprintln!("skipping {}: git not on PATH", $name);
+            return;
+        }
+    };
+}
+
+/// Run a git subcommand in `cwd`, asserting success. Pins identity and disables the
+/// operator's global/system config so the layout is hermetic across machines.
+fn git(cwd: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .output()
+        .expect("git runs in the test harness");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A repo with one commit (so `worktree add` has a HEAD to base on) at `base/repo`,
+/// returning that path. The repo is created *inside* `base` so a linked worktree
+/// added as a sibling lands outside the repo root — the boundary we're testing.
+fn init_repo_with_commit(base: &Path) -> std::path::PathBuf {
+    let repo = base.join("repo");
+    fs::create_dir(&repo).unwrap();
+    git(&repo, &["init", "-q"]);
+    fs::write(repo.join("README.md"), "main worktree\n").unwrap();
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-q", "-m", "seed"]);
+    repo
+}
+
+/// A linked worktree of an allowed repo is reachable: the path resolves and a read
+/// of a file unique to that worktree succeeds. This is the headline behavior — a
+/// sibling branch checkout is usable without an --allow-path.
+#[tokio::test]
+async fn linked_worktree_of_allowed_repo_is_admitted() {
+    require_git!("linked_worktree_of_allowed_repo_is_admitted");
+    let base = tempdir().unwrap();
+    let repo = init_repo_with_commit(base.path());
+    let wt = base.path().join("feature-wt");
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature",
+            wt.to_str().unwrap(),
+        ],
+    );
+    fs::write(wt.join("only-here.txt"), "in the worktree\n").unwrap();
+
+    // Allowed set is just the main repo; the worktree is a sibling outside it.
+    let handler = handler_with_allowed(Some(&repo), &[]);
+
+    let out = try_run(&handler, &wt.to_string_lossy(), "cat only-here.txt")
+        .await
+        .expect("a worktree of an allowed repo must be admitted");
+    assert!(
+        out.contains("in the worktree"),
+        "should read the worktree's own file, got: {out}"
+    );
+}
+
+/// Following a worktree must not relax the boundary for unrelated paths: a non-git
+/// directory outside the allowed set is still rejected. Pins that follow admits
+/// *only* genuine worktrees, not "anything outside".
+#[tokio::test]
+async fn follow_does_not_admit_unrelated_outside_path() {
+    require_git!("follow_does_not_admit_unrelated_outside_path");
+    let base = tempdir().unwrap();
+    let repo = init_repo_with_commit(base.path());
+    let stranger = base.path().join("not-a-worktree");
+    fs::create_dir(&stranger).unwrap();
+    fs::write(stranger.join("secret.txt"), "sensitive\n").unwrap();
+
+    let handler = handler_with_allowed(Some(&repo), &[]);
+
+    let err = try_run(&handler, &stranger.to_string_lossy(), "cat secret.txt")
+        .await
+        .expect_err("an unrelated outside path must still be rejected");
+    assert!(
+        err.to_lowercase().contains("allowed"),
+        "rejection must name the boundary, got: {err}"
+    );
+}
+
+/// A forged `.git` file on the candidate side cannot smuggle a foreign dir in. The
+/// stranger's `.git` points at a *real* registered worktree's git dir, so a naive
+/// "candidate points into us" check would admit it — but trust flows only outward
+/// from the allowed repo (which never vouches for this path), so it's rejected.
+#[tokio::test]
+async fn spoofed_dotgit_pointing_into_allowed_repo_is_rejected() {
+    require_git!("spoofed_dotgit_pointing_into_allowed_repo_is_rejected");
+    let base = tempdir().unwrap();
+    let repo = init_repo_with_commit(base.path());
+    let real_wt = base.path().join("real-wt");
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "real",
+            real_wt.to_str().unwrap(),
+        ],
+    );
+
+    // Foreign dir with a hand-crafted `.git` file aimed at the real worktree's git
+    // dir inside the allowed repo. The back-link (repo/.git/worktrees/real/gitdir)
+    // points to real_wt, not here — so the trusted side never names this path.
+    let spoof = base.path().join("spoof");
+    fs::create_dir(&spoof).unwrap();
+    fs::write(spoof.join("loot.txt"), "should stay unreachable\n").unwrap();
+    let canon_repo = fs::canonicalize(&repo).unwrap();
+    fs::write(
+        spoof.join(".git"),
+        format!("gitdir: {}/.git/worktrees/real\n", canon_repo.display()),
+    )
+    .unwrap();
+
+    let handler = handler_with_allowed(Some(&repo), &[]);
+
+    let err = try_run(&handler, &spoof.to_string_lossy(), "cat loot.txt")
+        .await
+        .expect_err("a forged .git must not admit a foreign path");
+    assert!(
+        err.to_lowercase().contains("allowed"),
+        "rejection must name the boundary, got: {err}"
+    );
+}
+
+/// `follow_worktrees = false` keeps the boundary strictly static: a genuine linked
+/// worktree of an allowed repo is rejected like any other outside path.
+#[tokio::test]
+async fn follow_disabled_rejects_a_real_worktree() {
+    require_git!("follow_disabled_rejects_a_real_worktree");
+    let base = tempdir().unwrap();
+    let repo = init_repo_with_commit(base.path());
+    let wt = base.path().join("feature-wt");
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature",
+            wt.to_str().unwrap(),
+        ],
+    );
+
+    let mut config = Config::builtin();
+    config.root = Some(repo.clone());
+    config.follow_worktrees = false;
+    let handler = KaiboHandler::new(config).expect("handler builds");
+
+    let err = try_run(&handler, &wt.to_string_lossy(), "cat README.md")
+        .await
+        .expect_err("with follow off, a worktree is just an outside path");
+    assert!(
+        err.to_lowercase().contains("allowed"),
+        "rejection must name the boundary, got: {err}"
+    );
+}
+
+/// Symmetry: when kaibo is rooted *at* a linked worktree, the repo's other
+/// worktrees (here, the main worktree) are reachable too — the common git dir is
+/// resolved via the worktree's `commondir`, not assumed to be the root's `.git`.
+#[tokio::test]
+async fn sibling_reachable_when_rooted_at_linked_worktree() {
+    require_git!("sibling_reachable_when_rooted_at_linked_worktree");
+    let base = tempdir().unwrap();
+    let repo = init_repo_with_commit(base.path());
+    let wt = base.path().join("feature-wt");
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature",
+            wt.to_str().unwrap(),
+        ],
+    );
+
+    // Root at the linked worktree; the main worktree (`repo`) is the sibling.
+    let handler = handler_with_allowed(Some(&wt), &[]);
+
+    let out = try_run(&handler, &repo.to_string_lossy(), "cat README.md")
+        .await
+        .expect("the main worktree must be reachable from a linked-worktree root");
+    assert!(
+        out.contains("main worktree"),
+        "should read the main worktree's file, got: {out}"
+    );
 }


### PR DESCRIPTION
## What

A `consult`/`run_kaish` `path` in a **linked git worktree of an already-allowed repo** is now reachable without an `--allow-path`. Previously it was rejected as "outside the allowed set" even though it's the same repo, forcing the branch back into the rooted worktree or a per-sibling `--allow-path`. So a feature branch you check out in a sibling directory — even one you spin up mid-session — just works.

## How (and why this way)

`git` is compiled out of the sandbox, so `git rev-parse` (the obvious resolver) is off the table — re-introducing it would breach the read-only invariant. We don't need it: git's worktree links are plain text files, exactly what kaibo's read-only layer reads. The new `src/worktree.rs` reads a worktree's `.git` file, the repo's `.git/worktrees/<name>/{gitdir,commondir}`, etc.

**Trust flows outward from the allowed repo.** On a containment miss (`resolve_root`), kaibo resolves the *allowed* repo's common git dir and admits a candidate only if it falls inside a worktree that common dir itself vouches for. It **never reads the candidate's own `.git`** to decide — so a foreign directory with a forged `gitdir:` pointer is structurally unable to smuggle itself in (immune by construction, not by a check). Chosen over the bidirectional "read candidate `.git` then verify back-link" approach the issue first sketched. Done per-call (not a startup enumeration) so mid-session worktrees are followed without a reconnect; the hit path is untouched.

## Surface

- Gated by `follow_worktrees` (default **on**); off via `--no-follow-worktrees` / `KAIBO_NO_FOLLOW_WORKTREES` / `[server] follow_worktrees = false`. Off restores the exact prior strict behavior.
- `kaibo://config` grows a `[runtime]` section for read-time-computed state (the follow knob + worktrees admitted beyond the static set right now), kept distinct from the configured knobs.
- Docs: `CHANGELOG.md`, `docs/config.md`, `docs/config.example.toml`.

## Tests

`tests/containment.rs` builds authentic layouts with the real `git` binary (and skips cleanly when git is absent): admit-a-worktree, reject the unrelated outside path, **reject a spoofed candidate `.git`**, follow-disabled rejects, and the rooted-at-linked-worktree symmetry case. Plus a `[runtime]`-render unit test.

## Review

- Cross-family reviewed with kaibo's own `consult` (cast `deepseek`): no blocking correctness or security issues; verified the trust-flows-outward property holds in every code path, git-layout correctness, and that containment isn't weakened.
- Verified live through the running MCP server: sibling worktree admitted + read, plain sibling still rejected, `[runtime].followed_worktrees` listed it, and a worktree created after startup appeared with no reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)