### PR TITLE
Bump kaish-kernel to 0.9.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,9 @@ requests — `main` is protected by convention, not a scratchpad.
   `v*` tag. Before tagging: confirm the `kaish-kernel` pin is current (next bullet),
   re-run `docs/sandbox-probes.md` and stamp its "Last run" line, and verify
   `cargo tree -i aws-lc-rs` is empty and the musl binary is `not a dynamic executable`.
-- **kaish pin.** Currently `kaish-kernel = "0.8.4"` — the release that fixed the bug
-  which surfaced just after `0.8.3`. The bump was clean (no API change); offline suite
-  green. Keep this current per the **Working here** kaish-bump discipline before cutting.
+- **kaish pin.** Currently `kaish-kernel = "0.9.0"`. The bump from `0.8.4` carried one
+  API break: the `mcp()` config constructors (`IgnoreConfig`/`OutputLimitConfig`/
+  `KernelConfig`) were renamed to `agent()` — same presets, just the embedder-facing
+  name. Adapted the three call sites in `sandbox.rs`; offline suite green, boundary
+  tests still have teeth. Keep this current per the **Working here** kaish-bump
+  discipline before cutting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7789b337d2dca16dbd62f5c6b52b5c59d35037200156cf78d0a3ee29d81fcc"
+checksum = "868f33bffc2574e15b1f0e95f35242781e4cb7bd9834307929a324440d4946f9"
 dependencies = [
  "async-trait",
  "ignore",
@@ -1288,18 +1288,18 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3e7a2f81430be4ab7046f7b24654fa38e9fc19ad33d6de7552b90936e8fcb1"
+checksum = "86409a898ec7075582df301a92b779eafe187606ec84923750f07cb207fc04e2"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478d843786658d8d8e6c51956b04eb5530a40434de613f863b222ef092f269e2"
+checksum = "398391c4b14ae5ad38903786946aea3f60de9dcc766318addc262bcde06420b5"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc465058212ca30a396eb07b4eb7d82720ccaa1a82dc92c029766bf7dda8c8af"
+checksum = "0ccb53fcb5f0ebb6bfef939199d86689bfe5fd920e38b1e121925b540cb2a39f"
 dependencies = [
  "async-trait",
  "clap",
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8a3f6c4f583ceaa89c8b0486db6d7982f388f34da12c5715b73fd141e8c870"
+checksum = "ab674433bd72c43972089d3454e8b291e3ba67bedb3cf03d52fddf3c63fa9eee"
 dependencies = [
  "base64",
  "serde",
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16e1f4189ba8719f8ac37dc21a21c502ce3e9c1c48aaee0a17b47e42b46939b"
+checksum = "c9c8f771613845ac69b9401d1c510d833bc37c95100c089a5e4839dd83208926"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # `os-integration` (trash) OFF — so those builtins are never compiled in. kaibo's
 # read-only safety is thus structural (the dangerous surface doesn't exist),
 # backed by the runtime read-only mount; see src/sandbox.rs.
-kaish-kernel = { version = "0.8.4", default-features = false, features = ["localfs"] }
+kaish-kernel = { version = "0.9.0", default-features = false, features = ["localfs"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
 async-trait = "0.1"
 anyhow = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1224,7 +1224,7 @@ struct RawKaish {
 
 /// The `[kaish.ignore]` sub-table — which gitignore-format files the file-walking
 /// builtins honor, and how broadly. Every key is optional and defaults to
-/// [`IgnoreConfig::mcp`]'s value, so an absent stanza (or a partial one) preserves
+/// [`IgnoreConfig::agent`]'s value, so an absent stanza (or a partial one) preserves
 /// today's `.gitignore`-aware, enforced-scope behavior. `files` *replaces* the
 /// default `[".gitignore"]` when given — list it explicitly alongside extras to keep
 /// it (though `auto_gitignore`, on by default, still walks nested `.gitignore`s
@@ -1625,7 +1625,7 @@ fn merge_sandbox(raw: RawSandbox) -> SandboxConfig {
 }
 
 /// Resolve `[kaish.ignore]` into the kernel's [`IgnoreConfig`]. Each key falls back
-/// to the [`IgnoreConfig::mcp`] default, so an absent stanza reproduces it exactly
+/// to the [`IgnoreConfig::agent`] default, so an absent stanza reproduces it exactly
 /// (`.gitignore` + built-in defaults, enforced scope) and a partial stanza overrides
 /// only the keys it names. An unrecognized `scope` is a load error, not a silent
 /// fallback to the default.
@@ -2454,11 +2454,11 @@ mod tests {
 
     // --- ignore policy ([kaish.ignore]) -----------------------------------------
 
-    /// An absent `[kaish]` stanza reproduces the kernel's MCP ignore default exactly:
+    /// An absent `[kaish]` stanza reproduces the kernel's agent ignore default exactly:
     /// `.gitignore` loaded, built-in defaults on, auto-gitignore on, enforced scope.
     /// So omitting it keeps today's behavior.
     #[test]
-    fn ignore_default_matches_mcp() {
+    fn ignore_default_matches_agent() {
         let cfg = Config::builtin();
         let ig = &cfg.sandbox.ignore;
         assert_eq!(ig.files(), &[".gitignore"]);
@@ -2481,7 +2481,7 @@ mod tests {
         );
     }
 
-    /// A partial stanza overrides only the keys it names; the rest keep the MCP
+    /// A partial stanza overrides only the keys it names; the rest keep the agent
     /// default. Here `scope = "advisory"` flips scope while `files`/`defaults` stay.
     #[test]
     fn ignore_partial_stanza_overrides_only_named_keys() {
@@ -2492,7 +2492,7 @@ mod tests {
         let ig = &cfg.sandbox.ignore;
         assert_eq!(ig.scope(), IgnoreScope::Advisory);
         assert!(ig.use_global_gitignore());
-        // Untouched keys keep their mcp defaults.
+        // Untouched keys keep their agent defaults.
         assert_eq!(ig.files(), &[".gitignore"]);
         assert!(ig.use_defaults());
         assert!(ig.auto_gitignore());

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -104,7 +104,7 @@ fn apply_disabled_builtins(registry: &mut ToolRegistry, disable: &[String]) {
 /// matches a patient MCP caller while still bounding a runaway.
 pub const KAISH_EXEC_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Default per-script output cap (matches `OutputLimitConfig::mcp()`'s 8 KB): a
+/// Default per-script output cap (matches `OutputLimitConfig::agent()`'s 8 KB): a
 /// single wide `cat`/`rg` can't flood the caller's context. Override via
 /// `[sandbox].output_limit_bytes`.
 pub const DEFAULT_OUTPUT_LIMIT_BYTES: usize = 8 * 1024;
@@ -143,7 +143,7 @@ pub struct SandboxConfig {
     /// Builtins to shadow-block on top of the structural read-only guards.
     pub disable_builtins: Vec<String>,
     /// Ignore-file policy for the file-walking builtins, sourced from
-    /// `[kaish.ignore]`. Defaults to [`IgnoreConfig::mcp`] (`.gitignore` + built-in
+    /// `[kaish.ignore]`. Defaults to [`IgnoreConfig::agent`] (`.gitignore` + built-in
     /// defaults, enforced scope) so omitting the stanza preserves today's behavior.
     pub ignore: IgnoreConfig,
 }
@@ -155,7 +155,7 @@ impl Default for SandboxConfig {
             output_limit_bytes: DEFAULT_OUTPUT_LIMIT_BYTES,
             scratch_limit_bytes: DEFAULT_SCRATCH_LIMIT_BYTES,
             disable_builtins: Vec::new(),
-            ignore: IgnoreConfig::mcp(),
+            ignore: IgnoreConfig::agent(),
         }
     }
 }
@@ -232,16 +232,16 @@ fn build_readonly_kernel_and_vfs(
     let project_vfs = Arc::new(vfs);
     let backend: Arc<dyn KernelBackend> = Arc::new(LocalBackend::new(project_vfs.clone()));
 
-    // Start from the MCP output limit (head+tail truncation) and set the configured
+    // Start from the agent output limit (head+tail truncation) and set the configured
     // cap so a runaway `cat` can't flood the caller's context; the timeout bounds
     // wall clock. Both guards matter for a caller-facing `run_kaish` with no turn cap.
-    let mut output_limit = OutputLimitConfig::mcp();
+    let mut output_limit = OutputLimitConfig::agent();
     output_limit.set_limit(Some(sandbox.output_limit_bytes));
-    // `mcp()` already seeds an `.gitignore`-aware filter; override with the resolved
+    // `agent()` already seeds an `.gitignore`-aware filter; override with the resolved
     // `[kaish.ignore]` policy so configured extra ignore files (`.claudeignore`, …)
     // and scope/default toggles reach every file-walking builtin — and the
     // orientation repo-map, which enumerates through this same kernel.
-    let config = KernelConfig::mcp()
+    let config = KernelConfig::agent()
         .with_cwd(root)
         .with_allow_external_commands(false)
         .with_request_timeout(sandbox.exec_timeout)

--- a/tests/guards.rs
+++ b/tests/guards.rs
@@ -55,7 +55,7 @@ async fn a_slow_script_is_killed_at_the_budget() {
 #[tokio::test(flavor = "current_thread")]
 async fn oversized_output_is_capped_or_marked() {
     let dir = tempdir().unwrap();
-    // 64 KB of content — well past the 8 KB cap KernelConfig::mcp() installs.
+    // 64 KB of content — well past the 8 KB cap KernelConfig::agent() installs.
     let big = "x".repeat(64 * 1024);
     fs::write(dir.path().join("big.txt"), &big).unwrap();
 

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -354,7 +354,7 @@ async fn configured_ignore_file_hides_its_matches() {
 
     // Configure `.claudeignore` on top of the defaults: secret.txt vanishes, keep.txt
     // stays.
-    let mut ignore = IgnoreConfig::mcp();
+    let mut ignore = IgnoreConfig::agent();
     ignore.add_file(".claudeignore");
     let sandbox = SandboxConfig {
         ignore,


### PR DESCRIPTION
Bumps the embedded `kaish-kernel` dependency from `0.8.4` to `0.9.0`.

## The breaking change
0.9.0 renamed the embedder-facing config presets: the `mcp()` constructors on `IgnoreConfig`, `OutputLimitConfig`, and `KernelConfig` are now `agent()`. The presets are unchanged (sandboxed VFS, non-interactive, `.gitignore`-aware filter, 8 KB head+tail output cap) — the new name just describes the "embed kaish as an untrusted agent's shell" role kaibo fills.

Per the kaish-bump discipline in `AGENTS.md`, we adapt to the new shape rather than pin around it:
- three call sites in `src/sandbox.rs`
- two test references (`tests/guards.rs`, `tests/sandbox.rs`)
- doc-comments naming the old constructor
- the kaish-pin note in `AGENTS.md`

## Why it's safe
Pure rename, no behavior change. The offline suite is green and the read-only boundary tests still have teeth — writes denied, output capped, ignore-file hiding all pass. `cargo tree -i aws-lc-rs` stays empty, so the static-musl TLS invariant holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)