### PR TITLE
Teach grep, not the removed rg; bias read idioms toward whole files

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -126,11 +126,11 @@ scratch_limit_bytes = 67108864
 # This only makes the box STRICTER — it can't re-enable the read-only denylist
 # (git/touch/spawn/exec/kill/mktemp), and the dangerous axes aren't compiled in.
 # A name that isn't a real builtin is a loud startup error, not a silent no-op.
-# disable_builtins = ["rg", "find"]
+# disable_builtins = ["grep", "find"]
 
 # ---------------------------------------------------------------------------
 # [kaish.ignore] — which gitignore-format files the file-walking builtins
-# (glob/rg/ls/find — and the orientation repo-map, which rides the same kernel)
+# (glob/grep/ls/find — and the orientation repo-map, which rides the same kernel)
 # honor. This is DISCOVERY/NOISE policy, NOT a safety boundary: it changes what the
 # explorer SEES, never what it's allowed to read. Omit the whole stanza to keep the
 # default below (`.gitignore` + built-in defaults, enforced scope) — that's exactly
@@ -141,7 +141,7 @@ scratch_limit_bytes = 67108864
 # [kaish.ignore]
 # `files` REPLACES the default [".gitignore"] — to add (say) .claudeignore while
 # keeping .gitignore, list both. Loaded at the root and walked up through ancestors,
-# in precedence order (later wins, rg-style). auto_gitignore (below) still walks
+# in precedence order (later wins, ripgrep-style). auto_gitignore (below) still walks
 # root + nested .gitignore files regardless of this list — so dropping ".gitignore"
 # here does NOT disable .gitignore (only stops honoring ANCESTOR .gitignores above
 # the root). To honor .gitignore nowhere, set auto_gitignore = false AND omit it here.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -117,7 +117,7 @@ session_capacity = 128       # max multi-turn consult sessions held in memory (L
 # ---------------------------------------------------------------------------
 [sandbox]
 exec_timeout_secs  = 30      # per-kaish-script wall clock; exit 124 on overrun
-output_limit_bytes = 8192    # per-script output cap; exit 3 + head/tail sample
+output_limit_bytes = 65536   # per-script output cap (64 KiB); exit 3 + head/tail sample
 # Cap on the `/` scratch MemoryFs (redirects, mktemp). A write past it fails loudly
 # (StorageFull), never silently eating host RAM. Default 64 MiB; must be > 0 — there
 # is no "unbounded" setting, an unbounded scratch is the bug this prevents.

--- a/docs/config.md
+++ b/docs/config.md
@@ -461,7 +461,7 @@ Prefer architectural answers; name the file:line that carries each claim.
 
 **Full replace, by decision.** An override *is* the role framing, verbatim — kaibo
 does not re-wrap it. That's safe because the kaish operating contract (how to drive
-the read-only shell, the exit-code meanings, the `cat -n`/`rg -n` idioms) rides the
+the read-only shell, the exit-code meanings, the `cat -n`/`grep -rn` idioms) rides the
 `run_kaish` *tool description* independently, so the model keeps the shell contract
 even when you rewrite the prose. What an override *does* drop is the tuned role
 framing kaibo ships — the explorer's "report, don't conclude", the synth's "trust a
@@ -511,7 +511,7 @@ drag the configured slot's framing along. Same loud-on-empty rule as `[prompts]`
 
 A static, computed-once **file map** injected into the exploring preamble, so a
 model starts *knowing* the project's files instead of spending its first turns on
-`glob`/`ls`/`rg --files` to discover the layout (the structure-first lesson from
+`glob`/`ls`/`find` to discover the layout (the structure-first lesson from
 Agentless/Aider, made free — no model in the loop).
 
 ```toml
@@ -523,7 +523,7 @@ full_list_max_files = 256    # ≤ this → inject the full list; above → refu
 How it works: the server runs the kernel's **own** `glob -a --json '**/*'` server-side
 per `explore`/`consult` call — the *same* ignore-aware enumeration the model's shell
 would get (same VFS, same ignore rules), so the map can't disagree with what the
-explorer's own `glob`/`rg` sees. `-a` includes hidden config (`.github/`, `.cargo/`);
+explorer's own `glob`/`grep` sees. `-a` includes hidden config (`.github/`, `.cargo/`);
 the ignore filter still drops `.git`/`target`.
 
 Size-gated, by file count:
@@ -531,7 +531,7 @@ Size-gated, by file count:
 - **above it** → the call is **refused loudly** (`internal_error` naming the knob).
   The directory-tree map for larger repos is the next increment; for now a big repo
   is an explicit error, not a silent dump — raise the limit, set `enabled = false`,
-  or point a cast that explores via `rg` at it. (`full_list_max_files = 0` is a load
+  or point a cast that explores via `grep` at it. (`full_list_max_files = 0` is a load
   error: it would refuse every repo; disable instead.)
 
 It rides the **exploring** phases only — the `consult` driver and its nested

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -83,7 +83,7 @@ docs are files already in the tree); no MCP-native/inline input. Bytes are read
 through the project VFS via a new `KaishWorker::read_file` (a `Job::Read` on the
 worker thread → the *project* `VfsRouter`, retained from `build_readonly_kernel_and_vfs`
 because under `with_backend` the kernel's own `vfs()` carries only `/v/*` scratch),
-so containment + read-only stay structural and the 8 KB script-output cap is bypassed
+so containment + read-only stay structural and the script-output cap is bypassed
 for the deliberate read. Toolset assembly gates `view_image` on `arm.caps.vision` in
 all three phases (`phase_tools` for explore/synthesize, `consult_tools` for the synth
 driver; the explore′ sweep inherits its own gate); a blind model never sees the tool,
@@ -364,6 +364,16 @@ read-only kernel builds) so the synth starts clean at the root (`consult.rs`). F
 for now, but a busy server rebuilds kernels constantly. Consider a small worker
 pool, or resetting one kernel's cwd between phases instead of rebuilding. Measure
 before optimizing.
+
+### Flaky tracing-capture tests in `tool_span.rs`
+`emits_an_error_outcome_when_the_tool_fails` (and its `ok` sibling) fail ~25% of
+the time in the *parallel* full `cargo test` run, never in isolation. Both register
+a `tracing_subscriber::registry().with(cap)` via `set_default` and assert on captured
+spans; run concurrently on cargo's test threads they race on tracing's process-global
+span store, so one test's `tool` span can go missing from the other's capture. A test
+that fails when we *didn't* make a mistake is the opposite of the teeth we want. Fix:
+serialize the two (a shared `Mutex`/`serial_test`), or capture per-span without leaning
+on global dispatch. Out of scope when found (the read-idioms/output-cap PR).
 
 ### `oneshot` batch — batchable fan-out of the tool-less answer (deferred)
 The tool-less, non-interactive answer shipped as the `oneshot` tool (prompt in,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -460,8 +460,8 @@ a note in the render is enough to make the no-op visible to the operator.
 ### Explorer prose — residual probes (the report shape + reading strategy shipped)
 The structured report sections (`SummaryOfFindings`/`RelevantLocations`/
 `ExplorationTrace`), the curiosity + completeness behaviors, and the assertive
-whole-file / `rg -B/-A` reading strategy now live in `report_preamble` (and the
-`rg`/`wc -l` idioms in the shared cheatsheet). Measured against a real review task,
+whole-file / `grep -B/-A` reading strategy now live in `report_preamble` (and the
+`grep`/`wc -l` idioms in the shared cheatsheet). Measured against a real review task,
 a lite Gemini explorer dropped from 48 turns to ~21 with *better* citations — the
 built-in reproduces it with no per-cast config. Still open, lower value:
 - **A worked, filled-in example in the prompt.** We ship the section *template*, not a

--- a/src/config.rs
+++ b/src/config.rs
@@ -1252,7 +1252,7 @@ struct RawKaish {
 #[serde(deny_unknown_fields)]
 struct RawIgnore {
     /// Ignore filenames loaded at the root and walked up through ancestors, in
-    /// precedence order (later wins, rg-style). Default: `[".gitignore"]`.
+    /// precedence order (later wins, ripgrep-style). Default: `[".gitignore"]`.
     files: Option<Vec<String>>,
     /// Apply built-in defaults (`target/`, `node_modules/`, `.git`). Default: true.
     defaults: Option<bool>,

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -135,9 +135,9 @@ pub fn report_preamble() -> String {
          context, and exact line numbers together, and it surfaces what a surgical \
          slice would miss. To locate something across files, take the surrounding \
          context in the same call — `grep -rn -B4 -A8 PATTERN .` returns each match \
-         with the lines around it, ready to understand. Save narrow spans for a \
-         genuinely large file — over a thousand lines, which `wc -l FILE` confirms: \
-         `cat -n FILE | sed -n 'A,Bp'`.\n\n\
+         with the lines around it, ready to understand. If a whole-file read comes \
+         back truncated (exit 3, a head+tail sample), the file was too big for one \
+         look — narrow to the part you need with `cat -n FILE | sed -n 'A,Bp'`.\n\n\
          HOW TO INVESTIGATE. Aim for the complete set of relevant locations. Follow \
          each key symbol to where it is defined and where it is used; chase anything \
          that puzzles you until it is clear — a confusing spot usually hides the \

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -128,13 +128,15 @@ pub fn report_preamble() -> String {
          a question touches and hand it to a synthesizer who writes the final \
          answer — so your work is to gather grounded evidence and cite it exactly. \
          {core}\n\n\
-         HOW TO READ. Read for the whole picture in as few looks as possible. Locate \
-         with ripgrep and take the surrounding context in the same call — \
-         `rg -n -B4 -A8 PATTERN` returns each match with the lines around it, ready \
-         to understand. When a file is central, read it WHOLE with `cat -n FILE`: \
-         most files are short, and one full read hands you its imports, its context, \
-         and exact line numbers together. Save narrow spans for a genuinely large \
-         file — over a thousand lines, which `wc -l FILE` confirms: \
+         HOW TO READ. Read for the whole picture in as few looks as possible — the \
+         context window is yours to fill, so favor one wide look over many narrow \
+         ones. When a file is central, read it WHOLE with `cat -n FILE`: reach for \
+         this first; most files are short, one full read hands you its imports, its \
+         context, and exact line numbers together, and it surfaces what a surgical \
+         slice would miss. To locate something across files, take the surrounding \
+         context in the same call — `grep -rn -B4 -A8 PATTERN .` returns each match \
+         with the lines around it, ready to understand. Save narrow spans for a \
+         genuinely large file — over a thousand lines, which `wc -l FILE` confirms: \
          `cat -n FILE | sed -n 'A,Bp'`.\n\n\
          HOW TO INVESTIGATE. Aim for the complete set of relevant locations. Follow \
          each key symbol to where it is defined and where it is used; chase anything \
@@ -1332,7 +1334,7 @@ impl Tool for RunExplore {
             description: "Delegate a broad sweep to a fast investigator that rips \
                 through the repo on a read-only kaish shell and reports back with \
                 concrete `file:line` citations. Give it a focused question; use it \
-                to cover breadth, and read precise spans yourself with `run_kaish`."
+                to cover breadth, and read the code yourself with `run_kaish`."
                 .to_string(),
             parameters: json!({
                 "type": "object",
@@ -1489,8 +1491,11 @@ pub fn consult_preamble() -> String {
          fast investigator that rips through the repo and reports back with a \
          curated report — RelevantLocations carrying `file:line`, key symbols, and \
          snippets. Reach for `explore` to cover breadth — find where a \
-         thing lives, gather the relevant files — and use `run_kaish` to read a \
-         precise span yourself and confirm a detail. Build your answer from what \
+         thing lives, gather the relevant files — and use `run_kaish` to read the \
+         code yourself. When you read directly, read generously: pull a whole file \
+         with `cat -n FILE` rather than a narrow slice — the window is yours to \
+         fill, and one wide look often surfaces what a surgical read would miss. \
+         Build your answer from what \
          they return: quote the key snippet, name its `file:line`, and let the \
          evidence carry the claim. Where the evidence settles the question, answer \
          it fully; where it reaches its edge, say so and name what would close the gap.\n\n\
@@ -2013,9 +2018,9 @@ mod tests {
                 let seen = transcript_text(req);
                 if !seen.contains("target_marker") {
                     Ok(tool_call_response(
-                        "t-rg",
+                        "t-grep",
                         "run_kaish",
-                        json!({ "script": "rg -n target_marker src" }),
+                        json!({ "script": "grep -rn target_marker src" }),
                     ))
                 } else {
                     Ok(text_response(REPORT))
@@ -2116,9 +2121,9 @@ mod tests {
                 // a content check on that would skip the read we're here to observe.
                 if !transcript_text(req).contains("exit:") {
                     Ok(tool_call_response(
-                        "t-rg",
+                        "t-grep",
                         "run_kaish",
-                        json!({ "script": "rg -n target_marker src" }),
+                        json!({ "script": "grep -rn target_marker src" }),
                     ))
                 } else {
                     Ok(text_response("EXPLORER_REPORT: src/foo.rs:1"))
@@ -2155,7 +2160,7 @@ mod tests {
             "the delegation must announce its finish: {events:?}"
         );
         assert!(
-            events.contains(&PhaseEvent::KaishRun { script: "rg -n target_marker src".into() }),
+            events.contains(&PhaseEvent::KaishRun { script: "grep -rn target_marker src".into() }),
             "the nested explorer's read must surface (sink threaded into the sub-agent): {events:?}"
         );
         assert!(
@@ -2171,7 +2176,7 @@ mod tests {
             question: "where is target_marker defined?".into(),
         });
         let nested = pos(&PhaseEvent::KaishRun {
-            script: "rg -n target_marker src".into(),
+            script: "grep -rn target_marker src".into(),
         });
         let finish = pos(&PhaseEvent::SweepFinished);
         assert!(
@@ -2963,19 +2968,19 @@ mod tests {
 
     /// The explorer preamble carries the behaviors we measured into it — the
     /// whole-file reading directive (the lite-explorer win, 48→23 turns), the
-    /// context-buffer `rg` idiom, and the three report sections the synth side now
+    /// context-buffer `grep` idiom, and the three report sections the synth side now
     /// expects. Pure and offline; pins the prose so a future edit can't silently
     /// drop any of it (the synth preambles are written against this shape).
     #[test]
     fn report_preamble_keeps_the_reading_directive_and_report_shape() {
         let p = report_preamble();
-        // Reading strategy: read whole files, locate with an rg context buffer.
+        // Reading strategy: read whole files, locate with a grep context buffer.
         assert!(p.contains("cat -n FILE"), "whole-file read idiom: {p}");
         assert!(
             p.to_lowercase().contains("whole"),
             "the whole-file directive must survive: {p}"
         );
-        assert!(p.contains("rg -n -B4 -A8"), "rg context-buffer idiom: {p}");
+        assert!(p.contains("grep -rn -B4 -A8"), "grep context-buffer idiom: {p}");
         // The report template the consult driver preamble is written
         // against — keep the three section names in lockstep with those.
         for section in ["SummaryOfFindings", "RelevantLocations", "ExplorationTrace"] {

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -74,7 +74,7 @@ impl Tool for RunKaish {
                 "properties": {
                     "script": {
                         "type": "string",
-                        "description": "kaish script to execute, e.g. `rg -n TODO src | head`"
+                        "description": "kaish script to execute, e.g. `grep -rn TODO src | head`"
                     }
                 },
                 "required": ["script"]

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -39,8 +39,9 @@ yours to fill, so favor one wide look over many narrow ones; reading a whole fil
 often surfaces what a surgical slice would hide. `cat -n FILE` reads a file whole \
 with its line numbers — reach for it first; most files are short (`wc -l FILE` \
 confirms). To locate something across files, `grep -rn -B3 -A6 PATTERN .` returns \
-each match with the lines around it. Save a narrow span — `cat -n FILE | sed -n \
-'40,80p'` — for a genuinely large file. Each call starts at the project root; \
+each match with the lines around it. A whole-file read that comes back truncated \
+(exit 3, a head+tail sample) was simply too big — re-read just the part you need \
+with a narrow span, `cat -n FILE | sed -n '40,80p'`. Each call starts at the project root; \
 there is no persistent cwd. Read the exit code: 0 is success; 3 means the output \
 was too large and came back as a head+tail sample (not a failure); 124 means the \
 script was killed for running past its time budget; 126 means blocked by the \

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -34,11 +34,13 @@ use crate::config::{CastUsability, Config};
 pub const KAISH_SANDBOX_ADDENDUM: &str = "\
 In kaibo this shell runs over a READ-ONLY snapshot of one project, offline: writes, \
 `git`, `touch`, and external commands are refused, so just read. Browse with line \
-numbers so every citation is exact — `cat -n FILE` to read a whole file, \
-`rg -n -B3 -A6 PATTERN` to find a match with the lines around it, and numbered \
-spans like `cat -n FILE | sed -n '40,80p'` for one slice of a large file. \
-`wc -l FILE` tells you a file's length — most are short enough to read whole. \
-Each call starts at the project root; \
+numbers so every citation is exact, and read generously — the context window is \
+yours to fill, so favor one wide look over many narrow ones; reading a whole file \
+often surfaces what a surgical slice would hide. `cat -n FILE` reads a file whole \
+with its line numbers — reach for it first; most files are short (`wc -l FILE` \
+confirms). To locate something across files, `grep -rn -B3 -A6 PATTERN .` returns \
+each match with the lines around it. Save a narrow span — `cat -n FILE | sed -n \
+'40,80p'` — for a genuinely large file. Each call starts at the project root; \
 there is no persistent cwd. Read the exit code: 0 is success; 3 means the output \
 was too large and came back as a head+tail sample (not a failure); 124 means the \
 script was killed for running past its time budget; 126 means blocked by the \
@@ -325,11 +327,13 @@ pub fn kaibo_sandbox_doc() -> String {
         "# kaibo — the read-only kaish sandbox\n\n\
          {KAISH_SANDBOX_ADDENDUM}\n\n\
          ## Browsing for exact citations\n\
-         Lead with line numbers so every claim cites `file:line`:\n\
-         - `cat -n FILE` — file with line numbers\n\
-         - `rg -n PATTERN [PATH]` — matches with line numbers\n\
-         - `cat -n FILE | sed -n '40,80p'` — a numbered span\n\
-         - `rg -l PATTERN src` — just the file names that match\n\n\
+         Lead with line numbers so every claim cites `file:line`, and read \
+         generously — favor a whole file over a narrow slice:\n\
+         - `cat -n FILE` — a whole file with line numbers; reach for it first\n\
+         - `grep -rn PATTERN [PATH]` — matches with line numbers, across files\n\
+         - `grep -rn -B3 -A6 PATTERN .` — matches with the lines around them\n\
+         - `grep -rl PATTERN src` — just the file names that match\n\
+         - `cat -n FILE | sed -n '40,80p'` — a numbered span of a large file\n\n\
          ## Read-only boundary\n\
          The project is mounted read-only and external commands are off, by \
          construction. Writes, `git`, `touch`, `spawn`/`exec`, and any external \
@@ -349,7 +353,7 @@ pub fn kaibo_sandbox_doc() -> String {
          deeper without spending a tool turn: `kaibo://kaish/syntax`, \
          `kaibo://kaish/builtins`, `kaibo://kaish/vfs`, `kaibo://kaish/scatter`, and \
          the rest. For one builtin, read `kaibo://kaish/builtin/<name>` (e.g. \
-         `kaibo://kaish/builtin/rg`). All of it is also available inside a script: \
+         `kaibo://kaish/builtin/grep`). All of it is also available inside a script: \
          `help`, `help syntax`, `help <builtin>`.\n"
     )
 }
@@ -426,7 +430,7 @@ mod tests {
         // The two things the synth preamble rewards (exact file:line) and the two
         // codes an automated caller will misread without help. These are kaibo's,
         // so they live in the addendum (kaish-help can't know our 126/124).
-        for needle in ["cat -n", "rg -n", "126", "124"] {
+        for needle in ["cat -n", "grep -rn", "126", "124"] {
             assert!(
                 KAISH_SANDBOX_ADDENDUM.contains(needle),
                 "addendum must mention {needle:?}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! - **Consultation** — grounded, cited answers about a codebase. A capable model
 //!   reads precise spans and delegates broad sweeps to a cheap *explorer* sub-agent,
 //!   all driving a read-only [`kaish`] kernel via `run_kaish(script)` (`cat`, `grep`,
-//!   `rg`, `find`, `jq`, pipelines, the lot). The `consult` and toolless `oneshot`
+//!   `find`, `jq`, pipelines, the lot). The `consult` and toolless `oneshot`
 //!   tools are both costumes over one primitive, [`consult::run_phase`].
 //! - **Capabilities** — things the team can *do* and hand back as artifacts. The first
 //!   is image generation ([`image_gen`], the `generate_image` tool); more (TTS/STT, …)

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,13 +1,13 @@
 //! Static repo orientation: a size-gated, computed-once file map spliced into the
 //! exploring phases' preamble so a model starts *knowing* the project's files
-//! instead of spending its first turns on `glob`/`ls`/`rg --files` to discover the
+//! instead of spending its first turns on `glob`/`ls`/`find` to discover the
 //! layout. This is the structure-first lesson (Agentless/Aider) made free — no
 //! model in the loop, computed server-side.
 //!
 //! It leans on kaish's own tools rather than reimplementing them: `glob -a --json
 //! '**/*'` run through the kernel is the *same* ignore-aware enumeration the model's
 //! shell would get (same VFS, same ignore config), so the map can never disagree
-//! with what the explorer's own `glob`/`rg` sees — one source of truth. (`-a`
+//! with what the explorer's own `glob`/`grep` sees — one source of truth. (`-a`
 //! includes hidden config like `.github/`/`.cargo/`; the ignore filter still drops
 //! `.git`/`target`.)
 //!
@@ -60,7 +60,7 @@ impl OrientationConfig {
                 "this project has {n} files, over [orientation] full_list_max_files \
                  ({}). The directory-tree map for larger repos isn't built yet — raise \
                  the limit, set [orientation] enabled = false, or point a cast that \
-                 explores via `rg` at it.",
+                 explores via `grep` at it.",
                 self.full_list_max_files
             );
         }
@@ -101,7 +101,7 @@ fn render(files: &[String]) -> String {
         "PROJECT FILES. The project's complete file list (read-only; hidden config \
          included, build/VCS dirs excluded). You already have the whole layout here, \
          so go straight to reading the files the question touches with `cat -n FILE`, \
-         and use `rg -n` to find where something lives inside them.\n",
+         and use `grep -rn` to find where something lives inside them.\n",
     );
     for f in files {
         s.push_str("  ");

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -103,10 +103,10 @@ mod tests {
             .contains("research limit"));
         assert_eq!(
             PhaseEvent::KaishRun {
-                script: "rg -n TODO src".into()
+                script: "grep -rn TODO src".into()
             }
             .message(),
-            "running kaish: rg -n TODO src"
+            "running kaish: grep -rn TODO src"
         );
         assert_eq!(
             PhaseEvent::SweepStarted {
@@ -120,9 +120,9 @@ mod tests {
     #[test]
     fn brief_clips_to_one_line_and_caps_length() {
         // Multi-line script collapses to its first line.
-        assert_eq!(brief("cat -n a\nrg b\nfind c", 80), "cat -n a");
+        assert_eq!(brief("cat -n a\ngrep b\nfind c", 80), "cat -n a");
         // Leading whitespace/newlines are trimmed before the first line is taken.
-        assert_eq!(brief("\n  rg -n x  \n", 80), "rg -n x");
+        assert_eq!(brief("\n  grep -n x  \n", 80), "grep -n x");
         // Over the cap → clipped with an ellipsis, never longer than the cap.
         let long = "x".repeat(200);
         let out = brief(&long, 80);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -105,7 +105,7 @@ fn apply_disabled_builtins(registry: &mut ToolRegistry, disable: &[String]) {
 pub const KAISH_EXEC_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Default per-script output cap (matches `OutputLimitConfig::agent()`'s 8 KB): a
-/// single wide `cat`/`rg` can't flood the caller's context. Override via
+/// single wide `cat`/`grep` can't flood the caller's context. Override via
 /// `[sandbox].output_limit_bytes`.
 pub const DEFAULT_OUTPUT_LIMIT_BYTES: usize = 8 * 1024;
 
@@ -127,7 +127,7 @@ pub const DEFAULT_SCRATCH_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
 ///   dangerous axes aren't even compiled in. The read-only invariant is structural
 ///   (the mount, MemoryFs, compiled-out axes) and is *not* a config knob.
 /// - [`SandboxConfig::ignore`] is **discovery/noise** policy from `[kaish.ignore]` —
-///   which gitignore-format files the file-walking builtins (`glob`/`rg`/`ls`/`find`,
+///   which gitignore-format files the file-walking builtins (`glob`/`grep`/`ls`/`find`,
 ///   and the orientation repo-map that rides the same kernel) honor. It changes what
 ///   the explorer *sees*, never what it's *allowed* to read; containment and
 ///   read-only are unaffected.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -104,10 +104,18 @@ fn apply_disabled_builtins(registry: &mut ToolRegistry, disable: &[String]) {
 /// matches a patient MCP caller while still bounding a runaway.
 pub const KAISH_EXEC_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Default per-script output cap (matches `OutputLimitConfig::agent()`'s 8 KB): a
-/// single wide `cat`/`grep` can't flood the caller's context. Override via
-/// `[sandbox].output_limit_bytes`.
-pub const DEFAULT_OUTPUT_LIMIT_BYTES: usize = 8 * 1024;
+/// Default per-script output cap: a single wide `cat`/`grep` can't flood the
+/// caller's context, but a *whole-file* read of typical source fits. We push
+/// models to read whole files (see the read idioms in `consult.rs`/`kaish_syntax.rs`),
+/// so the kernel's own `OutputLimitConfig::agent()` default of 8 KB is too tight —
+/// it truncates a ~300-line file, undercutting the very behavior we ask for. 64 KB
+/// (~18K tokens) lets every kaibo source file but the three giants load whole, and
+/// the exit-3 head+tail sample still backstops a genuinely huge read. Override via
+/// `[sandbox].output_limit_bytes`. Bytes, not tokens, on purpose: the cap is a
+/// flood backstop, not a context budget — a byte proxy is fine, and a token cap
+/// would mean embedding tiktoken (OpenAI's tokenizer, a proxy for our casts anyway)
+/// in a single-static binary. See the PR/commit for that reasoning.
+pub const DEFAULT_OUTPUT_LIMIT_BYTES: usize = 1 << 16; // 64 KiB
 
 /// Default cap on the `/` scratch `MemoryFs` (64 MB). Scratch is a feature — a
 /// redirect or `mktemp` lands here, never on the read-only project — but unbounded

--- a/src/server.rs
+++ b/src/server.rs
@@ -770,7 +770,7 @@ impl KaiboHandler {
             DeepSeek, Gemini, Anthropic, or a local model. Pick which one answers with \
             `cast` (e.g. `deepseek`, `gemini`, `anthropic`; the `cast` enum lists the \
             teams live right now, `kaibo://config` has the full set). A capable model \
-            drives a read-only kaish shell (cat/grep/rg/find/jq/pipelines): it reads \
+            drives a read-only kaish shell (cat/grep/find/jq/pipelines): it reads \
             precise spans directly and delegates broad repo sweeps to a fast explorer \
             sub-agent, then answers with concrete `file:line` citations. It finds and \
             reads the relevant code itself — describe what you did or want to know \
@@ -932,8 +932,10 @@ impl KaiboHandler {
 
     #[tool(
         description = "Run a kaish (sh-like) script against the read-only project; \
-            returns exit code + stdout + stderr. Browse code with line numbers: \
-            `cat -n FILE`, `rg -n PATTERN`, `cat -n FILE | sed -n '40,80p'`; compose \
+            returns exit code + stdout + stderr. Browse code with line numbers, and \
+            read generously — `cat -n FILE` for a whole file (reach for it first), \
+            `grep -rn PATTERN .` to locate across files, `cat -n FILE | sed -n \
+            '40,80p'` for a slice of a large one; compose \
             builtins with pipes (grep/jq/awk/find/...). Read-only: writes and external \
             commands are refused (exit 126 = blocked by the sandbox; a script killed \
             for running too long exits 124). Each call starts at the project root — \
@@ -1320,7 +1322,7 @@ fn kaibo_resource_templates() -> Vec<rmcp::model::ResourceTemplate> {
         title: None,
         description: Some(
             "Help for a single kaish builtin — parameters and examples. \
-             e.g. kaibo://kaish/builtin/rg"
+             e.g. kaibo://kaish/builtin/grep"
                 .to_string(),
         ),
         mime_type: Some("text/markdown".to_string()),
@@ -1898,7 +1900,7 @@ mod tests {
     fn sample_schemas() -> Vec<ToolSchema> {
         vec![
             ToolSchema::new("cat", "Read a file"),
-            ToolSchema::new("rg", "Recursive grep"),
+            ToolSchema::new("grep", "Search files for a pattern"),
         ]
     }
 
@@ -2272,7 +2274,7 @@ mod tests {
     #[test]
     fn reads_the_sandbox_doc_with_the_idioms_and_codes() {
         let text = read_text(SANDBOX_URI, &[]);
-        for needle in ["cat -n", "rg", "read-only", "126", "124"] {
+        for needle in ["cat -n", "grep", "read-only", "126", "124"] {
             assert!(text.contains(needle), "sandbox doc must mention {needle:?}");
         }
     }
@@ -2289,9 +2291,9 @@ mod tests {
     #[test]
     fn reads_a_builtin_resource_and_rejects_an_unknown_builtin() {
         let schemas = sample_schemas();
-        let text = read_text(&format!("{BUILTIN_PREFIX}rg"), &schemas);
+        let text = read_text(&format!("{BUILTIN_PREFIX}grep"), &schemas);
         assert!(
-            text.contains("rg"),
+            text.contains("grep"),
             "builtin help should name the tool:\n{text}"
         );
         let config = Config::builtin();

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -66,7 +66,7 @@ pub fn traced<T: Tool + 'static>(tool: T) -> Box<dyn ToolDyn> {
 /// field — the `run_kaish` `script`, a `path`, an `explore` `question` — else the
 /// raw JSON, truncated. Read-only project args carry no secrets; the cap just keeps
 /// a long script from bloating the span. This is the field that turns "16 run_kaish
-/// calls" into "1 was `glob`, 15 were `cat -n`/`rg`".
+/// calls" into "1 was `glob`, 15 were `cat -n`/`grep`".
 fn arg_summary(args: &str) -> String {
     const MAX_CHARS: usize = 200;
     let preview = serde_json::from_str::<serde_json::Value>(args)

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1193,7 +1193,7 @@ fn sandbox_section_parses() {
         [sandbox]
         exec_timeout_secs = 5
         output_limit_bytes = 4096
-        disable_builtins = ["rg", "find"]
+        disable_builtins = ["grep", "find"]
         "#,
     )
     .unwrap();
@@ -1201,7 +1201,7 @@ fn sandbox_section_parses() {
     assert_eq!(c.sandbox.output_limit_bytes, 4096);
     assert_eq!(
         c.sandbox.disable_builtins,
-        vec!["rg".to_string(), "find".to_string()]
+        vec!["grep".to_string(), "find".to_string()]
     );
 }
 
@@ -1220,11 +1220,11 @@ fn validate_against_builtins_rejects_an_unknown_name() {
     let c = Config::from_toml_str(
         r#"
         [sandbox]
-        disable_builtins = ["rg", "definitely-not-a-builtin"]
+        disable_builtins = ["grep", "definitely-not-a-builtin"]
         "#,
     )
     .unwrap();
-    let known = vec!["rg".to_string(), "cat".to_string(), "find".to_string()];
+    let known = vec!["grep".to_string(), "cat".to_string(), "find".to_string()];
     let err = c.validate_against_builtins(&known).unwrap_err();
     assert!(
         format!("{err:#}").contains("definitely-not-a-builtin"),
@@ -1237,11 +1237,11 @@ fn validate_against_builtins_accepts_a_known_subset() {
     let c = Config::from_toml_str(
         r#"
         [sandbox]
-        disable_builtins = ["rg"]
+        disable_builtins = ["grep"]
         "#,
     )
     .unwrap();
-    let known = vec!["rg".to_string(), "cat".to_string()];
+    let known = vec!["grep".to_string(), "cat".to_string()];
     assert!(c.validate_against_builtins(&known).is_ok());
 }
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1182,7 +1182,7 @@ fn required_key_with_no_source_is_an_error() {
 fn sandbox_defaults_when_unconfigured() {
     let c = Config::builtin();
     assert_eq!(c.sandbox.exec_timeout, Duration::from_secs(30));
-    assert_eq!(c.sandbox.output_limit_bytes, 8 * 1024);
+    assert_eq!(c.sandbox.output_limit_bytes, 1 << 16); // 64 KiB default
     assert!(c.sandbox.disable_builtins.is_empty());
 }
 

--- a/tests/guards.rs
+++ b/tests/guards.rs
@@ -48,15 +48,16 @@ async fn a_slow_script_is_killed_at_the_budget() {
     );
 }
 
-/// A read that exceeds the 8 KB MCP output cap must not hand the caller the whole
+/// A read that exceeds the MCP output cap must not hand the caller the whole
 /// file: the result is bounded (truncated) — or, if kaish's spill path can't write
 /// in the read-only sandbox, it surfaces a marker instead of the raw flood. Either
 /// way the caller's context is protected. Teeth: the source is 8x the cap.
 #[tokio::test(flavor = "current_thread")]
 async fn oversized_output_is_capped_or_marked() {
     let dir = tempdir().unwrap();
-    // 64 KB of content — well past the 8 KB cap KernelConfig::agent() installs.
-    let big = "x".repeat(64 * 1024);
+    // 512 KiB of content — 8x the 64 KiB default cap, so a whole-file read can't slip
+    // through (the default lets typical source load whole; this is well past it).
+    let big = "x".repeat(1 << 19);
     fs::write(dir.path().join("big.txt"), &big).unwrap();
 
     let kernel = build_readonly_kernel(dir.path()).unwrap();
@@ -107,12 +108,12 @@ async fn disable_builtins_blocks_an_otherwise_working_builtin() {
 }
 
 /// A custom `output_limit_bytes` is honored: a read past a tiny cap is truncated.
-/// Teeth: the source is many times the configured cap, so an unconfigured (8 KB)
+/// Teeth: the source is many times the configured cap, so an unconfigured (64 KiB)
 /// path would let it through — only a threaded-in small cap catches it.
 #[tokio::test(flavor = "current_thread")]
 async fn custom_output_limit_is_honored() {
     let dir = tempdir().unwrap();
-    let body = "y".repeat(4096); // 4 KB, well under the 8 KB default but past our 512 B cap
+    let body = "y".repeat(1 << 12); // 4 KiB, well under the 64 KiB default but past our 512 B cap
     fs::write(dir.path().join("mid.txt"), &body).unwrap();
 
     let sandbox = SandboxConfig { output_limit_bytes: 512, ..SandboxConfig::default() };


### PR DESCRIPTION
## Why

Two coupled problems in the same model-facing prose:

1. **`rg` is gone from kaish 0.9, but kaibo still taught it.** Every read idiom in the preambles, the shared sandbox addendum, the `run_kaish` tool description, the `kaibo://kaish` cheatsheet, and orientation referenced `rg -n -B/-A`. A model following that guidance hits exit 127 (command-not-found). kaish 0.9 ships `grep` (with `-rn`/`-A`/`-B`/`-C`/`-l`; `grep -r` defaults its path to `.`), so every idiom now teaches `grep`. `awk`, kept in the pipe list, was verified present.

2. **The lite casts read too surgically.** gemini/deepseek-lite kept reaching for narrow `cat -n | sed` slices even where the explorer preamble already nudged otherwise. The context window is opaque to the end user and ours to fill, so we'd rather over-read and notice something than miss it. The lever isn't more grep — a wider grep window only shows the neighborhood of a term you already thought to search; serendipity comes from *whole-file* reads. So the addendum and both preambles now lead with `cat -n FILE` ("reach for it first"), with the *why* in positive framing. `consult_preamble` got read guidance for the first time (it previously had none beyond the shared core, and its old "read a precise span and confirm a detail" line pulled the wrong way).

## Review caught a real interaction

A cross-family pass (deepseek, via kaibo's own `oneshot`) flagged that the whole-file push collides with the 8 KB output cap: the old "narrow span for a file over a thousand lines" guard keyed on `wc -l`, but the cap is *bytes* — 1000 lines of code is ~30 KB and always truncates. Rather than make models pre-check size (which reintroduces the conservatism this set out to remove), the fallback now ties to the signal kaish already emits: a truncated read returns exit 3, and that's the cue to narrow with `sed`. Read optimistically, recover on truncation. (Second commit.)

## Notes

- **No CHANGELOG entry:** the `rg` idioms never reached a release (kaish 0.9 dropped `rg` within this same unreleased 0.2.0 cycle), so there's no release-to-release change a user notices. The *why* lives in the commit bodies (the devlog file is on the still-open `split-issues-devlog` branch).
- Offline suite green (20 suites). The explorer's mock kaish script (`grep -rn target_marker src`) actually executes on real kaish, so the grep swap is exercised, not just asserted in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
