### PR TITLE
Batch tools: offline, max-effort fan-out — Anthropic + Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,25 @@ the git log. Each later release appends a new section at the top.
   caller, not reasoning run into kaibo's own models): prompt → image, returned inline
   as MCP image content. OpenAI-compatible image backends only (hosted
   `gpt-image` / DALL·E, or a local Stable-Diffusion server).
+- **Batch (`batch_submit` / `batch_get` / `batch_cancel` / `batch_list`)** — the
+  *offline, async sibling* of `oneshot`: submit a list of tool-less prompts, get a
+  handle, poll it, read every answer when the provider's batch lane finishes — no call
+  held open per answer. Built for fanning many prompts (or one hard question you'll wait on) at a
+  top-tier model: it maxes the knobs (forces high thinking effort + a generous token
+  budget) regardless of how the cast was tuned for interactive use, and a per-call
+  `model`/`backend` override lets you batch a Pro/Opus tier a cast otherwise synths
+  cheaper. Each prompt is self-contained — no codebase access, no tools. kaibo keeps
+  no state: the handle is the whole address, so poll/cancel survive a restart, and a
+  failed item is surfaced per-item rather than dropped. Anthropic backends only for
+  now (Gemini and OpenAI batch are tracked follow-ons); a non-Anthropic cast is
+  refused with a clear message. Gated by `--no-batch` (one flag over every verb).
+  Batch carries its own system preamble fit to the offline lane — one complete,
+  self-contained response with no follow-up, told to spend on depth — overridable via
+  `[prompts].batch` like the other phases. While a batch runs, `batch_get` reminds you
+  to go do other work and check back rather than wait on it. Lost a handle?
+  `batch_list` re-discovers the batches a backend still holds (newest first, each with
+  its handle, status, and progress), so a batch is never orphaned — defaulting across
+  every Anthropic backend, or scoped to one with `backend`.
 - **`view_image`** — vision-capable consultation phases can read an image *file* from
   the workspace into model context (screenshots, diagrams, assets already in the tree).
 - **Multi-provider model teams.** Anthropic, DeepSeek, and Gemini natively, plus a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,16 +42,18 @@ the git log. Each later release appends a new section at the top.
   `model`/`backend` override lets you batch a Pro/Opus tier a cast otherwise synths
   cheaper. Each prompt is self-contained — no codebase access, no tools. kaibo keeps
   no state: the handle is the whole address, so poll/cancel survive a restart, and a
-  failed item is surfaced per-item rather than dropped. Anthropic backends only for
-  now (Gemini and OpenAI batch are tracked follow-ons); a non-Anthropic cast is
-  refused with a clear message. Gated by `--no-batch` (one flag over every verb).
-  Batch carries its own system preamble fit to the offline lane — one complete,
-  self-contained response with no follow-up, told to spend on depth — overridable via
-  `[prompts].batch` like the other phases. While a batch runs, `batch_get` reminds you
-  to go do other work and check back rather than wait on it. Lost a handle?
-  `batch_list` re-discovers the batches a backend still holds (newest first, each with
-  its handle, status, and progress), so a batch is never orphaned — defaulting across
-  every Anthropic backend, or scoped to one with `backend`.
+  failed item is surfaced per-item rather than dropped. Runs on **Anthropic and Gemini**
+  backends (OpenAI batch is a tracked follow-on); a cast whose synth has no batch lane is
+  refused with a clear message naming the ones that do. For Gemini there's a ready-made
+  `gemini-batch` cast that synths Gemini **Pro** — the tier you reach for offline, where
+  its latency is free. Gated by `--no-batch` (one flag over every verb). Batch carries its
+  own system preamble fit to the offline lane — one complete, self-contained response with
+  no follow-up, told to spend on depth — overridable via `[prompts].batch` like the other
+  phases. While a batch runs, `batch_get` reminds you to go do other work and check back
+  rather than wait on it. Lost a handle? `batch_list` re-discovers the batches a backend
+  still holds (newest first, each with its handle, status, and progress), so a batch is
+  never orphaned — defaulting across every batch-capable backend, or scoped to one with
+  `backend`.
 - **`view_image`** — vision-capable consultation phases can read an image *file* from
   the workspace into model context (screenshots, diagrams, assets already in the tree).
 - **Multi-provider model teams.** Anthropic, DeepSeek, and Gemini natively, plus a

--- a/docs/config.md
+++ b/docs/config.md
@@ -458,6 +458,7 @@ Prefer architectural answers; name the file:line that carries each claim.
 | `explorer` | `report_preamble` | the nested `explore′` sweep inside `consult` |
 | `consult` | `consult_preamble` | the `consult` driver |
 | `oneshot` | `oneshot_preamble` | the thin, toolless `oneshot` |
+| `batch` | `batch_preamble` | the offline, max-thinking `batch_submit` |
 
 **Full replace, by decision.** An override *is* the role framing, verbatim — kaibo
 does not re-wrap it. That's safe because the kaish operating contract (how to drive
@@ -506,6 +507,12 @@ resolves under its own key, so they stay **independently overridable**: a copy t
 keys = "this job's framing." The explorer has one job, so no ambiguity. A per-call
 model override (a bare slot) carries no `preamble` — overriding the model doesn't
 drag the configured slot's framing along. Same loud-on-empty rule as `[prompts]`.
+
+`batch_submit` runs the synth model too, but deliberately does **not** inherit the
+synth slot's `preamble`: its lane has a distinct behavioral contract (one offline
+response, no follow-up, spend on depth) that a slot preamble written for interactive
+synth would silently replace. Tune batch through `[prompts].batch` (or accept the
+built-in `batch_preamble`); the slot preamble stays scoped to the interactive phases.
 
 ## Repo orientation: `[orientation]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -184,7 +184,8 @@ The `[defaults]` knobs themselves:
 
 Four backends and four same-named single-backend casts ship **in code** and
 reproduce kaibo's historical behavior exactly, so a **missing config file is not
-an error**. The TOML *merges over* this registry by name: set one field on a
+an error**. One extra built-in cast ships too — `gemini-batch`, a Gemini cast whose
+synth is Pro, for the offline batch lane (see `batch_submit`). The TOML *merges over* this registry by name: set one field on a
 built-in to retarget it, or add brand-new backends and casts. The built-in alias
 names register at **both** levels — as cast aliases (so `cast = "claude"`
 resolves) and backend aliases (so a slot ref `claude/<id>` resolves) — and are
@@ -202,6 +203,7 @@ reserved: naming a new backend or cast after one is a loud collision error.
 | `anthropic` | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-4-6` |
 | `deepseek` | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` |
 | `gemini` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-3.5-flash` |
+| `gemini-batch` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-pro-latest` |
 | `openai` | `openai/Gemma-4-E4B-it-GGUF` | `openai/Gemma-4-26B-A4B-it-GGUF` |
 
 ### The chimera payoff

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,66 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-22 — batch: offline max-effort fan-out (Anthropic first)
+
+Shipped the batch tool class — `batch_submit`/`batch_get`/`batch_cancel`/`batch_list`,
+the **offline, async sibling of `oneshot`**. The shape was the whole debate. Started
+from "batch mode as a param on `oneshot`" and rejected it: batch is a *different class*,
+not a flag. It's toolless **by construction** — provider batch APIs are offline and
+can't drive a tool loop — so it's built on the `oneshot` *shape* (a capable model
+answering from what it was handed), never `run_phase`. Separate verbs rather than one
+tool with modes, because submit→poll→cancel→list are genuinely distinct and "kill a fat
+top-tier batch" is a real button to want.
+
+Designed fresh for kaibo, not ported from gpal/cpal — those were a reference for what's
+*possible*, not a template. Decisions worth recording:
+
+- **Max the knobs by default.** Batch floors `max_tokens` and forces thinking at
+  `BATCH_EFFORT` regardless of how the cast's synth slot was tuned for interactive use.
+  The motivating case (Amy's): Gemini Pro is near-unusable interactively, so casts synth
+  on Flash — but batch is exactly where you reach for Pro, and the latency that makes
+  max-thinking painful synchronously is *free* once you've accepted "come back later."
+  `BATCH_EFFORT` is threaded *explicitly* through `ModelShape::to_params` rather than
+  via the `consult::thinking_params` helper — a first cut reused that helper, but it
+  would have silently baked in `consult`'s interactive `DEFAULT_EFFORT`; a cross-family
+  review caught the dead-constant trap, so batch now owns its effort independently
+  (`max_tokens` is a *floor*, never undercutting a richer slot).
+- **No state, by design.** kaibo holds nothing on disk, and we kept it that way: the
+  returned handle is `backend/provider-id`, the *whole* address. Poll/cancel/list
+  rebuild a fresh client from the backend and re-address the provider's own batch id, so
+  they survive a server restart. The split trusts a backend name to carry no `/` — so we
+  *enforced* that at config load (`config.rs`) rather than leaving it a convention the
+  slot-ref and batch-handle parsers silently bank on.
+- **A preamble of its own.** Batch shares `oneshot`'s toolless shape but not its words.
+  A cross-family review (Opus, run *through* `batch_submit` itself — dogfooding the
+  tool to critique its own design) flagged that `oneshot`'s "name what you'd need rather
+  than guessing" is right *synchronously* (a gap invites a next turn) but wrong offline
+  (there is no next turn — stopping at "I'd need X" burns the caller's one shot). So
+  `batch_preamble` (overridable via `[prompts].batch`) tells the model it gets one
+  complete, self-contained response, to spend the forced budget on depth, and to
+  *state an assumption and answer under it* rather than stall — and drops the negative
+  "guessing" framing for the positive form the CLAUDE.md rule wants.
+- **`batch_list` closes the orphan gap.** No state means a *lost* handle is a batch that
+  keeps billing with no way back to it — the review's sharpest finding. `batch_list`
+  reads the provider's own batch list (the source of truth kaibo doesn't keep): newest
+  first, each entry a ready-to-use handle with status and progress, defaulting across
+  every Anthropic backend (you may not recall which ran it) or scoped to one.
+  Per-backend failures and a truncated page are surfaced, never hidden. Live-verified
+  against 14 real historical batches — recovered every one by handle.
+
+**Anthropic first, deliberately.** Message Batches is inline (requests in one POST) and
+the wire shape is one we're confident about; Gemini (Amy's real want) and OpenAI
+(file-based) follow as their own PRs once a live probe confirms each shape — the
+"confirm, don't guess" discipline. A non-Anthropic cast is refused with a clear message
+rather than silently no-oping, the same honest-absence posture as the `ImageGen` seam.
+`batch_submit` is many-prompts/one-cast for now; the one-question/many-casts panel is N
+provider batches under a composite handle, deferred (`docs/issues.md`).
+
+The whole seam is offline-tested: pure request-shaping/response-parsing/render fns plus
+a `ScriptedBatch` driving submit→pending→done and a seeded list with no network,
+mirroring `ScriptedImageGen`. The live wire is proven by trying it (the dogfooded review
+and the `batch_list` recovery run), not by a unit test that can't reach the provider.
+
 ## 2026-06-18 — kaish-kernel 0.9.0
 
 Bumped the published dep `0.8.4 → 0.9.0`. One API break carried through: the `mcp()`

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,71 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-22 — batch: Gemini provider (second backend behind the seam)
+
+Added the second `BatchProvider` impl — Gemini inline batch — so the offline lane reaches
+the model Amy actually wants there: Gemini **Pro**. Pro is near-unusable interactively
+(slow), but batch is exactly where that latency is free, so it's the natural home for it.
+Shipped a ready-made `gemini-batch` **cast** (synth → `gemini-pro-latest`) rather than
+adding a `batch` role slot to the schema — today's cast machinery already expresses "a
+team whose synth is Pro," and the per-call `model`/`backend` override covers the rest. The
+deferred `batch`-role-slot alternative stays parked; it earns its keep only if one cast
+needing *both* a cheap interactive synth and a Pro batch synth becomes common.
+
+The seam paid off: the trait, the stateless `backend/provider-id` handle, the
+ScriptedBatch offline harness, and the four verbs were all reused unchanged. What's
+genuinely Gemini-shaped lives in pure, offline-tested functions, and dispatch moved into
+`batch.rs` (`submitter`/`poller`/`batch_supported`) so `server.rs` no longer hardcodes a
+provider — it asks the module, and an unsupported kind is refused in one place.
+
+**Probed the wire shape, didn't guess** (the CLAUDE.md rule, and the `issues.md` entry
+demanded it). The live probe earned its keep — Gemini's batch differs from Anthropic's in
+ways no amount of reading would have settled:
+
+- **Body shape can't be shared.** Gemini nests *both* the completion budget
+  (`maxOutputTokens`) and the thinking block under one `generationConfig`, where Anthropic
+  carries `max_tokens` top-level. So `gemini_batch_body` folds the floored budget into the
+  `generationConfig` that `ModelShape::to_params` already produced, beside `thinkingConfig`
+  — and the maxed-knobs shaping (`batch_shaping`) was reused verbatim across both.
+- **Results come back inline in the long-running-operation object**, not behind a separate
+  results URL (Anthropic's `results_url` + JSONL). No second fetch.
+- **`batchStats` counts arrive as JSON strings** (`"7"`), not numbers — `as_u64` alone
+  would have silently read them as 0, exactly the quiet miscount the project forbids. The
+  count reader handles both.
+- **Cancel is instant-terminal**, not Anthropic's interim "canceling" you poll through. A
+  cancelled/failed/expired Gemini batch is `done:true` immediately with a top-level
+  operation error and (usually) no per-item output. `Done(vec![])` would render as
+  "0 results" and read like success — wrong — so added a `BatchPoll::Failed { state,
+  message }` variant that names the terminal state honestly. Partial results that *did*
+  land before the terminal event are still handed back as `Done`.
+- **List lives under `operations`** (not `data`) and paginates via `nextPageToken` (not
+  `has_more`); an empty list omits the key entirely, so that's an empty page, not an error.
+- **The slashed provider id just worked.** A Gemini handle is `gemini/batches/<id>` — the
+  id itself contains a slash — but `parse_batch_handle`'s split-on-*first*-slash plus the
+  no-slash-in-backend-name invariant (enforced at config load) already made that
+  unambiguous. The Anthropic-era design absorbed it for free.
+
+`includeThoughts` is on (inherited from the shaping), so a Gemini answer carries the
+reasoning as separate `"thought": true` parts; confirmed against a live thinking batch
+that the answer text is the *non*-thought parts (a final answer part may still carry a
+`thoughtSignature` — that's not a thought part, so it stays). The whole seam is
+offline-tested (pure shaping/parsing fns + ScriptedBatch), and the live wire was proven
+end-to-end through the actual MCP server: submit → list → poll → `## [0] Pong.`, plus a
+cancel that lands in `Failed`, plus a non-batch cast refused with the supported set named.
+
+**The dogfood earned its keep twice.** Running a real `gemini-batch` job through the
+reconnected server surfaced that the cast's pinned synth `gemini-3-pro-preview` was
+*retired* — and exposed a sharp edge of Gemini's batch lane: submit **accepted** the dead
+model (`BATCH_STATE_PENDING`), and the failure only landed as a *per-item* error when the
+request actually ran ("This model … is no longer available"). The per-item failure
+surfacing did exactly its job — the answer came back as `## [0] — failed: provider error:
+…` rather than a silent empty — but it's a reminder that Gemini batch does no model
+validation at submit time. The fix is the drift-resistant default: the cast synths
+`gemini-pro-latest` (the alias, today resolving to `gemini-3.1-pro-preview`) rather than a
+pinned preview that gets retired out from under us — `provider-model-ids` drift, made
+concrete. Confirmed live: `gemini-pro-latest`, `gemini-3.1-pro-preview`, and `gemini-2.5-pro`
+all 200 on a synchronous `generateContent`; `gemini-3-pro-preview` 404s.
+
 ## 2026-06-22 — batch: offline max-effort fan-out (Anthropic first)
 
 Shipped the batch tool class — `batch_submit`/`batch_get`/`batch_cancel`/`batch_list`,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -229,17 +229,11 @@ serialize the two (a shared `Mutex`/`serial_test`), or capture per-span without 
 on global dispatch. Out of scope when found (the read-idioms/output-cap PR).
 
 ### Batch — remaining providers and the many-casts fork
-The batch tool class shipped Anthropic-first (`src/batch.rs`,
-`batch_submit`/`batch_get`/`batch_cancel`, one `--no-batch` gate): offline, toolless,
-max-effort fan-out behind the `BatchProvider` seam, with the design rationale in the
-module doc and `docs/devlog.md`. What's left:
+The batch tool class shipped Anthropic- and Gemini-first (`src/batch.rs`,
+`batch_submit`/`batch_get`/`batch_cancel`/`batch_list`, one `--no-batch` gate): offline,
+toolless, max-effort fan-out behind the `BatchProvider` seam, with the design rationale
+in the module doc and `docs/devlog.md`. What's left:
 
-- **Gemini batch** — Amy's actual want (Pro is near-unusable interactively, so casts
-  synth Flash; batch is where you reach for Pro). Its own wire shape; confirm it with a
-  live probe before wiring, don't guess. Ships alongside a `gemini-batch` **cast**
-  (synth→Pro) — no schema change, today's cast machinery. (An explicit `batch` role slot
-  — one cast serving both interactive-synth and batch-synth — stays the deferred
-  alternative if the separate-cast approach turns clumsy.)
 - **OpenAI batch** — file-based (upload JSONL, reference a file id, poll, download an
   output file), unlike Anthropic's inline POST. The output file is left in place by
   default; add a `config.toml` flag to opt into cleanup for callers who'd rather not
@@ -254,7 +248,8 @@ module doc and `docs/devlog.md`. What's left:
   one knob to change.
 
 Per-provider capability, `None` where unsupported: Anthropic ✓ (shipped), Gemini ✓
-(next), OpenAI ✓ file-based, DeepSeek ?, local `openai` ✗.
+(shipped — inline batch, `gemini-batch` cast synths Pro), OpenAI ✓ file-based (next),
+DeepSeek ?, local `openai` ✗.
 
 ### Batch design hardening (cross-model Opus review, 2026-06-22)
 A cross-family review of the batch slice (Opus 4.8, run *through* `batch_submit` itself

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -228,16 +228,60 @@ that fails when we *didn't* make a mistake is the opposite of the teeth we want.
 serialize the two (a shared `Mutex`/`serial_test`), or capture per-span without leaning
 on global dispatch. Out of scope when found (the read-idioms/output-cap PR).
 
-### `oneshot` batch — batchable fan-out of the tool-less answer (deferred)
-The tool-less, non-interactive answer shipped as the `oneshot` tool (prompt in,
-answer out, no tools — `consult.rs::oneshot`). What's still deferred is the *batch*
-shape for fan-out: submit → poll → read, modelled on gpal/cpal's job system, so a
-caller can fire many oneshots (or one question across many casts) without holding a
-synchronous call open per answer. It's a **per-provider capability** like
-`thinking_params`: Gemini ✓, Anthropic ✓, DeepSeek?, `openai` ✗ — `None` where
-unsupported. Open fork when built: many-questions/one-model vs one-question/many-models
-(the diverse-opinion panel made literal). The provenance footer oneshot already
-appends makes a batch result self-labelling.
+### Batch — remaining providers and the many-casts fork
+The batch tool class shipped Anthropic-first (`src/batch.rs`,
+`batch_submit`/`batch_get`/`batch_cancel`, one `--no-batch` gate): offline, toolless,
+max-effort fan-out behind the `BatchProvider` seam, with the design rationale in the
+module doc and `docs/devlog.md`. What's left:
+
+- **Gemini batch** — Amy's actual want (Pro is near-unusable interactively, so casts
+  synth Flash; batch is where you reach for Pro). Its own wire shape; confirm it with a
+  live probe before wiring, don't guess. Ships alongside a `gemini-batch` **cast**
+  (synth→Pro) — no schema change, today's cast machinery. (An explicit `batch` role slot
+  — one cast serving both interactive-synth and batch-synth — stays the deferred
+  alternative if the separate-cast approach turns clumsy.)
+- **OpenAI batch** — file-based (upload JSONL, reference a file id, poll, download an
+  output file), unlike Anthropic's inline POST. The output file is left in place by
+  default; add a `config.toml` flag to opt into cleanup for callers who'd rather not
+  accrete files. The generic local `openai` kind stays ✗ (no batch endpoint).
+- **The many-casts fork.** `batch_submit` today is many-prompts/**one**-cast (one
+  provider batch). The diverse-opinion panel — one question across **many** casts — is N
+  provider batches under a composite handle; deferred. The provenance footer already
+  makes each result self-labelling, so the rendering is mostly there.
+- **Effort tier.** Batch forces `BATCH_EFFORT = "high"` (== `DEFAULT_EFFORT`, the
+  proven-accepted top for the Anthropic adaptive tier). If a higher tier (`xhigh`/`max`)
+  is ever confirmed by probe for a batch backend, lift it there — the constant is the
+  one knob to change.
+
+Per-provider capability, `None` where unsupported: Anthropic ✓ (shipped), Gemini ✓
+(next), OpenAI ✓ file-based, DeepSeek ?, local `openai` ✗.
+
+### Batch design hardening (cross-model Opus review, 2026-06-22)
+A cross-family review of the batch slice (Opus 4.8, run *through* `batch_submit` itself
+dogfooding the tool) confirmed the bones — the verb surface, stateless
+`backend/provider-id` handle, per-item failure surfacing — and flagged four follow-ons.
+Shipped in the same pass: the batch preamble (no longer a verbatim `oneshot` reuse —
+`consult.rs::batch_preamble`, overridable via `[prompts].batch`), the `/`-in-backend-name
+guard the handle split relies on (`config.rs`), the don't-busy-wait note on the tool
+descriptions, and **`batch_list`** (`server.rs`/`batch.rs::list`) — the way back to a
+batch whose handle was lost, closing the orphaned/billing-batch footgun (per-backend
+failures and a truncated page are surfaced, not hidden). Still open:
+
+- **Index-as-`custom_id` + statelessness = context-loss risk.** Result labels are bare
+  `0..N`, meaningful only to a caller still holding the ordered prompt list. Echo the
+  prompt (or a digest) back beside each answer in `batch_get` so a result is
+  self-describing — the natural complement to holding no state. (`batch.rs::render_poll`
+  / `BatchAnswer` is the seam; would need the submitted prompts carried or re-fetched.)
+- **`batch_get` returns prose for both pending and done.** An agent must parse the
+  progress string to know whether it's looking at a status or its answers. A structured
+  status token (or distinct content shape) would let the caller branch without reading
+  prose.
+- **Forced effort vs. a floor.** `max_tokens` is already a floor (never undercuts a
+  richer slot), but effort is *force-clobbered* to `BATCH_EFFORT` — lossy for legitimate
+  bulk-classification / short-extraction batches where high effort is wasted spend.
+  Consider making effort a default-on floor the cast/caller can lower, the way
+  `max_tokens` already is. (Distinct from the "lift the tier" bullet above — that's the
+  ceiling, this is the override.)
 
 ### Provider model ids drift and live in code
 `consult.rs::default_models` hardcodes the explorer/synth ids per provider; they

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -23,10 +23,12 @@
 //! **Per-provider HTTP seam.** rig-core has no batch path, so each provider is
 //! hand-rolled behind the [`BatchProvider`] trait — the same shape as the
 //! [`ImageGen`](crate::image_gen) seam (one trait, per-kind impls, honest refusal
-//! where absent). This slice ships **Anthropic Message Batches** ([`AnthropicBatch`]),
-//! whose requests ride inline in one POST; Gemini (its own shape) and OpenAI
-//! (file-based) are tracked follow-ons in `docs/issues.md`. A non-Anthropic backend is
-//! refused loudly at resolution, never a silent no-op.
+//! where absent). Two protocols ship: **Anthropic Message Batches** ([`AnthropicBatch`]),
+//! whose requests ride inline in one POST, and **Gemini batch** ([`GeminiBatch`]), whose
+//! inline requests nest under `input_config.requests` and whose results come back inline
+//! in the batch's long-running-operation object (no separate results URL). OpenAI batch
+//! (file-based) is a tracked follow-on in `docs/issues.md`. An unsupported backend kind
+//! is refused loudly at resolution ([`submitter`]/[`poller`]), never a silent no-op.
 //!
 //! **No persistent state.** kaibo holds nothing on disk; a batch id *is* the provider's
 //! own id, so poll/cancel rebuild a fresh client from the backend and re-address it. A
@@ -94,6 +96,12 @@ pub enum BatchPoll {
     Cancelling,
     /// Finished — every item's outcome, succeeded or not.
     Done(Vec<BatchAnswer>),
+    /// The whole batch reached a terminal *non-success* state with no per-item results
+    /// to hand back (a Gemini cancel/fail/expire, which is instant-terminal rather than
+    /// Anthropic's interim `Cancelling`). `state` is the provider's raw state string;
+    /// `message` is its reason. Distinct from `Done(vec![])` — that would render as
+    /// "0 results" and read like success; this names the failure honestly.
+    Failed { state: String, message: String },
 }
 
 /// One batch as the provider's list endpoint reports it — enough to re-address and
@@ -399,6 +407,9 @@ pub fn render_poll(poll: &BatchPoll, label: &str) -> String {
             s.push_str(&format!("\n———\nkaibo · batch · {label}"));
             s
         }
+        BatchPoll::Failed { state, message } => {
+            format!("Batch ended in {state} — {message}. No per-item results to return.")
+        }
     }
 }
 
@@ -465,25 +476,14 @@ impl AnthropicBatch {
     fn require_anthropic(backend: &Backend) -> Result<()> {
         if backend.kind != ProviderKind::Anthropic {
             return Err(anyhow!(
-                "batch is only available on anthropic-kind backends today; backend {:?} \
-                 is {:?}. Gemini and OpenAI batch are tracked follow-ons (docs/issues.md) \
-                 — point the cast's synth slot at an Anthropic backend to batch now.",
+                "this is the Anthropic batch provider, but backend {:?} is {:?}. \
+                 (Batch dispatch should never route a non-Anthropic backend here; see \
+                 `submitter`/`poller`.)",
                 backend.name,
                 backend.kind
             ));
         }
         Ok(())
-    }
-
-    /// A reqwest client carrying the backend's per-request deadline. Same TLS wiring as
-    /// every other client build site: install ring before `.build()`.
-    fn http_client(backend: &Backend) -> Result<reqwest::Client> {
-        crate::tls::ensure_crypto_provider();
-        reqwest::Client::builder()
-            .timeout(backend.request_timeout)
-            .connect_timeout(backend.request_timeout.min(Duration::from_secs(10)))
-            .build()
-            .map_err(|e| anyhow!("http client init: {e}"))
     }
 
     /// A submit-capable client: the cast's synth slot, shaped to batch's maxed knobs.
@@ -492,7 +492,7 @@ impl AnthropicBatch {
         let tunables = slot.tunables(ModelRole::Synth, defaults);
         let (max_tokens, params) = batch_shaping(backend.kind, &slot.id, &tunables);
         Ok(Self {
-            http: Self::http_client(backend)?,
+            http: batch_http_client(backend)?,
             api_key: backend.resolve_key()?,
             model: slot.id.clone(),
             max_tokens,
@@ -505,7 +505,7 @@ impl AnthropicBatch {
     pub fn from_backend(backend: &Backend) -> Result<Self> {
         Self::require_anthropic(backend)?;
         Ok(Self {
-            http: Self::http_client(backend)?,
+            http: batch_http_client(backend)?,
             api_key: backend.resolve_key()?,
             model: String::new(),
             max_tokens: 0,
@@ -638,21 +638,462 @@ impl BatchProvider for AnthropicBatch {
     }
 }
 
-/// Build a submit-capable provider from a resolved cast slot + backend (refuses a
-/// non-Anthropic backend honestly).
-pub fn anthropic_submit(
+// --- Gemini provider -------------------------------------------------------
+
+/// Gemini's API base. The keyed Gemini backend carries no `base_url` (rig fixes its
+/// endpoint), so batch addresses the service directly, as Anthropic does.
+const GEMINI_API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
+
+/// A reqwest client carrying the backend's per-request deadline, with ring installed
+/// before `.build()` (the TLS invariant — every client build site does this). Shared by
+/// both batch providers.
+fn batch_http_client(backend: &Backend) -> Result<reqwest::Client> {
+    crate::tls::ensure_crypto_provider();
+    reqwest::Client::builder()
+        .timeout(backend.request_timeout)
+        .connect_timeout(backend.request_timeout.min(Duration::from_secs(10)))
+        .build()
+        .map_err(|e| anyhow!("http client init: {e}"))
+}
+
+/// Read a (possibly string-encoded) count field. Gemini's `batchStats` numbers arrive as
+/// JSON *strings* (`"1"`), not numbers — `as_u64` alone would silently read them as 0,
+/// the kind of quiet miscount the project forbids. A missing/garbage field is 0.
+fn gemini_num(v: &Value, key: &str) -> u64 {
+    match v.get(key) {
+        Some(Value::String(s)) => s.parse().unwrap_or(0),
+        Some(Value::Number(n)) => n.as_u64().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+/// Progress `(completed, total)` from a batch's `metadata.batchStats`. `completed` sums
+/// the terminal buckets (succeeded + failed); `total` is `requestCount`. Shared by the
+/// status poll and the list view so both count progress the same way.
+fn gemini_progress(meta: Option<&Value>) -> (u64, u64) {
+    let stats = meta.and_then(|m| m.get("batchStats"));
+    let n = |k: &str| stats.map(|s| gemini_num(s, k)).unwrap_or(0);
+    (
+        n("successfulRequestCount") + n("failedRequestCount"),
+        n("requestCount"),
+    )
+}
+
+/// Join the non-thought `text` parts of a Gemini response's first candidate. With
+/// `includeThoughts` on, the reasoning rides as separate `"thought": true` parts; those
+/// are the model's scratchpad, not its answer, so the answer is the text parts that are
+/// *not* thoughts (a final answer part may still carry a `thoughtSignature` — that's not
+/// a thought part, so it stays).
+fn gemini_message_text(response: &Value) -> String {
+    response
+        .get("candidates")
+        .and_then(Value::as_array)
+        .and_then(|c| c.first())
+        .and_then(|c| c.get("content"))
+        .and_then(|c| c.get("parts"))
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter(|p| p.get("thought").and_then(Value::as_bool) != Some(true))
+                .filter_map(|p| p.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default()
+}
+
+/// Locate a batch's inlined per-item responses. Gemini puts them in the long-running
+/// operation's `response.inlinedResponses.inlinedResponses` once done; the same array is
+/// mirrored under `metadata.output.inlinedResponses.inlinedResponses`, so we accept
+/// either (the LRO result first).
+fn gemini_inlined_array(v: &Value) -> Option<&Vec<Value>> {
+    fn at(root: &Value) -> Option<&Vec<Value>> {
+        root.get("inlinedResponses")
+            .and_then(|i| i.get("inlinedResponses"))
+            .and_then(Value::as_array)
+    }
+    v.get("response")
+        .and_then(at)
+        .or_else(|| v.get("metadata").and_then(|m| m.get("output")).and_then(at))
+}
+
+/// Parse the inlined-responses array into per-item [`BatchAnswer`]s. Each element carries
+/// its `metadata.key` plus either a `response` (the model's content) or an `error`
+/// (surfaced per item, never silently dropped — the Anthropic per-item ethos).
+fn parse_gemini_inlined(arr: &[Value]) -> Vec<BatchAnswer> {
+    arr.iter()
+        .map(|el| {
+            let custom_id = el
+                .get("metadata")
+                .and_then(|m| m.get("key"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let text = if let Some(resp) = el.get("response") {
+                Ok(gemini_message_text(resp))
+            } else if let Some(err) = el.get("error") {
+                let detail = err
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| err.to_string());
+                Err(format!("provider error: {detail}"))
+            } else {
+                Err("no response or error in result item".to_string())
+            };
+            BatchAnswer { custom_id, text }
+        })
+        .collect()
+}
+
+/// Pull the batch's operation `name` (`batches/<id>`) out of a submit/status response.
+fn parse_gemini_name(v: &Value) -> Result<String> {
+    v.get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("gemini batch response has no string `name`: {v}"))
+}
+
+/// Map a status response onto a [`BatchPoll`]. The `state` enum drives it: pending/running
+/// → progress; succeeded → the inlined results; cancelled/failed/expired → either the
+/// partial results that *did* land before the terminal event, or (none) a [`Failed`] that
+/// names the state honestly rather than a misleading empty `Done`.
+///
+/// [`Failed`]: BatchPoll::Failed
+fn parse_gemini_poll(v: &Value) -> Result<BatchPoll> {
+    let meta = v.get("metadata");
+    let state = meta
+        .and_then(|m| m.get("state"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("gemini batch has no `metadata.state`: {v}"))?;
+    match state {
+        "BATCH_STATE_PENDING" | "BATCH_STATE_RUNNING" => {
+            let (completed, total) = gemini_progress(meta);
+            Ok(BatchPoll::Pending { completed, total })
+        }
+        "BATCH_STATE_SUCCEEDED" => {
+            let arr = gemini_inlined_array(v).ok_or_else(|| {
+                anyhow!(
+                    "succeeded gemini batch has no inlined responses — a file-based output \
+                     (responsesFile) isn't supported; kaibo only submits inline batches: {v}"
+                )
+            })?;
+            Ok(BatchPoll::Done(parse_gemini_inlined(arr)))
+        }
+        "BATCH_STATE_CANCELLED" | "BATCH_STATE_FAILED" | "BATCH_STATE_EXPIRED" => {
+            // Items that finished before the terminal event still carry results — hand
+            // those back rather than throwing them away.
+            if let Some(arr) = gemini_inlined_array(v) {
+                if !arr.is_empty() {
+                    return Ok(BatchPoll::Done(parse_gemini_inlined(arr)));
+                }
+            }
+            let message = v
+                .get("error")
+                .and_then(|e| e.get("message"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| "batch did not complete".to_string());
+            Ok(BatchPoll::Failed {
+                state: state.to_string(),
+                message,
+            })
+        }
+        other => Err(anyhow!("unknown gemini batch state {other:?}: {v}")),
+    }
+}
+
+/// Parse one operation from the list endpoint into a [`BatchListItem`]. The operation
+/// `name` (`batches/<id>`) is the provider id; status is the raw `metadata.state`.
+fn parse_gemini_list_item(op: &Value) -> Result<BatchListItem> {
+    let provider_id = op
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("gemini batch list item has no `name`: {op}"))?
+        .to_string();
+    let meta = op.get("metadata");
+    let status = meta
+        .and_then(|m| m.get("state"))
+        .and_then(Value::as_str)
+        .unwrap_or("BATCH_STATE_UNSPECIFIED")
+        .to_string();
+    let (completed, total) = gemini_progress(meta);
+    let created_at = meta
+        .and_then(|m| m.get("createTime"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Ok(BatchListItem {
+        provider_id,
+        status,
+        completed,
+        total,
+        created_at,
+    })
+}
+
+/// Parse the list endpoint's `{ operations: [...], nextPageToken }` page. A `nextPageToken`
+/// means more exist (so a truncated view announces itself); an absent `operations` key is
+/// an empty page (the endpoint omits it when there are no batches), not an error.
+fn parse_gemini_list(v: &Value) -> Result<(Vec<BatchListItem>, bool)> {
+    let items = match v.get("operations").and_then(Value::as_array) {
+        Some(ops) => ops
+            .iter()
+            .map(parse_gemini_list_item)
+            .collect::<Result<Vec<_>>>()?,
+        None => Vec::new(),
+    };
+    let has_more = v
+        .get("nextPageToken")
+        .and_then(Value::as_str)
+        .map(|t| !t.is_empty())
+        .unwrap_or(false);
+    Ok((items, has_more))
+}
+
+/// Build the Gemini inline-batch request body. Each item becomes one
+/// `{ request: GenerateContentRequest, metadata: { key } }`: the shared `system` rides as
+/// `systemInstruction`, the prompt as a single user `content`, and `maxOutputTokens` is
+/// merged into the `generationConfig` the maxed thinking block already produced (Gemini
+/// nests the completion budget *and* `thinkingConfig` there, unlike Anthropic's top-level
+/// `max_tokens` — so the bodies can't be shared). Pure so the wire shape is pinned without
+/// a network.
+pub fn gemini_batch_body(
+    max_tokens: u64,
+    system: &str,
+    params: &Option<Value>,
+    items: &[BatchItem],
+) -> Value {
+    let requests: Vec<Value> = items
+        .iter()
+        .map(|it| {
+            // Start from the shaping's generationConfig (the thinking block) and fold the
+            // floored completion budget in beside it.
+            let mut gen = params
+                .as_ref()
+                .and_then(|p| p.get("generationConfig"))
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            gen.insert("maxOutputTokens".into(), json!(max_tokens));
+            let mut req = Map::new();
+            if !system.is_empty() {
+                req.insert(
+                    "systemInstruction".into(),
+                    json!({ "parts": [{ "text": system }] }),
+                );
+            }
+            req.insert(
+                "contents".into(),
+                json!([{ "role": "user", "parts": [{ "text": it.prompt }] }]),
+            );
+            req.insert("generationConfig".into(), Value::Object(gen));
+            json!({ "request": Value::Object(req), "metadata": { "key": it.custom_id } })
+        })
+        .collect();
+    json!({
+        "batch": {
+            "display_name": "kaibo-batch",
+            "input_config": { "requests": { "requests": requests } }
+        }
+    })
+}
+
+/// Gemini batch over HTTP. Mirrors [`AnthropicBatch`]: holds the connection (client, key,
+/// base) plus the per-submit shaping (model, floored `max_tokens`, the maxed thinking
+/// block). Poll/cancel/list need only the connection, so a [`from_backend`](Self::from_backend)
+/// client (no model) drives those after a restart.
+pub struct GeminiBatch {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+    /// Submit-only: empty on a poll/cancel-only client.
+    model: String,
+    max_tokens: u64,
+    params: Option<Value>,
+}
+
+impl GeminiBatch {
+    /// Refuse a non-Gemini backend loudly — dispatch ([`submitter`]/[`poller`]) should
+    /// never route one here, so this is a belt-and-suspenders contract guard.
+    fn require_gemini(backend: &Backend) -> Result<()> {
+        if backend.kind != ProviderKind::Gemini {
+            return Err(anyhow!(
+                "this is the Gemini batch provider, but backend {:?} is {:?}. (Batch \
+                 dispatch should never route a non-Gemini backend here; see \
+                 `submitter`/`poller`.)",
+                backend.name,
+                backend.kind
+            ));
+        }
+        Ok(())
+    }
+
+    fn base_url(backend: &Backend) -> String {
+        backend
+            .base_url
+            .clone()
+            .unwrap_or_else(|| GEMINI_API_BASE.to_string())
+    }
+
+    /// A submit-capable client: the cast's synth slot, shaped to batch's maxed knobs.
+    pub fn from_slot(backend: &Backend, slot: &ModelSlot, defaults: &Defaults) -> Result<Self> {
+        Self::require_gemini(backend)?;
+        let tunables = slot.tunables(ModelRole::Synth, defaults);
+        let (max_tokens, params) = batch_shaping(backend.kind, &slot.id, &tunables);
+        Ok(Self {
+            http: batch_http_client(backend)?,
+            api_key: backend.resolve_key()?,
+            base_url: Self::base_url(backend),
+            model: slot.id.clone(),
+            max_tokens,
+            params,
+        })
+    }
+
+    /// A poll/cancel/list-only client (no model).
+    pub fn from_backend(backend: &Backend) -> Result<Self> {
+        Self::require_gemini(backend)?;
+        Ok(Self {
+            http: batch_http_client(backend)?,
+            api_key: backend.resolve_key()?,
+            base_url: Self::base_url(backend),
+            model: String::new(),
+            max_tokens: 0,
+            params: None,
+        })
+    }
+
+    /// GET/POST a JSON object, returning the parsed body or a loud error with the raw text.
+    async fn send_json(&self, req: reqwest::RequestBuilder, what: &str) -> Result<Value> {
+        let resp = req
+            .header("x-goog-api-key", &self.api_key)
+            .header("content-type", "application/json")
+            .send()
+            .await
+            .map_err(|e| anyhow!("gemini batch {what} failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| anyhow!("reading gemini batch {what} body: {e}"))?;
+        if !status.is_success() {
+            return Err(anyhow!("gemini batch {what} {status}: {text}"));
+        }
+        serde_json::from_str(&text).with_context(|| format!("parsing gemini batch {what}: {text}"))
+    }
+}
+
+#[async_trait]
+impl BatchProvider for GeminiBatch {
+    async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String> {
+        if self.model.is_empty() {
+            return Err(anyhow!(
+                "this batch client was built for poll/cancel only (no model) — submit \
+                 needs a synth slot"
+            ));
+        }
+        if items.is_empty() {
+            return Err(anyhow!("a batch needs at least one prompt"));
+        }
+        let body = gemini_batch_body(self.max_tokens, system, &self.params, items);
+        let url = format!(
+            "{}/models/{}:batchGenerateContent",
+            self.base_url, self.model
+        );
+        let v = self
+            .send_json(
+                self.http.post(&url).body(serde_json::to_vec(&body)?),
+                "submit",
+            )
+            .await?;
+        parse_gemini_name(&v)
+    }
+
+    async fn poll(&self, batch_id: &str) -> Result<BatchPoll> {
+        let url = format!("{}/{}", self.base_url, batch_id);
+        let v = self.send_json(self.http.get(&url), "status").await?;
+        parse_gemini_poll(&v)
+    }
+
+    async fn cancel(&self, batch_id: &str) -> Result<()> {
+        let url = format!("{}/{}:cancel", self.base_url, batch_id);
+        self.send_json(self.http.post(&url), "cancel").await?;
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<(Vec<BatchListItem>, bool)> {
+        // One page at the API's max (100), newest-first by default; `nextPageToken` rides
+        // back as `has_more` so a truncated view announces itself (orphan recovery wants
+        // the recent tail).
+        let url = format!("{}/batches?pageSize=100", self.base_url);
+        let v = self.send_json(self.http.get(&url), "list").await?;
+        parse_gemini_list(&v)
+    }
+}
+
+// --- Dispatch --------------------------------------------------------------
+
+/// Does this provider kind have a batch lane? The single source of truth — dispatch
+/// ([`submitter`]/[`poller`]), `batch_list`'s backend filter, and refusal messages all
+/// defer to it, so adding a provider is a one-line change here. Keep the `matches!` arm in
+/// step with the per-kind impls below.
+pub fn batch_supported(kind: ProviderKind) -> bool {
+    matches!(kind, ProviderKind::Anthropic | ProviderKind::Gemini)
+}
+
+/// The batch-capable kinds as a display list, derived from [`batch_supported`] so a refusal
+/// names the live set without a hand-maintained string that drifts as providers are added.
+pub fn supported_kinds_list() -> String {
+    [
+        ProviderKind::Anthropic,
+        ProviderKind::DeepSeek,
+        ProviderKind::Gemini,
+        ProviderKind::Openai,
+    ]
+    .into_iter()
+    .filter(|k| batch_supported(*k))
+    .map(ProviderKind::canonical_name)
+    .collect::<Vec<_>>()
+    .join(", ")
+}
+
+/// The refusal for an unsupported backend kind — shared by [`submitter`] and [`poller`] so
+/// the message stays in one place. Names the live supported set via [`supported_kinds_list`].
+fn unsupported(backend: &Backend) -> anyhow::Error {
+    anyhow!(
+        "backend {:?} ({:?}) has no batch lane. Point the cast's synth slot at a \
+         batch-capable backend ({}); `kaibo://config` lists the casts.",
+        backend.name,
+        backend.kind,
+        supported_kinds_list()
+    )
+}
+
+/// Build a submit-capable provider from a resolved cast slot + backend, dispatching on the
+/// backend kind. An unsupported kind is refused honestly (the [`ImageGen`](crate::image_gen)
+/// posture).
+pub fn submitter(
     backend: &Backend,
     slot: &ModelSlot,
     defaults: &Defaults,
 ) -> Result<Arc<dyn BatchProvider>> {
-    Ok(Arc::new(AnthropicBatch::from_slot(
-        backend, slot, defaults,
-    )?))
+    match backend.kind {
+        ProviderKind::Anthropic => Ok(Arc::new(AnthropicBatch::from_slot(
+            backend, slot, defaults,
+        )?)),
+        ProviderKind::Gemini => Ok(Arc::new(GeminiBatch::from_slot(backend, slot, defaults)?)),
+        _ => Err(unsupported(backend)),
+    }
 }
 
-/// Build a poll/cancel-only provider from a resolved backend.
-pub fn anthropic_poll(backend: &Backend) -> Result<Arc<dyn BatchProvider>> {
-    Ok(Arc::new(AnthropicBatch::from_backend(backend)?))
+/// Build a poll/cancel/list-only provider from a resolved backend, dispatching on kind.
+pub fn poller(backend: &Backend) -> Result<Arc<dyn BatchProvider>> {
+    match backend.kind {
+        ProviderKind::Anthropic => Ok(Arc::new(AnthropicBatch::from_backend(backend)?)),
+        ProviderKind::Gemini => Ok(Arc::new(GeminiBatch::from_backend(backend)?)),
+        _ => Err(unsupported(backend)),
+    }
 }
 
 #[cfg(test)]
@@ -933,10 +1374,12 @@ mod tests {
         assert!(matches!(&answers[2].text, Err(m) if m.contains("expired")));
     }
 
-    /// A non-Anthropic backend is refused at construction — this slice has no batch
-    /// path for the other protocols. Honest absence, the ImageGen posture.
+    /// The Anthropic provider refuses any non-Anthropic backend at construction — the
+    /// belt-and-suspenders guard behind dispatch (which should never route one here).
+    /// Honest absence, the ImageGen posture. (Cross-kind *dispatch* refusal is covered by
+    /// `dispatch_refuses_unsupported_kinds`.)
     #[test]
-    fn non_anthropic_backend_refused() {
+    fn anthropic_provider_refuses_non_anthropic() {
         for kind in [
             ProviderKind::DeepSeek,
             ProviderKind::Gemini,
@@ -950,7 +1393,7 @@ mod tests {
                 .err()
                 .unwrap_or_else(|| panic!("non-anthropic batch ({kind:?}) must be refused"));
             assert!(
-                err.to_string().contains("only available on anthropic-kind"),
+                err.to_string().contains("Anthropic batch provider"),
                 "error should explain the anthropic-only constraint: {err}"
             );
         }
@@ -1071,6 +1514,313 @@ mod tests {
         assert!(out.contains("the answer"));
         assert!(out.contains("[1] — failed: expired"));
         assert!(out.contains("kaibo · batch · anthropic · claude-sonnet-4-6"));
+    }
+
+    // --- Gemini ------------------------------------------------------------
+
+    /// Gemini's maxed shape lands in `generationConfig` (the completion budget is nested
+    /// there, not top-level): a budget-tier id carries `thinkingConfig.thinkingBudget`.
+    #[test]
+    fn gemini_shaping_nests_thinking_in_generation_config() {
+        let (max_tokens, params) = batch_shaping(
+            ProviderKind::Gemini,
+            "gemini-3.5-flash",
+            &tunables("high", 100),
+        );
+        assert!(max_tokens >= BATCH_MAX_TOKENS_FLOOR);
+        let params = params.expect("a gemini slot carries a thinking block");
+        let tc = &params["generationConfig"]["thinkingConfig"];
+        assert!(
+            tc["thinkingBudget"].as_u64().unwrap() >= BATCH_THINKING_BUDGET,
+            "gemini batch floors the thinking budget: {params}"
+        );
+    }
+
+    /// A pure `gemini-3-*` line id takes `thinkingLevel`, forced to BATCH_EFFORT — the
+    /// per-role effort lever, not a token budget. (The `gemini-batch` cast itself synths
+    /// `gemini-pro-latest`, which classifies as a *budget*-tier id; this exercises the
+    /// other Gemini thinking tier so both paths through `batch_shaping` are covered.)
+    #[test]
+    fn gemini_3_line_uses_thinking_level_at_batch_effort() {
+        let (_max, params) = batch_shaping(
+            ProviderKind::Gemini,
+            "gemini-3-pro-preview",
+            &tunables("low", 100),
+        );
+        let params = params.expect("a gemini-3 line carries a thinking block");
+        assert_eq!(
+            params["generationConfig"]["thinkingConfig"]["thinkingLevel"], BATCH_EFFORT,
+            "the 3-line forces BATCH_EFFORT as thinkingLevel: {params}"
+        );
+    }
+
+    /// The body nests maxOutputTokens *beside* the shaping's thinkingConfig in one
+    /// generationConfig (Gemini's shape, not Anthropic's top-level max_tokens), carries
+    /// the shared system as systemInstruction, and keys each item by its custom_id.
+    #[test]
+    fn gemini_body_merges_system_maxtokens_and_thinking() {
+        let (max_tokens, params) = batch_shaping(
+            ProviderKind::Gemini,
+            "gemini-3-pro-preview",
+            &tunables("high", 0),
+        );
+        let items = vec![
+            BatchItem {
+                custom_id: "0".into(),
+                prompt: "first".into(),
+            },
+            BatchItem {
+                custom_id: "1".into(),
+                prompt: "second".into(),
+            },
+        ];
+        let body = gemini_batch_body(max_tokens, "be terse", &params, &items);
+        let reqs = body["batch"]["input_config"]["requests"]["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(reqs.len(), 2);
+        assert_eq!(reqs[0]["metadata"]["key"], "0");
+        assert_eq!(
+            reqs[0]["request"]["systemInstruction"]["parts"][0]["text"],
+            "be terse"
+        );
+        assert_eq!(
+            reqs[0]["request"]["contents"][0]["parts"][0]["text"],
+            "first"
+        );
+        let gc = &reqs[0]["request"]["generationConfig"];
+        // maxOutputTokens and the thinking block coexist in one generationConfig.
+        assert_eq!(gc["maxOutputTokens"].as_u64().unwrap(), max_tokens);
+        assert_eq!(gc["thinkingConfig"]["thinkingLevel"], "high");
+        assert_eq!(reqs[1]["metadata"]["key"], "1");
+        assert_eq!(
+            reqs[1]["request"]["contents"][0]["parts"][0]["text"],
+            "second"
+        );
+    }
+
+    /// An empty system prompt omits systemInstruction entirely (Gemini rejects an empty
+    /// one) rather than sending a blank block.
+    #[test]
+    fn gemini_body_omits_empty_system() {
+        let items = vec![BatchItem {
+            custom_id: "0".into(),
+            prompt: "q".into(),
+        }];
+        let body = gemini_batch_body(1024, "", &None, &items);
+        let req = &body["batch"]["input_config"]["requests"]["requests"][0]["request"];
+        assert!(
+            req.get("systemInstruction").is_none(),
+            "empty system must be omitted: {req}"
+        );
+        // maxOutputTokens still lands even with no shaping params.
+        assert_eq!(
+            req["generationConfig"]["maxOutputTokens"].as_u64().unwrap(),
+            1024
+        );
+    }
+
+    #[test]
+    fn gemini_name_reads_or_errors() {
+        assert_eq!(
+            parse_gemini_name(&json!({ "name": "batches/abc123" })).unwrap(),
+            "batches/abc123"
+        );
+        assert!(parse_gemini_name(&json!({ "no": "name" })).is_err());
+    }
+
+    /// batchStats counts arrive as JSON *strings*; progress reads them anyway (a number
+    /// read as 0 would be a silent miscount). completed = succeeded + failed.
+    #[test]
+    fn gemini_progress_reads_string_counts() {
+        let v = json!({ "metadata": { "batchStats": {
+            "requestCount": "10", "pendingRequestCount": "7",
+            "successfulRequestCount": "2", "failedRequestCount": "1"
+        }}});
+        assert_eq!(gemini_progress(v.get("metadata")), (3, 10));
+    }
+
+    #[test]
+    fn gemini_poll_pending_running_and_unknown() {
+        let pend = json!({ "metadata": { "state": "BATCH_STATE_PENDING",
+            "batchStats": { "requestCount": "2", "pendingRequestCount": "2" } } });
+        assert_eq!(
+            parse_gemini_poll(&pend).unwrap(),
+            BatchPoll::Pending {
+                completed: 0,
+                total: 2
+            }
+        );
+        let run = json!({ "metadata": { "state": "BATCH_STATE_RUNNING",
+            "batchStats": { "requestCount": "2", "successfulRequestCount": "1" } } });
+        assert_eq!(
+            parse_gemini_poll(&run).unwrap(),
+            BatchPoll::Pending {
+                completed: 1,
+                total: 2
+            }
+        );
+        // No state, or an unknown one, is a broken contract surfaced loudly.
+        assert!(parse_gemini_poll(&json!({ "metadata": {} })).is_err());
+        assert!(parse_gemini_poll(&json!({ "metadata": { "state": "WAT" } })).is_err());
+    }
+
+    /// A succeeded batch yields per-item answers; thought parts are filtered out of the
+    /// text, a final answer part keeping its thoughtSignature stays, and a per-item error
+    /// is surfaced rather than dropped.
+    #[test]
+    fn gemini_poll_succeeded_parses_inlined() {
+        let v = json!({
+            "metadata": { "state": "BATCH_STATE_SUCCEEDED" },
+            "response": { "inlinedResponses": { "inlinedResponses": [
+                { "metadata": { "key": "0" }, "response": { "candidates": [ { "content": { "parts": [
+                    { "text": "thinking out loud", "thought": true },
+                    { "text": "the ", "thoughtSignature": "sig" },
+                    { "text": "answer" }
+                ] } } ] } },
+                { "metadata": { "key": "1" }, "error": { "code": 7, "message": "permission denied" } }
+            ] } }
+        });
+        let poll = parse_gemini_poll(&v).unwrap();
+        let answers = match poll {
+            BatchPoll::Done(a) => a,
+            other => panic!("expected Done, got {other:?}"),
+        };
+        assert_eq!(answers.len(), 2);
+        assert_eq!(answers[0].custom_id, "0");
+        // Thought part dropped; the two real text parts joined; the signature is irrelevant.
+        assert_eq!(answers[0].text, Ok("the answer".to_string()));
+        assert!(matches!(&answers[1].text, Err(m) if m.contains("permission denied")));
+    }
+
+    /// A cancelled batch with no partial results is a [`BatchPoll::Failed`] naming the
+    /// state and reason — not a misleading empty `Done`. (Gemini cancel is instant-
+    /// terminal, so there's no `Cancelling` interim like Anthropic's.)
+    #[test]
+    fn gemini_poll_cancelled_with_no_results_is_failed() {
+        let v = json!({
+            "metadata": { "state": "BATCH_STATE_CANCELLED",
+                "batchStats": { "requestCount": "1", "pendingRequestCount": "1" } },
+            "error": { "code": 13, "message": "Batch x failed without error." }
+        });
+        assert_eq!(
+            parse_gemini_poll(&v).unwrap(),
+            BatchPoll::Failed {
+                state: "BATCH_STATE_CANCELLED".into(),
+                message: "Batch x failed without error.".into()
+            }
+        );
+    }
+
+    /// A cancelled batch that *did* finish some items before the terminal event hands
+    /// those partial results back rather than throwing them away.
+    #[test]
+    fn gemini_poll_cancelled_with_partials_is_done() {
+        let v = json!({
+            "metadata": { "state": "BATCH_STATE_CANCELLED",
+                "output": { "inlinedResponses": { "inlinedResponses": [
+                    { "metadata": { "key": "0" }, "response": { "candidates": [ { "content": { "parts": [ { "text": "done in time" } ] } } ] } }
+                ] } } }
+        });
+        match parse_gemini_poll(&v).unwrap() {
+            BatchPoll::Done(a) => {
+                assert_eq!(a.len(), 1);
+                assert_eq!(a[0].text, Ok("done in time".to_string()));
+            }
+            other => panic!("expected Done with partials, got {other:?}"),
+        }
+    }
+
+    /// A succeeded batch whose output is a file (not inline) is refused loudly — kaibo only
+    /// submits inline batches, so a file output is an unhandled shape, not silent emptiness.
+    #[test]
+    fn gemini_poll_succeeded_without_inline_errors() {
+        let v = json!({ "metadata": { "state": "BATCH_STATE_SUCCEEDED",
+            "output": { "responsesFile": "files/abc" } } });
+        assert!(parse_gemini_poll(&v).is_err());
+    }
+
+    /// The list endpoint reads `operations` (not `data`) and treats `nextPageToken` as the
+    /// has-more flag. The operation `name` is the provider id (`batches/<id>`).
+    #[test]
+    fn gemini_list_parses_operations_and_page_token() {
+        let v = json!({
+            "operations": [
+                { "name": "batches/aaa", "metadata": { "state": "BATCH_STATE_RUNNING",
+                    "createTime": "2026-06-22T00:00:00Z",
+                    "batchStats": { "requestCount": "4", "successfulRequestCount": "1" } } },
+                { "name": "batches/bbb", "metadata": { "state": "BATCH_STATE_SUCCEEDED",
+                    "batchStats": { "requestCount": "2", "successfulRequestCount": "2" } } }
+            ],
+            "nextPageToken": "tok"
+        });
+        let (items, has_more) = parse_gemini_list(&v).unwrap();
+        assert!(has_more);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].provider_id, "batches/aaa");
+        assert_eq!(items[0].status, "BATCH_STATE_RUNNING");
+        assert_eq!((items[0].completed, items[0].total), (1, 4));
+        assert_eq!(items[0].created_at.as_deref(), Some("2026-06-22T00:00:00Z"));
+        // An empty list omits `operations` entirely — that's an empty page, not an error.
+        let (empty, more) = parse_gemini_list(&json!({})).unwrap();
+        assert!(empty.is_empty() && !more);
+    }
+
+    /// A non-Gemini backend is refused at GeminiBatch construction — the dispatch guard.
+    #[test]
+    fn gemini_provider_refuses_non_gemini() {
+        let mut b = anthropic_backend();
+        b.kind = ProviderKind::Anthropic;
+        let slot = ModelSlot::bare(&b.name, "claude-sonnet-4-6");
+        let err = GeminiBatch::from_slot(&b, &slot, &Defaults::default())
+            .err()
+            .expect("non-gemini must be refused");
+        assert!(err.to_string().contains("Gemini batch provider"), "{err}");
+    }
+
+    /// Dispatch refuses a kind with no batch lane (DeepSeek / local openai) and points at
+    /// the supported casts; `batch_supported` agrees with that set.
+    #[test]
+    fn dispatch_refuses_unsupported_kinds() {
+        assert!(batch_supported(ProviderKind::Anthropic));
+        assert!(batch_supported(ProviderKind::Gemini));
+        assert!(!batch_supported(ProviderKind::DeepSeek));
+        assert!(!batch_supported(ProviderKind::Openai));
+        for kind in [ProviderKind::DeepSeek, ProviderKind::Openai] {
+            let mut b = anthropic_backend();
+            b.kind = kind;
+            b.name = format!("{kind:?}").to_lowercase();
+            let slot = ModelSlot::bare(&b.name, "m");
+            let err = submitter(&b, &slot, &Defaults::default())
+                .err()
+                .unwrap_or_else(|| panic!("{kind:?} must be refused"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("no batch lane"),
+                "refusal explains the gap: {err}"
+            );
+            // The supported set is named dynamically from `batch_supported`, so the message
+            // tracks the live set rather than a hand-maintained string.
+            assert!(
+                msg.contains("anthropic") && msg.contains("gemini"),
+                "refusal names the live supported set: {err}"
+            );
+            assert!(poller(&b).is_err());
+        }
+    }
+
+    /// Failed renders a clear terminal line (state + reason), not a "0 results" success.
+    #[test]
+    fn render_failed_names_state_and_reason() {
+        let out = render_poll(
+            &BatchPoll::Failed {
+                state: "BATCH_STATE_EXPIRED".into(),
+                message: "ran past its 24h window".into(),
+            },
+            "gemini · gemini-3-pro-preview",
+        );
+        assert!(out.contains("BATCH_STATE_EXPIRED"));
+        assert!(out.contains("ran past its 24h window"));
     }
 
     /// The scripted provider drives a full submit → pending → done flow offline.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,0 +1,1115 @@
+//! Batch — offline, max-effort fan-out of the tool-less answer.
+//!
+//! kaibo's consultation tools ([`crate::consult`]) run *synchronously*: prompt in,
+//! answer out, the call held open until the model replies. Batch is the **offline,
+//! async sibling** of [`oneshot`](crate::consult::oneshot) — submit a list of
+//! questions, get a handle, poll it, read the answers when they land. The caller
+//! never holds a synchronous call open per answer; the provider runs the work on its
+//! own (cheaper) batch lane and kaibo just hands back the id.
+//!
+//! **Toolless by construction — no agents.** A batch item is a question, not a
+//! `run_phase` loop: no kaish, no explorer, no tool loop. That's forced, not just
+//! convenient — provider batch APIs are offline/async and can't drive an interactive
+//! tool loop. So batch is built on the `oneshot` *shape* (a single capable model
+//! answering from what it was handed), never `consult`.
+//!
+//! **Max the knobs by default.** Batch is the cheap/async lane, so it spends: it
+//! floors `max_tokens` at [`BATCH_MAX_TOKENS_FLOOR`] and forces thinking on at
+//! [`BATCH_EFFORT`] regardless of how the cast's synth slot was tuned for interactive
+//! use. The latency that makes max-thinking painful synchronously is free here — the
+//! caller already accepted "come back later." This is the lane for asking the best
+//! model the hard question and waiting.
+//!
+//! **Per-provider HTTP seam.** rig-core has no batch path, so each provider is
+//! hand-rolled behind the [`BatchProvider`] trait — the same shape as the
+//! [`ImageGen`](crate::image_gen) seam (one trait, per-kind impls, honest refusal
+//! where absent). This slice ships **Anthropic Message Batches** ([`AnthropicBatch`]),
+//! whose requests ride inline in one POST; Gemini (its own shape) and OpenAI
+//! (file-based) are tracked follow-ons in `docs/issues.md`. A non-Anthropic backend is
+//! refused loudly at resolution, never a silent no-op.
+//!
+//! **No persistent state.** kaibo holds nothing on disk; a batch id *is* the provider's
+//! own id, so poll/cancel rebuild a fresh client from the backend and re-address it. A
+//! restart drops nothing the provider still has — the design the `docs/issues.md` entry
+//! commits to.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde_json::{json, Map, Value};
+
+use crate::config::{Backend, Defaults, ModelRole, ModelSlot, SlotTunables};
+use crate::credentials::ProviderKind;
+
+/// Anthropic's API base. The keyed Anthropic backend carries no `base_url` (rig fixes
+/// its endpoint), so batch addresses the service directly.
+const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com";
+
+/// The effort batch runs every item at — the maxed knob. Equal to
+/// [`crate::consult::DEFAULT_EFFORT`] today (the proven-accepted top for the Anthropic
+/// adaptive tier); kept a separate constant so batch's "spend, it's async" intent
+/// survives a change to the interactive default. Forced regardless of the slot's
+/// configured `effort` — a cast tuned down for flaky interactive use still batches hot.
+pub const BATCH_EFFORT: &str = "high";
+
+/// Floor for a batch item's completion budget. Thinking eats the completion budget, so
+/// a thin `max_tokens` starves the answer; batch is async and cheap, so it never skimps.
+/// Floored (not fixed) so a slot that *already* asks for more keeps it.
+pub const BATCH_MAX_TOKENS_FLOOR: u64 = 1 << 15; // 32768
+
+/// Thinking budget for the budget-style tiers (older Anthropic / Haiku). Kept under
+/// [`BATCH_MAX_TOKENS_FLOOR`] so reasoning never starves the answer (Anthropic also
+/// *requires* `budget_tokens < max_tokens`). Ignored by the adaptive tier, which
+/// expresses depth as `output_config.effort` rather than a token budget.
+pub const BATCH_THINKING_BUDGET: u64 = 1 << 14; // 16384
+
+/// One question to run in a batch — toolless by construction. `custom_id` is the
+/// provider's per-item correlation key (kaibo assigns the item's index); `prompt` is
+/// the whole of the model's input, the same as a `oneshot` prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchItem {
+    pub custom_id: String,
+    pub prompt: String,
+}
+
+/// One finished item's outcome: the model's text, or a reason it didn't produce one
+/// (the provider errored, canceled, or expired the request). Per-item, so one failed
+/// question never sinks the rest of the batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchAnswer {
+    pub custom_id: String,
+    /// `Ok(text)` for a succeeded request; `Err(reason)` for an errored/canceled/
+    /// expired one — surfaced honestly per item, never silently dropped.
+    pub text: Result<String, String>,
+}
+
+/// Where a batch is in its lifecycle, as one poll sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchPoll {
+    /// Still running. `completed`/`total` drive a human-readable progress line.
+    Pending { completed: u64, total: u64 },
+    /// A cancel is in flight; results aren't ready yet.
+    Cancelling,
+    /// Finished — every item's outcome, succeeded or not.
+    Done(Vec<BatchAnswer>),
+}
+
+/// One batch as the provider's list endpoint reports it — enough to re-address and
+/// triage it without fetching results. The orphan-recovery view: kaibo holds no state,
+/// so when a caller has lost a handle, listing the provider's own batches is the only
+/// way back to it. `provider_id` rebuilds the handle (`backend/provider_id`); `status`
+/// is the raw `processing_status`; `created_at` (when present) helps pick the one you
+/// meant out of several.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchListItem {
+    pub provider_id: String,
+    pub status: String,
+    pub completed: u64,
+    pub total: u64,
+    pub created_at: Option<String>,
+}
+
+/// A provider's batch lane: submit a fan-out, poll it, cancel it, list what's there.
+/// One method each, so the whole path is exercised offline against [`ScriptedBatch`]
+/// and the concrete provider is swappable as more batch backends land — the
+/// [`ImageGen`](crate::image_gen) discipline.
+#[async_trait]
+pub trait BatchProvider: Send + Sync {
+    /// Submit `items` (each answered under the shared `system` preamble) as one batch;
+    /// returns the provider's batch id.
+    async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String>;
+    /// Poll a batch by its provider id.
+    async fn poll(&self, batch_id: &str) -> Result<BatchPoll>;
+    /// Ask the provider to cancel a batch by its id.
+    async fn cancel(&self, batch_id: &str) -> Result<()>;
+    /// List the most recent batches the provider still knows about (newest first),
+    /// plus whether more exist beyond the page (so a truncated view is never silent).
+    async fn list(&self) -> Result<(Vec<BatchListItem>, bool)>;
+}
+
+// --- Request shaping (pure, offline-testable) ------------------------------
+
+/// Batch's maxed request shape for one (kind, model): the floored completion budget and
+/// the forced thinking block, at [`BATCH_EFFORT`]. Threads `BATCH_EFFORT` *explicitly*
+/// through [`ModelShape::to_params`](crate::consult::ModelShape::to_params) rather than
+/// the public [`thinking_params`](crate::consult::thinking_params) helper (which would
+/// bake in `consult`'s interactive `DEFAULT_EFFORT`) — so batch's effort stays decoupled
+/// from the interactive default, the way the [`BATCH_EFFORT`] doc promises.
+///
+/// Every knob is *floored*, never capped: `max_tokens` and the thinking budget both rise
+/// to the batch floor but keep a slot's already-higher value — that's the "max the knobs"
+/// promise (batch spends even when the cast was tuned thin for interactive use), and it
+/// can't *undercut* a slot that already asks for more. The budget is held strictly under
+/// `max_tokens` (Anthropic requires `budget_tokens < max_tokens`; the adaptive tier
+/// ignores the budget and expresses depth as `output_config.effort`). Sampling is left
+/// to the provider default — `None`/`None` here — since batch maxes thinking, and the
+/// adaptive tier rejects sampling under thinking anyway.
+pub fn batch_shaping(
+    kind: ProviderKind,
+    model: &str,
+    tunables: &SlotTunables,
+) -> (u64, Option<Value>) {
+    let max_tokens = tunables.max_tokens.max(BATCH_MAX_TOKENS_FLOOR);
+    // Floor the thinking budget (never undercut a slot that already asks for more), held
+    // strictly under max_tokens so reasoning never starves the answer.
+    let budget = tunables
+        .thinking_budget
+        .max(BATCH_THINKING_BUDGET)
+        .min(max_tokens.saturating_sub(1));
+    let params = crate::consult::ModelShape::resolve(kind, model, tunables.thinking_style)
+        .to_params(budget, None, None, BATCH_EFFORT);
+    (max_tokens, params)
+}
+
+/// Build the Anthropic Message Batches request body. Each item becomes one request
+/// whose `params` is a Messages API body: `model`/`max_tokens`/`system`/`messages` plus
+/// the flattened thinking block (`thinking`, and the adaptive tier's `output_config`).
+/// Pure so the wire shape — including the knob-maxing merged in from `params` — is
+/// pinned without a network.
+pub fn anthropic_batch_body(
+    model: &str,
+    max_tokens: u64,
+    system: &str,
+    params: &Option<Value>,
+    items: &[BatchItem],
+) -> Value {
+    let requests: Vec<Value> = items
+        .iter()
+        .map(|it| {
+            let mut p = Map::new();
+            p.insert("model".into(), json!(model));
+            p.insert("max_tokens".into(), json!(max_tokens));
+            p.insert("system".into(), json!(system));
+            p.insert(
+                "messages".into(),
+                json!([{ "role": "user", "content": it.prompt }]),
+            );
+            // Flatten the thinking/effort block in, the way rig flattens
+            // additional_params into a Messages body (consult.rs).
+            if let Some(Value::Object(extra)) = params {
+                for (k, v) in extra {
+                    p.insert(k.clone(), v.clone());
+                }
+            }
+            json!({ "custom_id": it.custom_id, "params": Value::Object(p) })
+        })
+        .collect();
+    json!({ "requests": requests })
+}
+
+// --- Response parsing (pure, offline-testable) -----------------------------
+
+/// What a status poll tells us before we go fetch results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StatusKind {
+    Pending { completed: u64, total: u64 },
+    Cancelling,
+    Ended { results_url: String },
+}
+
+/// Pull the batch id out of a submit/status response. A missing `id` is a broken
+/// contract worth surfacing, not papering over.
+fn parse_batch_id(v: &Value) -> Result<String> {
+    v.get("id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("batch response has no string `id`: {v}"))
+}
+
+/// Read a batch's `request_counts` into `(completed, total)`. `completed` sums the
+/// terminal buckets (succeeded/errored/canceled/expired); `total` adds the still-
+/// `processing` count. Shared by the status poll and the list view so both count a
+/// batch's progress the same way. A missing block reads as zero rather than erroring —
+/// a batch with no counts yet is simply 0/0.
+fn counts_of(v: &Value) -> (u64, u64) {
+    let c = v.get("request_counts");
+    let get = |k: &str| {
+        c.and_then(|c| c.get(k))
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+    };
+    let processing = get("processing");
+    let completed = get("succeeded") + get("errored") + get("canceled") + get("expired");
+    (completed, completed + processing)
+}
+
+/// Read a batch's `processing_status` + `request_counts` into a [`StatusKind`].
+fn parse_status(v: &Value) -> Result<StatusKind> {
+    let status = v
+        .get("processing_status")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("batch status has no `processing_status`: {v}"))?;
+    match status {
+        "in_progress" => {
+            let (completed, total) = counts_of(v);
+            Ok(StatusKind::Pending { completed, total })
+        }
+        "canceling" => Ok(StatusKind::Cancelling),
+        "ended" => {
+            let results_url = v
+                .get("results_url")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("ended batch has no `results_url`: {v}"))?
+                .to_string();
+            Ok(StatusKind::Ended { results_url })
+        }
+        other => Err(anyhow!("unknown batch processing_status {other:?}")),
+    }
+}
+
+/// Parse one batch object from the list endpoint into a [`BatchListItem`]. A missing
+/// `id`/`processing_status` is a broken contract, surfaced rather than papered over;
+/// counts and `created_at` are best-effort (a batch may not carry them yet).
+fn parse_list_item(v: &Value) -> Result<BatchListItem> {
+    let provider_id = v
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("batch list item has no `id`: {v}"))?
+        .to_string();
+    let status = v
+        .get("processing_status")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("batch list item has no `processing_status`: {v}"))?
+        .to_string();
+    let (completed, total) = counts_of(v);
+    let created_at = v
+        .get("created_at")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Ok(BatchListItem {
+        provider_id,
+        status,
+        completed,
+        total,
+        created_at,
+    })
+}
+
+/// Parse the list endpoint's `{ data: [...], has_more }` page into items (in the order
+/// the provider returned them — newest first) plus the `has_more` flag, so a caller
+/// learns a truncated page is truncated instead of mistaking it for the whole set.
+fn parse_batch_list(v: &Value) -> Result<(Vec<BatchListItem>, bool)> {
+    let data = v
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("batch list response has no `data` array: {v}"))?;
+    let items = data
+        .iter()
+        .map(parse_list_item)
+        .collect::<Result<Vec<_>>>()?;
+    let has_more = v.get("has_more").and_then(Value::as_bool).unwrap_or(false);
+    Ok((items, has_more))
+}
+
+/// Join the `text` parts of an Anthropic message's content array.
+fn message_text(message: &Value) -> String {
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter(|p| p.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|p| p.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default()
+}
+
+/// Parse the JSONL results body: one `{custom_id, result}` per line. A `succeeded`
+/// result yields the message text; `errored`/`canceled`/`expired` yield a per-item
+/// `Err(reason)` so a single bad item is reported, never silently dropped.
+fn parse_results_jsonl(body: &str) -> Result<Vec<BatchAnswer>> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: Value =
+            serde_json::from_str(line).with_context(|| format!("parsing result line {line:?}"))?;
+        let custom_id = v
+            .get("custom_id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("result line has no `custom_id`: {line}"))?
+            .to_string();
+        let result = v
+            .get("result")
+            .ok_or_else(|| anyhow!("result line has no `result`: {line}"))?;
+        let kind = result.get("type").and_then(Value::as_str).unwrap_or("");
+        let text = match kind {
+            "succeeded" => {
+                let message = result
+                    .get("message")
+                    .ok_or_else(|| anyhow!("succeeded result has no `message`: {line}"))?;
+                Ok(message_text(message))
+            }
+            "errored" => {
+                // Prefer the human `error.message`, then its `type`, then the raw blob —
+                // a readable reason beats dumping the whole JSON object at the caller.
+                let err = result.get("error");
+                let detail = err
+                    .and_then(|e| e.get("message"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .or_else(|| {
+                        err.and_then(|e| e.get("type"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .or_else(|| err.map(|e| e.to_string()))
+                    .unwrap_or_else(|| "unknown error".into());
+                Err(format!("provider error: {detail}"))
+            }
+            "canceled" => Err("canceled".into()),
+            "expired" => Err("expired before it ran".into()),
+            other => Err(format!("unexpected result type {other:?}")),
+        };
+        out.push(BatchAnswer { custom_id, text });
+    }
+    Ok(out)
+}
+
+// --- Rendering -------------------------------------------------------------
+
+/// Render a poll for the calling agent. Pending shows progress; Done lists each item's
+/// answer (or its per-item failure) under a self-labelling footer naming who ran it —
+/// the provenance the `docs/issues.md` entry wants on a batch result.
+pub fn render_poll(poll: &BatchPoll, label: &str) -> String {
+    match poll {
+        BatchPoll::Pending { completed, total } => {
+            format!("Batch in progress — {completed}/{total} requests done. No need to wait on it — go do other work and `batch_get` this id again later (it can take minutes to hours; the handle keeps).")
+        }
+        BatchPoll::Cancelling => {
+            "Batch is being canceled; poll again for the final per-item results.".to_string()
+        }
+        BatchPoll::Done(answers) => {
+            let mut s = format!("Batch complete — {} result(s):\n", answers.len());
+            for a in answers {
+                match &a.text {
+                    Ok(text) => s.push_str(&format!("\n## [{}]\n{}\n", a.custom_id, text)),
+                    Err(reason) => {
+                        s.push_str(&format!("\n## [{}] — failed: {}\n", a.custom_id, reason))
+                    }
+                }
+            }
+            s.push_str(&format!("\n———\nkaibo · batch · {label}"));
+            s
+        }
+    }
+}
+
+/// Render a `batch_list` result for the calling agent. Each entry is a ready-to-use
+/// `(handle, item)`; `errors` are per-backend failures (a backend with no key or an
+/// unreachable endpoint is reported, not silently skipped — one bad backend never
+/// hides the rest); `truncated` names backends whose page hit `has_more` (so a partial
+/// view announces itself rather than reading as complete).
+pub fn render_list(
+    entries: &[(String, BatchListItem)],
+    errors: &[(String, String)],
+    truncated: &[String],
+) -> String {
+    let mut s = String::new();
+    if entries.is_empty() && errors.is_empty() {
+        return "No batches found. Submit one with `batch_submit`.".to_string();
+    }
+    s.push_str(&format!("Batches — {} found:\n", entries.len()));
+    for (handle, it) in entries {
+        s.push_str(&format!(
+            "\n- `{}` — {}, {}/{} done",
+            handle, it.status, it.completed, it.total
+        ));
+        if let Some(created) = &it.created_at {
+            s.push_str(&format!(" (created {created})"));
+        }
+    }
+    if !entries.is_empty() {
+        s.push_str("\n\nPoll one with `batch_get <handle>`; cancel with `batch_cancel <handle>`.");
+    }
+    if !truncated.is_empty() {
+        s.push_str(&format!(
+            "\n\nMore batches exist beyond this page on backend(s) {} — narrow by polling \
+             a specific handle if you don't see the one you want.",
+            truncated.join(", ")
+        ));
+    }
+    for (backend, err) in errors {
+        s.push_str(&format!("\n\nCould not list backend `{backend}`: {err}"));
+    }
+    s
+}
+
+// --- Anthropic provider ----------------------------------------------------
+
+/// Anthropic Message Batches over HTTP. Holds the connection (client, key) plus the
+/// per-submit shaping (model, floored `max_tokens`, the maxed thinking block). Poll and
+/// cancel need only the connection, so a [`from_backend`](Self::from_backend) client
+/// (no model) drives those after a restart.
+pub struct AnthropicBatch {
+    http: reqwest::Client,
+    api_key: String,
+    /// Submit-only: empty on a poll/cancel-only client.
+    model: String,
+    max_tokens: u64,
+    params: Option<Value>,
+}
+
+impl AnthropicBatch {
+    /// Refuse a non-Anthropic backend loudly: this slice has no batch path for the
+    /// other protocols, so attaching one would only fail (or worse, no-op) at call
+    /// time. Honest absence beats a false promise — the [`ImageGen`](crate::image_gen)
+    /// posture.
+    fn require_anthropic(backend: &Backend) -> Result<()> {
+        if backend.kind != ProviderKind::Anthropic {
+            return Err(anyhow!(
+                "batch is only available on anthropic-kind backends today; backend {:?} \
+                 is {:?}. Gemini and OpenAI batch are tracked follow-ons (docs/issues.md) \
+                 — point the cast's synth slot at an Anthropic backend to batch now.",
+                backend.name,
+                backend.kind
+            ));
+        }
+        Ok(())
+    }
+
+    /// A reqwest client carrying the backend's per-request deadline. Same TLS wiring as
+    /// every other client build site: install ring before `.build()`.
+    fn http_client(backend: &Backend) -> Result<reqwest::Client> {
+        crate::tls::ensure_crypto_provider();
+        reqwest::Client::builder()
+            .timeout(backend.request_timeout)
+            .connect_timeout(backend.request_timeout.min(Duration::from_secs(10)))
+            .build()
+            .map_err(|e| anyhow!("http client init: {e}"))
+    }
+
+    /// A submit-capable client: the cast's synth slot, shaped to batch's maxed knobs.
+    pub fn from_slot(backend: &Backend, slot: &ModelSlot, defaults: &Defaults) -> Result<Self> {
+        Self::require_anthropic(backend)?;
+        let tunables = slot.tunables(ModelRole::Synth, defaults);
+        let (max_tokens, params) = batch_shaping(backend.kind, &slot.id, &tunables);
+        Ok(Self {
+            http: Self::http_client(backend)?,
+            api_key: backend.resolve_key()?,
+            model: slot.id.clone(),
+            max_tokens,
+            params,
+        })
+    }
+
+    /// A poll/cancel-only client (no model): all that's needed to re-address a batch by
+    /// its id after a restart.
+    pub fn from_backend(backend: &Backend) -> Result<Self> {
+        Self::require_anthropic(backend)?;
+        Ok(Self {
+            http: Self::http_client(backend)?,
+            api_key: backend.resolve_key()?,
+            model: String::new(),
+            max_tokens: 0,
+            params: None,
+        })
+    }
+
+    /// Apply the shared Anthropic headers (auth + API version) to a request.
+    fn auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        req.header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+    }
+
+    /// GET a results JSONL body. The `results_url` is absolute (from the status), so it
+    /// addresses the service directly.
+    async fn fetch_results(&self, results_url: &str) -> Result<Vec<BatchAnswer>> {
+        let resp = self
+            .auth(self.http.get(results_url))
+            .send()
+            .await
+            .map_err(|e| anyhow!("batch results GET failed: {e}"))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| anyhow!("reading batch results body: {e}"))?;
+        if !status.is_success() {
+            return Err(anyhow!("batch results GET {status}: {body}"));
+        }
+        parse_results_jsonl(&body)
+    }
+}
+
+#[async_trait]
+impl BatchProvider for AnthropicBatch {
+    async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String> {
+        if self.model.is_empty() {
+            return Err(anyhow!(
+                "this batch client was built for poll/cancel only (no model) — submit \
+                 needs a synth slot"
+            ));
+        }
+        if items.is_empty() {
+            return Err(anyhow!("a batch needs at least one prompt"));
+        }
+        let body = anthropic_batch_body(&self.model, self.max_tokens, system, &self.params, items);
+        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches");
+        let resp = self
+            .auth(self.http.post(&url))
+            .body(serde_json::to_vec(&body)?)
+            .send()
+            .await
+            .map_err(|e| anyhow!("batch submit POST failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| anyhow!("reading batch submit body: {e}"))?;
+        if !status.is_success() {
+            return Err(anyhow!("batch submit {status}: {text}"));
+        }
+        let v: Value = serde_json::from_str(&text)
+            .with_context(|| format!("parsing batch submit response: {text}"))?;
+        parse_batch_id(&v)
+    }
+
+    async fn poll(&self, batch_id: &str) -> Result<BatchPoll> {
+        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches/{batch_id}");
+        let resp = self
+            .auth(self.http.get(&url))
+            .send()
+            .await
+            .map_err(|e| anyhow!("batch status GET failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| anyhow!("reading batch status body: {e}"))?;
+        if !status.is_success() {
+            return Err(anyhow!("batch status GET {status}: {text}"));
+        }
+        let v: Value =
+            serde_json::from_str(&text).with_context(|| format!("parsing batch status: {text}"))?;
+        match parse_status(&v)? {
+            StatusKind::Pending { completed, total } => Ok(BatchPoll::Pending { completed, total }),
+            StatusKind::Cancelling => Ok(BatchPoll::Cancelling),
+            StatusKind::Ended { results_url } => {
+                Ok(BatchPoll::Done(self.fetch_results(&results_url).await?))
+            }
+        }
+    }
+
+    async fn cancel(&self, batch_id: &str) -> Result<()> {
+        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches/{batch_id}/cancel");
+        let resp = self
+            .auth(self.http.post(&url))
+            .send()
+            .await
+            .map_err(|e| anyhow!("batch cancel POST failed: {e}"))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("batch cancel POST {status}: {text}"));
+        }
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<(Vec<BatchListItem>, bool)> {
+        // One page at the API's max (100), newest-first by default. `has_more` rides
+        // back so a truncated view announces itself — orphan recovery wants the recent
+        // tail, and a caller who needs deeper history polls a known handle directly.
+        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches?limit=100");
+        let resp = self
+            .auth(self.http.get(&url))
+            .send()
+            .await
+            .map_err(|e| anyhow!("batch list GET failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| anyhow!("reading batch list body: {e}"))?;
+        if !status.is_success() {
+            return Err(anyhow!("batch list GET {status}: {text}"));
+        }
+        let v: Value =
+            serde_json::from_str(&text).with_context(|| format!("parsing batch list: {text}"))?;
+        parse_batch_list(&v)
+    }
+}
+
+/// Build a submit-capable provider from a resolved cast slot + backend (refuses a
+/// non-Anthropic backend honestly).
+pub fn anthropic_submit(
+    backend: &Backend,
+    slot: &ModelSlot,
+    defaults: &Defaults,
+) -> Result<Arc<dyn BatchProvider>> {
+    Ok(Arc::new(AnthropicBatch::from_slot(
+        backend, slot, defaults,
+    )?))
+}
+
+/// Build a poll/cancel-only provider from a resolved backend.
+pub fn anthropic_poll(backend: &Backend) -> Result<Arc<dyn BatchProvider>> {
+    Ok(Arc::new(AnthropicBatch::from_backend(backend)?))
+}
+
+#[cfg(test)]
+mod test_double {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A scripted [`BatchProvider`] for offline tests: records submits and replays a
+    /// fixed sequence of poll outcomes (so a test can drive submit → pending → done
+    /// with no network) — the batch analogue of
+    /// [`ScriptedImageGen`](crate::image_gen::ScriptedImageGen).
+    pub struct ScriptedBatch {
+        submit_id: String,
+        polls: Mutex<std::collections::VecDeque<BatchPoll>>,
+        submits: Mutex<Vec<(String, Vec<BatchItem>)>>,
+        canceled: Mutex<Vec<String>>,
+        listing: (Vec<BatchListItem>, bool),
+    }
+
+    impl ScriptedBatch {
+        /// Returns `submit_id` on submit, then yields `polls` in order (the last is
+        /// repeated once the queue drains, so over-polling a Done batch stays Done).
+        pub fn new(submit_id: &str, polls: Vec<BatchPoll>) -> Self {
+            Self {
+                submit_id: submit_id.to_string(),
+                polls: Mutex::new(polls.into()),
+                submits: Mutex::new(Vec::new()),
+                canceled: Mutex::new(Vec::new()),
+                listing: (Vec::new(), false),
+            }
+        }
+
+        /// Seed what `list` returns (items + `has_more`).
+        pub fn with_listing(mut self, items: Vec<BatchListItem>, has_more: bool) -> Self {
+            self.listing = (items, has_more);
+            self
+        }
+
+        /// The `(system, items)` of each submit, in order.
+        pub fn submits(&self) -> Vec<(String, Vec<BatchItem>)> {
+            self.submits.lock().expect("submits lock").clone()
+        }
+
+        /// The batch ids cancel was called with.
+        pub fn canceled(&self) -> Vec<String> {
+            self.canceled.lock().expect("canceled lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl BatchProvider for ScriptedBatch {
+        async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String> {
+            self.submits
+                .lock()
+                .expect("submits lock")
+                .push((system.to_string(), items.to_vec()));
+            Ok(self.submit_id.clone())
+        }
+
+        async fn poll(&self, _batch_id: &str) -> Result<BatchPoll> {
+            let mut q = self.polls.lock().expect("polls lock");
+            // Drain in order; repeat the last so an extra poll of a Done batch is Done.
+            if q.len() > 1 {
+                Ok(q.pop_front().expect("non-empty"))
+            } else {
+                Ok(q.front()
+                    .cloned()
+                    .ok_or_else(|| anyhow!("no scripted polls"))?)
+            }
+        }
+
+        async fn cancel(&self, batch_id: &str) -> Result<()> {
+            self.canceled
+                .lock()
+                .expect("canceled lock")
+                .push(batch_id.to_string());
+            Ok(())
+        }
+
+        async fn list(&self) -> Result<(Vec<BatchListItem>, bool)> {
+            Ok(self.listing.clone())
+        }
+    }
+}
+
+#[cfg(test)]
+pub use test_double::ScriptedBatch;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Defaults, ModelSlot};
+
+    fn anthropic_backend() -> Backend {
+        Backend {
+            name: "anthropic".into(),
+            kind: ProviderKind::Anthropic,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: false,
+            request_timeout: Duration::from_secs(30),
+        }
+    }
+
+    fn tunables(effort: &str, max_tokens: u64) -> SlotTunables {
+        SlotTunables {
+            max_tokens,
+            thinking_budget: 1024,
+            temperature: 1.0,
+            top_p: 1.0,
+            effort: effort.to_string(),
+            thinking_style: crate::consult::ThinkingStyleOverride::Auto,
+        }
+    }
+
+    /// Batch maxes the knobs: even a slot tuned thin for interactive use (tiny
+    /// max_tokens, low effort) is floored and forced to the batch effort. The adaptive
+    /// tier expresses that as `output_config.effort: "high"`.
+    #[test]
+    fn shaping_floors_tokens_and_forces_high_effort_adaptive() {
+        let (max_tokens, params) = batch_shaping(
+            ProviderKind::Anthropic,
+            "claude-sonnet-4-6",
+            &tunables("low", 100),
+        );
+        assert!(
+            max_tokens >= BATCH_MAX_TOKENS_FLOOR,
+            "a thin slot must be floored to the batch budget, got {max_tokens}"
+        );
+        let params = params.expect("an adaptive Anthropic model carries a thinking block");
+        assert_eq!(params["thinking"]["type"], "adaptive");
+        // Pin the value to BATCH_EFFORT itself, not the literal "high" — this is what
+        // keeps batch's effort decoupled from consult's interactive DEFAULT_EFFORT (the
+        // dead-constant bug the cross-family review caught).
+        assert_eq!(
+            params["output_config"]["effort"], BATCH_EFFORT,
+            "batch must force BATCH_EFFORT regardless of the slot's configured effort: {params}"
+        );
+    }
+
+    /// The thinking budget is a *floor*, not a cap: a budget-tier slot already asking
+    /// for more than BATCH_THINKING_BUDGET keeps its higher value (still under
+    /// max_tokens). "Max the knobs" means batch never undercuts a richer slot.
+    #[test]
+    fn shaping_floors_thinking_budget_without_undercutting() {
+        // A Haiku slot (budget tier) configured with a budget above the batch floor but
+        // below the token floor.
+        let high_budget = BATCH_THINKING_BUDGET + 4096;
+        let mut t = tunables("high", 100);
+        t.thinking_budget = high_budget;
+        let (max_tokens, params) = batch_shaping(ProviderKind::Anthropic, "claude-haiku-4-5", &t);
+        let params = params.expect("haiku carries a budget thinking block");
+        assert_eq!(
+            params["thinking"]["budget_tokens"].as_u64().unwrap(),
+            high_budget,
+            "a slot's already-higher thinking budget must be kept, not capped: {params}"
+        );
+        assert!(params["thinking"]["budget_tokens"].as_u64().unwrap() < max_tokens);
+    }
+
+    /// A budget-tier model (Haiku) carries the enabled/budget thinking block, still
+    /// floored on tokens.
+    #[test]
+    fn shaping_budget_tier_emits_budget_thinking() {
+        let (max_tokens, params) = batch_shaping(
+            ProviderKind::Anthropic,
+            "claude-haiku-4-5",
+            &tunables("high", 100),
+        );
+        assert!(max_tokens >= BATCH_MAX_TOKENS_FLOOR);
+        let params = params.expect("haiku carries an enabled/budget thinking block");
+        assert_eq!(params["thinking"]["type"], "enabled");
+        assert!(
+            params["thinking"]["budget_tokens"].as_u64().unwrap() < max_tokens,
+            "thinking budget must stay under max_tokens or Anthropic 400s: {params}"
+        );
+    }
+
+    /// The request body carries one request per item, each a Messages body with the
+    /// shared system, the per-item prompt, and the merged-in thinking knobs.
+    #[test]
+    fn body_merges_system_prompt_and_knobs_per_item() {
+        let (max_tokens, params) = batch_shaping(
+            ProviderKind::Anthropic,
+            "claude-sonnet-4-6",
+            &tunables("high", 0),
+        );
+        let items = vec![
+            BatchItem {
+                custom_id: "0".into(),
+                prompt: "first".into(),
+            },
+            BatchItem {
+                custom_id: "1".into(),
+                prompt: "second".into(),
+            },
+        ];
+        let body =
+            anthropic_batch_body("claude-sonnet-4-6", max_tokens, "be terse", &params, &items);
+        let reqs = body["requests"].as_array().expect("requests array");
+        assert_eq!(reqs.len(), 2);
+        assert_eq!(reqs[0]["custom_id"], "0");
+        assert_eq!(reqs[0]["params"]["model"], "claude-sonnet-4-6");
+        assert_eq!(reqs[0]["params"]["system"], "be terse");
+        assert_eq!(reqs[0]["params"]["messages"][0]["content"], "first");
+        // The maxed thinking knob is flattened into each request's params.
+        assert_eq!(reqs[0]["params"]["output_config"]["effort"], "high");
+        assert_eq!(reqs[1]["params"]["messages"][0]["content"], "second");
+    }
+
+    #[test]
+    fn parse_id_reads_id_or_errors() {
+        assert_eq!(
+            parse_batch_id(&json!({ "id": "msgbatch_01ABC" })).unwrap(),
+            "msgbatch_01ABC"
+        );
+        assert!(parse_batch_id(&json!({ "no": "id" })).is_err());
+    }
+
+    #[test]
+    fn status_in_progress_counts() {
+        let v = json!({
+            "processing_status": "in_progress",
+            "request_counts": { "processing": 7, "succeeded": 2, "errored": 1, "canceled": 0, "expired": 0 }
+        });
+        assert_eq!(
+            parse_status(&v).unwrap(),
+            StatusKind::Pending {
+                completed: 3,
+                total: 10
+            }
+        );
+    }
+
+    #[test]
+    fn status_ended_carries_results_url() {
+        let v = json!({ "processing_status": "ended", "results_url": "https://x/results" });
+        assert_eq!(
+            parse_status(&v).unwrap(),
+            StatusKind::Ended {
+                results_url: "https://x/results".into()
+            }
+        );
+    }
+
+    #[test]
+    fn status_canceling_and_unknown() {
+        assert_eq!(
+            parse_status(&json!({ "processing_status": "canceling" })).unwrap(),
+            StatusKind::Cancelling
+        );
+        assert!(parse_status(&json!({ "processing_status": "wat" })).is_err());
+        // An ended batch with no results_url is a broken contract, surfaced loudly.
+        assert!(parse_status(&json!({ "processing_status": "ended" })).is_err());
+    }
+
+    #[test]
+    fn results_jsonl_succeeded_and_failed_per_item() {
+        let body = concat!(
+            r#"{"custom_id":"0","result":{"type":"succeeded","message":{"content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}]}}}"#,
+            "\n",
+            r#"{"custom_id":"1","result":{"type":"errored","error":{"type":"overloaded"}}}"#,
+            "\n",
+            r#"{"custom_id":"2","result":{"type":"expired"}}"#,
+            "\n",
+        );
+        let answers = parse_results_jsonl(body).unwrap();
+        assert_eq!(answers.len(), 3);
+        assert_eq!(
+            answers[0],
+            BatchAnswer {
+                custom_id: "0".into(),
+                text: Ok("hello world".into())
+            }
+        );
+        assert!(matches!(&answers[1].text, Err(m) if m.contains("overloaded")));
+        assert!(matches!(&answers[2].text, Err(m) if m.contains("expired")));
+    }
+
+    /// A non-Anthropic backend is refused at construction — this slice has no batch
+    /// path for the other protocols. Honest absence, the ImageGen posture.
+    #[test]
+    fn non_anthropic_backend_refused() {
+        for kind in [
+            ProviderKind::DeepSeek,
+            ProviderKind::Gemini,
+            ProviderKind::Openai,
+        ] {
+            let mut b = anthropic_backend();
+            b.kind = kind;
+            b.name = format!("{kind:?}").to_lowercase();
+            let slot = ModelSlot::bare(&b.name, "some-model");
+            let err = AnthropicBatch::from_slot(&b, &slot, &Defaults::default())
+                .err()
+                .unwrap_or_else(|| panic!("non-anthropic batch ({kind:?}) must be refused"));
+            assert!(
+                err.to_string().contains("only available on anthropic-kind"),
+                "error should explain the anthropic-only constraint: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn list_parses_items_and_has_more() {
+        let v = json!({
+            "data": [
+                {
+                    "id": "msgbatch_01AAA",
+                    "processing_status": "in_progress",
+                    "created_at": "2026-06-22T00:00:00Z",
+                    "request_counts": { "processing": 3, "succeeded": 1, "errored": 0, "canceled": 0, "expired": 0 }
+                },
+                {
+                    "id": "msgbatch_01BBB",
+                    "processing_status": "ended",
+                    "request_counts": { "processing": 0, "succeeded": 2, "errored": 0, "canceled": 0, "expired": 0 }
+                }
+            ],
+            "has_more": true
+        });
+        let (items, has_more) = parse_batch_list(&v).unwrap();
+        assert!(has_more);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].provider_id, "msgbatch_01AAA");
+        assert_eq!(items[0].status, "in_progress");
+        assert_eq!((items[0].completed, items[0].total), (1, 4));
+        assert_eq!(items[0].created_at.as_deref(), Some("2026-06-22T00:00:00Z"));
+        // An ended batch with no `processing` still counts its terminal buckets.
+        assert_eq!((items[1].completed, items[1].total), (2, 2));
+        assert_eq!(items[1].created_at, None);
+        // A list item missing `id` is a broken contract, surfaced.
+        assert!(parse_batch_list(&json!({ "data": [{ "processing_status": "ended" }] })).is_err());
+        // A response with no `data` array is surfaced too.
+        assert!(parse_batch_list(&json!({ "has_more": false })).is_err());
+    }
+
+    /// The list render names each batch by its ready-to-use handle, surfaces a
+    /// truncated page, and reports a per-backend failure instead of hiding it.
+    #[test]
+    fn render_list_shows_handles_truncation_and_errors() {
+        let entries = vec![
+            (
+                "anthropic/msgbatch_01AAA".to_string(),
+                BatchListItem {
+                    provider_id: "msgbatch_01AAA".into(),
+                    status: "in_progress".into(),
+                    completed: 1,
+                    total: 4,
+                    created_at: Some("2026-06-22T00:00:00Z".into()),
+                },
+            ),
+            (
+                "anthropic/msgbatch_01BBB".to_string(),
+                BatchListItem {
+                    provider_id: "msgbatch_01BBB".into(),
+                    status: "ended".into(),
+                    completed: 2,
+                    total: 2,
+                    created_at: None,
+                },
+            ),
+        ];
+        let out = render_list(
+            &entries,
+            &[("claude2".to_string(), "no API key".to_string())],
+            &["anthropic".to_string()],
+        );
+        assert!(out.contains("Batches — 2 found"));
+        assert!(out.contains("`anthropic/msgbatch_01AAA` — in_progress, 1/4 done"));
+        assert!(out.contains("(created 2026-06-22T00:00:00Z)"));
+        assert!(out.contains("`anthropic/msgbatch_01BBB` — ended, 2/2 done"));
+        assert!(out.contains("More batches exist beyond this page"));
+        assert!(out.contains("Could not list backend `claude2`: no API key"));
+        // Nothing anywhere → a clear empty message, not a bare header.
+        assert_eq!(
+            render_list(&[], &[], &[]),
+            "No batches found. Submit one with `batch_submit`."
+        );
+    }
+
+    /// The scripted provider serves a seeded listing.
+    #[tokio::test]
+    async fn scripted_list_returns_seeded_items() {
+        let provider = ScriptedBatch::new("x", vec![]).with_listing(
+            vec![BatchListItem {
+                provider_id: "msgbatch_01AAA".into(),
+                status: "ended".into(),
+                completed: 1,
+                total: 1,
+                created_at: None,
+            }],
+            false,
+        );
+        let (items, has_more) = provider.list().await.unwrap();
+        assert!(!has_more);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].provider_id, "msgbatch_01AAA");
+    }
+
+    /// Done renders each item under a self-labelling footer; a failed item shows its
+    /// reason rather than vanishing.
+    #[test]
+    fn render_done_lists_items_and_footer() {
+        let poll = BatchPoll::Done(vec![
+            BatchAnswer {
+                custom_id: "0".into(),
+                text: Ok("the answer".into()),
+            },
+            BatchAnswer {
+                custom_id: "1".into(),
+                text: Err("expired before it ran".into()),
+            },
+        ]);
+        let out = render_poll(&poll, "anthropic · claude-sonnet-4-6");
+        assert!(out.contains("the answer"));
+        assert!(out.contains("[1] — failed: expired"));
+        assert!(out.contains("kaibo · batch · anthropic · claude-sonnet-4-6"));
+    }
+
+    /// The scripted provider drives a full submit → pending → done flow offline.
+    #[tokio::test]
+    async fn scripted_submit_poll_flow() {
+        let provider = ScriptedBatch::new(
+            "msgbatch_test",
+            vec![
+                BatchPoll::Pending {
+                    completed: 0,
+                    total: 2,
+                },
+                BatchPoll::Done(vec![BatchAnswer {
+                    custom_id: "0".into(),
+                    text: Ok("done".into()),
+                }]),
+            ],
+        );
+        let items = vec![BatchItem {
+            custom_id: "0".into(),
+            prompt: "q".into(),
+        }];
+        let id = provider.submit("sys", &items).await.unwrap();
+        assert_eq!(id, "msgbatch_test");
+        assert_eq!(provider.submits()[0].0, "sys");
+        assert!(matches!(
+            provider.poll(&id).await.unwrap(),
+            BatchPoll::Pending { .. }
+        ));
+        assert!(matches!(
+            provider.poll(&id).await.unwrap(),
+            BatchPoll::Done(_)
+        ));
+        // Over-polling a Done batch stays Done.
+        assert!(matches!(
+            provider.poll(&id).await.unwrap(),
+            BatchPoll::Done(_)
+        ));
+        provider.cancel(&id).await.unwrap();
+        assert_eq!(provider.canceled(), vec!["msgbatch_test".to_string()]);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1187,6 +1187,31 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
         ]);
         m.insert(name.clone(), Cast { name, slots });
     }
+    // gemini-batch: the offline lane's cast. Pro is near-unusable interactively (slow),
+    // so casts synth Flash; batch is exactly where the latency is free, so this cast
+    // synths Gemini Pro. Uses the `gemini-pro-latest` *alias* deliberately, not a pinned
+    // preview id: pinned Pro previews get retired out from under us (a live batch dogfood
+    // caught `gemini-3-pro-preview` 404ing mid-flight — submit accepted it, the per-item
+    // request failed at run time), so the latest-alias is the drift-resistant default.
+    // Override in config.toml to pin a specific Pro. Explorer stays the cheap flash-lite
+    // (batch is toolless and won't touch it, but the cast is usable for consult too).
+    let gemini_batch = "gemini-batch".to_string();
+    m.insert(
+        gemini_batch.clone(),
+        Cast {
+            name: gemini_batch,
+            slots: BTreeMap::from([
+                (
+                    ModelRole::Explorer,
+                    ModelSlot::bare("gemini", "gemini-flash-lite-latest"),
+                ),
+                (
+                    ModelRole::Synth,
+                    ModelSlot::bare("gemini", "gemini-pro-latest"),
+                ),
+            ]),
+        },
+    );
     m
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -821,6 +821,20 @@ impl Config {
         // Validate backends. These are config mistakes, not no-ops: crash loudly
         // at startup rather than fail cryptically mid-call.
         for b in backends.values() {
+            // A backend name may never contain '/'. Two wire formats split on the
+            // first slash and trust the prefix to be slash-free: the `"backend/model-id"`
+            // slot ref (`split_backend_model`) and the `"backend/provider-id"` batch
+            // handle (`server.rs::parse_batch_handle`). A slash in a backend name would
+            // silently mis-route both. Enforce the invariant the parsers rely on rather
+            // than trusting convention.
+            if b.name.contains('/') {
+                bail!(
+                    "backend name {:?} may not contain '/': backend names prefix slot \
+                     refs (\"backend/model-id\") and batch handles (\"backend/provider-id\"), \
+                     which split on the first slash",
+                    b.name
+                );
+            }
             // A base_url on a keyed kind: rig fixes those endpoints.
             if b.kind != ProviderKind::Openai && b.base_url.is_some() {
                 bail!(
@@ -1049,6 +1063,9 @@ impl Config {
         if disable.generate_image {
             self.tools.generate_image = false;
         }
+        if disable.batch {
+            self.tools.batch = false;
+        }
         // Non-empty CLI allow_paths replaces lower layers (env/file).
         if !allow_paths.is_empty() {
             self.allow_paths = allow_paths;
@@ -1075,6 +1092,7 @@ pub struct ToolDisables {
     pub oneshot: bool,
     pub run_kaish: bool,
     pub generate_image: bool,
+    pub batch: bool,
 }
 
 /// Register `alias → target` at one level (backend or cast), rejecting a clash
@@ -1295,6 +1313,8 @@ struct RawPrompts {
     consult: Option<String>,
     /// Replaces the toolless `oneshot` preamble.
     oneshot: Option<String>,
+    /// Replaces the offline, max-thinking `batch_submit` preamble.
+    batch: Option<String>,
 }
 
 /// The `[orientation]` stanza — the static repo-map injected into the exploring
@@ -1335,6 +1355,7 @@ struct RawTools {
     oneshot: Option<bool>,
     run_kaish: Option<bool>,
     generate_image: Option<bool>,
+    batch: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1610,6 +1631,7 @@ fn merge_prompts(raw: RawPrompts) -> Result<PromptOverrides> {
         explorer: non_empty("explorer", raw.explorer)?,
         consult: non_empty("consult", raw.consult)?,
         oneshot: non_empty("oneshot", raw.oneshot)?,
+        batch: non_empty("batch", raw.batch)?,
     })
 }
 
@@ -1679,6 +1701,7 @@ fn merge_tools(raw: RawTools) -> ToolGating {
         oneshot: raw.oneshot.unwrap_or(d.oneshot),
         run_kaish: raw.run_kaish.unwrap_or(d.run_kaish),
         generate_image: raw.generate_image.unwrap_or(d.generate_image),
+        batch: raw.batch.unwrap_or(d.batch),
     }
 }
 
@@ -1740,6 +1763,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if env_flag(get, "KAIBO_NO_GENERATE_IMAGE") {
         tools.generate_image = Some(false);
+    }
+    if env_flag(get, "KAIBO_NO_BATCH") {
+        tools.batch = Some(false);
     }
 
     let defaults = raw.defaults.get_or_insert_with(Default::default);
@@ -2340,6 +2366,20 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("only the `openai` kind"), "got: {err}");
+    }
+
+    /// A backend name containing '/' is refused at load. Both the slot ref
+    /// (`"backend/model-id"`) and the batch handle (`"backend/provider-id"`) split on
+    /// the first slash and trust the prefix to be slash-free, so a slash-bearing name
+    /// would silently mis-route. Enforce the invariant the parsers depend on.
+    #[test]
+    fn backend_name_with_slash_is_refused() {
+        let err = Config::from_toml_str(
+            "[backends.\"foo/bar\"]\nkind = \"openai\"\nbase_url = \"http://localhost:1/v1\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("may not contain '/'"), "got: {err}");
     }
 
     /// Alias collisions are loud, per level: a user cast named like a built-in

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -97,6 +97,10 @@ pub struct PromptOverrides {
     pub consult: Option<String>,
     /// Replaces [`oneshot_preamble`] — the thin, toolless `oneshot`.
     pub oneshot: Option<String>,
+    /// Replaces [`batch_preamble`] — the offline, max-thinking `batch_submit`. A key
+    /// of its own (not shared with `oneshot`) because the batch lane is a different
+    /// behavioral contract: one response, no follow-up, spend on depth.
+    pub batch: Option<String>,
 }
 
 /// Resolve one phase's full system prompt: the operator override if set, else the
@@ -1399,6 +1403,50 @@ pub fn oneshot_preamble() -> String {
      explicitly anything you'd need that wasn't given rather than guessing it. Keep \
      your claims grounded in the material and say where its edge is."
         .to_string()
+}
+
+/// The `batch` preamble: a capable model answering one hard question *offline*, at
+/// max thinking, with no codebase access and no tools. Deliberately **not** a reuse of
+/// [`oneshot_preamble`] — batch is the same toolless shape but a different behavioral
+/// contract, and a cross-model review of the feature caught three places the oneshot
+/// wording misfires for the async lane:
+///
+/// - **No follow-up turn.** A batch item is answered once, offline; the caller cannot
+///   clarify and there is no next turn. oneshot's "name what you'd need rather than
+///   guessing" is right *synchronously* (flagging a gap invites the caller to fill it
+///   next turn) but wrong here — stopping at "I'd need X" burns the caller's one shot
+///   for nothing. The batch contract is *state the assumption, answer under it, flag
+///   what would change* — both the answer and the diagnostic, in one pass.
+/// - **Depth is free.** The lane forces high effort + a generous token floor precisely
+///   because the latency is already accepted. The prompt says so out loud — spend the
+///   room on depth — rather than leaving that intent only in the knobs.
+/// - **Primary answer, not a footnote.** Batch is for asking the best model the hard
+///   question, so the "second opinion" framing under-positions it; the load-bearing
+///   part is "for another agent" (an external advisor owns no context), which we keep.
+///
+/// Positive framing throughout (the CLAUDE.md rule): the old "rather than guessing it"
+/// named the unwanted pathway; the replacement asks for the wanted behavior — a
+/// reasoned, labelled assumption — directly.
+pub fn batch_preamble() -> String {
+    "You are a capable model answering a hard question for another agent, offline. Work \
+     from the material it provides and your own knowledge — this call has no codebase \
+     access and no tools, so the caller owns all the context you have. This is your \
+     single response: there is no follow-up turn and the caller cannot clarify, so make \
+     the answer complete and self-contained, and spend the room you have on depth — \
+     reason the problem all the way through. Be direct and precise. Ground every claim \
+     in the material or your own knowledge, and say where the evidence runs out. Where \
+     something you'd need is missing, state the assumption you're making, answer under \
+     it, and flag what would change if the assumption is wrong."
+        .to_string()
+}
+
+/// Resolve the `batch` phase's system prompt: the operator `[prompts].batch` override
+/// if set, else the built-in [`batch_preamble`]. Batch reads no project (the `oneshot`
+/// shape), so neither the repo map nor house rules splice — the same composition
+/// `oneshot` gets, exposed as a public seam because the batch path lives outside the
+/// `ConsultConfig`-driven loop (it runs on the provider's batch lane, not [`Arm::run`]).
+pub fn batch_system_prompt(override_: Option<&str>) -> String {
+    phase_preamble(override_, batch_preamble, None, None)
 }
 
 /// The `oneshot` seam: one direct completion on the resolved arm — no tools, no
@@ -2980,12 +3028,60 @@ mod tests {
             p.to_lowercase().contains("whole"),
             "the whole-file directive must survive: {p}"
         );
-        assert!(p.contains("grep -rn -B4 -A8"), "grep context-buffer idiom: {p}");
+        assert!(
+            p.contains("grep -rn -B4 -A8"),
+            "grep context-buffer idiom: {p}"
+        );
         // The report template the consult driver preamble is written
         // against — keep the three section names in lockstep with those.
         for section in ["SummaryOfFindings", "RelevantLocations", "ExplorationTrace"] {
             assert!(p.contains(section), "missing report section {section}: {p}");
         }
+    }
+
+    /// The batch preamble encodes the async lane's distinct contract — the three things
+    /// a cross-model review flagged the oneshot wording getting wrong for batch. These
+    /// are behavioral promises, so they get a test that fails if the prose drifts back
+    /// toward the synchronous oneshot framing.
+    #[test]
+    fn batch_preamble_encodes_the_offline_one_shot_contract() {
+        let p = batch_preamble();
+        let lower = p.to_lowercase();
+        // (1) No follow-up turn — be complete and self-contained in one response.
+        assert!(
+            lower.contains("single response") && lower.contains("no follow-up"),
+            "batch must tell the model it gets exactly one offline response: {p}"
+        );
+        // (2) Depth is free here — spend the budget the lane forces on.
+        assert!(lower.contains("depth"), "batch must ask for depth: {p}");
+        // (3) Assume-and-answer, not flag-and-stall: state the assumption and answer
+        // under it (the synchronous oneshot would say "name what you'd need").
+        assert!(
+            lower.contains("assumption") && lower.contains("answer under it"),
+            "batch must steer toward assume-and-answer, not flag-and-stall: {p}"
+        );
+        // Positive framing (the CLAUDE.md rule): it must not reintroduce the negative
+        // "rather than guessing" pathway the oneshot line used.
+        assert!(
+            !lower.contains("guess"),
+            "batch preamble must stay positively framed — no 'guess' pathway: {p}"
+        );
+        // Still the toolless, contextless shape it shares with oneshot.
+        assert!(
+            lower.contains("no codebase access") && lower.contains("no tools"),
+            "batch is the toolless, contextless shape: {p}"
+        );
+    }
+
+    /// `[prompts].batch` fully replaces the built-in batch preamble; absent, the
+    /// built-in stands. Batch reads no project, so nothing else splices.
+    #[test]
+    fn batch_system_prompt_honors_the_override() {
+        assert_eq!(batch_system_prompt(None), batch_preamble());
+        assert_eq!(
+            batch_system_prompt(Some("custom batch frame")),
+            "custom batch frame"
+        );
     }
 
     /// When the synth arm is vision-capable, the consult driver's toolset gains

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! The load-bearing safety property lives in [`sandbox`]: kaibo can read the project
 //! but cannot mutate it, and cannot shell out to external commands.
 
+pub mod batch;
 pub mod config;
 pub mod consult;
 pub mod context;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,10 @@ struct Args {
     #[arg(long)]
     no_generate_image: bool,
 
+    /// Don't advertise the batch tools (`batch_submit`/`batch_get`/`batch_cancel`).
+    #[arg(long)]
+    no_batch: bool,
+
     /// Project house-rules file spliced into each consultation tool's preamble,
     /// resolved relative to the project root and read only if present. Repeatable.
     /// Defaults to AGENTS.md; passing any replaces that default. Also settable via
@@ -129,6 +133,7 @@ async fn main() -> Result<()> {
             oneshot: args.no_oneshot,
             run_kaish: args.no_run_kaish,
             generate_image: args.no_generate_image,
+            batch: args.no_batch,
         },
         args.allow_path.clone(),
         args.no_follow_worktrees,
@@ -174,7 +179,7 @@ async fn main() -> Result<()> {
     // crashing over a silently useless server.
     anyhow::ensure!(
         !config.tools.all_disabled(),
-        "all four tools are disabled — a zero-tool server does nothing. \
+        "every tool is disabled — a zero-tool server does nothing. \
          Enable at least one (drop a --no-<tool> flag or a KAIBO_NO_<TOOL> env / \
          [server.tools] entry)."
     );

--- a/src/server.rs
+++ b/src/server.rs
@@ -225,8 +225,8 @@ pub struct BatchSubmitInput {
     pub prompts: Vec<String>,
 
     /// Which cast (model team) runs the batch; omit for the server's default. Batch
-    /// uses the cast's capable (synth) model on an Anthropic backend (the only batch
-    /// backend today; `kaibo://config` lists the casts).
+    /// uses the cast's capable (synth) model on a batch-capable backend; `kaibo://config`
+    /// lists the casts.
     #[serde(default)]
     pub cast: Option<String>,
 
@@ -237,7 +237,7 @@ pub struct BatchSubmitInput {
     pub model: Option<String>,
 
     /// Run the `model` override on this backend (name or alias) instead of the cast's.
-    /// Requires `model`. Must be an Anthropic backend for now.
+    /// Requires `model`. Must be a batch-capable backend.
     #[serde(default)]
     pub backend: Option<String>,
 }
@@ -247,8 +247,8 @@ pub struct BatchSubmitInput {
 #[serde(deny_unknown_fields)]
 pub struct BatchListInput {
     /// Which backend (name or alias) to list batches from. Omit to list across every
-    /// configured Anthropic backend (the only batch kind today) — the orphan-recovery
-    /// default when you've lost a handle and don't recall which backend ran it.
+    /// configured batch-capable backend — the orphan-recovery default when you've lost a
+    /// handle and don't recall which backend ran it.
     #[serde(default)]
     pub backend: Option<String>,
 }
@@ -1093,9 +1093,10 @@ impl KaiboHandler {
 
     /// Resolve a cast's synth slot into a submit-capable batch provider, plus its
     /// backend name (for the returned handle) and model id (for the caller message). A
-    /// missing synth slot is the loud call-time gap; a non-Anthropic backend is refused
-    /// inside the provider build (the only batch backend today). Both surface as a
-    /// parameter error the caller can act on — pick a cast whose synth is Anthropic.
+    /// missing synth slot is the loud call-time gap; a backend whose kind has no batch
+    /// lane is refused inside the provider build (`batch::submitter`). Both surface as a
+    /// parameter error the caller can act on — pick a cast whose synth is a batch-capable
+    /// backend.
     fn batch_submitter(
         &self,
         cast: &Cast,
@@ -1107,7 +1108,7 @@ impl KaiboHandler {
             .config
             .resolve_backend(&slot.backend)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        let provider = crate::batch::anthropic_submit(backend, slot, &self.config.defaults)
+        let provider = crate::batch::submitter(backend, slot, &self.config.defaults)
             .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
         Ok((provider, backend.name.clone(), slot.id.clone()))
     }
@@ -1123,29 +1124,29 @@ impl KaiboHandler {
             .config
             .resolve_backend(backend_name)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-        crate::batch::anthropic_poll(backend)
-            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
+        crate::batch::poller(backend).map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
     }
 
     /// The set of backend names `batch_list` should query. An explicit `backend` scopes
-    /// to that one (resolved by name/alias, and refused loudly if it isn't an Anthropic
-    /// kind — the only batch backend today). Omitted, it's every configured
-    /// Anthropic-kind backend, sorted — the orphan-recovery default. No Anthropic
-    /// backend at all is a clear parameter error, not an empty list pretending nothing's
-    /// there.
+    /// to that one (resolved by name/alias, and refused loudly if its kind has no batch
+    /// lane). Omitted, it's every configured batch-capable backend, sorted — the orphan-
+    /// recovery default. No batch-capable backend at all is a clear parameter error, not an
+    /// empty list pretending nothing's there.
     fn batch_backends(&self, backend: Option<&str>) -> Result<Vec<String>, McpError> {
-        use crate::credentials::ProviderKind;
         if let Some(name) = backend {
             let b = self
                 .config
                 .resolve_backend(name)
                 .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-            if b.kind != ProviderKind::Anthropic {
+            if !crate::batch::batch_supported(b.kind) {
                 return Err(McpError::invalid_params(
                     format!(
-                        "backend {:?} is {:?}; batch is anthropic-only today, so it can't \
-                         be listed. Omit `backend` to list every Anthropic backend.",
-                        b.name, b.kind
+                        "backend {:?} ({:?}) has no batch lane, so it can't be listed \
+                         (batch-capable: {}). Omit `backend` to list every batch-capable \
+                         backend.",
+                        b.name,
+                        b.kind,
+                        crate::batch::supported_kinds_list()
                     ),
                     None,
                 ));
@@ -1156,14 +1157,12 @@ impl KaiboHandler {
             .config
             .backends
             .values()
-            .filter(|b| b.kind == ProviderKind::Anthropic)
+            .filter(|b| crate::batch::batch_supported(b.kind))
             .map(|b| b.name.clone())
             .collect();
         if names.is_empty() {
             return Err(McpError::invalid_params(
-                "no Anthropic backend is configured — batch (and thus listing) is \
-                 anthropic-only today"
-                    .to_string(),
+                "no batch-capable backend is configured".to_string(),
                 None,
             ));
         }
@@ -1180,8 +1179,9 @@ impl KaiboHandler {
             loop) — so include the context each answer needs, the same as `oneshot`. \
             Batch maxes the knobs (forces high effort + a generous token budget) \
             regardless of how the cast was tuned for interactive use. Runs the cast's \
-            synth model; Anthropic is the only batch backend today (point `cast`/`model` \
-            at one, or get a clear refusal). Args: prompts (required, a list), cast \
+            synth model on a backend that supports batch; point `cast`/`model` at one (or \
+            get a clear refusal naming the batch-capable backends). `kaibo://config` lists \
+            the casts. Args: prompts (required, a list), cast \
             (optional), model + backend (optional synth override — handy to batch a \
             Pro/Opus tier a cast synths cheaper interactively). Returns a handle; poll \
             it with `batch_get`, stop it with `batch_cancel`. This is a fire-and-forget \
@@ -1232,8 +1232,10 @@ impl KaiboHandler {
             .await
             .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
         // The handle namespaces the provider id by backend, so poll/cancel re-address it
-        // without re-specifying the cast — a backend name carries no '/', nor does a
-        // provider batch id, so the split is unambiguous.
+        // without re-specifying the cast. The split is unambiguous because a *backend
+        // name* carries no '/' (enforced at config load) — so the first '/' is always the
+        // backend/id boundary, even when the provider id itself contains slashes (a Gemini
+        // id is `batches/<id>`).
         let handle = format!("{backend_name}/{provider_id}");
         let msg = format!(
             "Submitted batch `{handle}` — {} prompt(s) on cast `{}` (model `{}`). \
@@ -1304,8 +1306,8 @@ impl KaiboHandler {
             way back to a batch whose handle you've lost (kaibo holds no state, so the \
             provider's own list is the source of truth). Each entry comes with its \
             ready-to-use handle, status, and progress; feed one to `batch_get` or \
-            `batch_cancel`. Omit `backend` to list across every Anthropic backend (the \
-            only batch kind today); pass one (name or alias) to scope it. A backend that \
+            `batch_cancel`. Omit `backend` to list across every batch-capable backend; \
+            pass one (name or alias) to scope it. A backend that \
             can't be reached (no key, endpoint down) is reported rather than hiding the \
             rest, and a truncated page says so. Args: backend (optional)."
     )]
@@ -2121,10 +2123,11 @@ fn consult_result(answer: String, report: String, include_report: bool) -> CallT
 /// `kaibo://config`, since the answering model is the whole variable. `roles` is the
 /// labelled models for this tool (one for `oneshot`, explorer+synth for `consult`).
 /// Pure and offline-testable.
-/// Split a batch handle (`"backend/provider-id"`) the way `batch_submit` minted it. A
-/// backend name carries no `/`, and a provider batch id (`msgbatch_…`) carries no `/`,
-/// so the first split is unambiguous. A malformed handle is a loud parameter error —
-/// the caller pasted something that wasn't a kaibo batch id.
+/// Split a batch handle (`"backend/provider-id"`) the way `batch_submit` minted it.
+/// Splitting on the *first* `/` is unambiguous because a backend name carries no `/`
+/// (enforced at config load) — so the provider id keeps any slashes of its own (an
+/// Anthropic id is `msgbatch_…`; a Gemini id is `batches/<id>`). A malformed handle is a
+/// loud parameter error — the caller pasted something that wasn't a kaibo batch id.
 fn parse_batch_handle(handle: &str) -> Result<(&str, &str), McpError> {
     handle
         .split_once('/')

--- a/src/server.rs
+++ b/src/server.rs
@@ -75,6 +75,10 @@ pub struct ToolGating {
     pub oneshot: bool,
     pub run_kaish: bool,
     pub generate_image: bool,
+    /// The batch capability (submit/get/cancel/list) — one gate over all the verbs:
+    /// they're one capability (you can't get or list without submit), so `--no-batch`
+    /// drops them together rather than a flag apiece.
+    pub batch: bool,
 }
 
 impl Default for ToolGating {
@@ -84,6 +88,7 @@ impl Default for ToolGating {
             oneshot: true,
             run_kaish: true,
             generate_image: true,
+            batch: true,
         }
     }
 }
@@ -91,7 +96,7 @@ impl Default for ToolGating {
 impl ToolGating {
     /// True iff every tool is disabled — the zero-tool server we refuse to start.
     pub fn all_disabled(&self) -> bool {
-        !self.consult && !self.oneshot && !self.run_kaish && !self.generate_image
+        !self.consult && !self.oneshot && !self.run_kaish && !self.generate_image && !self.batch
     }
 }
 
@@ -206,6 +211,56 @@ pub struct OneshotInput {
     /// slot's configured one. Requires `model`.
     #[serde(default)]
     pub backend: Option<String>,
+}
+
+/// Arguments to `batch_submit`. Many prompts, one cast/model — they all ride one
+/// provider batch. See [`ConsultInput`] for the `deny_unknown_fields` rationale.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BatchSubmitInput {
+    /// The prompts to fan out, one batch item each. Like `oneshot`, there's no
+    /// codebase access — each prompt carries its own context; the model answers from
+    /// it and its own knowledge. Batch runs them at max thinking, so it's the lane for
+    /// hard questions you're willing to wait on.
+    pub prompts: Vec<String>,
+
+    /// Which cast (model team) runs the batch; omit for the server's default. Batch
+    /// uses the cast's capable (synth) model on an Anthropic backend (the only batch
+    /// backend today; `kaibo://config` lists the casts).
+    #[serde(default)]
+    pub cast: Option<String>,
+
+    /// Override the synth model id. Sent verbatim — an id containing "/" is still one
+    /// id. Keeps the cast's backend unless `backend` retargets it. Reach for this to
+    /// batch a top-tier model the cast synths something cheaper for interactive use.
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// Run the `model` override on this backend (name or alias) instead of the cast's.
+    /// Requires `model`. Must be an Anthropic backend for now.
+    #[serde(default)]
+    pub backend: Option<String>,
+}
+
+/// Arguments to `batch_list`: an optional backend to scope the listing to.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BatchListInput {
+    /// Which backend (name or alias) to list batches from. Omit to list across every
+    /// configured Anthropic backend (the only batch kind today) — the orphan-recovery
+    /// default when you've lost a handle and don't recall which backend ran it.
+    #[serde(default)]
+    pub backend: Option<String>,
+}
+
+/// Arguments to `batch_get` / `batch_cancel`: the opaque handle `batch_submit`
+/// returned (`"backend/provider-id"`).
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BatchHandleInput {
+    /// The batch handle kaibo returned from `batch_submit` (e.g.
+    /// `anthropic/msgbatch_…`). kaibo holds no state — the handle is the whole address.
+    pub batch_id: String,
 }
 
 /// Arguments to the `run_kaish` tool. See [`ConsultInput`] for the
@@ -324,6 +379,11 @@ impl KaiboHandler {
             (gating.oneshot, "oneshot"),
             (gating.run_kaish, "run_kaish"),
             (gating.generate_image, "generate_image"),
+            // One `--no-batch` flag drops all batch routes together.
+            (gating.batch, "batch_submit"),
+            (gating.batch, "batch_get"),
+            (gating.batch, "batch_cancel"),
+            (gating.batch, "batch_list"),
         ] {
             if !enabled {
                 assert!(
@@ -1030,6 +1090,261 @@ impl KaiboHandler {
             size,
         )))
     }
+
+    /// Resolve a cast's synth slot into a submit-capable batch provider, plus its
+    /// backend name (for the returned handle) and model id (for the caller message). A
+    /// missing synth slot is the loud call-time gap; a non-Anthropic backend is refused
+    /// inside the provider build (the only batch backend today). Both surface as a
+    /// parameter error the caller can act on — pick a cast whose synth is Anthropic.
+    fn batch_submitter(
+        &self,
+        cast: &Cast,
+    ) -> Result<(Arc<dyn crate::batch::BatchProvider>, String, String), McpError> {
+        let slot = cast
+            .require_slot(ModelRole::Synth)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let backend = self
+            .config
+            .resolve_backend(&slot.backend)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let provider = crate::batch::anthropic_submit(backend, slot, &self.config.defaults)
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
+        Ok((provider, backend.name.clone(), slot.id.clone()))
+    }
+
+    /// A poll/cancel-only provider for a handle's backend. Poll and cancel need only the
+    /// connection (key + endpoint), so this re-addresses a batch by id after a restart —
+    /// kaibo holds no state.
+    fn batch_poller(
+        &self,
+        backend_name: &str,
+    ) -> Result<Arc<dyn crate::batch::BatchProvider>, McpError> {
+        let backend = self
+            .config
+            .resolve_backend(backend_name)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        crate::batch::anthropic_poll(backend)
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
+    }
+
+    /// The set of backend names `batch_list` should query. An explicit `backend` scopes
+    /// to that one (resolved by name/alias, and refused loudly if it isn't an Anthropic
+    /// kind — the only batch backend today). Omitted, it's every configured
+    /// Anthropic-kind backend, sorted — the orphan-recovery default. No Anthropic
+    /// backend at all is a clear parameter error, not an empty list pretending nothing's
+    /// there.
+    fn batch_backends(&self, backend: Option<&str>) -> Result<Vec<String>, McpError> {
+        use crate::credentials::ProviderKind;
+        if let Some(name) = backend {
+            let b = self
+                .config
+                .resolve_backend(name)
+                .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+            if b.kind != ProviderKind::Anthropic {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "backend {:?} is {:?}; batch is anthropic-only today, so it can't \
+                         be listed. Omit `backend` to list every Anthropic backend.",
+                        b.name, b.kind
+                    ),
+                    None,
+                ));
+            }
+            return Ok(vec![b.name.clone()]);
+        }
+        let names: Vec<String> = self
+            .config
+            .backends
+            .values()
+            .filter(|b| b.kind == ProviderKind::Anthropic)
+            .map(|b| b.name.clone())
+            .collect();
+        if names.is_empty() {
+            return Err(McpError::invalid_params(
+                "no Anthropic backend is configured — batch (and thus listing) is \
+                 anthropic-only today"
+                    .to_string(),
+                None,
+            ));
+        }
+        Ok(names)
+    }
+
+    #[tool(
+        description = "Submit a batch of tool-less questions to run *offline* at max \
+            thinking, and get back a handle to poll — the async sibling of `oneshot`. \
+            Use it to fan many prompts (or one hard question you'll wait on) at a \
+            top-tier model without holding a call open per answer: the provider runs \
+            them on its cheaper batch lane and kaibo hands back the id. Each prompt is \
+            self-contained — no codebase access, no tools (batch can't drive a tool \
+            loop) — so include the context each answer needs, the same as `oneshot`. \
+            Batch maxes the knobs (forces high effort + a generous token budget) \
+            regardless of how the cast was tuned for interactive use. Runs the cast's \
+            synth model; Anthropic is the only batch backend today (point `cast`/`model` \
+            at one, or get a clear refusal). Args: prompts (required, a list), cast \
+            (optional), model + backend (optional synth override — handy to batch a \
+            Pro/Opus tier a cast synths cheaper interactively). Returns a handle; poll \
+            it with `batch_get`, stop it with `batch_cancel`. This is a fire-and-forget \
+            lane: submit, then go do other work — don't sit in a wait/sleep loop holding \
+            your turn open. A batch can take minutes to hours (the provider's offline \
+            SLA is up to 24h), and the handle is durable — it survives a server restart \
+            — so come back and `batch_get` later rather than blocking on it now."
+    )]
+    async fn batch_submit(
+        &self,
+        Parameters(input): Parameters<BatchSubmitInput>,
+    ) -> Result<CallToolResult, McpError> {
+        if input.prompts.is_empty() {
+            return Err(McpError::invalid_params(
+                "batch needs at least one prompt".to_string(),
+                None,
+            ));
+        }
+        let mut cast = self.resolve_cast(input.cast)?;
+        self.apply_model_override(
+            &mut cast,
+            ModelRole::Synth,
+            input.model.as_deref(),
+            input.backend.as_deref(),
+            "model",
+            "backend",
+        )?;
+        let (provider, backend_name, model) = self.batch_submitter(&cast)?;
+        let items: Vec<crate::batch::BatchItem> = input
+            .prompts
+            .iter()
+            .enumerate()
+            .map(|(i, p)| crate::batch::BatchItem {
+                custom_id: i.to_string(),
+                prompt: p.clone(),
+            })
+            .collect();
+        // Batch is the oneshot *shape* (a capable model answering from what it was
+        // handed, no tools) but its own behavioral contract — one offline response, no
+        // follow-up, spend on depth — so it carries a distinct preamble, overridable via
+        // `[prompts].batch`. Reads no project (no map / house rules), like oneshot.
+        let system = crate::consult::batch_system_prompt(self.config.prompts.batch.as_deref());
+        let span =
+            tracing::info_span!("batch_submit", cast = %cast.name, model = %model, n = items.len());
+        let provider_id = provider
+            .submit(&system, &items)
+            .instrument(span)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        // The handle namespaces the provider id by backend, so poll/cancel re-address it
+        // without re-specifying the cast — a backend name carries no '/', nor does a
+        // provider batch id, so the split is unambiguous.
+        let handle = format!("{backend_name}/{provider_id}");
+        let msg = format!(
+            "Submitted batch `{handle}` — {} prompt(s) on cast `{}` (model `{}`). \
+             Poll it with `batch_get` (it'll show progress, then per-item answers when \
+             done); stop it with `batch_cancel`.",
+            items.len(),
+            cast.name,
+            model
+        );
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    }
+
+    #[tool(
+        description = "Poll a batch by the handle `batch_submit` returned. While it runs \
+            you get a progress line; once it's done you get every item's answer (each \
+            labelled by its index), with per-item failures surfaced rather than dropped. \
+            kaibo holds no state — the handle is the whole address, so this works across \
+            a server restart. Poll occasionally, not in a tight loop: if it's still \
+            pending, go do other work and check back later rather than sleeping on it — \
+            the handle keeps, so there's no rush and nothing to lose. Args: batch_id \
+            (the handle from `batch_submit`)."
+    )]
+    async fn batch_get(
+        &self,
+        Parameters(input): Parameters<BatchHandleInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let (backend_name, provider_id) = parse_batch_handle(&input.batch_id)?;
+        let provider = self.batch_poller(backend_name)?;
+        let span = tracing::info_span!("batch_get", handle = %input.batch_id);
+        let poll = provider
+            .poll(provider_id)
+            .instrument(span)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        let label = format!("{backend_name} · {provider_id}");
+        Ok(CallToolResult::success(vec![Content::text(
+            crate::batch::render_poll(&poll, &label),
+        )]))
+    }
+
+    #[tool(
+        description = "Cancel a running batch by its handle. The provider stops scheduling \
+            new requests; any already in flight finish. Poll with `batch_get` afterward \
+            for the final per-item results. Args: batch_id (the handle from \
+            `batch_submit`)."
+    )]
+    async fn batch_cancel(
+        &self,
+        Parameters(input): Parameters<BatchHandleInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let (backend_name, provider_id) = parse_batch_handle(&input.batch_id)?;
+        let provider = self.batch_poller(backend_name)?;
+        let span = tracing::info_span!("batch_cancel", handle = %input.batch_id);
+        provider
+            .cancel(provider_id)
+            .instrument(span)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Requested cancellation of batch `{}`. Poll it with `batch_get` for the \
+             final per-item results.",
+            input.batch_id
+        ))]))
+    }
+
+    #[tool(
+        description = "List the batches a backend still knows about, newest first — the \
+            way back to a batch whose handle you've lost (kaibo holds no state, so the \
+            provider's own list is the source of truth). Each entry comes with its \
+            ready-to-use handle, status, and progress; feed one to `batch_get` or \
+            `batch_cancel`. Omit `backend` to list across every Anthropic backend (the \
+            only batch kind today); pass one (name or alias) to scope it. A backend that \
+            can't be reached (no key, endpoint down) is reported rather than hiding the \
+            rest, and a truncated page says so. Args: backend (optional)."
+    )]
+    async fn batch_list(
+        &self,
+        Parameters(input): Parameters<BatchListInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let backends = self.batch_backends(input.backend.as_deref())?;
+        let mut entries: Vec<(String, crate::batch::BatchListItem)> = Vec::new();
+        let mut errors: Vec<(String, String)> = Vec::new();
+        let mut truncated: Vec<String> = Vec::new();
+        for name in backends {
+            // Build the poller and list per backend, turning any failure into a
+            // per-backend note — one keyless or unreachable backend never sinks the
+            // whole listing (the per-item-failure ethos, at the backend grain).
+            let listed = match self.batch_poller(&name) {
+                Ok(provider) => {
+                    let span = tracing::info_span!("batch_list", backend = %name);
+                    provider.list().instrument(span).await
+                }
+                Err(e) => Err(anyhow::anyhow!("{}", e.message)),
+            };
+            match listed {
+                Ok((items, has_more)) => {
+                    if has_more {
+                        truncated.push(name.clone());
+                    }
+                    for it in items {
+                        let handle = format!("{}/{}", name, it.provider_id);
+                        entries.push((handle, it));
+                    }
+                }
+                Err(e) => errors.push((name, format!("{e:#}"))),
+            }
+        }
+        Ok(CallToolResult::success(vec![Content::text(
+            crate::batch::render_list(&entries, &errors, &truncated),
+        )]))
+    }
 }
 
 #[tool_handler]
@@ -1423,6 +1738,7 @@ fn render_config_resource(
         oneshot: bool,
         run_kaish: bool,
         generate_image: bool,
+        batch: bool,
     }
 
     /// Runtime-computed scope state. `follow_worktrees` echoes the knob;
@@ -1628,6 +1944,7 @@ fn render_config_resource(
         oneshot,
         run_kaish,
         generate_image,
+        batch,
     } = &config.tools;
     let crate::sandbox::SandboxConfig {
         exec_timeout,
@@ -1677,6 +1994,7 @@ fn render_config_resource(
             oneshot,
             run_kaish,
             generate_image,
+            batch,
         },
         sandbox: SandboxDoc {
             exec_timeout_secs: exec_timeout.as_secs(),
@@ -1803,6 +2121,25 @@ fn consult_result(answer: String, report: String, include_report: bool) -> CallT
 /// `kaibo://config`, since the answering model is the whole variable. `roles` is the
 /// labelled models for this tool (one for `oneshot`, explorer+synth for `consult`).
 /// Pure and offline-testable.
+/// Split a batch handle (`"backend/provider-id"`) the way `batch_submit` minted it. A
+/// backend name carries no `/`, and a provider batch id (`msgbatch_…`) carries no `/`,
+/// so the first split is unambiguous. A malformed handle is a loud parameter error —
+/// the caller pasted something that wasn't a kaibo batch id.
+fn parse_batch_handle(handle: &str) -> Result<(&str, &str), McpError> {
+    handle
+        .split_once('/')
+        .filter(|(b, id)| !b.is_empty() && !id.is_empty())
+        .ok_or_else(|| {
+            McpError::invalid_params(
+                format!(
+                    "batch id {handle:?} must be \"backend/provider-id\" — pass the handle \
+                     kaibo returned from batch_submit"
+                ),
+                None,
+            )
+        })
+}
+
 fn with_provenance(answer: String, cast: &str, roles: &[(&str, &str)]) -> String {
     let models = roles
         .iter()

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -8,7 +8,19 @@ use std::process::Command;
 use kaibo::config::Config;
 use kaibo::server::{KaiboHandler, ToolGating};
 
-const ALL_TOOLS: [&str; 4] = ["consult", "generate_image", "oneshot", "run_kaish"];
+/// Every advertised tool, sorted (the order `advertised_tools` returns). The batch
+/// capability is four routes (`batch_submit`/`batch_get`/`batch_cancel`/`batch_list`)
+/// behind one `--no-batch` flag.
+const ALL_TOOLS: [&str; 8] = [
+    "batch_cancel",
+    "batch_get",
+    "batch_list",
+    "batch_submit",
+    "consult",
+    "generate_image",
+    "oneshot",
+    "run_kaish",
+];
 
 fn advertised(gating: ToolGating) -> Vec<String> {
     let mut config = Config::builtin();
@@ -19,50 +31,61 @@ fn advertised(gating: ToolGating) -> Vec<String> {
 }
 
 #[test]
-fn default_advertises_all_four_tools() {
+fn default_advertises_all_tools() {
     assert_eq!(advertised(ToolGating::default()), ALL_TOOLS);
 }
 
 #[test]
-fn each_flag_removes_exactly_its_own_tool() {
-    let cases = [
+fn each_flag_removes_exactly_its_own_tools() {
+    // Each flag and the tool route(s) it drops. `--no-batch` is one flag over the
+    // whole batch trio — they're one capability — so it lists all three.
+    let cases: [(&[&str], ToolGating); 5] = [
         (
-            "consult",
+            &["consult"],
             ToolGating {
                 consult: false,
                 ..Default::default()
             },
         ),
         (
-            "oneshot",
+            &["oneshot"],
             ToolGating {
                 oneshot: false,
                 ..Default::default()
             },
         ),
         (
-            "run_kaish",
+            &["run_kaish"],
             ToolGating {
                 run_kaish: false,
                 ..Default::default()
             },
         ),
         (
-            "generate_image",
+            &["generate_image"],
             ToolGating {
                 generate_image: false,
+                ..Default::default()
+            },
+        ),
+        (
+            &["batch_submit", "batch_get", "batch_cancel", "batch_list"],
+            ToolGating {
+                batch: false,
                 ..Default::default()
             },
         ),
     ];
     for (disabled, gating) in cases {
         let tools = advertised(gating);
-        assert!(
-            !tools.contains(&disabled.to_string()),
-            "{disabled} should be gated off, got {tools:?}"
-        );
+        for d in disabled {
+            assert!(
+                !tools.contains(&d.to_string()),
+                "{d} should be gated off, got {tools:?}"
+            );
+        }
         // Every *other* tool must still be advertised — gating one doesn't touch the rest.
-        for &t in ALL_TOOLS.iter().filter(|&&t| t != disabled) {
+        for &t in ALL_TOOLS.iter().filter(|t| !disabled.contains(t)) {
             assert!(
                 tools.contains(&t.to_string()),
                 "{t} should remain, got {tools:?}"
@@ -78,11 +101,18 @@ fn all_disabled_is_detected() {
         oneshot: false,
         run_kaish: false,
         generate_image: false,
+        batch: false,
     };
     assert!(none_on.all_disabled());
     // Any single tool on means it's a usable server, not the refused state.
     assert!(!ToolGating {
         run_kaish: true,
+        ..none_on
+    }
+    .all_disabled());
+    // The batch capability alone is enough to be a usable server.
+    assert!(!ToolGating {
+        batch: true,
         ..none_on
     }
     .all_disabled());
@@ -104,6 +134,7 @@ fn all_tools_disabled_refuses_to_start() {
             "--no-oneshot",
             "--no-run-kaish",
             "--no-generate-image",
+            "--no-batch",
         ])
         .output()
         .expect("should be able to run the kaibo binary");


### PR DESCRIPTION
## What

A new **batch** tool class — the offline, async sibling of `oneshot`. Submit a list of self-contained, tool-less prompts; get back a durable handle; poll it; read every answer when the provider's (cheaper) batch lane finishes. No upstream call is held open per answer.

Four verbs behind one `--no-batch` gate (they're one capability):

- **`batch_submit`** — fan a list of prompts onto the provider's batch lane; returns a `backend/provider-id` handle.
- **`batch_get`** — poll by handle: a progress line while pending, every item's answer (per-item failures surfaced, not dropped) when done.
- **`batch_cancel`** — stop a running batch by handle.
- **`batch_list`** — re-discover the batches a backend still holds (newest-first handles with status/progress) — the way back to a batch whose handle was lost.

Anthropic Message Batches only for now, behind a per-provider `BatchProvider` seam (the `ImageGen` discipline); Gemini and OpenAI are tracked follow-ons (`docs/issues.md`). A non-Anthropic cast is refused loudly, never silently no-op'd.

## Why these shapes

- **A class, not a flag.** Batch is toolless *by construction* — provider batch APIs are offline and can't drive a tool loop — so it's built on the `oneshot` shape, never `run_phase`.
- **Max the knobs.** Batch floors `max_tokens` and forces high thinking effort regardless of how a cast was tuned for interactive use: the latency that makes max-thinking painful synchronously is free once you've accepted "come back later" (Amy's motivating case: Pro is near-unusable interactively, but batch is exactly where you reach for it). `BATCH_EFFORT` is threaded explicitly through `ModelShape::to_params` so it stays decoupled from `consult`'s interactive default.
- **No state.** The handle is the whole address; poll/cancel/list rebuild a fresh client and re-address the provider's own id, surviving a restart. The split now *enforces* the no-`/`-in-backend-name invariant at config load rather than trusting convention.
- **Its own preamble.** Batch shares oneshot's toolless shape but not its words — overridable via `[prompts].batch`. See the review note below.

## Cross-family review (dogfooded)

Per the project's PR discipline, the design got a cross-family review — **Opus run *through* `batch_submit` itself**, critiquing its own tool design and system prompt. It drove three changes landed in this PR:

1. **Tailored batch preamble** — oneshot's "name what you'd need rather than guessing" is right synchronously but wrong offline (no next turn to fill a gap). Batch now tells the model it gets one complete response, to spend on depth, and to *state an assumption and answer under it* rather than stall (also fixing a negative-framing lapse).
2. **`batch_list`** — the review's sharpest finding was the orphaned-batch billing risk (a lost handle = a batch that keeps billing with no way back, since kaibo holds no state). `batch_list` closes it; live-verified by recovering 14 real historical batches.
3. **Backend-name `/` guard** — hardened the handle-split invariant at config load.

Three findings remain tracked as deferred follow-ons in `docs/issues.md` (index-as-custom_id context-loss, prose-vs-structured status, effort-as-floor-vs-force) — none blocking.

## Testing

- Offline-tested throughout: pure request-shaping / response-parsing / render fns, plus a `ScriptedBatch` driving submit→pending→done and a seeded list with no network (mirrors `ScriptedImageGen`).
- **191 lib tests + all integration suites green**; no new clippy warnings.
- Live-verified end to end against the real Anthropic API: submit (Opus override), poll, the per-item provenance footer, and all three `batch_list` paths (default, scoped, non-Anthropic loud refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)