### PR TITLE
Fix tool_span flake (root cause) + two P3 honesty/discoverability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ the git log. Each later release appends a new section at the top.
 - **`generate_image`** — kaibo's first *capability* (an artifact handed back to the
   caller, not reasoning run into kaibo's own models): prompt → image, returned inline
   as MCP image content. OpenAI-compatible image backends only (hosted
-  `gpt-image` / DALL·E, or a local Stable-Diffusion server).
+  `gpt-image` / DALL·E, or a local Stable-Diffusion server). Its `cast` parameter
+  advertises the casts that actually carry a usable image slot as a schema enum, so a
+  host agent picks one off the schema — as discoverable as the consultation tools.
 - **Batch (`batch_submit` / `batch_get` / `batch_cancel` / `batch_list`)** — the
   *offline, async sibling* of `oneshot`: submit a list of tool-less prompts, get a
   handle, poll it, read every answer when the provider's batch lane finishes — no call
@@ -66,7 +68,10 @@ the git log. Each later release appends a new section at the top.
 - **Guided setup.** A built-in `configure` MCP prompt walks your host agent through
   writing `config.toml`, alongside `kaibo://config` (resolved runtime state) and
   `kaibo://config/example` (annotated template) resources. Secrets are referenced by
-  env-var name or key-file path, never inlined.
+  env-var name or key-file path, never inlined. `kaibo://config` flags any per-slot
+  tunable the slot's resolved model shape will never send (an `inert_tunables` list —
+  e.g. a `thinking_budget` on an effort-only model, an `effort` on a budget-only one),
+  so a no-op knob is visible to the operator instead of rendering as if effective.
 - **Zero-config workspace root.** When no `--root` is set, kaibo adopts its launch
   cwd as the inferred default root (it already scoped containment to that cwd, and
   MCP clients start stdio servers with cwd = workspace), so a call may omit `path`

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,40 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-22 — kill the `tool_span.rs` capture flake (root cause, not symptom)
+
+The two span-capturing tests in `tool_span.rs` failed ~5% of full-suite runs (the
+issue guessed ~25%), never in isolation — a test failing when we *didn't* make a
+mistake, the opposite of teeth. The issue's two guesses (serialize the pair; race on
+a "process-global span store") were both off the real mark. We traced it instead of
+guessing, and the contributing factors turned out to be one specific tracing
+fast-path:
+
+`info_span!("tool")` registers its callsite **lazily**, on first hit. While tracing's
+`has_just_one` optimization holds — true whenever ≤1 dispatcher is registered, which
+is *exactly* our case since each test installs a single subscriber via `set_default` —
+that first registration computes the callsite's `Interest` from **the registering
+thread's current default**, not from the test's installed subscriber. This binary is
+full of `consult`-loop tests that run the real tool loop with *no* subscriber. When
+one of them won the race to first-touch the `tool` callsite during a capture test's
+window, it cached `Interest::never()` against `NoSubscriber`, gating the span off
+process-wide → an empty capture. So serializing the two capture tests can't fix it:
+the poisoning thread is a *third* test with no subscriber at all.
+
+The fix matches the cause. We hold one extra registered dispatcher alive for the whole
+process (`force_multi_dispatcher`, a leaked `Dispatch::new(registry())`), forcing
+`has_just_one` false so every callsite registration consults the *registered-dispatcher
+set* — which contains a span-enabling registry — regardless of which thread triggers
+it. It is never any thread's default, so it receives no events; it exists only to keep
+the registration path honest. We kept a serialization `Mutex` over the two tests too
+(belt and suspenders against their `set_default` installs/teardowns interleaving), and
+moved them off `#[tokio::test]` onto a private current-thread runtime via `block_on`,
+so the ordering guard isn't held across an `.await` and the future polls on the same
+thread whose `set_default` is in scope. Proven: 0 failures in 150 full-suite runs
+(was ~5%), and both tests still fail under deliberate mutation of the span name and
+the outcome field. Rejected the symptom-level "just serialize" because it left the
+~1% consult-thread poisoning window open — measured, didn't assume.
+
 ## 2026-06-22 — batch: Gemini provider (second backend behind the seam)
 
 Added the second `BatchProvider` impl — Gemini inline batch — so the offline lane reaches

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,34 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-22 — two honesty/discoverability fixes: image cast enum + inert-tunable flag
+
+Both came off the P3 list; both are about not lying to the caller by omission.
+
+**`generate_image` now advertises its cast enum.** The consultation tools stamp the
+usable-cast roster onto their `cast` param as a JSON-Schema enum so an agent reads the
+menu off the schema, but image gen didn't — its menu is a *different* filter, since it
+selects the `image` slot, not explorer/synth. Wrote `Config::image_capable_casts`
+(casts with an `image` slot on an openai backend whose key resolves — the only kind rig
+0.38 drives for images) and generalized `inject_cast_enum` to take the tool list, so
+the same advisory-enum machinery now serves both groups. Deliberately a *separate*
+filter from `usable_casts`: a cast with a stranded explorer key but a working image
+slot belongs on the image menu and not the consult menu, and vice versa.
+
+**`kaibo://config` flags inert per-slot tunables.** A slot whose resolved `ModelShape`
+has no sink for a knob still load-validated it and rendered it as if effective — a
+`thinking_budget` on an effort-driven model (Gemini 3-line, Anthropic adaptive) or the
+toggle-less openai path, an `effort` on a budget model, a `temperature` an Anthropic
+slot drops under thinking. Added three predicates to `ModelShape`
+(`sinks_thinking_budget` / `sinks_effort` / `sinks_sampling`) as the single source of
+truth — they mirror `write_thinking`/`to_params` exactly — and the render now lists any
+set-but-unsent knob as `inert_tunables`. Chose render-time flagging over a load-time
+warning: the same knob is live or inert depending on the model id it lands on, so the
+resolved view is where the truth is, and a `[defaults]` value that's inert for one slot
+but live for another shouldn't warn globally. Didn't *reject* inert knobs — they're
+valid config that simply doesn't apply to this model, and a slot may keep one for when
+its model id changes; surfacing beats forbidding.
+
 ## 2026-06-22 — kill the `tool_span.rs` capture flake (root cause, not symptom)
 
 The two span-capturing tests in `tool_span.rs` failed ~5% of full-suite runs (the

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -341,17 +341,6 @@ tunables — if a provider caps output low, cap that slot, not the global, per t
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.
 
-### Tunables with no sink are accepted (and rendered) silently
-A slot whose resolved `ModelShape` has no sink for a knob still accepts it,
-load-validates it, and renders it at `kaibo://config` as if effective:
-`thinking_budget` on a Gemini 3-line slot (the level line never sends a budget,
-yet the `< max_tokens` inversion check still applies to it), and
-`effort`/`thinking_budget` on an openai-kind slot (`ThinkingStyle::None` sends
-neither). The effort half of this was fixed for the 3-line (it now maps onto
-`thinkingLevel`); the rest is invisible-no-op residue. Fix shape: at load (or in
-the render), flag per-slot tunables the slot's resolved shape will never send —
-a note in the render is enough to make the no-op visible to the operator.
-
 ### Explorer prose — residual probes (the report shape + reading strategy shipped)
 The structured report sections (`SummaryOfFindings`/`RelevantLocations`/
 `ExplorationTrace`), the curiosity + completeness behaviors, and the assertive
@@ -367,15 +356,6 @@ built-in reproduces it with no per-cast config. Still open, lower value:
 - **Debug affordance:** dump the *assembled* preamble (built-in/override + house rules)
   to a file, à la gemini-cli's `GEMINI_WRITE_SYSTEM_MD` — useful now that prompts
   compose per model from `[prompts]`, slot `preamble`, and `[context]`.
-
-### `generate_image` doesn't advertise its cast `enum`
-The consultation tools stamp the usable-cast roster onto their `cast` param as a
-JSON-Schema enum (`inject_cast_enum`, `server.rs`); `generate_image` doesn't. Its
-`cast` selects the **`image`** slot (openai-kind only), so the right menu is a
-different filter — "casts with a usable image slot", not the explorer/synth
-`usable_casts` — i.e. a `Config::image_capable_casts` to write. Add it so image gen
-is as discoverable as consultation. Advisory like the others (serde ignores the enum
-in `call_tool`), so it never rejects a config-only cast.
 
 ### Server doesn't validate backend health at startup
 Usable *casts* are now advertised — the handshake `## Casts` list and the `cast`

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -218,16 +218,6 @@ for now, but a busy server rebuilds kernels constantly. Consider a small worker
 pool, or resetting one kernel's cwd between phases instead of rebuilding. Measure
 before optimizing.
 
-### Flaky tracing-capture tests in `tool_span.rs`
-`emits_an_error_outcome_when_the_tool_fails` (and its `ok` sibling) fail ~25% of
-the time in the *parallel* full `cargo test` run, never in isolation. Both register
-a `tracing_subscriber::registry().with(cap)` via `set_default` and assert on captured
-spans; run concurrently on cargo's test threads they race on tracing's process-global
-span store, so one test's `tool` span can go missing from the other's capture. A test
-that fails when we *didn't* make a mistake is the opposite of the teeth we want. Fix:
-serialize the two (a shared `Mutex`/`serial_test`), or capture per-span without leaning
-on global dispatch. Out of scope when found (the read-idioms/output-cap PR).
-
 ### Batch — remaining providers and the many-casts fork
 The batch tool class shipped Anthropic- and Gemini-first (`src/batch.rs`,
 `batch_submit`/`batch_get`/`batch_cancel`/`batch_list`, one `--no-batch` gate): offline,
@@ -249,7 +239,10 @@ in the module doc and `docs/devlog.md`. What's left:
 
 Per-provider capability, `None` where unsupported: Anthropic ✓ (shipped), Gemini ✓
 (shipped — inline batch, `gemini-batch` cast synths Pro), OpenAI ✓ file-based (next),
-DeepSeek ?, local `openai` ✗.
+DeepSeek ✗ (confirmed 2026-06-22 against the official API reference — no batch endpoint;
+its routes are chat/completions/models only, and its cost-saving lane is off-peak
+discount pricing, not a batch API; third-party batch like Novita/Together/Bedrock wraps
+the model, out of reach of the keyed `deepseek` backend), local `openai` ✗.
 
 ### Batch design hardening (cross-model Opus review, 2026-06-22)
 A cross-family review of the batch slice (Opus 4.8, run *through* `batch_submit` itself

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,6 +696,35 @@ impl Config {
             .collect()
     }
 
+    /// The casts that can actually serve `generate_image` *right now*: those carrying
+    /// an `image` slot on an OpenAI-compatible backend (the only kind rig 0.38 drives
+    /// for image generation) whose key resolves. This is the image-tool analogue of
+    /// [`usable_casts`](Self::usable_casts) — a deliberately *different* filter, because
+    /// `generate_image` selects the `image` slot, not explorer/synth: a cast with a
+    /// stranded explorer key but a working image slot belongs here (and a fully-keyed
+    /// cast with no image slot does not). Sorted by name (the `casts` `BTreeMap` order);
+    /// includes config.toml casts the static `cast` enum can't name. Env lookup injected
+    /// for testability, mirroring [`usable_casts`](Self::usable_casts).
+    pub fn image_capable_casts(&self, get_env: impl Fn(&str) -> Option<String>) -> Vec<String> {
+        self.casts
+            .iter()
+            .filter(|(_, cast)| {
+                let Some(slot) = cast.slot(ModelRole::Image) else {
+                    return false;
+                };
+                // Slot backend refs resolve at merge time; skip defensively rather than
+                // panic if that ever changes. Only openai-kind has a rig image path, and
+                // a Missing key means the slot can't reach a model — neither is usable.
+                let Ok(backend) = self.resolve_backend(&slot.backend) else {
+                    return false;
+                };
+                backend.kind == ProviderKind::Openai
+                    && !matches!(backend.key_status(&get_env), KeyStatus::Missing)
+            })
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
     /// [`cast_usability`](Self::cast_usability) for the default cast — what `get_info`
     /// reads to decide whether to surface setup guidance. If the default cast somehow
     /// doesn't resolve (it's validated to at startup), treat it as `Unconfigured` so we
@@ -2144,6 +2173,36 @@ mod tests {
             vec![("openai".to_string(), CastUsability::LocalUnverified)],
             "no env key ⇒ only the keyless local cast is usable"
         );
+    }
+
+    /// `image_capable_casts` is a *different* filter than `usable_casts`: it keeps only
+    /// casts whose `image` slot rides an openai backend with a resolvable key. A cast
+    /// with an openai image slot survives even with no env key (the local backend is
+    /// keyless); a cast whose image slot is on a non-openai backend is dropped (rig has
+    /// no image path there); a cast with no image slot at all never appears.
+    #[test]
+    fn image_capable_casts_keeps_only_openai_image_slots() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.art]
+            image = { backend = "openai", id = "sd-xl" }
+
+            [casts.wrongkind]
+            image = { backend = "anthropic", id = "imagen-ish" }
+            "#,
+        )
+        .unwrap();
+        // No env key at all: the openai image cast still qualifies (keyless local),
+        // the anthropic-backed one is excluded by kind, and the built-in agent-only
+        // casts (no image slot) never appear.
+        assert_eq!(
+            cfg.image_capable_casts(|_| None),
+            vec!["art".to_string()],
+            "only the openai-backed image cast is image-capable"
+        );
+        // An anthropic key in the env changes nothing — wrong kind stays excluded.
+        let with_key = |k: &str| (k == "ANTHROPIC_API_KEY").then(|| "sk-test".to_string());
+        assert_eq!(cfg.image_capable_casts(with_key), vec!["art".to_string()]);
     }
 
     /// The built-in aliases register at BOTH levels: `claude` resolves as a cast

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -383,6 +383,40 @@ impl ModelShape {
         }
     }
 
+    /// Does this shape have a sink for a `thinking_budget` tunable? Only the two
+    /// explicit-budget styles emit it (`budget_tokens` / `thinkingBudget`); the
+    /// effort-driven styles (Anthropic adaptive, the Gemini 3-line, DeepSeek) and the
+    /// toggle-less openai path ignore a budget entirely. Lets the `kaibo://config`
+    /// render flag a per-slot `thinking_budget` that will never leave the process.
+    pub fn sinks_thinking_budget(&self) -> bool {
+        matches!(
+            self.thinking,
+            ThinkingStyle::AnthropicBudget | ThinkingStyle::GeminiBudget
+        )
+    }
+
+    /// Does this shape have a sink for an `effort` tunable? Only the effort-driven
+    /// styles route it (`output_config.effort` / `thinkingLevel` / `reasoning_effort`);
+    /// the budget styles and the openai path drop it. Counterpart to
+    /// [`sinks_thinking_budget`](Self::sinks_thinking_budget) for the render's no-op flag.
+    pub fn sinks_effort(&self) -> bool {
+        matches!(
+            self.thinking,
+            ThinkingStyle::AnthropicAdaptive
+                | ThinkingStyle::GeminiLevel
+                | ThinkingStyle::DeepSeekEffort
+        )
+    }
+
+    /// Does this shape actually send sampling (`temperature`/`top_p`)? Kaibo runs
+    /// thinking on by default, and a model that rejects sampling under thinking
+    /// (Anthropic, any tier) has it dropped — so a per-slot `temperature` there is
+    /// inert. The toggle-less openai path (`thinking == None`) keeps sampling, as do
+    /// Gemini/DeepSeek. Mirrors the drop in [`to_params`](Self::to_params).
+    pub fn sinks_sampling(&self) -> bool {
+        self.thinking == ThinkingStyle::None || self.sampling_under_thinking
+    }
+
     /// Just the thinking block (no sampling), with the default effort — the body of the
     /// [`thinking_params`] wrapper.
     fn thinking_only(&self, budget: u64) -> Option<Value> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,7 +29,7 @@ use serde_json::json;
 use tracing::Instrument;
 
 use crate::config::{Cast, Config, ModelRole, ModelSlot};
-use crate::consult::{consult, oneshot, Arm, ConsultConfig, PromptOverrides};
+use crate::consult::{consult, oneshot, Arm, ConsultConfig, ModelShape, PromptOverrides};
 use crate::explorer::format_output;
 use crate::generate_image::GenerateImageInput;
 use crate::image_gen::ImageGen;
@@ -329,7 +329,7 @@ pub struct KaiboHandler {
 /// reach a model), because an empty `enum` reads as "no valid value" to a strict
 /// client and would wrongly forbid the field, which is optional. A gated-off tool
 /// is already absent from `router`, so the lookups simply skip it.
-fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, casts: &[String]) {
+fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, tools: &[&str], casts: &[String]) {
     if casts.is_empty() {
         return;
     }
@@ -337,8 +337,8 @@ fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, casts: &[String]) {
         .iter()
         .map(|c| serde_json::Value::String(c.clone()))
         .collect();
-    for name in ["consult", "oneshot"] {
-        let Some(route) = router.map.get_mut(name) else {
+    for name in tools {
+        let Some(route) = router.map.get_mut(*name) else {
             continue;
         };
         let mut schema = (*route.attr.input_schema).clone();
@@ -462,7 +462,12 @@ impl KaiboHandler {
             .into_iter()
             .map(|(name, _)| name)
             .collect();
-        inject_cast_enum(&mut tool_router, &usable);
+        inject_cast_enum(&mut tool_router, &["consult", "oneshot"], &usable);
+        // `generate_image` selects the `image` slot, not explorer/synth, so its menu is
+        // a different filter — casts with a usable image slot, not `usable_casts`. Same
+        // advisory enum so image gen is as discoverable as consultation.
+        let image_casts = config.image_capable_casts(|k| std::env::var(k).ok());
+        inject_cast_enum(&mut tool_router, &["generate_image"], &image_casts);
 
         let sessions = SessionStore::new(config.defaults.session_capacity);
         Ok(Self {
@@ -1857,6 +1862,13 @@ fn render_config_resource(
         /// operator's own framing). Absent when unset.
         #[serde(skip_serializing_if = "Option::is_none")]
         preamble: Option<String>,
+        /// Per-slot tunables that *are* set here but this slot's resolved request shape
+        /// will never send — the honest no-op flag. A `thinking_budget` on an
+        /// effort-driven or toggle-less model, an `effort` on a budget model, a
+        /// `temperature` an Anthropic slot drops under thinking: each load-validates and
+        /// would otherwise render as if effective. Absent when every set knob has a sink.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        inert_tunables: Vec<&'static str>,
     }
 
     /// A cast's role table, keyed by role. Only configured roles appear.
@@ -1919,6 +1931,25 @@ fn render_config_resource(
                     let caps = config
                         .slot_caps(slot)
                         .expect("a loaded cast's slot backend resolves");
+                    // Resolve the slot's request shape so we can flag tunables it will
+                    // never send (e.g. a budget on an effort-driven model) — making the
+                    // invisible no-op visible rather than rendering it as if effective.
+                    let kind = config
+                        .resolve_backend(&slot.backend)
+                        .expect("a loaded cast's slot backend resolves")
+                        .kind;
+                    let shape =
+                        ModelShape::resolve(kind, &slot.id, thinking_style.unwrap_or_default());
+                    let mut inert_tunables = Vec::new();
+                    if thinking_budget.is_some() && !shape.sinks_thinking_budget() {
+                        inert_tunables.push("thinking_budget");
+                    }
+                    if effort.is_some() && !shape.sinks_effort() {
+                        inert_tunables.push("effort");
+                    }
+                    if temperature.is_some() && !shape.sinks_sampling() {
+                        inert_tunables.push("temperature");
+                    }
                     (
                         role.key(),
                         SlotDoc {
@@ -1930,6 +1961,7 @@ fn render_config_resource(
                             effort: effort.clone(),
                             thinking_style: thinking_style.map(|s| format!("{s:?}").to_lowercase()),
                             preamble: preamble.clone(),
+                            inert_tunables,
                         },
                     )
                 })
@@ -2281,6 +2313,52 @@ mod tests {
         }
     }
 
+    /// `generate_image` advertises its own, *differently-filtered* roster: casts with a
+    /// usable `image` slot on an openai backend — not the explorer/synth `usable_casts`.
+    /// So a config-only cast that carries an openai `image` slot shows up, while a cast
+    /// with no image slot (or one on a non-openai backend) does not.
+    #[test]
+    fn generate_image_advertises_image_capable_casts_only() {
+        let h = handler_from_toml(
+            r#"
+            # An openai `image` slot on the keyless local backend → image-capable.
+            [casts.art]
+            image = { backend = "openai", id = "sd-xl" }
+
+            # An `image` slot on a non-openai backend → rig has no path → excluded.
+            [casts.wrongkind]
+            image = { backend = "anthropic", id = "imagen-ish" }
+            "#,
+        );
+        let schema = h
+            .tool_router
+            .get("generate_image")
+            .expect("generate_image advertised")
+            .input_schema
+            .clone();
+        let variants: Vec<&str> = schema
+            .get("properties")
+            .and_then(|p| p.get("cast"))
+            .and_then(|c| c.get("enum"))
+            .and_then(|e| e.as_array())
+            .unwrap_or_else(|| panic!("generate_image cast param should carry an enum:\n{schema:#?}"))
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(
+            variants.contains(&"art"),
+            "the openai image cast should be listed, got {variants:?}"
+        );
+        assert!(
+            !variants.contains(&"wrongkind"),
+            "a non-openai image cast has no rig path and must not be listed: {variants:?}"
+        );
+        assert!(
+            !variants.contains(&"openai"),
+            "the builtin `openai` cast has no image slot and must not be listed: {variants:?}"
+        );
+    }
+
     /// An empty roster (no cast can reach a model) leaves `cast` enum-free: an empty
     /// `enum` would read as "no valid value" and wrongly forbid the optional field.
     /// `inject_cast_enum` is the seam — driving it with `[]` keeps the test honest
@@ -2288,7 +2366,7 @@ mod tests {
     #[test]
     fn empty_cast_roster_leaves_the_param_unconstrained() {
         let mut router = KaiboHandler::tool_router();
-        inject_cast_enum(&mut router, &[]);
+        inject_cast_enum(&mut router, &["consult", "oneshot"], &[]);
         let schema = router
             .get("consult")
             .expect("tool present")
@@ -2866,6 +2944,72 @@ mod tests {
         assert!(
             body.contains("/tmp/the-repo-feature"),
             "runtime section must list the followed worktree:\n{body}"
+        );
+    }
+
+    /// A per-slot tunable that the slot's resolved request shape will never send is
+    /// flagged `inert_tunables` in the render, so the operator sees the no-op instead of
+    /// a knob that looks effective. The matrix: a budget on an effort-driven model
+    /// (Gemini 3-line, Anthropic adaptive) or the toggle-less openai path; an effort on
+    /// a budget model; a temperature an Anthropic slot drops under thinking. A knob that
+    /// *does* have a sink is never flagged.
+    #[test]
+    fn config_render_flags_inert_per_slot_tunables() {
+        let config = Config::from_toml_str(
+            r#"
+            # Gemini 3-line: takes thinkingLevel (effort), no budget.
+            [casts.gem]
+            explorer = { backend = "gemini", id = "gemini-3-pro", thinking_budget = 4096, effort = "low" }
+
+            # openai (toggle-less): sends neither effort nor budget; keeps sampling.
+            [casts.oai]
+            synth = { backend = "openai", id = "gemma-local", thinking_budget = 8192, effort = "high", temperature = 0.7 }
+
+            # Anthropic budget tier: takes budget_tokens, no effort; drops sampling under thinking.
+            [casts.ant_budget]
+            explorer = { backend = "anthropic", id = "claude-haiku-4-5", effort = "high", temperature = 0.5 }
+
+            # Anthropic adaptive: takes output_config.effort, no budget.
+            [casts.ant_adaptive]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", effort = "high", thinking_budget = 2048 }
+            "#,
+        )
+        .unwrap();
+        let body = render_config_resource(&config, &[], None, false, vec![]);
+        let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
+        let inert = |cast: &str, role: &str| -> Vec<String> {
+            doc.get("casts")
+                .and_then(|c| c.get(cast))
+                .and_then(|c| c.get(role))
+                .and_then(|s| s.get("inert_tunables"))
+                .map(|a| {
+                    a.as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|v| v.as_str().unwrap().to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        assert_eq!(
+            inert("gem", "explorer"),
+            vec!["thinking_budget"],
+            "Gemini 3-line sinks effort (thinkingLevel) but not a budget"
+        );
+        assert_eq!(
+            inert("oai", "synth"),
+            vec!["thinking_budget", "effort"],
+            "openai sends neither thinking knob; temperature it does send"
+        );
+        assert_eq!(
+            inert("ant_budget", "explorer"),
+            vec!["effort", "temperature"],
+            "budget tier ignores effort; Anthropic drops sampling under thinking"
+        );
+        assert_eq!(
+            inert("ant_adaptive", "synth"),
+            vec!["thinking_budget"],
+            "adaptive sinks effort but rejects a budget"
         );
     }
 

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -95,6 +95,41 @@ mod tests {
     use tracing_subscriber::registry::LookupSpan;
     use tracing_subscriber::Layer;
 
+    /// Serializes the span-capturing tests so their `set_default` installs and
+    /// teardowns — which mutate *process-global* tracing state (the callsite interest
+    /// cache, the live-dispatcher set, the global max-level) via
+    /// `Dispatch::new` → `callsite::register_dispatch` — never interleave with each
+    /// other. Belt to the [`force_multi_dispatcher`] suspenders below.
+    static CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
+
+    /// A leaked, permanently-registered second dispatcher, established once.
+    ///
+    /// The flake this kills: `info_span!("tool")` registers its callsite *lazily*, on
+    /// first hit. While tracing's `has_just_one` fast path holds — true whenever ≤1
+    /// dispatcher is registered, which is exactly our case since each test installs a
+    /// single subscriber — that first registration computes the callsite's interest
+    /// from **the registering thread's current default**, not from the installed
+    /// subscriber. So when a no-subscriber `consult` test (this binary is full of them)
+    /// wins the race to first-touch the `tool` callsite during a capture test's window,
+    /// it caches `Interest::never()` against `NoSubscriber`, gating the span off — an
+    /// empty capture, the ~5% full-suite flake. Serializing the two capture tests can't
+    /// prevent that: the poisoning thread is a *third* test with no subscriber.
+    ///
+    /// Holding a second registered dispatcher forever forces `has_just_one` false, so
+    /// every callsite registration instead consults the registered-dispatcher set —
+    /// which contains a span-enabling registry — regardless of which thread triggers
+    /// it. It is never a thread's default, so it receives no events; it exists only to
+    /// keep the registration path honest. Leaked deliberately: it must outlive every
+    /// test in the process.
+    fn force_multi_dispatcher() {
+        use std::sync::OnceLock;
+        static KEEPALIVE: OnceLock<()> = OnceLock::new();
+        KEEPALIVE.get_or_init(|| {
+            let keep = tracing::Dispatch::new(tracing_subscriber::registry());
+            std::mem::forget(keep);
+        });
+    }
+
     /// A trivial tool to wrap: echoes its `msg`, or errors on "boom".
     struct Echo;
     #[derive(Deserialize)]
@@ -152,9 +187,12 @@ mod tests {
         assert!(s.ends_with('…'), "marked truncated: {s}");
     }
 
-    /// Captures (span name, tool name, arguments, outcome) for each span closed.
+    /// One closed span as captured: (span name, tool name, arguments, outcome).
+    type CapturedSpan = (String, String, String, String);
+
+    /// Captures each [`CapturedSpan`] as its span closes.
     #[derive(Clone, Default)]
-    struct Capture(Arc<Mutex<Vec<(String, String, String, String)>>>);
+    struct Capture(Arc<Mutex<Vec<CapturedSpan>>>);
 
     #[derive(Default)]
     struct Grab {
@@ -232,46 +270,63 @@ mod tests {
         }
     }
 
+    /// Drive an async body to completion on a private current-thread runtime while
+    /// holding [`CAPTURE_SERIAL`]. Sync (not `#[tokio::test]`) so the ordering guard
+    /// isn't held across an `.await`, and `block_on` polls the future on *this* thread
+    /// — the one whose `set_default` is in scope, so the span routes to our capture.
+    fn serialized_capture<F: std::future::Future>(body: F) {
+        let _serial = CAPTURE_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        force_multi_dispatcher();
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(body);
+    }
+
     /// A success emits a `tool` span tagged with the tool's name, an args summary,
     /// and outcome=ok; the output passes through.
-    #[tokio::test]
-    async fn emits_a_tool_span_with_name_args_and_outcome() {
-        let cap = Capture::default();
-        let sub = tracing_subscriber::registry().with(cap.clone());
-        let _g = tracing::subscriber::set_default(sub);
+    #[test]
+    fn emits_a_tool_span_with_name_args_and_outcome() {
+        serialized_capture(async {
+            let cap = Capture::default();
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
 
-        let tool = traced(Echo);
-        let out = tool.call(r#"{"msg":"hi"}"#.to_string()).await.unwrap();
-        assert!(out.contains("hi"), "output passes through: {out}");
+            let tool = traced(Echo);
+            let out = tool.call(r#"{"msg":"hi"}"#.to_string()).await.unwrap();
+            assert!(out.contains("hi"), "output passes through: {out}");
 
-        drop(_g);
-        let spans = cap.0.lock().unwrap().clone();
-        assert!(
-            spans.iter().any(|(n, tool, args, oc)| n == "tool"
-                && tool == "echo"
-                && args.contains("hi")
-                && oc == "ok"),
-            "a `tool` span with name/args/outcome: {spans:?}"
-        );
+            drop(_g);
+            let spans = cap.0.lock().unwrap().clone();
+            assert!(
+                spans.iter().any(|(n, tool, args, oc)| n == "tool"
+                    && tool == "echo"
+                    && args.contains("hi")
+                    && oc == "ok"),
+                "a `tool` span with name/args/outcome: {spans:?}"
+            );
+        });
     }
 
     /// An error still emits the span, tagged outcome=error.
-    #[tokio::test]
-    async fn emits_an_error_outcome_when_the_tool_fails() {
-        let cap = Capture::default();
-        let sub = tracing_subscriber::registry().with(cap.clone());
-        let _g = tracing::subscriber::set_default(sub);
+    #[test]
+    fn emits_an_error_outcome_when_the_tool_fails() {
+        serialized_capture(async {
+            let cap = Capture::default();
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
 
-        let tool = traced(Echo);
-        assert!(tool.call(r#"{"msg":"boom"}"#.to_string()).await.is_err());
+            let tool = traced(Echo);
+            assert!(tool.call(r#"{"msg":"boom"}"#.to_string()).await.is_err());
 
-        drop(_g);
-        let spans = cap.0.lock().unwrap().clone();
-        assert!(
-            spans
-                .iter()
-                .any(|(n, tool, _args, oc)| n == "tool" && tool == "echo" && oc == "error"),
-            "a `tool` span tagged outcome=error: {spans:?}"
-        );
+            drop(_g);
+            let spans = cap.0.lock().unwrap().clone();
+            assert!(
+                spans
+                    .iter()
+                    .any(|(n, tool, _args, oc)| n == "tool" && tool == "echo" && oc == "error"),
+                "a `tool` span tagged outcome=error: {spans:?}"
+            );
+        });
     }
 }

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -121,6 +121,16 @@ mod tests {
     /// it. It is never a thread's default, so it receives no events; it exists only to
     /// keep the registration path honest. Leaked deliberately: it must outlive every
     /// test in the process.
+    ///
+    /// A subtlety worth stating, because it looks like a residual race and isn't: a
+    /// no-subscriber test *can* poison the `tool` callsite to `never` before the first
+    /// capture test runs. But registering a dispatcher (`Dispatch::new` →
+    /// `callsite::register_dispatch`) *rebuilds the interest cache for every already-
+    /// registered callsite* against the live set — so this very call un-poisons `tool`,
+    /// and the test's own `set_default` rebuilds it again. The only window that ever
+    /// mattered was poisoning *after* those rebuilds but before the span fires, by a
+    /// concurrent first-touch under `has_just_one` — which is exactly the window forcing
+    /// `has_just_one` false closes. Hence 0/150 full-suite runs (was ~5%).
     fn force_multi_dispatcher() {
         use std::sync::OnceLock;
         static KEEPALIVE: OnceLock<()> = OnceLock::new();


### PR DESCRIPTION
Three changes, all small and independently reviewable. `batch-attach` will want #1's clean test run, hence merging soon.

## 1. tool_span capture flake — root-cause fix, not symptom

The two span-capturing tests failed ~5% of full-suite runs (the old issue guessed ~25%), never in isolation — a test failing when we didn't make a mistake. Traced rather than guessed: `info_span!("tool")` registers its callsite lazily, and while tracing's `has_just_one` fast path holds (≤1 registered dispatcher — exactly our case, each test installs one subscriber) the first registration computes `Interest` from the *registering thread's* current default. This binary is full of `consult` tests running the real tool loop with no subscriber; one winning the race to first-touch the callsite caches `Interest::never()` process-wide → empty capture. Serializing the two capture tests can't fix it (the poisoning thread is a third, subscriber-less test).

Fix matches the cause: leak one extra registered dispatcher (`force_multi_dispatcher`) to force `has_just_one` false, so registration consults the registered-dispatcher set regardless of triggering thread. Kept a serialization `Mutex` + current-thread `block_on` as belt-and-suspenders (guard not held across `.await`). Proven: 0 failures in 150 full-suite runs; both tests still fail under deliberate mutation of the span name and outcome field.

## 2. `generate_image` advertises its cast enum

The consultation tools stamp the usable-cast roster onto their `cast` param as a JSON-Schema enum so a host agent reads the menu off the schema; image gen didn't. Added `Config::image_capable_casts` (a deliberately *different* filter — casts with an `image` slot on an openai backend whose key resolves, the only kind rig 0.38 drives for images) and generalized `inject_cast_enum` to take the tool list.

## 3. `kaibo://config` flags inert per-slot tunables

A slot whose resolved `ModelShape` has no sink for a knob rendered it as if effective — a `thinking_budget` on an effort-driven/toggle-less model, an `effort` on a budget model, a `temperature` an Anthropic slot drops under thinking. Added `sinks_thinking_budget`/`sinks_effort`/`sinks_sampling` predicates (mirroring `write_thinking`/`to_params`); the render now lists any set-but-unsent knob under `inert_tunables`. Render-time, not load-time: the same knob is live or inert depending on the model id it resolves against.

## Review

Cross-family review by **DeepSeek** (run through kaibo's own `consult`, grounded in a worktree of the branch): 0 real bugs across all three. It verified the sink matrix cell-by-cell against the emission code, confirmed the `image_capable_casts` filter is panic-free, and confirmed the `inject_cast_enum` generalization is regression-free. Its one flagged "residual race" on the flake fix was checked against `tracing-core` and is not real — `Dispatch::new` → `register_dispatch` rebuilds the whole interest cache, healing any prior poison — but the comment now documents that explicitly (commit `0f6372e`) so it isn't re-derived.

CHANGELOG / devlog updated; shipped entries deleted from `docs/issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)