### PR TITLE
Batch attachments: inline workspace files as context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,13 @@ the git log. Each later release appends a new section at the top.
   rather than wait on it. Lost a handle? `batch_list` re-discovers the batches a backend
   still holds (newest first, each with its handle, status, and progress), so a batch is
   never orphaned — defaulting across every batch-capable backend, or scoped to one with
-  `backend`.
+  `backend`. **`attach`** lets you name workspace files to inline as shared context for
+  every prompt — "review README.md" with `attach: ["README.md"]`, or `git diff > x.diff`
+  and `attach: ["x.diff"]` — so the file's bytes never pass through your own context.
+  Text files splice in as text; images (png/jpeg/gif/webp) ride as native image parts
+  (with a vision-capable synth model). Paths obey the same workspace boundary as
+  everything else (worktrees included); a file outside it, a directory, an oversized
+  file, or a binary that isn't a known image is refused with a clear error.
 - **`view_image`** — vision-capable consultation phases can read an image *file* from
   the workspace into model context (screenshots, diagrams, assets already in the tree).
 - **Multi-provider model teams.** Anthropic, DeepSeek, and Gemini natively, plus a

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -76,6 +76,55 @@ thread whose `set_default` is in scope. Proven: 0 failures in 150 full-suite run
 the outcome field. Rejected the symptom-level "just serialize" because it left the
 ~1% consult-thread poisoning window open — measured, didn't assume.
 
+## 2026-06-22 — batch: `attach` — inline workspace files as context
+
+Amy wanted "let's get gemini pro batch to give us feedback on README.md" to mean *attach
+the file*, not paste it: kaibo reads README (or a `git diff > x.diff`) and inlines it, so
+the bytes never round-trip through the calling agent's context. That framing — "if the
+provider has attachments cool, but I don't care, just inline it for us" — settled the whole
+design. **Caller-side inlining, not provider attachment APIs.**
+
+The decisions, and what we rejected:
+
+- **Same surface, two encodings.** One `attach: [paths]` param, *shared* across every
+  prompt in the batch (the way `system` is shared) — because the stated cases are one
+  prompt + one file, and "N questions about the same README" is the natural multi-prompt
+  shape. Per-prompt attachments (prompts-as-objects) were rejected as YAGNI. Text splices
+  in as `<file path="…">…</file>`; an **image** can't splice into a string, so it becomes a
+  structured base64 part the provider carries natively (Anthropic `image` block / Gemini
+  `inlineData`). That's the real cost: the two body builders had to stop emitting a bare
+  string and emit **structured parts** — built now (even though text is the common case) so
+  image wasn't a later re-architecture. Anthropic content stays a plain string when there
+  are no attachments, preserving the existing wire shape.
+
+- **Reusing the boundary, not a parallel one.** "Restricted to workspace and worktrees like
+  everything else" became *literally* the same code: factored `resolve_root`'s containment
+  into `contained` + `containment_error`, and `resolve_attachments` calls them — so an
+  attachment can't read outside the workspace any more than `run_kaish` can. This is a
+  *second* fs-read path outside the kaish VFS, but it doesn't weaken read-only (we only
+  read), and it's the same pattern `[context]`/house-rules already use (server-side Rust
+  reads a file into a preamble). Proved the teeth: defeating `contained` makes the
+  outside-path and symlink-escape tests read outside bytes and fail.
+
+- **Images gated on real vision capability.** An image to a vision-blind synth would be
+  silently ignored or error upstream, so we refuse honestly up front via the existing
+  `ModelCaps` classifier — and we moved that gate (and attachment resolution) *before*
+  building the network client, so a vision misconfig is reported with **no key and no
+  network**. That also made the gate offline-testable (pin a slot `vision = false`, attach
+  an image, assert the refusal).
+
+- **Loud failures, no silent truncation.** A path outside the set, a directory, an
+  oversized file, or a binary that's neither UTF-8 nor a known image is a clear refusal —
+  the UTF-8/image sniff (shared with `view_image`) is the branch point, not just a guard.
+
+**Gemini File API: designed for, deliberately not built.** It's real (upload → `file_uri`
+→ `fileData` part) and could ride in batch, but it's *Gemini-only* and the use cases are
+text/inline-image, which both providers carry natively with no upload lifecycle. So it's a
+reserved typed `FileRef` variant (see `issues.md`), earning its keep only for
+genuinely-too-big-to-inline media. **`oneshot` deferred** the same way: same win, but it
+runs through rig (not the hand-rolled batch HTTP), so its image path needs rig multimodal
+messages — a later, separate piece.
+
 ## 2026-06-22 — batch: Gemini provider (second backend behind the seam)
 
 Added the second `BatchProvider` impl — Gemini inline batch — so the offline lane reaches

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -299,6 +299,19 @@ failures and a truncated page are surfaced, not hidden). Still open:
   Consider making effort a default-on floor the cast/caller can lower, the way
   `max_tokens` already is. (Distinct from the "lift the tier" bullet above — that's the
   ceiling, this is the override.)
+- **Shared `attach` duplicates per item — a payload/memory ceiling as batches grow.**
+  Attachments are shared across the batch but inlined *per item*: `anthropic_content`/
+  `gemini_parts` (`batch.rs`) re-encode every attachment into every item's request, so a
+  1 MiB attachment on a 1000-prompt batch is ~1 GiB in the JSON AST and again in the
+  serialized body. Inherent — provider batch APIs carry bytes inline per request, and
+  prompt caching doesn't shrink the JSONL — so the real fix is a guard, not dedup: bound
+  total submitted payload (sum of prompts + attachments×items) with a loud refusal before
+  it OOMs or trips the provider's body-size limit, the way single-file size is already
+  capped. Surfaced by the holistic review (Gemini Pro, 2026-06-22). Low priority until a
+  big-attachment × many-prompt batch is real — measure first; today's single-digit-prompt
+  reviews are nowhere near it. Note this interacts with the `FileRef`/File-API path
+  (`attach.rs` module doc): a `fileUri` reference is tiny and *reused* across items, so
+  remote-referenced media is the eventual escape from this duplication for large files.
 
 ### Provider model ids drift and live in code
 `consult.rs::default_models` hardcodes the explorer/synth ids per provider; they

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -152,6 +152,22 @@ completes, while a pure-script spin still dies at 30s.
 
 ## P2 — Focused fixes & hardening
 
+### Path containment is check-then-open (a narrow TOCTOU)
+Both `resolve_root` and `resolve_attachments` (`server.rs`) check containment on the
+*canonical* path and then open/read it as a separate step — a classic check-then-open
+window. A concurrent writer could swap the canonical path for an outside-pointing symlink
+between the `contained` check and the read, escaping the boundary. Surfaced by the
+cross-family review of the batch `attach` feature (DeepSeek, 2026-06-22), which judged the
+boundary otherwise sound. The attacker model keeps it narrow: kaibo cannot write the
+workspace, so the race needs a concurrent writer to the very tree the calling agent owns
+(a self-attack), inside a sub-millisecond window. `resolve_root` is the less-exposed of
+the two — it hands the canonical path to the kaish kernel, which opens a directory fd and
+works through it — while the attachment path reads a file one-shot and discards the fd.
+Structural fix when justified: open `O_NOFOLLOW`, `fstat` the fd, re-check containment via
+`/proc/self/fd/N`, then read from the already-open fd. Deferred until the attacker model
+(a workspace writable by someone other than the caller) is real; documented in
+`resolve_attachments`' doc-comment so it isn't rediscovered.
+
 ### Review the provider retry + failure policy (and document it)
 We don't have a stated, audited answer for what a `consult`/`oneshot`
 call does when a provider misbehaves mid-flight: a 429/529 overload, a connection

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -236,6 +236,19 @@ in the module doc and `docs/devlog.md`. What's left:
   proven-accepted top for the Anthropic adaptive tier). If a higher tier (`xhigh`/`max`)
   is ever confirmed by probe for a batch backend, lift it there — the constant is the
   one knob to change.
+- **Attachments on `oneshot` (deferred — batch shipped).** `batch_submit` now takes
+  `attach: [paths]` — workspace files (text spliced inline, images as native base64
+  parts) read + containment-checked server-side so the bytes never transit the calling
+  agent's context (`src/attach.rs`, `server.rs::resolve_attachments`, the shared
+  `contained`/`containment_error` the session-root check also uses; both batch body
+  builders emit structured parts now). `oneshot` is the natural sibling — the same
+  "name a file instead of pasting it" win for the synchronous tool-less call — but it
+  runs through **rig**, not the hand-rolled batch HTTP, so *text* attachment is a cheap
+  prompt-string splice while *image* attachment needs rig multimodal-message building
+  (different plumbing). Consider it later; the `Attachment`/`classify` seam is reusable
+  as-is. A typed `FileRef` variant is reserved for the Gemini File API path (oversized/
+  reused media, Gemini-only) — only worth it once a genuinely-too-big-to-inline case
+  shows up.
 
 Per-provider capability, `None` where unsupported: Anthropic ✓ (shipped), Gemini ✓
 (shipped — inline batch, `gemini-batch` cast synths Pro), OpenAI ✓ file-based (next),

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -20,9 +20,17 @@
 //! Size caps are loud too (a file past its cap is refused, never silently truncated).
 //!
 //! A typed `FileRef` variant is reserved here in spirit for the later Gemini File API
-//! path (oversized/reused media, Gemini-only) — see `docs/issues.md`. We design the
-//! seam typed so that path slots in beside `Image` rather than re-architecting the
-//! body builders.
+//! path (oversized/reused media, Gemini-only) — see `docs/issues.md`. The *enum* is
+//! additive — a new variant beside `Text`/`Image` — but be honest about the cost: `Text`
+//! and `Image` carry their bytes **inline**, which is exactly what lets the body builders
+//! stay pure synchronous functions. The File API is a stateful two-step (async-upload the
+//! bytes → get a `fileUri` → reference it), and `resolve_attachments` is deliberately
+//! key-free, so it can't do that upload. Landing `FileRef` therefore means a
+//! provider-specific **upload pre-pass inside `submit`** that resolves local bytes to a
+//! URI *before* the pure builder runs — the builders stay pure, fed an already-resolved
+//! reference. So `Attachment` as written is an *inline-data* handle, not a universal
+//! media handle; don't assume `FileRef` is free of pipeline work. (Holistic review,
+//! Gemini Pro, 2026-06-22.)
 
 use anyhow::{bail, Result};
 use base64::Engine;

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -1,0 +1,229 @@
+//! Attachments — inline a workspace file into a tool-less prompt as context.
+//!
+//! The tool-less tools (batch today, `oneshot` a tracked follow-on in
+//! `docs/issues.md`) answer from what the caller hands them. An attachment lets the
+//! caller name a *file* in the workspace instead of pasting its bytes through the
+//! calling agent's own context: kaibo reads it, containment-checks it against the
+//! same allowed set every other path obeys
+//! ([`resolve_attachments`](crate::server::KaiboHandler::resolve_attachments)), and
+//! inlines it. The point is to keep the bytes off the calling agent's context window —
+//! "review README.md" or `git diff > x.diff` instead of pasting the file.
+//!
+//! **Two encodings, picked by content, not extension.**
+//! - **text** (valid UTF-8) splices into the prompt as `<file path="…">…</file>`.
+//! - **image** (a sniffed image magic number, shared with [`crate::view_image`])
+//!   rides as a base64 part the provider carries natively (an Anthropic `image`
+//!   block / a Gemini `inlineData` part).
+//!
+//! Anything else — a binary that isn't a recognized image — is **refused loudly**
+//! rather than inlined as mojibake: crash over corruption, per the project ethos.
+//! Size caps are loud too (a file past its cap is refused, never silently truncated).
+//!
+//! A typed `FileRef` variant is reserved here in spirit for the later Gemini File API
+//! path (oversized/reused media, Gemini-only) — see `docs/issues.md`. We design the
+//! seam typed so that path slots in beside `Image` rather than re-architecting the
+//! body builders.
+
+use anyhow::{bail, Result};
+use base64::Engine;
+
+/// Cap on an attached *text* file's raw bytes. Generous — a large diff or source file
+/// fits — but bounded so a runaway file is refused loudly, not folded silently into
+/// every prompt (the `[context]` no-cap mistake in `docs/issues.md` is the lesson).
+pub const DEFAULT_MAX_TEXT_BYTES: usize = 1 << 20; // 1 MiB
+
+/// Cap on an attached *image*'s raw (pre-base64) bytes — reuses
+/// [`crate::view_image::DEFAULT_MAX_IMAGE_BYTES`] so a read image and an attached one
+/// share one ceiling.
+pub use crate::view_image::DEFAULT_MAX_IMAGE_BYTES;
+
+/// One resolved attachment, ready to fold into a provider request. The path is the
+/// caller-facing label (what they passed), kept for the `<file>` wrapper and the image
+/// part's provenance — never the canonical on-disk path, which is an implementation
+/// detail of the containment check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Attachment {
+    /// A UTF-8 text file, inlined as prompt text under a `<file>` wrapper.
+    Text { path: String, body: String },
+    /// An image, carried as a base64 part labelled with its sniffed mime.
+    Image {
+        path: String,
+        mime: &'static str,
+        data_b64: String,
+    },
+}
+
+impl Attachment {
+    /// The `<file>`-wrapped text for a *text* attachment — the exact form spliced into
+    /// a prompt as context, so both provider body builders wrap identically (one source
+    /// of truth for the wrapper). `None` for an image (which rides as a base64 part).
+    pub fn wrapped_text(&self) -> Option<String> {
+        match self {
+            Attachment::Text { path, body } => {
+                Some(format!("<file path=\"{path}\">\n{body}\n</file>"))
+            }
+            Attachment::Image { .. } => None,
+        }
+    }
+}
+
+/// Classify a file's bytes into an [`Attachment`], picking the encoding by *content*
+/// (the magic number), not the path's extension — a `.md` full of PNG bytes is an
+/// image, and we hand a `mimeType` straight to the provider, so the bytes are the only
+/// honest source. `display_path` labels the result.
+///
+/// Loud failures, never silent: a file past its (encoding-specific) cap is refused, and
+/// a binary that is neither valid UTF-8 nor a recognized image is refused rather than
+/// inlined as garbage.
+pub fn classify(
+    display_path: &str,
+    bytes: &[u8],
+    max_text: usize,
+    max_image: usize,
+) -> Result<Attachment> {
+    // Content decides the encoding. An image magic number wins — it can't be inlined
+    // as text, and the sniffer is the same one `view_image`/`generate_image` trust.
+    if let Some(mime) = crate::view_image::sniff_mime(bytes) {
+        if bytes.len() > max_image {
+            bail!(
+                "attachment `{display_path}` is {} bytes, over the {max_image}-byte image cap — \
+                 too large to inline (the Gemini File API path for oversized media is a tracked \
+                 follow-on; see docs/issues.md)",
+                bytes.len()
+            );
+        }
+        let data_b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+        return Ok(Attachment::Image {
+            path: display_path.to_string(),
+            mime,
+            data_b64,
+        });
+    }
+    // Not a recognized image — it must be UTF-8 text to inline honestly.
+    match std::str::from_utf8(bytes) {
+        Ok(text) => {
+            if bytes.len() > max_text {
+                bail!(
+                    "attachment `{display_path}` is {} bytes, over the {max_text}-byte text cap — \
+                     trim it or split the batch rather than inlining a runaway file into every prompt",
+                    bytes.len()
+                );
+            }
+            Ok(Attachment::Text {
+                path: display_path.to_string(),
+                body: text.to_string(),
+            })
+        }
+        Err(_) => bail!(
+            "attachment `{display_path}` is neither valid UTF-8 text nor a recognized image \
+             (png/jpeg/gif/webp); kaibo won't inline binary as text — paste the relevant text, \
+             or convert it first"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal blob with a real PNG signature — we never decode it, so a valid header
+    /// plus filler exercises sniff + round-trip (mirrors `view_image`'s test helper).
+    fn fake_png(filler: usize) -> Vec<u8> {
+        let mut v = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        v.extend(std::iter::repeat_n(0xAB, filler));
+        v
+    }
+
+    /// A UTF-8 file becomes a Text attachment whose wrapper names the path and carries
+    /// the body verbatim — the form a prompt sees.
+    #[test]
+    fn utf8_file_classifies_as_text_and_wraps() {
+        let att = classify(
+            "README.md",
+            b"# Title\nbody\n",
+            DEFAULT_MAX_TEXT_BYTES,
+            DEFAULT_MAX_IMAGE_BYTES,
+        )
+        .expect("utf8 inlines as text");
+        assert_eq!(
+            att,
+            Attachment::Text {
+                path: "README.md".into(),
+                body: "# Title\nbody\n".into()
+            }
+        );
+        let wrapped = att.wrapped_text().expect("text attachments wrap");
+        assert!(
+            wrapped.contains("path=\"README.md\""),
+            "wrapper names the path: {wrapped}"
+        );
+        assert!(
+            wrapped.contains("# Title\nbody\n"),
+            "wrapper carries the body verbatim: {wrapped}"
+        );
+    }
+
+    /// An image magic number becomes an Image attachment with the sniffed mime and a
+    /// base64 that decodes back to the original bytes.
+    #[test]
+    fn image_file_classifies_as_base64_image() {
+        let bytes = fake_png(32);
+        let att = classify(
+            "logo.png",
+            &bytes,
+            DEFAULT_MAX_TEXT_BYTES,
+            DEFAULT_MAX_IMAGE_BYTES,
+        )
+        .expect("a png inlines as an image part");
+        let (mime, data_b64) = match &att {
+            Attachment::Image { mime, data_b64, .. } => (*mime, data_b64.clone()),
+            other => panic!("expected Image, got {other:?}"),
+        };
+        assert_eq!(mime, "image/png");
+        assert!(att.wrapped_text().is_none(), "an image is not text-wrapped");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(data_b64)
+            .expect("the base64 decodes");
+        assert_eq!(decoded, bytes, "the round-trip preserves the bytes");
+    }
+
+    /// A text file past the text cap is refused loudly (no truncation), and the error
+    /// names the cap so the caller can act.
+    #[test]
+    fn oversized_text_is_refused() {
+        let big = vec![b'a'; 64];
+        let err = classify("notes.txt", &big, 32, DEFAULT_MAX_IMAGE_BYTES)
+            .expect_err("a text file over the cap must be refused, not truncated");
+        assert!(err.to_string().contains("text cap"), "names the cap: {err}");
+    }
+
+    /// An image past the image cap is refused loudly.
+    #[test]
+    fn oversized_image_is_refused() {
+        let bytes = fake_png(64);
+        let err = classify("big.png", &bytes, DEFAULT_MAX_TEXT_BYTES, 16)
+            .expect_err("an image over the cap must be refused");
+        assert!(
+            err.to_string().contains("image cap"),
+            "names the cap: {err}"
+        );
+    }
+
+    /// Binary that is neither valid UTF-8 nor a recognized image is refused rather than
+    /// inlined as mojibake — crash over corruption.
+    #[test]
+    fn non_text_non_image_binary_is_refused() {
+        // 0xFF is an invalid UTF-8 lead byte and matches no image magic.
+        let err = classify(
+            "mystery.bin",
+            &[0x00, 0xFF, 0xFE, 0xFD],
+            DEFAULT_MAX_TEXT_BYTES,
+            DEFAULT_MAX_IMAGE_BYTES,
+        )
+        .expect_err("non-text non-image binary must be refused");
+        assert!(
+            err.to_string().contains("neither valid UTF-8"),
+            "refusal explains the encoding gap: {err}"
+        );
+    }
+}

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -42,6 +42,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use serde_json::{json, Map, Value};
 
+use crate::attach::Attachment;
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot, SlotTunables};
 use crate::credentials::ProviderKind;
 
@@ -126,8 +127,15 @@ pub struct BatchListItem {
 #[async_trait]
 pub trait BatchProvider: Send + Sync {
     /// Submit `items` (each answered under the shared `system` preamble) as one batch;
-    /// returns the provider's batch id.
-    async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String>;
+    /// returns the provider's batch id. `attachments` are shared workspace files inlined
+    /// as context ahead of *every* item's prompt — text spliced inline, images carried as
+    /// native base64 parts (see [`crate::attach`]).
+    async fn submit(
+        &self,
+        system: &str,
+        attachments: &[Attachment],
+        items: &[BatchItem],
+    ) -> Result<String>;
     /// Poll a batch by its provider id.
     async fn poll(&self, batch_id: &str) -> Result<BatchPoll>;
     /// Ask the provider to cancel a batch by its id.
@@ -171,6 +179,31 @@ pub fn batch_shaping(
     (max_tokens, params)
 }
 
+/// Build one Anthropic message `content` for a prompt plus the shared attachments.
+/// With no attachments it stays a plain string (the unchanged wire shape — a bare
+/// prompt). With attachments it becomes a content-block array: the attachments first
+/// (as *context* — a text file as a `<file>`-wrapped text block, an image as a base64
+/// `image` block, Anthropic recommending image-before-text), then the prompt last.
+fn anthropic_content(attachments: &[Attachment], prompt: &str) -> Value {
+    if attachments.is_empty() {
+        return json!(prompt);
+    }
+    let mut blocks: Vec<Value> = attachments
+        .iter()
+        .map(|att| match att {
+            Attachment::Text { .. } => {
+                json!({ "type": "text", "text": att.wrapped_text().expect("text attachment wraps") })
+            }
+            Attachment::Image { mime, data_b64, .. } => json!({
+                "type": "image",
+                "source": { "type": "base64", "media_type": mime, "data": data_b64 }
+            }),
+        })
+        .collect();
+    blocks.push(json!({ "type": "text", "text": prompt }));
+    Value::Array(blocks)
+}
+
 /// Build the Anthropic Message Batches request body. Each item becomes one request
 /// whose `params` is a Messages API body: `model`/`max_tokens`/`system`/`messages` plus
 /// the flattened thinking block (`thinking`, and the adaptive tier's `output_config`).
@@ -181,6 +214,7 @@ pub fn anthropic_batch_body(
     max_tokens: u64,
     system: &str,
     params: &Option<Value>,
+    attachments: &[Attachment],
     items: &[BatchItem],
 ) -> Value {
     let requests: Vec<Value> = items
@@ -192,7 +226,7 @@ pub fn anthropic_batch_body(
             p.insert("system".into(), json!(system));
             p.insert(
                 "messages".into(),
-                json!([{ "role": "user", "content": it.prompt }]),
+                json!([{ "role": "user", "content": anthropic_content(attachments, &it.prompt) }]),
             );
             // Flatten the thinking/effort block in, the way rig flattens
             // additional_params into a Messages body (consult.rs).
@@ -542,7 +576,12 @@ impl AnthropicBatch {
 
 #[async_trait]
 impl BatchProvider for AnthropicBatch {
-    async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String> {
+    async fn submit(
+        &self,
+        system: &str,
+        attachments: &[Attachment],
+        items: &[BatchItem],
+    ) -> Result<String> {
         if self.model.is_empty() {
             return Err(anyhow!(
                 "this batch client was built for poll/cancel only (no model) — submit \
@@ -552,7 +591,14 @@ impl BatchProvider for AnthropicBatch {
         if items.is_empty() {
             return Err(anyhow!("a batch needs at least one prompt"));
         }
-        let body = anthropic_batch_body(&self.model, self.max_tokens, system, &self.params, items);
+        let body = anthropic_batch_body(
+            &self.model,
+            self.max_tokens,
+            system,
+            &self.params,
+            attachments,
+            items,
+        );
         let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches");
         let resp = self
             .auth(self.http.post(&url))
@@ -862,6 +908,7 @@ pub fn gemini_batch_body(
     max_tokens: u64,
     system: &str,
     params: &Option<Value>,
+    attachments: &[Attachment],
     items: &[BatchItem],
 ) -> Value {
     let requests: Vec<Value> = items
@@ -885,7 +932,7 @@ pub fn gemini_batch_body(
             }
             req.insert(
                 "contents".into(),
-                json!([{ "role": "user", "parts": [{ "text": it.prompt }] }]),
+                json!([{ "role": "user", "parts": gemini_parts(attachments, &it.prompt) }]),
             );
             req.insert("generationConfig".into(), Value::Object(gen));
             json!({ "request": Value::Object(req), "metadata": { "key": it.custom_id } })
@@ -897,6 +944,27 @@ pub fn gemini_batch_body(
             "input_config": { "requests": { "requests": requests } }
         }
     })
+}
+
+/// Build one Gemini user-turn `parts` array for a prompt plus the shared attachments:
+/// the attachments first as context (a text file as a `<file>`-wrapped text part, an
+/// image as an `inlineData` part), then the prompt last. Always an array (Gemini's
+/// native part shape), so the no-attachment case is just `[{ text: prompt }]` — the
+/// unchanged wire shape.
+fn gemini_parts(attachments: &[Attachment], prompt: &str) -> Value {
+    let mut parts: Vec<Value> = attachments
+        .iter()
+        .map(|att| match att {
+            Attachment::Text { .. } => {
+                json!({ "text": att.wrapped_text().expect("text attachment wraps") })
+            }
+            Attachment::Image { mime, data_b64, .. } => {
+                json!({ "inlineData": { "mimeType": mime, "data": data_b64 } })
+            }
+        })
+        .collect();
+    parts.push(json!({ "text": prompt }));
+    Value::Array(parts)
 }
 
 /// Gemini batch over HTTP. Mirrors [`AnthropicBatch`]: holds the connection (client, key,
@@ -986,7 +1054,12 @@ impl GeminiBatch {
 
 #[async_trait]
 impl BatchProvider for GeminiBatch {
-    async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String> {
+    async fn submit(
+        &self,
+        system: &str,
+        attachments: &[Attachment],
+        items: &[BatchItem],
+    ) -> Result<String> {
         if self.model.is_empty() {
             return Err(anyhow!(
                 "this batch client was built for poll/cancel only (no model) — submit \
@@ -996,7 +1069,7 @@ impl BatchProvider for GeminiBatch {
         if items.is_empty() {
             return Err(anyhow!("a batch needs at least one prompt"));
         }
-        let body = gemini_batch_body(self.max_tokens, system, &self.params, items);
+        let body = gemini_batch_body(self.max_tokens, system, &self.params, attachments, items);
         let url = format!(
             "{}/models/{}:batchGenerateContent",
             self.base_url, self.model
@@ -1101,6 +1174,9 @@ mod test_double {
     use super::*;
     use std::sync::Mutex;
 
+    /// One recorded submit: the shared `(system, attachments, items)` a test asserts on.
+    type SubmitRecord = (String, Vec<Attachment>, Vec<BatchItem>);
+
     /// A scripted [`BatchProvider`] for offline tests: records submits and replays a
     /// fixed sequence of poll outcomes (so a test can drive submit → pending → done
     /// with no network) — the batch analogue of
@@ -1108,7 +1184,7 @@ mod test_double {
     pub struct ScriptedBatch {
         submit_id: String,
         polls: Mutex<std::collections::VecDeque<BatchPoll>>,
-        submits: Mutex<Vec<(String, Vec<BatchItem>)>>,
+        submits: Mutex<Vec<SubmitRecord>>,
         canceled: Mutex<Vec<String>>,
         listing: (Vec<BatchListItem>, bool),
     }
@@ -1132,8 +1208,8 @@ mod test_double {
             self
         }
 
-        /// The `(system, items)` of each submit, in order.
-        pub fn submits(&self) -> Vec<(String, Vec<BatchItem>)> {
+        /// The `(system, attachments, items)` of each submit, in order.
+        pub fn submits(&self) -> Vec<SubmitRecord> {
             self.submits.lock().expect("submits lock").clone()
         }
 
@@ -1145,11 +1221,17 @@ mod test_double {
 
     #[async_trait]
     impl BatchProvider for ScriptedBatch {
-        async fn submit(&self, system: &str, items: &[BatchItem]) -> Result<String> {
-            self.submits
-                .lock()
-                .expect("submits lock")
-                .push((system.to_string(), items.to_vec()));
+        async fn submit(
+            &self,
+            system: &str,
+            attachments: &[Attachment],
+            items: &[BatchItem],
+        ) -> Result<String> {
+            self.submits.lock().expect("submits lock").push((
+                system.to_string(),
+                attachments.to_vec(),
+                items.to_vec(),
+            ));
             Ok(self.submit_id.clone())
         }
 
@@ -1293,7 +1375,7 @@ mod tests {
             },
         ];
         let body =
-            anthropic_batch_body("claude-sonnet-4-6", max_tokens, "be terse", &params, &items);
+            anthropic_batch_body("claude-sonnet-4-6", max_tokens, "be terse", &params, &[], &items);
         let reqs = body["requests"].as_array().expect("requests array");
         assert_eq!(reqs.len(), 2);
         assert_eq!(reqs[0]["custom_id"], "0");
@@ -1303,6 +1385,58 @@ mod tests {
         // The maxed thinking knob is flattened into each request's params.
         assert_eq!(reqs[0]["params"]["output_config"]["effort"], "high");
         assert_eq!(reqs[1]["params"]["messages"][0]["content"], "second");
+    }
+
+    /// With shared attachments, each Anthropic item's `content` becomes a block array:
+    /// the attachments first (a `<file>`-wrapped text block, then a base64 `image`
+    /// block), then the prompt last — the same shared attachments on every item.
+    #[test]
+    fn anthropic_content_carries_text_and_image_attachments() {
+        let attachments = vec![
+            Attachment::Text {
+                path: "README.md".into(),
+                body: "hello".into(),
+            },
+            Attachment::Image {
+                path: "logo.png".into(),
+                mime: "image/png",
+                data_b64: "QUJD".into(),
+            },
+        ];
+        let items = vec![
+            BatchItem {
+                custom_id: "0".into(),
+                prompt: "review this".into(),
+            },
+            BatchItem {
+                custom_id: "1".into(),
+                prompt: "and this".into(),
+            },
+        ];
+        let body = anthropic_batch_body("claude-sonnet-4-6", 1024, "sys", &None, &attachments, &items);
+        let content = &body["requests"][0]["params"]["messages"][0]["content"];
+        let blocks = content.as_array().expect("attachments make content a block array");
+        // [text-attachment, image-attachment, prompt]
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(blocks[0]["type"], "text");
+        assert!(
+            blocks[0]["text"].as_str().unwrap().contains("path=\"README.md\""),
+            "the text block wraps the file: {}",
+            blocks[0]["text"]
+        );
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["type"], "base64");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        assert_eq!(blocks[1]["source"]["data"], "QUJD");
+        // The prompt rides last, after the context.
+        assert_eq!(blocks[2]["type"], "text");
+        assert_eq!(blocks[2]["text"], "review this");
+        // The same shared attachments ride on the second item, ahead of its own prompt.
+        let c1 = body["requests"][1]["params"]["messages"][0]["content"]
+            .as_array()
+            .expect("second item also a block array");
+        assert_eq!(c1[2]["text"], "and this");
+        assert_eq!(c1[1]["source"]["data"], "QUJD");
     }
 
     #[test]
@@ -1574,7 +1708,7 @@ mod tests {
                 prompt: "second".into(),
             },
         ];
-        let body = gemini_batch_body(max_tokens, "be terse", &params, &items);
+        let body = gemini_batch_body(max_tokens, "be terse", &params, &[], &items);
         let reqs = body["batch"]["input_config"]["requests"]["requests"]
             .as_array()
             .expect("requests array");
@@ -1607,7 +1741,7 @@ mod tests {
             custom_id: "0".into(),
             prompt: "q".into(),
         }];
-        let body = gemini_batch_body(1024, "", &None, &items);
+        let body = gemini_batch_body(1024, "", &None, &[], &items);
         let req = &body["batch"]["input_config"]["requests"]["requests"][0]["request"];
         assert!(
             req.get("systemInstruction").is_none(),
@@ -1618,6 +1752,42 @@ mod tests {
             req["generationConfig"]["maxOutputTokens"].as_u64().unwrap(),
             1024
         );
+    }
+
+    /// With shared attachments, each Gemini item's `parts` array leads with the
+    /// attachments as context (a `<file>`-wrapped text part, then an `inlineData` image
+    /// part), then the prompt last.
+    #[test]
+    fn gemini_parts_carry_text_and_image_attachments() {
+        let attachments = vec![
+            Attachment::Text {
+                path: "diff.patch".into(),
+                body: "@@ -1 +1 @@".into(),
+            },
+            Attachment::Image {
+                path: "shot.png".into(),
+                mime: "image/png",
+                data_b64: "QUJD".into(),
+            },
+        ];
+        let items = vec![BatchItem {
+            custom_id: "0".into(),
+            prompt: "review".into(),
+        }];
+        let body = gemini_batch_body(1024, "sys", &None, &attachments, &items);
+        let parts = body["batch"]["input_config"]["requests"]["requests"][0]["request"]["contents"]
+            [0]["parts"]
+            .as_array()
+            .expect("parts array");
+        assert_eq!(parts.len(), 3);
+        assert!(
+            parts[0]["text"].as_str().unwrap().contains("path=\"diff.patch\""),
+            "the text part wraps the file: {}",
+            parts[0]["text"]
+        );
+        assert_eq!(parts[1]["inlineData"]["mimeType"], "image/png");
+        assert_eq!(parts[1]["inlineData"]["data"], "QUJD");
+        assert_eq!(parts[2]["text"], "review");
     }
 
     #[test]
@@ -1843,9 +2013,10 @@ mod tests {
             custom_id: "0".into(),
             prompt: "q".into(),
         }];
-        let id = provider.submit("sys", &items).await.unwrap();
+        let id = provider.submit("sys", &[], &items).await.unwrap();
         assert_eq!(id, "msgbatch_test");
         assert_eq!(provider.submits()[0].0, "sys");
+        assert!(provider.submits()[0].1.is_empty(), "no attachments in this flow");
         assert!(matches!(
             provider.poll(&id).await.unwrap(),
             BatchPoll::Pending { .. }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! The load-bearing safety property lives in [`sandbox`]: kaibo can read the project
 //! but cannot mutate it, and cannot shell out to external commands.
 
+pub mod attach;
 pub mod batch;
 pub mod config;
 pub mod consult;

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tracing::Instrument;
 
-use crate::config::{Cast, Config, ModelRole, ModelSlot};
+use crate::config::{Backend, Cast, Config, ModelRole, ModelSlot};
 use crate::consult::{consult, oneshot, Arm, ConsultConfig, ModelShape, PromptOverrides};
 use crate::explorer::format_output;
 use crate::generate_image::GenerateImageInput;
@@ -223,6 +223,17 @@ pub struct BatchSubmitInput {
     /// it and its own knowledge. Batch runs them at max thinking, so it's the lane for
     /// hard questions you're willing to wait on.
     pub prompts: Vec<String>,
+
+    /// Workspace files to inline as shared context for *every* prompt in the batch —
+    /// absolute or relative paths under the allowed set (same boundary as `path`
+    /// elsewhere; worktrees included). kaibo reads each file and inlines it so its bytes
+    /// never pass through your context: say "review README.md" and attach `["README.md"]`,
+    /// or `git diff > x.diff` and attach `["x.diff"]`. Text files splice in as text;
+    /// images (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable
+    /// synth model). A path outside the workspace, a directory, an oversized file, or a
+    /// binary that isn't a known image is refused with a clear error. Omit for none.
+    #[serde(default)]
+    pub attach: Vec<String>,
 
     /// Which cast (model team) runs the batch; omit for the server's default. Batch
     /// uses the cast's capable (synth) model on a batch-capable backend; `kaibo://config`
@@ -577,28 +588,38 @@ impl KaiboHandler {
             ));
         }
 
-        // Step 3: containment check — must be at-or-under an allowed tree.
-        let allowed = &self.allowed_set;
-        if allowed.iter().any(|tree| canon.starts_with(tree)) {
+        // Step 3: containment check — must be at-or-under an allowed tree (or a
+        // followed worktree of one). Shared with `resolve_attachments` so a file
+        // attachment obeys the exact same boundary as a session root, not a parallel
+        // check that could drift.
+        if self.contained(&canon) {
             return Ok(canon);
         }
+        Err(self.containment_error(&raw, &canon))
+    }
 
-        // Step 3b: worktree follow. A path that misses the static set is still
-        // admitted when it lives in a linked git worktree of an *already-allowed*
-        // repo — so a sibling worktree (a branch you check out next to the project,
-        // possibly mid-session) is reachable without an --allow-path. Resolved by
-        // reading git's link files, never by running git (subprocess/git are
-        // compiled out — see sandbox.rs). Trust flows only outward from the allowed
-        // repo: we enumerate the worktrees the allowed tree's own common git dir
-        // vouches for and never consult the candidate's `.git`, so a foreign dir
-        // can't forge its way in. Off when `follow_worktrees` is false.
-        if self.config.follow_worktrees && self.is_followed_worktree(&canon) {
-            return Ok(canon);
+    /// Is `canon` (already canonicalized) inside the allowed boundary? At-or-under a
+    /// static allowed tree, or — when `follow_worktrees` is on — inside a linked git
+    /// worktree that an already-allowed repo vouches for (a sibling branch checkout
+    /// reachable without an --allow-path). Worktree membership is resolved by reading
+    /// git's link files, never by running git (subprocess/git are compiled out — see
+    /// sandbox.rs), and trust flows only outward from the allowed repo (we enumerate
+    /// the worktrees its own common git dir names and never consult the candidate's
+    /// `.git`), so a foreign dir can't forge its way in. The single containment
+    /// predicate — `resolve_root` and `resolve_attachments` both defer to it.
+    fn contained(&self, canon: &std::path::Path) -> bool {
+        if self.allowed_set.iter().any(|tree| canon.starts_with(tree)) {
+            return true;
         }
+        self.config.follow_worktrees && self.is_followed_worktree(canon)
+    }
 
-        // Violation: name the allowed set and the three widening knobs.
-        let trees: Vec<String> = allowed.iter().map(|p| p.display().to_string()).collect();
-        Err(McpError::invalid_params(
+    /// The shared "outside the allowed set" rejection, naming the boundary and the three
+    /// widening knobs. Used wherever [`contained`](Self::contained) says no, so the
+    /// caller always learns where the edge is and how to move it.
+    fn containment_error(&self, raw: &std::path::Path, canon: &std::path::Path) -> McpError {
+        let trees: Vec<String> = self.allowed_set.iter().map(|p| p.display().to_string()).collect();
+        McpError::invalid_params(
             format!(
                 "path {} resolves to {}, which is outside the allowed set [{}]. \
                  To widen the boundary: pass --allow-path DIR on the command line, \
@@ -609,7 +630,80 @@ impl KaiboHandler {
                 trees.join(", "),
             ),
             None,
-        ))
+        )
+    }
+
+    /// Resolve caller-named attachment paths into [`Attachment`](crate::attach::Attachment)s,
+    /// read and encoded server-side so the bytes never transit the calling agent's
+    /// context. Each path obeys the *same* boundary as a session root — canonicalize
+    /// (symlinks + `..` resolved), require a regular file, then the shared
+    /// [`contained`](Self::contained) check (allowed set + followed worktrees) — so
+    /// attachments can't read outside the workspace any more than `run_kaish` can.
+    ///
+    /// Failures are loud and per-path: a missing file, a directory, an over-cap or
+    /// non-text/non-image file is a clear `invalid_params`, never a silent skip — an
+    /// attachment the caller named but we dropped would be a corrupt answer. An absolute
+    /// size ceiling is enforced *before* reading (via the file's metadata) so a giant
+    /// file is refused without first slurping it into memory.
+    pub fn resolve_attachments(
+        &self,
+        paths: &[String],
+    ) -> Result<Vec<crate::attach::Attachment>, McpError> {
+        use crate::attach::{classify, DEFAULT_MAX_IMAGE_BYTES, DEFAULT_MAX_TEXT_BYTES};
+        // The pre-read ceiling: whichever encoding cap is larger. `classify` applies the
+        // precise per-encoding cap after sniffing; this just bounds the read itself.
+        let read_ceiling = DEFAULT_MAX_TEXT_BYTES.max(DEFAULT_MAX_IMAGE_BYTES);
+        paths
+            .iter()
+            .map(|p| {
+                let raw = std::path::PathBuf::from(p);
+                let canon = std::fs::canonicalize(&raw).map_err(|e| {
+                    McpError::invalid_params(
+                        format!("attachment {} could not be resolved: {e}", raw.display()),
+                        None,
+                    )
+                })?;
+                // A regular file, not a directory — symmetric with resolve_root's dir
+                // check, the mirror image (we inline a file's bytes, not mount a tree).
+                let meta = std::fs::metadata(&canon).map_err(|e| {
+                    McpError::invalid_params(
+                        format!("attachment {} could not be read: {e}", canon.display()),
+                        None,
+                    )
+                })?;
+                if !meta.is_file() {
+                    return Err(McpError::invalid_params(
+                        format!("attachment {} is not a regular file", canon.display()),
+                        None,
+                    ));
+                }
+                // Same boundary as a session root.
+                if !self.contained(&canon) {
+                    return Err(self.containment_error(&raw, &canon));
+                }
+                // Bound the read by the absolute ceiling before slurping.
+                if meta.len() > read_ceiling as u64 {
+                    return Err(McpError::invalid_params(
+                        format!(
+                            "attachment {} is {} bytes, over the {read_ceiling}-byte limit",
+                            canon.display(),
+                            meta.len()
+                        ),
+                        None,
+                    ));
+                }
+                let bytes = std::fs::read(&canon).map_err(|e| {
+                    McpError::invalid_params(
+                        format!("attachment {} could not be read: {e}", canon.display()),
+                        None,
+                    )
+                })?;
+                // Label the attachment with the caller's path (what they typed), not the
+                // canonical one — it's their reference and it's what the model should see.
+                classify(p, &bytes, DEFAULT_MAX_TEXT_BYTES, DEFAULT_MAX_IMAGE_BYTES)
+                    .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
+            })
+            .collect()
     }
 
     /// True when `canon` falls inside a git worktree that an already-allowed repo
@@ -1096,16 +1190,17 @@ impl KaiboHandler {
         )))
     }
 
-    /// Resolve a cast's synth slot into a submit-capable batch provider, plus its
-    /// backend name (for the returned handle) and model id (for the caller message). A
-    /// missing synth slot is the loud call-time gap; a backend whose kind has no batch
-    /// lane is refused inside the provider build (`batch::submitter`). Both surface as a
-    /// parameter error the caller can act on — pick a cast whose synth is a batch-capable
-    /// backend.
-    fn batch_submitter(
-        &self,
-        cast: &Cast,
-    ) -> Result<(Arc<dyn crate::batch::BatchProvider>, String, String), McpError> {
+    /// Resolve a cast's synth slot for batch: its slot + backend, plus whether the model
+    /// accepts image input (`vision`). Cheap and key-free — it does *not* build a network
+    /// client, so the caller can resolve attachments and gate vision (both request-shaping,
+    /// not connection) before paying for a provider. A missing synth slot is the loud
+    /// call-time gap; the batch-lane check rides the later `batch::submitter` build. The
+    /// vision answer comes from the same slot the provider will use, so the gate and the
+    /// wire agree on which model runs.
+    fn batch_synth<'a>(
+        &'a self,
+        cast: &'a Cast,
+    ) -> Result<(&'a ModelSlot, &'a Backend, bool), McpError> {
         let slot = cast
             .require_slot(ModelRole::Synth)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
@@ -1113,9 +1208,12 @@ impl KaiboHandler {
             .config
             .resolve_backend(&slot.backend)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        let provider = crate::batch::submitter(backend, slot, &self.config.defaults)
-            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
-        Ok((provider, backend.name.clone(), slot.id.clone()))
+        let vision = self
+            .config
+            .slot_caps(slot)
+            .map(|c| c.vision)
+            .unwrap_or(false);
+        Ok((slot, backend, vision))
     }
 
     /// A poll/cancel-only provider for a handle's backend. Poll and cancel need only the
@@ -1195,7 +1293,7 @@ impl KaiboHandler {
             SLA is up to 24h), and the handle is durable — it survives a server restart \
             — so come back and `batch_get` later rather than blocking on it now."
     )]
-    async fn batch_submit(
+    pub async fn batch_submit(
         &self,
         Parameters(input): Parameters<BatchSubmitInput>,
     ) -> Result<CallToolResult, McpError> {
@@ -1214,7 +1312,36 @@ impl KaiboHandler {
             "model",
             "backend",
         )?;
-        let (provider, backend_name, model) = self.batch_submitter(&cast)?;
+        let (slot, backend, vision) = self.batch_synth(&cast)?;
+        let backend_name = backend.name.clone();
+        let model = slot.id.clone();
+        // Read + containment-check the attachments before anything hits the network: a
+        // bad path is a clean refusal, not a half-submitted batch. The bytes are inlined
+        // server-side so they never transit the calling agent's context.
+        let attachments = self.resolve_attachments(&input.attach)?;
+        // Gate image attachments on the synth model's vision capability — a blind model
+        // would silently ignore (or error on) an image part, so refuse honestly up front
+        // (the project posture), naming the cast so the caller can pick a vision one. This
+        // runs before the provider is built, so a vision misconfig needs no key to report.
+        if !vision
+            && attachments
+                .iter()
+                .any(|a| matches!(a, crate::attach::Attachment::Image { .. }))
+        {
+            return Err(McpError::invalid_params(
+                format!(
+                    "an image attachment was given, but the synth model `{model}` on cast \
+                     `{}` doesn't accept image input. Use a vision-capable cast/model, or \
+                     attach only text files. `kaibo://config` lists each slot's `vision`.",
+                    cast.name
+                ),
+                None,
+            ));
+        }
+        // Now build the network client (resolves the key); a batch-incapable backend is
+        // refused honestly here.
+        let provider = crate::batch::submitter(backend, slot, &self.config.defaults)
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
         let items: Vec<crate::batch::BatchItem> = input
             .prompts
             .iter()
@@ -1232,7 +1359,7 @@ impl KaiboHandler {
         let span =
             tracing::info_span!("batch_submit", cast = %cast.name, model = %model, n = items.len());
         let provider_id = provider
-            .submit(&system, &items)
+            .submit(&system, &attachments, &items)
             .instrument(span)
             .await
             .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -645,6 +645,15 @@ impl KaiboHandler {
     /// attachment the caller named but we dropped would be a corrupt answer. An absolute
     /// size ceiling is enforced *before* reading (via the file's metadata) so a giant
     /// file is refused without first slurping it into memory.
+    ///
+    /// Containment is checked on the *canonical* path, then the read follows — a
+    /// check-then-open TOCTOU window, the same class `resolve_root` carries (and tracked
+    /// in `docs/issues.md`). The attacker model makes it narrow: kaibo cannot write the
+    /// workspace, so swapping the canonical path for an outside-pointing symlink in the
+    /// sub-millisecond window needs a *concurrent* writer to the very workspace the
+    /// calling agent owns — a self-attack. Closing it structurally (open `O_NOFOLLOW`,
+    /// `fstat` the fd, contain via `/proc/self/fd`, read from the fd) is deferred until
+    /// the attacker model justifies it.
     pub fn resolve_attachments(
         &self,
         paths: &[String],

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,7 +29,7 @@ use serde_json::json;
 use tracing::Instrument;
 
 use crate::config::{Backend, Cast, Config, ModelRole, ModelSlot};
-use crate::consult::{consult, oneshot, Arm, ConsultConfig, ModelShape, PromptOverrides};
+use crate::consult::{consult, oneshot, Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides};
 use crate::explorer::format_output;
 use crate::generate_image::GenerateImageInput;
 use crate::image_gen::ImageGen;
@@ -1199,17 +1199,18 @@ impl KaiboHandler {
         )))
     }
 
-    /// Resolve a cast's synth slot for batch: its slot + backend, plus whether the model
-    /// accepts image input (`vision`). Cheap and key-free — it does *not* build a network
-    /// client, so the caller can resolve attachments and gate vision (both request-shaping,
+    /// Resolve a cast's synth slot for batch: its slot + backend, plus the model's
+    /// resolved [`ModelCaps`]. Cheap and key-free — it does *not* build a network client,
+    /// so the caller can resolve attachments and gate on capability (both request-shaping,
     /// not connection) before paying for a provider. A missing synth slot is the loud
     /// call-time gap; the batch-lane check rides the later `batch::submitter` build. The
-    /// vision answer comes from the same slot the provider will use, so the gate and the
-    /// wire agree on which model runs.
+    /// caps come from the same slot the provider will use, so the gate and the wire agree
+    /// on which model runs. Returns the whole `ModelCaps` (not just `vision`) so a future
+    /// audio/video attachment gate has its answer without growing this signature.
     fn batch_synth<'a>(
         &'a self,
         cast: &'a Cast,
-    ) -> Result<(&'a ModelSlot, &'a Backend, bool), McpError> {
+    ) -> Result<(&'a ModelSlot, &'a Backend, ModelCaps), McpError> {
         let slot = cast
             .require_slot(ModelRole::Synth)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
@@ -1217,12 +1218,8 @@ impl KaiboHandler {
             .config
             .resolve_backend(&slot.backend)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        let vision = self
-            .config
-            .slot_caps(slot)
-            .map(|c| c.vision)
-            .unwrap_or(false);
-        Ok((slot, backend, vision))
+        let caps = ModelCaps::resolve(backend.kind, &slot.id, slot.vision);
+        Ok((slot, backend, caps))
     }
 
     /// A poll/cancel-only provider for a handle's backend. Poll and cancel need only the
@@ -1321,7 +1318,7 @@ impl KaiboHandler {
             "model",
             "backend",
         )?;
-        let (slot, backend, vision) = self.batch_synth(&cast)?;
+        let (slot, backend, caps) = self.batch_synth(&cast)?;
         let backend_name = backend.name.clone();
         let model = slot.id.clone();
         // Read + containment-check the attachments before anything hits the network: a
@@ -1332,7 +1329,7 @@ impl KaiboHandler {
         // would silently ignore (or error on) an image part, so refuse honestly up front
         // (the project posture), naming the cast so the caller can pick a vision one. This
         // runs before the provider is built, so a vision misconfig needs no key to report.
-        if !vision
+        if !caps.vision
             && attachments
                 .iter()
                 .any(|a| matches!(a, crate::attach::Attachment::Image { .. }))

--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -1,0 +1,199 @@
+//! Attachments: a tool-less call may name workspace files to inline as context, read
+//! and containment-checked server-side so the bytes never transit the calling agent's
+//! context. The boundary is the *same* allowed-set check every path obeys — these tests
+//! are the teeth proving an attachment can't read outside the workspace, plus the vision
+//! gate that refuses an image to a blind synth model.
+//!
+//! Written first (TDD): they exercise the real `resolve_attachments` containment path
+//! and the real `batch_submit` vision gate, both offline (no provider key needed — the
+//! gate fires before any network client is built).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use kaibo::attach::Attachment;
+use kaibo::config::{Cast, Config, ModelRole, ModelSlot};
+use kaibo::server::{BatchSubmitInput, KaiboHandler};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::tempdir;
+
+/// A handler whose allowed set is just `root` (the default-root path, which also enters
+/// the allowed set) — the single-workspace shape attachments are scoped to.
+fn handler_rooted_at(root: &Path) -> KaiboHandler {
+    let mut config = Config::builtin();
+    config.root = Some(root.to_path_buf());
+    config.allow_paths = vec![];
+    KaiboHandler::new(config).expect("handler builds")
+}
+
+/// A minimal blob with a real PNG signature — enough to exercise sniff + base64 without
+/// decoding a real image.
+fn fake_png() -> Vec<u8> {
+    let mut v = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    v.extend(std::iter::repeat_n(0xAB, 32));
+    v
+}
+
+// --- happy paths: a workspace file inlines ----------------------------------
+
+/// A UTF-8 file inside the workspace resolves to a Text attachment carrying its body.
+#[test]
+fn workspace_text_file_inlines_as_text() {
+    let root = tempdir().unwrap();
+    let file = root.path().join("README.md");
+    fs::write(&file, "# kaibo\nhello\n").unwrap();
+    let handler = handler_rooted_at(root.path());
+
+    let atts = handler
+        .resolve_attachments(&[file.to_string_lossy().to_string()])
+        .expect("an in-workspace text file must inline");
+    assert_eq!(atts.len(), 1);
+    match &atts[0] {
+        Attachment::Text { body, .. } => assert!(body.contains("hello"), "body carried: {body}"),
+        other => panic!("expected Text, got {other:?}"),
+    }
+}
+
+/// A workspace image resolves to an Image attachment with the sniffed mime.
+#[test]
+fn workspace_image_file_inlines_as_image() {
+    let root = tempdir().unwrap();
+    let file = root.path().join("logo.png");
+    fs::write(&file, fake_png()).unwrap();
+    let handler = handler_rooted_at(root.path());
+
+    let atts = handler
+        .resolve_attachments(&[file.to_string_lossy().to_string()])
+        .expect("an in-workspace image must inline");
+    match &atts[0] {
+        Attachment::Image { mime, .. } => assert_eq!(*mime, "image/png"),
+        other => panic!("expected Image, got {other:?}"),
+    }
+}
+
+// --- teeth: the boundary holds ----------------------------------------------
+
+/// An attachment whose path resolves *outside* the allowed set is refused, naming the
+/// boundary and a widening knob — the same rejection a session root gets.
+#[test]
+fn attachment_outside_allowed_set_is_rejected() {
+    let allowed = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let secret = outside.path().join("secret.txt");
+    fs::write(&secret, "sensitive\n").unwrap();
+    let handler = handler_rooted_at(allowed.path());
+
+    let err = handler
+        .resolve_attachments(&[secret.to_string_lossy().to_string()])
+        .expect_err("a file outside the workspace must be refused");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.to_lowercase().contains("allowed") || msg.contains("--allow-path"),
+        "rejection must name the boundary, got: {msg}"
+    );
+}
+
+/// A symlink *inside* the workspace whose target is outside is refused: `canonicalize`
+/// resolves the link, so the containment check sees the real outside path. This proves
+/// the boundary is canonicalize-based, not string-prefix-based — the read-escape teeth.
+#[test]
+fn attachment_symlink_escaping_workspace_is_rejected() {
+    let allowed = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let secret = outside.path().join("secret.txt");
+    fs::write(&secret, "outside\n").unwrap();
+    let link = allowed.path().join("link.txt");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+    let handler = handler_rooted_at(allowed.path());
+
+    let err = handler
+        .resolve_attachments(&[link.to_string_lossy().to_string()])
+        .expect_err("a symlink whose target is outside must be refused");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.to_lowercase().contains("allowed") || msg.contains("--allow-path"),
+        "rejection must name the boundary, got: {msg}"
+    );
+}
+
+/// A directory is not a regular file — refused, since attachments inline a file's bytes
+/// rather than mount a tree (the mirror image of `resolve_root`'s dir requirement).
+#[test]
+fn attachment_directory_is_rejected() {
+    let root = tempdir().unwrap();
+    let sub = root.path().join("sub");
+    fs::create_dir(&sub).unwrap();
+    let handler = handler_rooted_at(root.path());
+
+    let err = handler
+        .resolve_attachments(&[sub.to_string_lossy().to_string()])
+        .expect_err("a directory must be refused");
+    assert!(
+        format!("{err:?}").contains("not a regular file"),
+        "rejection must explain the file requirement, got: {err:?}"
+    );
+}
+
+/// A binary file that is neither valid UTF-8 nor a recognized image is refused rather
+/// than inlined as mojibake — crash over corruption, even from inside the workspace.
+#[test]
+fn attachment_binary_inside_workspace_is_refused() {
+    let root = tempdir().unwrap();
+    let file = root.path().join("mystery.bin");
+    fs::write(&file, [0x00, 0xFF, 0xFE, 0xFD]).unwrap();
+    let handler = handler_rooted_at(root.path());
+
+    let err = handler
+        .resolve_attachments(&[file.to_string_lossy().to_string()])
+        .expect_err("non-text non-image binary must be refused");
+    assert!(
+        format!("{err:?}").contains("neither valid UTF-8"),
+        "rejection must explain the encoding gap, got: {err:?}"
+    );
+}
+
+// --- vision gate: an image to a blind synth is refused offline ----------------
+
+/// `batch_submit` with an image attachment on a synth model pinned vision-blind is
+/// refused before any provider client is built — so the misconfig is reported with no
+/// key and no network. Proves images are gated on the model's actual vision capability.
+#[tokio::test]
+async fn image_attachment_to_blind_synth_is_refused() {
+    let root = tempdir().unwrap();
+    let png = root.path().join("shot.png");
+    fs::write(&png, fake_png()).unwrap();
+
+    // A cast whose synth slot is pinned vision-blind on a (batch-capable) anthropic
+    // backend. The vision pin forces the gate regardless of the model's real caps.
+    let mut config = Config::builtin();
+    config.root = Some(root.path().to_path_buf());
+    let mut slot = ModelSlot::bare("anthropic", "claude-sonnet-4-6");
+    slot.vision = Some(false);
+    let mut slots = BTreeMap::new();
+    slots.insert(ModelRole::Synth, slot);
+    config.casts.insert(
+        "blindcast".to_string(),
+        Cast {
+            name: "blindcast".to_string(),
+            slots,
+        },
+    );
+    let handler = KaiboHandler::new(config).expect("handler builds");
+
+    let err = handler
+        .batch_submit(Parameters(BatchSubmitInput {
+            prompts: vec!["describe this".to_string()],
+            attach: vec![png.to_string_lossy().to_string()],
+            cast: Some("blindcast".to_string()),
+            model: None,
+            backend: None,
+        }))
+        .await
+        .expect_err("an image to a vision-blind synth must be refused");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("image") && msg.to_lowercase().contains("vision"),
+        "refusal must name the image/vision mismatch, got: {msg}"
+    );
+}


### PR DESCRIPTION
## What

`batch_submit` now takes **`attach: [paths]`** — workspace files inlined as shared context for every prompt in the batch, so the file's bytes never round-trip through the calling agent's context. The motivating ask: "get gemini pro batch to give feedback on README.md" should mean *attach the file*, not paste it. Works equally for `git diff > x.diff` + `attach: ["x.diff"]`.

This is **caller-side inlining**, not provider attachment APIs — kaibo reads the file and inlines it (text spliced as `<file path="…">…</file>`; images as native base64 parts).

## Design decisions (full rationale in `docs/devlog.md`)

- **Shared `attach` list**, not per-prompt (the stated cases are one prompt + one file; "N questions about the same README" is the natural multi-prompt shape). Per-prompt was rejected as YAGNI.
- **Containment reused, not reinvented.** Factored `resolve_root`'s check into `contained` + `containment_error`; `resolve_attachments` calls the exact same boundary (workspace + followed worktrees). An attachment can't read outside the workspace any more than `run_kaish` can. Read-only preserved — we only read, mirroring how `[context]`/house-rules already read files into a preamble.
- **Structured parts** in both body builders (Anthropic `image` block / Gemini `inlineData`), built now so image wasn't a later re-architecture. Anthropic content stays a bare string when there are no attachments (unchanged wire shape).
- **Vision gate** on the synth's real `ModelCaps`, run *before* the network client is built — a misconfig is reported with no key and no network.
- **Loud failures only** — outside-path, directory, oversized, or non-text/non-image binary all refused; no silent truncation.
- **Gemini File API** is designed-for (reserved typed `FileRef` variant) but not built — Gemini-only, for genuinely-too-big-to-inline media. **`oneshot` attachments** deferred the same way (rig multimodal plumbing). Both tracked in `docs/issues.md`.

## Tests (TDD; full suite green)

- Unit tests for `attach::classify` (text/image/oversized/binary).
- Integration teeth in `tests/attach.rs` — **proven to have teeth**: defeating `contained` makes the outside-path and symlink-escape tests read outside bytes and fail.
- Offline vision-gate test (pin `vision = false`, attach an image, assert refusal — no key, no network).

## Review

Cross-family review dogfooding kaibo's own `consult` (DeepSeek synth, a different lineage than wrote it) judged **the boundary sound**. It flagged a narrow check-then-open TOCTOU shared with `resolve_root` (needs a concurrent writer to a workspace kaibo can't write to — a self-attack); addressed by documenting it honestly in the doc-comment + a tracked P2 issue rather than over-engineering. See the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)