### PR TITLE
oneshot attachments + sharpen the attach follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,11 @@ the git log. Each later release appends a new section at the top.
   prompt in, answer out, no codebase access and no tools, exactly one upstream
   request. The counterpart to `consult` for when you already own the context (you've
   pasted what's needed, or the question is general). Pick the model with `cast`; the
-  answer carries the same provenance footer.
+  answer carries the same provenance footer. Takes the same **`attach`** as
+  `batch_submit` — name workspace files ("review README.md", or `git diff > x.diff`
+  then `attach: ["x.diff"]`) and kaibo inlines them (text as text, images as native
+  image parts on a vision-capable model) so their bytes never pass through your context.
+  So "call Opus once with these files, no tools, no waiting" is a single call.
 - **`run_kaish`** — drive the read-only kaish shell yourself, no model in the loop:
   exit code + stdout + stderr.
 - **`generate_image`** — kaibo's first *capability* (an artifact handed back to the

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,42 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-22 — `oneshot` grows `attach` (the interactive twin of batch attach)
+
+Amy's framing: `oneshot` should be as close to `batch` as the API split allows — "call
+Claude Opus in a single shot with some files, no tools, no wait." So `oneshot` now takes
+the same `attach: [paths]`, reusing the whole containment + classify seam batch built
+(`resolve_attachments`, `classify`, the shared `contained`/`containment_error`). The only
+thing that differs is the wire, and that's the decision this entry records.
+
+**Chose "grow oneshot against rig" over "a batch-shaped seam with an interactive impl."**
+oneshot already runs through rig's completion path, so the cheap, honest factoring is to
+map each `Attachment` onto rig's own message parts rather than invent a second submit
+abstraction. Text folds into the prompt string via `attach::with_text_context` (the same
+`<file>` wrapper batch emits — `Attachment::wrapped_text` is the one source of truth, so
+batch and oneshot wrap identically). Images become `UserContent::image_base64` parts on
+the single user turn. The rejected alternative — making the `BatchProvider` seam carry an
+"interactive" variant that calls rig — is heavier and only pays off if a third lane shows
+up; noted in issues.md, not built.
+
+**The one structural change: `run_phase` takes an `extra_parts: Vec<UserContent>`.** The
+shared loop built its initial message as `Message::user(string)` — text only. oneshot's
+images need to ride on that *initial* turn beside the text, so the parameter threads
+through `Arm::run` → `PhaseRunner` → `run_phase`, which now builds a multi-part user
+message when parts are present. Every other phase (consult, explore) passes `Vec::new()`
+and gets byte-for-byte the old `Message::user(prompt)` — pinned by a test
+(`oneshot_without_attachments_is_the_bare_prompt`) so the no-attachment path can't drift.
+This is the "image is the new plumbing" cost the batch entry predicted; it lives in the
+shared loop, not a oneshot fork, so it's one initial-message builder for everyone.
+
+**DRY'd the vision gate.** batch and oneshot refuse an image to a vision-blind model
+identically, so the check moved to one `KaiboHandler::gate_image_attachments` both call —
+and being a plain method (no `Peer`), it's unit-testable directly, which the oneshot
+handler (needs a `Peer` to drive end-to-end) otherwise isn't. rig gives us
+`ImageMediaType::from_mime_type` to turn our sniffed mime into rig's media type, so the
+image round-trips cleanly. Offline test drives the real loop and asserts the inbound
+request carries both the `<file>`-wrapped text and a structured image part.
+
 ## 2026-06-22 — two honesty/discoverability fixes: image cast enum + inert-tunable flag
 
 Both came off the P3 list; both are about not lying to the caller by omission.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -183,6 +183,18 @@ mount-layer test to the attachment path. Deferred until the attacker model (a wo
 writable by someone other than the caller) is real, but it's *more correct* regardless, so
 likely worth doing on its own merits. Documented in `resolve_attachments`' doc-comment.
 
+### The `<file>` attachment wrapper doesn't escape its body
+`Attachment::wrapped_text` (`attach.rs`) wraps a text attachment as
+`<file path="…">{body}</file>` without escaping `body`, so a file that itself contains a
+literal `</file>` produces a malformed wrapper — the model *may* still read it as intended
+(LLMs are robust to it), but the delimiter is ambiguous. Shared by both attach surfaces
+(batch body builders + oneshot), and self-inflicted (the caller owns the workspace file),
+so low-stakes — flagged by both cross-family reviews (DeepSeek + Gemini, 2026-06-22) as a
+defense-in-depth nit, not a bug. Fix when it bites: escape the body (CDATA, or replace the
+close tag) in the one wrapper so batch and oneshot inherit it together; the `path`
+attribute is server-controlled (the caller's path string), not a second injection point of
+concern. Lower priority than a real delimiter the model is told to trust.
+
 ### Review the provider retry + failure policy (and document it)
 We don't have a stated, audited answer for what a `consult`/`oneshot`
 call does when a provider misbehaves mid-flight: a 429/529 overload, a connection

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -267,27 +267,6 @@ in the module doc and `docs/devlog.md`. What's left:
   proven-accepted top for the Anthropic adaptive tier). If a higher tier (`xhigh`/`max`)
   is ever confirmed by probe for a batch backend, lift it there — the constant is the
   one knob to change.
-- **Attachments on `oneshot` — bring it as close to `batch` as the API split allows
-  (in progress).** `batch_submit` takes `attach: [paths]` — workspace files (text spliced
-  inline, images as native base64 parts) read + containment-checked server-side so the
-  bytes never transit the calling agent's context (`src/attach.rs`,
-  `server.rs::resolve_attachments`, the shared `contained`/`containment_error` the
-  session-root check also uses). `oneshot` is the same shape — a tool-less prompt to a
-  capable model, caller owns the context — minus the offline/async lane, so it *should*
-  share the cast resolution and the `Attachment`/`classify` seam wholesale; the only real
-  difference is the wire (interactive vs. provider batch). Two ways to factor that, decide
-  when we build it:
-  - **`oneshot` grows `attach` against rig.** It already runs through rig, so reuse
-    `resolve_attachments` + `classify`, then map each `Attachment` onto a rig
-    `Message`/`UserContent` (text part + image part) instead of a provider-JSON part.
-    `Attachment::wrapped_text` keeps the `<file>` wrapper identical to batch; the
-    image branch is the new plumbing (rig multimodal message, not the hand-rolled JSON
-    `anthropic_content`/`gemini_parts`). The win Amy named: "call Claude Opus in a single
-    shot with some files, no tools, no wait."
-  - **A `batch`-shaped seam with an *interactive* impl back to rig.** Make the
-    `BatchProvider`-style abstraction carry an "interactive" variant that calls rig's
-    sync completion instead of a provider batch endpoint, so one submit path serves both
-    lanes. Heavier; only worth it if a third lane appears. Default to the first.
 - **`FileRef` / Gemini File API for *batch* is bigger than "a variant beside `Image`"
   — and may be the wrong shape.** Re-scoped after checking gpal + Google's docs (2026-06-22):
   - **gpal's batch is inline-only** (`create_batch` → `InlinedRequest(contents=prompt)`,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -162,11 +162,26 @@ boundary otherwise sound. The attacker model keeps it narrow: kaibo cannot write
 workspace, so the race needs a concurrent writer to the very tree the calling agent owns
 (a self-attack), inside a sub-millisecond window. `resolve_root` is the less-exposed of
 the two — it hands the canonical path to the kaish kernel, which opens a directory fd and
-works through it — while the attachment path reads a file one-shot and discards the fd.
-Structural fix when justified: open `O_NOFOLLOW`, `fstat` the fd, re-check containment via
-`/proc/self/fd/N`, then read from the already-open fd. Deferred until the attacker model
-(a workspace writable by someone other than the caller) is real; documented in
-`resolve_attachments`' doc-comment so it isn't rediscovered.
+works through it — while the attachment path reads a file one-shot with `std::fs::read`
+and discards the fd.
+
+**Likely structural fix: read attachments *through the kaish VFS*, not `std::fs::read`** —
+the project's own "read-only is structural" mechanism, and `view_image` already does
+exactly this (`view_image.rs`: `worker.read_file(&canon)` on a `KaishWorker`, the same
+read-only mount `run_kaish` uses). The VFS resolves within its mount and **refuses to
+follow a symlink out of the allowed tree** (proved by `tests/containment.rs`'s
+`mount_layer_symlink_in_allowed_pointing_outside`), so a swapped escaping symlink is
+rejected regardless of timing — the window closes structurally, and it's portable (no
+`/proc`, no `O_NOFOLLOW` per-platform dance). `resolve_attachments` keeps its
+`std`-level canonicalize + `contained` check for the friendly early error; the *read*
+moves to the worker. Open wrinkle to settle when we build it: `resolve_attachments` spans
+multiple allowed trees + followed worktrees, while a `KaishWorker` is rooted at one tree —
+so either root a worker per containing tree, or reuse the worker `batch_submit` would
+already have. A flaky racy "prove the TOCTOU" test isn't worth it (the project hates flaky
+tests); the deterministic proof is that the VFS refuses the escaping read — extend the
+mount-layer test to the attachment path. Deferred until the attacker model (a workspace
+writable by someone other than the caller) is real, but it's *more correct* regardless, so
+likely worth doing on its own merits. Documented in `resolve_attachments`' doc-comment.
 
 ### Review the provider retry + failure policy (and document it)
 We don't have a stated, audited answer for what a `consult`/`oneshot`
@@ -252,19 +267,44 @@ in the module doc and `docs/devlog.md`. What's left:
   proven-accepted top for the Anthropic adaptive tier). If a higher tier (`xhigh`/`max`)
   is ever confirmed by probe for a batch backend, lift it there — the constant is the
   one knob to change.
-- **Attachments on `oneshot` (deferred — batch shipped).** `batch_submit` now takes
-  `attach: [paths]` — workspace files (text spliced inline, images as native base64
-  parts) read + containment-checked server-side so the bytes never transit the calling
-  agent's context (`src/attach.rs`, `server.rs::resolve_attachments`, the shared
-  `contained`/`containment_error` the session-root check also uses; both batch body
-  builders emit structured parts now). `oneshot` is the natural sibling — the same
-  "name a file instead of pasting it" win for the synchronous tool-less call — but it
-  runs through **rig**, not the hand-rolled batch HTTP, so *text* attachment is a cheap
-  prompt-string splice while *image* attachment needs rig multimodal-message building
-  (different plumbing). Consider it later; the `Attachment`/`classify` seam is reusable
-  as-is. A typed `FileRef` variant is reserved for the Gemini File API path (oversized/
-  reused media, Gemini-only) — only worth it once a genuinely-too-big-to-inline case
-  shows up.
+- **Attachments on `oneshot` — bring it as close to `batch` as the API split allows
+  (in progress).** `batch_submit` takes `attach: [paths]` — workspace files (text spliced
+  inline, images as native base64 parts) read + containment-checked server-side so the
+  bytes never transit the calling agent's context (`src/attach.rs`,
+  `server.rs::resolve_attachments`, the shared `contained`/`containment_error` the
+  session-root check also uses). `oneshot` is the same shape — a tool-less prompt to a
+  capable model, caller owns the context — minus the offline/async lane, so it *should*
+  share the cast resolution and the `Attachment`/`classify` seam wholesale; the only real
+  difference is the wire (interactive vs. provider batch). Two ways to factor that, decide
+  when we build it:
+  - **`oneshot` grows `attach` against rig.** It already runs through rig, so reuse
+    `resolve_attachments` + `classify`, then map each `Attachment` onto a rig
+    `Message`/`UserContent` (text part + image part) instead of a provider-JSON part.
+    `Attachment::wrapped_text` keeps the `<file>` wrapper identical to batch; the
+    image branch is the new plumbing (rig multimodal message, not the hand-rolled JSON
+    `anthropic_content`/`gemini_parts`). The win Amy named: "call Claude Opus in a single
+    shot with some files, no tools, no wait."
+  - **A `batch`-shaped seam with an *interactive* impl back to rig.** Make the
+    `BatchProvider`-style abstraction carry an "interactive" variant that calls rig's
+    sync completion instead of a provider batch endpoint, so one submit path serves both
+    lanes. Heavier; only worth it if a third lane appears. Default to the first.
+- **`FileRef` / Gemini File API for *batch* is bigger than "a variant beside `Image`"
+  — and may be the wrong shape.** Re-scoped after checking gpal + Google's docs (2026-06-22):
+  - **gpal's batch is inline-only** (`create_batch` → `InlinedRequest(contents=prompt)`,
+    `/home/atobey/src/gpal/src/gpal/server.py:2394`). Its File-API uploads (`file_uris`,
+    `Part.from_uri`) and **context caching** (`cached_content`) — the things that make
+    gpal's `consult` fast on big/reused context — all live on the *interactive*
+    `consult_gemini` path, **never** its batch. So gpal (which inspired kaibo) does *not*
+    validate File-API-with-batch; don't cite it as precedent.
+  - **Gemini *inlined* batch caps at ~20 MB total** (file-based JSONL batch goes to 2 GB).
+    kaibo submits inlined, so 20 MB is the real ceiling (see the duplication entry below).
+  - **File refs in an *inlined* batch request are unconfirmed** — Google's
+    [batch-api docs](https://ai.google.dev/gemini-api/docs/batch-api) only document
+    referencing uploaded files from a *file-based* JSONL batch, not inline. So a
+    `FileRef` variant that just rides beside inline `Image` may not even be accepted; the
+    real "files in batch" path is **adopting file-based JSONL submission** (write a JSONL,
+    upload it, reference uploaded files, poll a file output) — a whole second submission
+    mode, not a body-builder tweak. Park `FileRef` until that mode is on the table.
 
 Per-provider capability, `None` where unsupported: Anthropic ✓ (shipped), Gemini ✓
 (shipped — inline batch, `gemini-batch` cast synths Pro), OpenAI ✓ file-based (next),
@@ -299,19 +339,30 @@ failures and a truncated page are surfaced, not hidden). Still open:
   Consider making effort a default-on floor the cast/caller can lower, the way
   `max_tokens` already is. (Distinct from the "lift the tier" bullet above — that's the
   ceiling, this is the override.)
-- **Shared `attach` duplicates per item — a payload/memory ceiling as batches grow.**
+- **Shared `attach` duplicates per item — bounded by the inlined-batch payload cap.**
   Attachments are shared across the batch but inlined *per item*: `anthropic_content`/
   `gemini_parts` (`batch.rs`) re-encode every attachment into every item's request, so a
-  1 MiB attachment on a 1000-prompt batch is ~1 GiB in the JSON AST and again in the
-  serialized body. Inherent — provider batch APIs carry bytes inline per request, and
-  prompt caching doesn't shrink the JSONL — so the real fix is a guard, not dedup: bound
-  total submitted payload (sum of prompts + attachments×items) with a loud refusal before
-  it OOMs or trips the provider's body-size limit, the way single-file size is already
-  capped. Surfaced by the holistic review (Gemini Pro, 2026-06-22). Low priority until a
-  big-attachment × many-prompt batch is real — measure first; today's single-digit-prompt
-  reviews are nowhere near it. Note this interacts with the `FileRef`/File-API path
-  (`attach.rs` module doc): a `fileUri` reference is tiny and *reused* across items, so
-  remote-referenced media is the eventual escape from this duplication for large files.
+  1 MiB attachment on a 20-prompt batch is ~20 MiB of body. The binding limit is the
+  provider's: **Gemini inlined batch caps at ~20 MB total**
+  ([batch-api docs](https://ai.google.dev/gemini-api/docs/batch-api); file-based JSONL
+  batch is the 2 GB tier, which kaibo doesn't use), and Anthropic has its own per-request
+  ceiling — so the wire rejects an over-cap batch before kaibo OOMs. We will **not**
+  dedupe in memory (a shared `Arc<str>` would still serialize N times on the wire — the
+  providers require the bytes inline per inlined request). Two real directions, in order:
+  - **Near-term, cheap: a loud pre-flight guard.** Refuse before submit when the estimated
+    total inlined payload (Σ prompts + attachments×items) would exceed the backend's inline
+    cap, naming the cap — beats an opaque provider 400. The per-file size cap already exists;
+    this is the per-batch total.
+  - **Structural, later: stop holding the content in RAM / off the inline wire.** Two levers,
+    both better than dedup. (a) **Context caching** (`cached_content`) — Gemini supports it
+    *per request in batch*, and kaibo's attachments are *shared*, so cache the shared context
+    once and have every item reference it: one upload, cache-hit pricing, no N× inline bytes.
+    Near-perfect fit for our model. (b) **File-based JSONL batch** (the 2 GB tier) — spill the
+    JSONL (and any uploaded file refs) to an **XDG cache dir on disk**, upload it, let kaibo
+    release the in-RAM content, poll a file output. This is the "write to disk so we can let go
+    of the content" direction, and it's the same machinery the `FileRef`/File-API item above
+    needs — so they land together if they land. Surfaced by the holistic review (Gemini Pro,
+    2026-06-22) and the docs follow-up; low priority until a big × many batch is real.
 
 ### Provider model ids drift and live in code
 `consult.rs::default_models` hardcodes the explorer/synth ids per provider; they

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -1,7 +1,7 @@
 //! Attachments — inline a workspace file into a tool-less prompt as context.
 //!
-//! The tool-less tools (batch today, `oneshot` a tracked follow-on in
-//! `docs/issues.md`) answer from what the caller hands them. An attachment lets the
+//! The tool-less tools (`batch` and `oneshot`) answer from what the caller hands
+//! them. An attachment lets the
 //! caller name a *file* in the workspace instead of pasting its bytes through the
 //! calling agent's own context: kaibo reads it, containment-checks it against the
 //! same allowed set every other path obeys
@@ -72,6 +72,32 @@ impl Attachment {
             }
             Attachment::Image { .. } => None,
         }
+    }
+}
+
+/// The shared **text** context block for a set of attachments — every text attachment's
+/// `<file>` wrapper, joined, blank-line separated. Empty when there are no text
+/// attachments (images carry no text). This is the form a *toolless* caller (oneshot)
+/// prepends to its prompt: the text rides inline as context, the same wrapper the batch
+/// body builders emit, while images ride beside it as native parts. One source of truth
+/// for "text attachments → a context string."
+pub fn text_context(attachments: &[Attachment]) -> String {
+    attachments
+        .iter()
+        .filter_map(Attachment::wrapped_text)
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Prepend the attachments' text context to `prompt` (context first, then the ask —
+/// matching the batch builders' ordering). Returns `prompt` unchanged when no text
+/// attachment is present, so the no-attachment path is byte-for-byte the bare prompt.
+pub fn with_text_context(attachments: &[Attachment], prompt: &str) -> String {
+    let ctx = text_context(attachments);
+    if ctx.is_empty() {
+        prompt.to_string()
+    } else {
+        format!("{ctx}\n\n{prompt}")
     }
 }
 
@@ -215,6 +241,51 @@ mod tests {
             err.to_string().contains("image cap"),
             "names the cap: {err}"
         );
+    }
+
+    /// The text-context helper joins only text attachments (images contribute none) and
+    /// prepends them as context ahead of the prompt; with no text attachment the prompt
+    /// is returned byte-for-byte (the no-attachment path stays the bare prompt).
+    #[test]
+    fn text_context_joins_text_and_leaves_prompt_bare_when_empty() {
+        let atts = vec![
+            Attachment::Text {
+                path: "a.txt".into(),
+                body: "alpha".into(),
+            },
+            Attachment::Image {
+                path: "i.png".into(),
+                mime: "image/png",
+                data_b64: "QUJD".into(),
+            },
+            Attachment::Text {
+                path: "b.txt".into(),
+                body: "beta".into(),
+            },
+        ];
+        let ctx = text_context(&atts);
+        assert!(ctx.contains("path=\"a.txt\"") && ctx.contains("alpha"));
+        assert!(ctx.contains("path=\"b.txt\"") && ctx.contains("beta"));
+        assert!(
+            !ctx.contains("QUJD"),
+            "the image contributes no text: {ctx}"
+        );
+
+        let with = with_text_context(&atts, "the question");
+        assert!(
+            with.starts_with("<file path=\"a.txt\">"),
+            "context leads: {with}"
+        );
+        assert!(with.ends_with("the question"), "prompt trails: {with}");
+
+        // No text attachment → the prompt is returned unchanged (bare-prompt path).
+        let only_image = vec![Attachment::Image {
+            path: "i.png".into(),
+            mime: "image/png",
+            data_b64: "QUJD".into(),
+        }];
+        assert_eq!(with_text_context(&only_image, "just ask"), "just ask");
+        assert_eq!(with_text_context(&[], "just ask"), "just ask");
     }
 
     /// Binary that is neither valid UTF-8 nor a recognized image is refused rather than

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -31,7 +31,8 @@ use anyhow::{anyhow, Context, Result};
 use rig_core::agent::{HookAction, PromptHook};
 use rig_core::client::CompletionClient;
 use rig_core::completion::message::{
-    AssistantContent, Image, ToolChoice, ToolResult, ToolResultContent, UserContent,
+    AssistantContent, Image, ImageMediaType, MimeType, ToolChoice, ToolResult,
+    ToolResultContent, UserContent,
 };
 use rig_core::completion::{CompletionModel, Message, Prompt, PromptError, ToolDefinition};
 use rig_core::providers::{anthropic, deepseek, gemini, openai};
@@ -40,6 +41,7 @@ use rig_core::OneOrMany;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::attach::Attachment;
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot};
 use crate::credentials::ProviderKind;
 use crate::explorer::RunKaish;
@@ -570,6 +572,7 @@ trait PhaseRunner: Send + Sync {
         preamble: &'a str,
         max_tokens: u64,
         user_prompt: String,
+        extra_parts: Vec<UserContent>,
         max_turns: usize,
         params: Option<&'a Value>,
         progress: &'a dyn ProgressSink,
@@ -594,6 +597,7 @@ where
         preamble: &'a str,
         max_tokens: u64,
         user_prompt: String,
+        extra_parts: Vec<UserContent>,
         max_turns: usize,
         params: Option<&'a Value>,
         progress: &'a dyn ProgressSink,
@@ -606,6 +610,7 @@ where
             preamble,
             max_tokens,
             user_prompt,
+            extra_parts,
             max_turns,
             params,
             progress,
@@ -792,6 +797,7 @@ impl Arm {
         &self,
         preamble: &str,
         user_prompt: String,
+        extra_parts: Vec<UserContent>,
         max_turns: usize,
         progress: &dyn ProgressSink,
         make_tools: ToolFactory<'_>,
@@ -801,6 +807,7 @@ impl Arm {
                 preamble,
                 self.max_tokens,
                 user_prompt,
+                extra_parts,
                 max_turns,
                 self.params.as_ref(),
                 progress,
@@ -1144,6 +1151,7 @@ pub(crate) async fn run_phase<C, F>(
     preamble: &str,
     max_tokens: u64,
     user_prompt: String,
+    extra_parts: Vec<UserContent>,
     max_turns: usize,
     thinking: Option<&Value>,
     progress: &dyn ProgressSink,
@@ -1158,7 +1166,21 @@ where
     // Loop state across view_image-break resumes. The first pass is the bare prompt
     // with no history — byte-for-byte the old single call. Each break rewrites the
     // transcript (image onto the user-turn channel) and re-enters here.
-    let mut prompt: Message = Message::user(user_prompt);
+    //
+    // `extra_parts` are caller-supplied attachment parts (oneshot's inlined images) that
+    // ride on the *initial* user turn beside the text prompt — context first, prompt
+    // text last. Empty for every other phase, so their initial message stays exactly
+    // `Message::user(prompt)`, byte-for-byte unchanged.
+    let mut prompt: Message = if extra_parts.is_empty() {
+        Message::user(user_prompt)
+    } else {
+        let mut parts = Vec::with_capacity(extra_parts.len() + 1);
+        parts.push(UserContent::text(user_prompt));
+        parts.extend(extra_parts);
+        Message::User {
+            content: OneOrMany::many(parts).expect("a oneshot prompt part is always present"),
+        }
+    };
     let mut history: Vec<Message> = Vec::new();
 
     loop {
@@ -1403,6 +1425,7 @@ impl Tool for RunExplore {
             .run(
                 &self.preamble,
                 args.question,
+                Vec::new(),
                 self.max_turns,
                 self.progress.as_ref(),
                 &|| -> Result<Vec<Box<dyn ToolDyn>>> {
@@ -1495,10 +1518,36 @@ pub fn batch_system_prompt(override_: Option<&str>) -> String {
 /// so the break hook can never fire and the single turn always completes cleanly. If
 /// you ever give oneshot a tool, revisit this — a live break would consume the turn
 /// and land in the turn-cap finalize path.
-pub async fn oneshot(prompt: &str, arm: &Arm, cfg: &ConsultConfig) -> Result<String> {
+///
+/// `attachments` are caller-named workspace files inlined as context (the `attach` arg),
+/// resolved server-side so their bytes never transit the calling agent's context — the
+/// same seam batch uses. Text files prepend to the prompt as `<file>`-wrapped context
+/// (`attach::with_text_context`); images ride beside the prompt as native rig image parts
+/// on the single user turn. The image caller must already have gated on the model's
+/// vision cap (the server does, before this runs). With no attachments this is exactly
+/// the bare prompt and an empty part list — byte-for-byte the old single call.
+pub async fn oneshot(
+    prompt: &str,
+    attachments: &[Attachment],
+    arm: &Arm,
+    cfg: &ConsultConfig,
+) -> Result<String> {
+    let user_prompt = crate::attach::with_text_context(attachments, prompt);
+    let image_parts: Vec<UserContent> = attachments
+        .iter()
+        .filter_map(|a| match a {
+            Attachment::Image { mime, data_b64, .. } => Some(UserContent::image_base64(
+                data_b64.clone(),
+                ImageMediaType::from_mime_type(mime),
+                None,
+            )),
+            Attachment::Text { .. } => None,
+        })
+        .collect();
     arm.run(
         &phase_preamble(cfg.prompts.oneshot.as_deref(), oneshot_preamble, None, None),
-        prompt.to_string(),
+        user_prompt,
+        image_parts,
         1,
         cfg.progress.as_ref(),
         &|| Ok(Vec::new()),
@@ -1666,6 +1715,7 @@ pub(crate) async fn consult_with(
                 cfg.house_rules.as_deref(),
             ),
             user_prompt.to_string(),
+            Vec::new(),
             cfg.synth_max_turns,
             cfg.progress.as_ref(),
             // Rebuilt per call (main loop, and again if run_phase forces a final
@@ -2008,7 +2058,7 @@ mod tests {
             },
             ..ConsultConfig::default()
         };
-        oneshot("q", &arm(&client, MODEL), &cfg).await.unwrap();
+        oneshot("q", &[], &arm(&client, MODEL), &cfg).await.unwrap();
 
         let pre = client.requests_for(MODEL)[0]
             .preamble
@@ -2037,6 +2087,7 @@ mod tests {
             .build();
         oneshot(
             "just answer this",
+            &[],
             &arm(&client, MODEL),
             &ConsultConfig::default(),
         )
@@ -2049,6 +2100,100 @@ mod tests {
             "oneshot must offer no tools, got {:?}",
             reqs[0].tool_names
         );
+    }
+
+    /// `oneshot` inlines its attachments onto the single user turn: a text file prepends
+    /// as `<file>`-wrapped context ahead of the prompt, and an image rides as a native
+    /// rig image part on the same message — the toolless analogue of batch's attach,
+    /// driven through the real loop offline.
+    #[tokio::test]
+    async fn oneshot_inlines_text_and_image_attachments() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        const MODEL: &str = "synth";
+
+        // The mock inspects the inbound request for an image part — the only way to
+        // assert the image rode as a structured part (the text capture flattens parts).
+        let saw_image = Arc::new(AtomicBool::new(false));
+        let flag = saw_image.clone();
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, move |req| {
+                let has_image = req.chat_history.iter().any(|m| match m {
+                    Message::User { content } => {
+                        content.iter().any(|c| matches!(c, UserContent::Image(_)))
+                    }
+                    _ => false,
+                });
+                if has_image {
+                    flag.store(true, Ordering::SeqCst);
+                }
+                Ok(text_response("done"))
+            })
+            .build();
+
+        let attachments = vec![
+            Attachment::Text {
+                path: "README.md".into(),
+                body: "hello world".into(),
+            },
+            Attachment::Image {
+                path: "shot.png".into(),
+                mime: "image/png",
+                data_b64: "QUJD".into(),
+            },
+        ];
+        oneshot(
+            "review these",
+            &attachments,
+            &arm(&client, MODEL),
+            &ConsultConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        let reqs = client.requests_for(MODEL);
+        assert_eq!(reqs.len(), 1, "oneshot is exactly one upstream request");
+        // The text file rode inline as `<file>`-wrapped context, ahead of the prompt.
+        let ut = &reqs[0].user_text;
+        assert!(ut.contains("<file path=\"README.md\">"), "text file inlined as context: {ut}");
+        assert!(ut.contains("hello world"), "the file body rode inline: {ut}");
+        assert!(ut.contains("review these"), "the prompt is still present: {ut}");
+        // The image rode as a native image part, not flattened into text.
+        assert!(
+            saw_image.load(Ordering::SeqCst),
+            "the image attachment must ride as a structured image part"
+        );
+    }
+
+    /// With no attachments, `oneshot`'s user turn is exactly the bare prompt and carries
+    /// no image part — the no-attachment path stays byte-for-byte the old single call.
+    #[tokio::test]
+    async fn oneshot_without_attachments_is_the_bare_prompt() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        const MODEL: &str = "synth";
+        let saw_image = Arc::new(AtomicBool::new(false));
+        let flag = saw_image.clone();
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, move |req| {
+                let has_image = req.chat_history.iter().any(|m| match m {
+                    Message::User { content } => {
+                        content.iter().any(|c| matches!(c, UserContent::Image(_)))
+                    }
+                    _ => false,
+                });
+                if has_image {
+                    flag.store(true, Ordering::SeqCst);
+                }
+                Ok(text_response("done"))
+            })
+            .build();
+        oneshot("just ask", &[], &arm(&client, MODEL), &ConsultConfig::default())
+            .await
+            .unwrap();
+        let reqs = client.requests_for(MODEL);
+        assert_eq!(reqs[0].user_text.trim(), "just ask", "bare prompt, no wrapper");
+        assert!(!saw_image.load(Ordering::SeqCst), "no attachment, no image part");
     }
 
     /// The load-bearing e2e: a scripted consult that delegates a sweep to `explore′`,

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -571,8 +571,7 @@ trait PhaseRunner: Send + Sync {
         &'a self,
         preamble: &'a str,
         max_tokens: u64,
-        user_prompt: String,
-        extra_parts: Vec<UserContent>,
+        initial_prompt: Message,
         max_turns: usize,
         params: Option<&'a Value>,
         progress: &'a dyn ProgressSink,
@@ -596,8 +595,7 @@ where
         &'a self,
         preamble: &'a str,
         max_tokens: u64,
-        user_prompt: String,
-        extra_parts: Vec<UserContent>,
+        initial_prompt: Message,
         max_turns: usize,
         params: Option<&'a Value>,
         progress: &'a dyn ProgressSink,
@@ -609,8 +607,7 @@ where
             &self.model,
             preamble,
             max_tokens,
-            user_prompt,
-            extra_parts,
+            initial_prompt,
             max_turns,
             params,
             progress,
@@ -796,8 +793,7 @@ impl Arm {
     pub(crate) async fn run(
         &self,
         preamble: &str,
-        user_prompt: String,
-        extra_parts: Vec<UserContent>,
+        initial_prompt: Message,
         max_turns: usize,
         progress: &dyn ProgressSink,
         make_tools: ToolFactory<'_>,
@@ -806,8 +802,7 @@ impl Arm {
             .run_phase(
                 preamble,
                 self.max_tokens,
-                user_prompt,
-                extra_parts,
+                initial_prompt,
                 max_turns,
                 self.params.as_ref(),
                 progress,
@@ -1150,8 +1145,7 @@ pub(crate) async fn run_phase<C, F>(
     model: &str,
     preamble: &str,
     max_tokens: u64,
-    user_prompt: String,
-    extra_parts: Vec<UserContent>,
+    initial_prompt: Message,
     max_turns: usize,
     thinking: Option<&Value>,
     progress: &dyn ProgressSink,
@@ -1163,29 +1157,13 @@ where
     C::CompletionModel: 'static,
     F: Fn() -> Result<Vec<Box<dyn ToolDyn>>>,
 {
-    // Loop state across view_image-break resumes. The first pass is the bare prompt
-    // with no history — byte-for-byte the old single call. Each break rewrites the
-    // transcript (image onto the user-turn channel) and re-enters here.
-    //
-    // `extra_parts` are caller-supplied attachment parts (oneshot's inlined images) that
-    // ride on the *initial* user turn beside the text prompt — context first, prompt
-    // text last. Empty for every other phase, so their initial message stays exactly
-    // `Message::user(prompt)`, byte-for-byte unchanged.
-    let mut prompt: Message = if extra_parts.is_empty() {
-        Message::user(user_prompt)
-    } else {
-        let mut parts = Vec::with_capacity(extra_parts.len() + 1);
-        // Skip an empty text part (image-only attach with an empty prompt) — an empty
-        // `{type:text, text:""}` block is a benign but pointless chunk; the image parts
-        // are enough. `extra_parts` is non-empty here, so the message is never empty.
-        if !user_prompt.is_empty() {
-            parts.push(UserContent::text(user_prompt));
-        }
-        parts.extend(extra_parts);
-        Message::User {
-            content: OneOrMany::many(parts).expect("extra_parts is non-empty on this branch"),
-        }
-    };
+    // Loop state across view_image-break resumes. The caller hands us the *assembled*
+    // first user turn — a bare `Message::user(prompt)` for every tool-driven phase, or a
+    // multi-part turn (oneshot's inlined attachment images beside the text) built in
+    // `oneshot`. Keeping the assembly in the caller keeps this engine free of multimodal
+    // concerns: it just runs whatever turn it's given, then each view_image break rewrites
+    // the transcript and re-enters here (holistic review, Gemini Pro 2026-06-22).
+    let mut prompt: Message = initial_prompt;
     let mut history: Vec<Message> = Vec::new();
 
     loop {
@@ -1429,8 +1407,7 @@ impl Tool for RunExplore {
             .arm
             .run(
                 &self.preamble,
-                args.question,
-                Vec::new(),
+                Message::user(args.question),
                 self.max_turns,
                 self.progress.as_ref(),
                 &|| -> Result<Vec<Box<dyn ToolDyn>>> {
@@ -1549,10 +1526,25 @@ pub async fn oneshot(
             Attachment::Text { .. } => None,
         })
         .collect();
+    // Assemble the single user turn here — multimodal awareness lives in oneshot, not the
+    // shared loop. No images → a bare `Message::user` (byte-for-byte the old call). With
+    // images, the text rides as the first part (skipped when empty — image-only with an
+    // empty prompt shouldn't emit a pointless `{type:text,text:""}` block), then the images.
+    let initial_prompt = if image_parts.is_empty() {
+        Message::user(user_prompt)
+    } else {
+        let mut parts = Vec::with_capacity(image_parts.len() + 1);
+        if !user_prompt.is_empty() {
+            parts.push(UserContent::text(user_prompt));
+        }
+        parts.extend(image_parts);
+        Message::User {
+            content: OneOrMany::many(parts).expect("image_parts is non-empty on this branch"),
+        }
+    };
     arm.run(
         &phase_preamble(cfg.prompts.oneshot.as_deref(), oneshot_preamble, None, None),
-        user_prompt,
-        image_parts,
+        initial_prompt,
         1,
         cfg.progress.as_ref(),
         &|| Ok(Vec::new()),
@@ -1719,8 +1711,7 @@ pub(crate) async fn consult_with(
                 cfg.orientation.as_deref(),
                 cfg.house_rules.as_deref(),
             ),
-            user_prompt.to_string(),
-            Vec::new(),
+            Message::user(user_prompt.to_string()),
             cfg.synth_max_turns,
             cfg.progress.as_ref(),
             // Rebuilt per call (main loop, and again if run_phase forces a final

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -1175,10 +1175,15 @@ where
         Message::user(user_prompt)
     } else {
         let mut parts = Vec::with_capacity(extra_parts.len() + 1);
-        parts.push(UserContent::text(user_prompt));
+        // Skip an empty text part (image-only attach with an empty prompt) — an empty
+        // `{type:text, text:""}` block is a benign but pointless chunk; the image parts
+        // are enough. `extra_parts` is non-empty here, so the message is never empty.
+        if !user_prompt.is_empty() {
+            parts.push(UserContent::text(user_prompt));
+        }
         parts.extend(extra_parts);
         Message::User {
-            content: OneOrMany::many(parts).expect("a oneshot prompt part is always present"),
+            content: OneOrMany::many(parts).expect("extra_parts is non-empty on this branch"),
         }
     };
     let mut history: Vec<Message> = Vec::new();
@@ -2194,6 +2199,50 @@ mod tests {
         let reqs = client.requests_for(MODEL);
         assert_eq!(reqs[0].user_text.trim(), "just ask", "bare prompt, no wrapper");
         assert!(!saw_image.load(Ordering::SeqCst), "no attachment, no image part");
+    }
+
+    /// An image-only attach with an empty prompt sends *just* the image part — no empty
+    /// `{type:text, text:""}` chunk. Without the guard the user turn would carry a useless
+    /// empty text part, so this counts text parts and pins it at zero.
+    #[tokio::test]
+    async fn oneshot_empty_prompt_image_only_omits_empty_text_part() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        const MODEL: &str = "synth";
+        let text_parts = Arc::new(AtomicUsize::new(usize::MAX));
+        let counter = text_parts.clone();
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, move |req| {
+                let n = req
+                    .chat_history
+                    .iter()
+                    .find_map(|m| match m {
+                        Message::User { content } => Some(
+                            content
+                                .iter()
+                                .filter(|c| matches!(c, UserContent::Text(_)))
+                                .count(),
+                        ),
+                        _ => None,
+                    })
+                    .unwrap_or(0);
+                counter.store(n, Ordering::SeqCst);
+                Ok(text_response("done"))
+            })
+            .build();
+        let img = Attachment::Image {
+            path: "x.png".into(),
+            mime: "image/png",
+            data_b64: "QUJD".into(),
+        };
+        oneshot("", &[img], &arm(&client, MODEL), &ConsultConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            text_parts.load(Ordering::SeqCst),
+            0,
+            "an empty prompt must not add an empty text part beside the image"
+        );
     }
 
     /// The load-bearing e2e: a scripted consult that delegates a sweep to `explore′`,

--- a/src/server.rs
+++ b/src/server.rs
@@ -200,9 +200,12 @@ pub struct OneshotInput {
     /// kaibo reads each file and inlines it so its bytes never pass through your context.
     /// Prefer **whole files**: a tool-less model has no way to go read the repo itself, so
     /// give it the full file(s) it needs — `["README.md", "src/server.rs"]` — not a snippet.
-    /// (A `git diff > changes.diff` then `["changes.diff"]` works for reviewing *uncommitted*
-    /// changes, but a diff is leaner context than the files themselves.) The same surface as
-    /// `batch_submit`'s `attach`, on the interactive (synchronous) call. Text files splice in
+    /// Top-tier models carry very large context windows (1M+ tokens), so don't be stingy —
+    /// attach whole files, even several, rather than trimming; it has plenty of room to work
+    /// with the full source. (A `git diff > changes.diff` then `["changes.diff"]` works for
+    /// reviewing *uncommitted* changes, but a diff is leaner context than the files
+    /// themselves.) The same surface as `batch_submit`'s `attach`, on the interactive
+    /// (synchronous) call. Text files splice in
     /// as text; images (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable
     /// model). A path outside the workspace, a directory, an oversized file, or a binary that
     /// isn't a known image is refused with a clear error. Omit for none.
@@ -243,9 +246,11 @@ pub struct BatchSubmitInput {
     /// elsewhere; worktrees included). kaibo reads each file and inlines it so its bytes
     /// never pass through your context. Prefer **whole files**: a tool-less model has no way
     /// to go read the repo itself, so give it the full file(s) it needs —
-    /// `["README.md", "src/server.rs"]` — not a snippet. (A `git diff > changes.diff` then
-    /// `["changes.diff"]` works for reviewing *uncommitted* changes, but a diff is leaner
-    /// context than the files themselves.) Text files splice in as text; images
+    /// `["README.md", "src/server.rs"]` — not a snippet. Top-tier models carry very large
+    /// context windows (1M+ tokens), so don't be stingy — attach whole files, even several,
+    /// rather than trimming. (A `git diff > changes.diff` then `["changes.diff"]` works for
+    /// reviewing *uncommitted* changes, but a diff is leaner context than the files
+    /// themselves.) Text files splice in as text; images
     /// (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable
     /// synth model). A path outside the workspace, a directory, an oversized file, or a
     /// binary that isn't a known image is refused with a clear error. Omit for none.

--- a/src/server.rs
+++ b/src/server.rs
@@ -195,6 +195,18 @@ pub struct OneshotInput {
     /// the model answers from this and its own knowledge, nothing else.
     pub prompt: String,
 
+    /// Workspace files to inline as context for the prompt — absolute or relative paths
+    /// under the allowed set (same boundary as `path` elsewhere; worktrees included).
+    /// kaibo reads each file and inlines it so its bytes never pass through your context:
+    /// say "review README.md" and attach `["README.md"]`, or `git diff > x.diff` and
+    /// attach `["x.diff"]`. The same surface as `batch_submit`'s `attach`, on the
+    /// interactive (synchronous) call. Text files splice in as text; images
+    /// (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable model). A
+    /// path outside the workspace, a directory, an oversized file, or a binary that isn't
+    /// a known image is refused with a clear error. Omit for none.
+    #[serde(default)]
+    pub attach: Vec<String>,
+
     /// Which cast (model team) runs this call; omit for the server's default. Pick
     /// from this param's `enum` — the casts live right now; `kaibo://config` lists
     /// every configured cast and backend, with their aliases. kaibo runs the cast's
@@ -631,6 +643,36 @@ impl KaiboHandler {
             ),
             None,
         )
+    }
+
+    /// Refuse image attachments to a vision-blind model, naming the cast so the caller
+    /// can pick a vision-capable one. Shared by the tool-less attach surfaces (`batch` and
+    /// `oneshot`) so the refusal reads identically and lives in one place; a blind model
+    /// would silently ignore or error on an image part, so we refuse honestly up front
+    /// (the project posture) rather than ship a no-op image. Text-only attachments (and
+    /// the no-attachment case) always pass.
+    pub fn gate_image_attachments(
+        &self,
+        vision: bool,
+        attachments: &[crate::attach::Attachment],
+        model: &str,
+        cast: &str,
+    ) -> Result<(), McpError> {
+        if !vision
+            && attachments
+                .iter()
+                .any(|a| matches!(a, crate::attach::Attachment::Image { .. }))
+        {
+            return Err(McpError::invalid_params(
+                format!(
+                    "an image attachment was given, but the model `{model}` on cast `{cast}` \
+                     doesn't accept image input. Use a vision-capable cast/model, or attach \
+                     only text files. `kaibo://config` lists each slot's `vision`."
+                ),
+                None,
+            ));
+        }
+        Ok(())
     }
 
     /// Resolve caller-named attachment paths into [`Attachment`](crate::attach::Attachment)s,
@@ -1073,6 +1115,11 @@ impl KaiboHandler {
             "backend",
         )?;
         let arm = self.arm(&cast, ModelRole::Synth)?;
+        // Read + containment-check the attachments (same boundary as a session root); the
+        // bytes are inlined server-side so they never transit the calling agent's context.
+        let attachments = self.resolve_attachments(&input.attach)?;
+        // Gate image attachments on the model's vision capability (shared with batch).
+        self.gate_image_attachments(arm.caps.vision, &attachments, &arm.model, &cast.name)?;
         let progress = progress_sink(peer, &meta);
         let defaults = &self.config.defaults;
         let cfg = ConsultConfig {
@@ -1088,7 +1135,7 @@ impl KaiboHandler {
 
         let span = tracing::info_span!("oneshot", cast = %cast.name, model = %arm.model);
         progress.emit(PhaseEvent::PhaseStarted { phase: "oneshot" });
-        let answer = oneshot(&input.prompt, &arm, &cfg)
+        let answer = oneshot(&input.prompt, &attachments, &arm, &cfg)
             .instrument(span)
             .await
             .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
@@ -1325,25 +1372,9 @@ impl KaiboHandler {
         // bad path is a clean refusal, not a half-submitted batch. The bytes are inlined
         // server-side so they never transit the calling agent's context.
         let attachments = self.resolve_attachments(&input.attach)?;
-        // Gate image attachments on the synth model's vision capability — a blind model
-        // would silently ignore (or error on) an image part, so refuse honestly up front
-        // (the project posture), naming the cast so the caller can pick a vision one. This
-        // runs before the provider is built, so a vision misconfig needs no key to report.
-        if !caps.vision
-            && attachments
-                .iter()
-                .any(|a| matches!(a, crate::attach::Attachment::Image { .. }))
-        {
-            return Err(McpError::invalid_params(
-                format!(
-                    "an image attachment was given, but the synth model `{model}` on cast \
-                     `{}` doesn't accept image input. Use a vision-capable cast/model, or \
-                     attach only text files. `kaibo://config` lists each slot's `vision`.",
-                    cast.name
-                ),
-                None,
-            ));
-        }
+        // Gate image attachments on the synth model's vision capability before the
+        // provider is built — so a vision misconfig needs no key to report.
+        self.gate_image_attachments(caps.vision, &attachments, &model, &cast.name)?;
         // Now build the network client (resolves the key); a batch-incapable backend is
         // refused honestly here.
         let provider = crate::batch::submitter(backend, slot, &self.config.defaults)

--- a/src/server.rs
+++ b/src/server.rs
@@ -197,13 +197,15 @@ pub struct OneshotInput {
 
     /// Workspace files to inline as context for the prompt — absolute or relative paths
     /// under the allowed set (same boundary as `path` elsewhere; worktrees included).
-    /// kaibo reads each file and inlines it so its bytes never pass through your context:
-    /// say "review README.md" and attach `["README.md"]`, or `git diff > x.diff` and
-    /// attach `["x.diff"]`. The same surface as `batch_submit`'s `attach`, on the
-    /// interactive (synchronous) call. Text files splice in as text; images
-    /// (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable model). A
-    /// path outside the workspace, a directory, an oversized file, or a binary that isn't
-    /// a known image is refused with a clear error. Omit for none.
+    /// kaibo reads each file and inlines it so its bytes never pass through your context.
+    /// Prefer **whole files**: a tool-less model has no way to go read the repo itself, so
+    /// give it the full file(s) it needs — `["README.md", "src/server.rs"]` — not a snippet.
+    /// (A `git diff > changes.diff` then `["changes.diff"]` works for reviewing *uncommitted*
+    /// changes, but a diff is leaner context than the files themselves.) The same surface as
+    /// `batch_submit`'s `attach`, on the interactive (synchronous) call. Text files splice in
+    /// as text; images (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable
+    /// model). A path outside the workspace, a directory, an oversized file, or a binary that
+    /// isn't a known image is refused with a clear error. Omit for none.
     #[serde(default)]
     pub attach: Vec<String>,
 
@@ -239,9 +241,12 @@ pub struct BatchSubmitInput {
     /// Workspace files to inline as shared context for *every* prompt in the batch —
     /// absolute or relative paths under the allowed set (same boundary as `path`
     /// elsewhere; worktrees included). kaibo reads each file and inlines it so its bytes
-    /// never pass through your context: say "review README.md" and attach `["README.md"]`,
-    /// or `git diff > x.diff` and attach `["x.diff"]`. Text files splice in as text;
-    /// images (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable
+    /// never pass through your context. Prefer **whole files**: a tool-less model has no way
+    /// to go read the repo itself, so give it the full file(s) it needs —
+    /// `["README.md", "src/server.rs"]` — not a snippet. (A `git diff > changes.diff` then
+    /// `["changes.diff"]` works for reviewing *uncommitted* changes, but a diff is leaner
+    /// context than the files themselves.) Text files splice in as text; images
+    /// (png/jpeg/gif/webp) ride as native image parts (needs a vision-capable
     /// synth model). A path outside the workspace, a directory, an oversized file, or a
     /// binary that isn't a known image is refused with a clear error. Omit for none.
     #[serde(default)]

--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -197,3 +197,55 @@ async fn image_attachment_to_blind_synth_is_refused() {
         "refusal must name the image/vision mismatch, got: {msg}"
     );
 }
+
+// --- the shared vision gate (batch + oneshot use it identically) -------------
+
+/// `gate_image_attachments` — the one gate both `batch` and `oneshot` call — refuses an
+/// image to a vision-blind model, passes text-only and the no-attachment case, and lets
+/// an image through to a vision-capable model. This pins the shared rule directly (the
+/// `oneshot` handler needs a `Peer` to drive end-to-end, so the gate is tested here).
+#[test]
+fn shared_vision_gate_refuses_image_to_blind_model_only() {
+    let handler = handler_rooted_at(tempdir().unwrap().path());
+    let text = Attachment::Text {
+        path: "a.txt".into(),
+        body: "x".into(),
+    };
+    let image = Attachment::Image {
+        path: "a.png".into(),
+        mime: "image/png",
+        data_b64: "QUJD".into(),
+    };
+
+    // Blind model + image → refused, naming the model, the cast, and the mismatch.
+    let err = handler
+        .gate_image_attachments(
+            false,
+            std::slice::from_ref(&image),
+            "some-model",
+            "blindcast",
+        )
+        .expect_err("an image to a blind model must be refused");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("some-model") && msg.contains("blindcast"),
+        "names model + cast: {msg}"
+    );
+    assert!(
+        msg.contains("image") && msg.to_lowercase().contains("vision"),
+        "names the mismatch: {msg}"
+    );
+
+    // Blind model + text-only → allowed (text needs no vision).
+    handler
+        .gate_image_attachments(false, std::slice::from_ref(&text), "some-model", "c")
+        .expect("text-only attachments need no vision");
+    // Blind model + nothing → allowed.
+    handler
+        .gate_image_attachments(false, &[], "some-model", "c")
+        .expect("no attachments, no gate");
+    // Vision model + image → allowed.
+    handler
+        .gate_image_attachments(true, &[image], "vlm", "c")
+        .expect("a vision model accepts an image");
+}

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -1259,6 +1259,7 @@ async fn secondary_local_cast_from_user_config_runs() {
         "Context: src/sandbox.rs builds a read-only kernel; writes and external \
          commands are refused.\n\nIn one sentence, what does kaibo's read-only sandbox \
          prevent?",
+        &[],
         &arm,
         &ConsultConfig::default(),
     )
@@ -1319,6 +1320,7 @@ async fn oneshot_answers_from_pasted_context() {
         "Context: src/sandbox.rs builds a read-only kernel; the LocalFs read-only \
          mount refuses every write.\n\nIn one sentence, which file enforces kaibo's \
          read-only sandbox?",
+        &[],
         &arm,
         &ConsultConfig::default(),
     )

--- a/tests/llm_timeout.rs
+++ b/tests/llm_timeout.rs
@@ -64,6 +64,7 @@ async fn oneshot_aborts_when_the_provider_never_responds() {
         Duration::from_secs(20),
         oneshot(
             "What does the sandbox prevent?",
+            &[],
             &arm,
             &ConsultConfig::default(),
         ),


### PR DESCRIPTION
Builds on the batch `attach` feature (PR #10): brings the same workspace-file inlining to the interactive **`oneshot`** tool, and sharpens the tracked follow-ups with what we learned from `gpal` and Google's docs.

## What's here

**`oneshot` grows `attach`** — the interactive twin of batch attach. Name workspace files; kaibo reads + inlines them (text folded into the prompt via the shared `<file>` wrapper, images as native rig image parts) so their bytes never pass through the calling agent's context. "Call Opus once with these files, no tools, no waiting" is now one call.

- **Chose "grow oneshot against rig"** over a batch-shaped interactive seam — oneshot already runs through rig, so map each `Attachment` onto rig's own message parts rather than invent a second submit abstraction. Reuses the whole batch seam: `resolve_attachments`, `classify`, the shared `contained` containment boundary, and `Attachment::wrapped_text` (one source of truth for the `<file>` wrapper).
- **Vision gate DRY'd** into `KaiboHandler::gate_image_attachments`, called by both batch and oneshot — identical refusal, and unit-testable directly (the oneshot handler needs a `Peer`).
- **The loop stays pure.** Per the Gemini Pro holistic review, `run_phase`/`Arm::run`/`PhaseRunner` take a pre-built `initial_prompt: Message` (not `prompt + extra_parts`); oneshot assembles its own multi-part turn, consult/explore pass `Message::user(prompt)` byte-for-byte. Multimodal awareness lives only in oneshot.

**issues.md sharpened** with gpal + Gemini-docs findings (no code impact):
- `FileRef`/Gemini File API for batch is bigger than "a variant beside Image" and maybe the wrong shape — gpal's batch is inline-only; Google's docs only document file refs for *file-based JSONL* batch, not inlined.
- Per-item duplication is bounded by the ~20 MB inlined-batch cap; dropped the dedupe framing (a shared `Arc` still serializes N times on the wire). Real escapes: context caching (`cached_content`, shared-attachment fit) and the file-based JSONL tier spilled to an XDG cache.
- TOCTOU likely fix reframed from `/proc`+`O_NOFOLLOW` to reading through the kaish VFS like `view_image` (portable, structural).
- Noted the `<file>` wrapper's lack of body-escaping (shared by batch+oneshot, self-inflicted, defense-in-depth).

**Tool-description tuning** — de-emphasized `git diff > x.diff` (a tool-less model reviews best from whole files, not changed hunks); noted that top-tier models' 1M+ context windows mean you can attach a lot.

## Review

Dogfooded both ways on the live server: **DeepSeek realtime** via `oneshot`+`attach` (reviewing this very change through the feature it adds), and **Gemini Pro async** via `batch_submit`+`attach`. Both judged it sound; DeepSeek's nits (empty-text-part wart, expect wording) and Gemini's one structural call (the `initial_prompt: Message` refactor above) are folded in. Full suite green throughout.

## Not in scope (tracked in issues.md)

`consult`-attach (a different semantic — pin whole files as trusted starting evidence, overlapping the existing `context` param), the File-API/file-based-batch path, context caching, the payload-cap guard, and the TOCTOU structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)