### PR TITLE
Expand $VAR / ${VAR} in root and allow_paths for portable scratch reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,9 +95,11 @@ the git log. Each later release appends a new section at the top.
   `path` entirely. (Previously a literal `~` was taken verbatim and failed
   canonicalization at startup.) Environment variables make a scratch space portable:
   `allow_paths = ["$TMPDIR"]` or `["$XDG_RUNTIME_DIR/kaibo"]` lets kaibo read artifacts
-  a workflow drops in a temp dir without hardcoding a host-specific `/tmp`. An undefined
-  variable is a loud load error, never a silent gap that would misplace the read
-  boundary; the `configure` prompt now walks you through this opt-in.
+  a workflow drops in a temp dir without hardcoding a host-specific `/tmp`. A variable
+  that is unset, **set but empty**, or non-UTF-8 is a loud load error, never a silent gap
+  that would misplace the read boundary (an empty `$EMPTY/` would otherwise collapse to
+  `/`); write `$$` for a literal `$`. The `configure` prompt now walks you through this
+  opt-in.
 - **Follow git worktrees automatically.** A `path` in a linked git worktree of an
   already-allowed repo is now reachable without an `--allow-path` — so a sibling
   branch you check out next to the project (even one you spin up mid-session) just

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,11 +88,16 @@ the git log. Each later release appends a new section at the top.
   and still land on the project. The scope handshake and `kaibo://config` tag the
   root as inferred. An `--allow-path` that excludes the cwd leaves no default root —
   kaibo never defaults to a path its own containment check would reject.
-- **`~` expands in `[server] root` and `allow_paths`** (config-file and `KAIBO_*`
-  env layers), matching the tilde handling key files and `[context]` paths already
-  get. Set `allow_paths = ["~/src"]` once and every project under it is in-bounds —
-  with cwd inferred as the default root, you stop thinking about `path` entirely.
-  (Previously a literal `~` was taken verbatim and failed canonicalization at startup.)
+- **`~` *and* `$VAR` / `${VAR}` expand in `[server] root` and `allow_paths`**
+  (config-file and `KAIBO_*` env layers), matching the tilde handling key files and
+  `[context]` paths already get. Set `allow_paths = ["~/src"]` once and every project
+  under it is in-bounds — with cwd inferred as the default root, you stop thinking about
+  `path` entirely. (Previously a literal `~` was taken verbatim and failed
+  canonicalization at startup.) Environment variables make a scratch space portable:
+  `allow_paths = ["$TMPDIR"]` or `["$XDG_RUNTIME_DIR/kaibo"]` lets kaibo read artifacts
+  a workflow drops in a temp dir without hardcoding a host-specific `/tmp`. An undefined
+  variable is a loud load error, never a silent gap that would misplace the read
+  boundary; the `configure` prompt now walks you through this opt-in.
 - **Follow git worktrees automatically.** A `path` in a linked git worktree of an
   already-allowed repo is now reachable without an `--allow-path` — so a sibling
   branch you check out next to the project (even one you spin up mid-session) just

--- a/docs/config.md
+++ b/docs/config.md
@@ -596,10 +596,29 @@ precedence rule as `--root`). To lift all limits: `--allow-path /`.
 **Set it once.** Putting your whole workspace tree in `allow_paths`
 (`["~/src"]`) means every project under it is in-bounds, and because the client's
 cwd/workspace lands inside that tree, kaibo infers it as the [default root](#path-containment)
-automatically — so you configure access once and never pass `path` per call. A
-leading `~` in `root` / `allow_paths` expands to `$HOME` (file and env layers), the
-same as key files and `[context]` paths; the CLI relies on your shell's own
-expansion. Other paths are taken as written.
+automatically — so you configure access once and never pass `path` per call.
+
+**Path expansion.** In `root` / `allow_paths`, the file and env layers expand a leading
+`~` to `$HOME` *and* `$VAR` / `${VAR}` from the environment; an undefined variable is a
+loud load error, not a silent gap that would point the boundary somewhere unexpected. The
+CLI relies on your shell's own expansion instead. Paths with no `~`/`$` are taken as
+written. (A bare `$` not forming a reference is left literal; there's no escaping yet, so
+a directory literally named `$foo` isn't expressible in config — use the CLI for that.)
+
+**Reading a scratch / temp space.** kaibo reads only what's in the allowed set and never
+writes anywhere — so to let it read artifacts a workflow drops in a temp dir (a diff, a
+generated file, a log), add that dir to `allow_paths`. Write it portably with the env var
+rather than a host-specific literal, so it resolves on whatever machine kaibo runs on:
+
+```toml
+[server]
+allow_paths = ["~/src", "$TMPDIR", "$XDG_RUNTIME_DIR/kaibo"]
+```
+
+`$TMPDIR` (POSIX) and `$XDG_RUNTIME_DIR` (XDG) land on the per-user scratch dir on macOS
+and sandboxed Linux respectively, where a bare `/tmp` would be wrong. This is an opt-in:
+widening to a shared, world-writable space like `/tmp` is a real (read-only) boundary
+move, so kaibo never adds it for you.
 
 **When defaulting does *not* happen.** If `--allow-path` is set to a tree that does
 not contain the launch cwd and no `--root` is given, there is no default root: the

--- a/docs/config.md
+++ b/docs/config.md
@@ -599,11 +599,13 @@ cwd/workspace lands inside that tree, kaibo infers it as the [default root](#pat
 automatically — so you configure access once and never pass `path` per call.
 
 **Path expansion.** In `root` / `allow_paths`, the file and env layers expand a leading
-`~` to `$HOME` *and* `$VAR` / `${VAR}` from the environment; an undefined variable is a
-loud load error, not a silent gap that would point the boundary somewhere unexpected. The
-CLI relies on your shell's own expansion instead. Paths with no `~`/`$` are taken as
-written. (A bare `$` not forming a reference is left literal; there's no escaping yet, so
-a directory literally named `$foo` isn't expressible in config — use the CLI for that.)
+`~` to `$HOME` *and* `$VAR` / `${VAR}` from the environment; the CLI relies on your shell's
+own expansion instead. Paths with no `~`/`$` are taken as written. A variable that is unset,
+**set but empty**, or non-UTF-8 is a loud load error rather than a silent gap that would
+misplace the boundary — an empty value matters because `$EMPTY/scratch` would collapse to
+`/scratch` and `$EMPTY/` to `/` (the whole filesystem). Write `$$` for a literal `$`; a
+stray `$` that begins no reference is itself an error, so a typo can't slip through as a
+literal segment. (A directory literally named `$foo` is written `$$foo`.)
 
 **Reading a scratch / temp space.** kaibo reads only what's in the allowed set and never
 writes anywhere — so to let it read artifacts a workflow drops in a temp dir (a diff, a

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,43 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-22 — `$VAR` expansion in `root` / `allow_paths`, for portable scratch reads
+
+Amy asked the real question behind "can a user easily allow kaibo to read `/tmp`?": the
+mechanism existed (`--allow-path` / `KAIBO_ALLOW_PATHS` / `[server] allow_paths`), but the
+*path* you had to write was host-specific — a literal `/tmp` is wrong on macOS (per-user
+`/var/folders/...`) and on sandboxed Linux (`$XDG_RUNTIME_DIR`). kaibo already followed
+XDG for the config file but had no XDG/POSIX awareness in the read boundary. The fix is to
+let `root` / `allow_paths` expand `$VAR` / `${VAR}` (and the leading `~` they already did),
+so `allow_paths = ["$TMPDIR"]` resolves per machine.
+
+**Chose general `$VAR` expansion over a curated temp-var set or an `--allow-tmp` knob.**
+Amy's call: the general form is least-surprising to anyone who's used a shell, and it
+costs no more than the narrow one — `$TMPDIR`/`$XDG_RUNTIME_DIR`/`$HOME` all just fall out,
+plus whatever else a user names. A one-off `--allow-tmp` switch would have been more magic
+for less reach.
+
+**Expansion order is env-first, then tilde.** Two reasons it's not the other way: the
+tilde step keeps operating on an `OsString` `$HOME` (a non-UTF-8 home survives, as it did
+before), and a variable whose *value* carries a leading `~` (`MYDIR=~/data`) still expands.
+A single pass only — a variable's value is never re-scanned for `$`, so there's no
+expansion-injection surprise from environment contents.
+
+**Undefined variable is a loud load error, not a passthrough.** A silent gap (`$TMPDR`
+typo → empty segment → a path that canonicalizes *somewhere*) is exactly the data-corruption
+failure mode the house rule rejects; better to refuse at startup. A bare `$` that doesn't
+form a reference stays literal, shell-style — the one accepted limitation is that a
+directory literally named `$foo` isn't expressible in config (no escaping yet; noted in
+issues.md).
+
+**Scoped to the boundary knobs (`root` / `allow_paths`), not every path field.** `[context]`
+`user_files` and the key-file paths still tilde-only; extending them is consistency work,
+not the temp-read goal, and it widens the fallible surface — logged as a follow-up rather
+than smuggled in. The rest of the surface Amy asked for shipped together: the `configure`
+prompt gained an opt-in read-scope step, the containment-error message names the portable
+`$TMPDIR` form, and `docs/config.md` documents it — so a user meets the idiom wherever they
+hit the boundary.
+
 ## 2026-06-22 — `oneshot` grows `attach` (the interactive twin of batch attach)
 
 Amy's framing: `oneshot` should be as close to `batch` as the API split allows — "call

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -36,12 +36,20 @@ before), and a variable whose *value* carries a leading `~` (`MYDIR=~/data`) sti
 A single pass only — a variable's value is never re-scanned for `$`, so there's no
 expansion-injection surprise from environment contents.
 
-**Undefined variable is a loud load error, not a passthrough.** A silent gap (`$TMPDR`
-typo → empty segment → a path that canonicalizes *somewhere*) is exactly the data-corruption
-failure mode the house rule rejects; better to refuse at startup. A bare `$` that doesn't
-form a reference stays literal, shell-style — the one accepted limitation is that a
-directory literally named `$foo` isn't expressible in config (no escaping yet; noted in
-issues.md).
+**Undefined / empty / non-UTF-8 variable is a loud load error, not a passthrough.** A
+silent gap (`$TMPDR` typo → empty segment → a path that canonicalizes *somewhere*) is
+exactly the data-corruption failure mode the house rule rejects; refuse at startup. Two
+cross-family reviews (DeepSeek V4 Pro via `consult`, Gemini 3.1 Pro via the batch lane)
+hardened this: Gemini caught that `undefined → error` does *not* cover a **set-but-empty**
+variable — `$EMPTY/scratch` collapses to `/scratch`, `$EMPTY/` to `/` (the whole
+filesystem) — a real silent boundary-widening, now refused in `resolve_var` (extracted as a
+pure seam so the rejection is unit-tested without mutating process env). Both flagged the
+`$HOME`-non-UTF-8 error conflating "set but not UTF-8" with "not set"; now distinguished.
+And on the bare-`$` question the two reviewers split — DeepSeek called shell-style
+passthrough fine, Gemini argued a stray `$` in a boundary path masks a typo and there's no
+way to write a literal `$`. Took Gemini's stricter line as the better fit for "silent
+fallbacks are a mistake": `$$` now escapes a literal `$`, and any other stray `$` is an
+error.
 
 **Scoped to the boundary knobs (`root` / `allow_paths`), not every path field.** `[context]`
 `user_files` and the key-file paths still tilde-only; extending them is consistency work,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -224,9 +224,8 @@ would. Scoped out of the temp-read change deliberately (those two callers are in
 today; switching them to `expand_path` means threading `Result` through `merge_context`
 and the credential loader). Extend them to `expand_path` for one uniform rule — then a user
 never has to remember "env vars work here but not there." Low risk, mechanical; the only
-care is keeping the undefined-var error loud at load. Also unbuilt: escaping a literal `$`
-(today a path named `$foo` isn't expressible in config; a `\$` / `$$` escape would close it
-if anyone hits it).
+care is keeping the undefined/empty/non-UTF-8 errors loud at load (and that the extended
+callers get the same `$$`-escape + stray-`$`-is-error rules `expand_env_vars` enforces).
 
 ### Expand the `kaibo://config` `[runtime]` section beyond followed worktrees
 The config resource grew a `[runtime]` table for state that's *computed at read

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -215,6 +215,19 @@ the scripted `CompletionClient` (`test_support.rs`) is the natural guard.
 
 ## P3 — Infra, perf, polish
 
+### Path expansion is inconsistent: `$VAR` only in `root` / `allow_paths`
+`expand_path` (`config.rs`) expands `$VAR` / `${VAR}` and a leading `~` for the boundary
+knobs (`root`, `allow_paths`), but `[context]` `user_files` (`merge_context`) and the
+key-file paths (`api_key_file`) still go through `expand_tilde` — tilde only. So
+`user_files = ["$XDG_CONFIG_HOME/notes.md"]` silently fails to expand where `allow_paths`
+would. Scoped out of the temp-read change deliberately (those two callers are infallible
+today; switching them to `expand_path` means threading `Result` through `merge_context`
+and the credential loader). Extend them to `expand_path` for one uniform rule — then a user
+never has to remember "env vars work here but not there." Low risk, mechanical; the only
+care is keeping the undefined-var error loud at load. Also unbuilt: escaping a literal `$`
+(today a path named `$foo` isn't expressible in config; a `\$` / `$$` escape would close it
+if anyone hits it).
+
 ### Expand the `kaibo://config` `[runtime]` section beyond followed worktrees
 The config resource grew a `[runtime]` table for state that's *computed at read
 time* rather than configured — currently `follow_worktrees` (the knob) and

--- a/src/config.rs
+++ b/src/config.rs
@@ -1991,17 +1991,47 @@ fn expand_tilde(s: &str) -> PathBuf {
 /// *via the `~` form* (`expand_tilde` uses `var_os`); `$HOME` spelled out goes through
 /// UTF-8 `std::env::var`, so on the rare non-UTF-8 home, write `~`. This is
 /// what lets a user write the environment-portable `allow_paths = ["$TMPDIR"]` /
-/// `["$XDG_RUNTIME_DIR/scratch"]` instead of hardcoding a host-specific `/tmp`. A bare
-/// `$` not forming a reference (followed by a non-name char) is left literal, shell-style;
-/// a path that genuinely contains `$name` would be read as a reference — an accepted,
-/// documented limitation (no escaping yet).
+/// `["$XDG_RUNTIME_DIR/scratch"]` instead of hardcoding a host-specific `/tmp`. `$$` writes
+/// a literal `$`; a stray `$` that begins no reference is a loud error rather than a silent
+/// literal (a typo in a boundary path is worth catching), as is a set-but-empty or
+/// non-UTF-8 variable — an empty segment must never silently re-anchor the path.
 fn expand_path(s: &str) -> anyhow::Result<PathBuf> {
     Ok(expand_tilde(&expand_env_vars(s)?))
 }
 
-/// Substitute `$VAR` and `${VAR}` from the process environment. Undefined → loud error
-/// (see [`expand_path`]). A `$` that doesn't begin a `{` or a valid name char is emitted
-/// verbatim. `[A-Za-z_][A-Za-z0-9_]*` is the accepted name shape, matching POSIX.
+/// Resolve one variable lookup to its value, refusing the two set-but-unusable cases that
+/// would otherwise misplace the read boundary *silently*. Pure (the lookup result is passed
+/// in) so the boundary-relevant rejections are unit-testable without mutating process env.
+///
+/// - **Set but empty** (`Ok("")`): an empty segment re-anchors the path — `$EMPTY/scratch`
+///   collapses to `/scratch`, `$EMPTY/` to `/` (the whole filesystem root). `undefined →
+///   error` doesn't catch this because an empty var *is* defined, so it's refused here.
+/// - **Set but non-UTF-8** (`Err(NotUnicode)`): reported accurately instead of as "not set"
+///   (the variable *is* set), pointing at `~` which handles a non-UTF-8 home via `var_os`.
+fn resolve_var(name: &str, full: &str, value: Result<String, std::env::VarError>) -> anyhow::Result<String> {
+    use std::env::VarError;
+    match value {
+        Ok(v) if v.is_empty() => bail!(
+            "path {full:?} references environment variable ${name}, which is set but empty \
+             — an empty segment would re-anchor the path (`$EMPTY/x` → `/x`, `$EMPTY/` → \
+             `/`), so it's refused"
+        ),
+        Ok(v) => Ok(v),
+        Err(VarError::NotPresent) => bail!(
+            "path {full:?} references environment variable ${name}, which is not set \
+             — set it, or write the literal path"
+        ),
+        Err(VarError::NotUnicode(_)) => bail!(
+            "path {full:?} references environment variable ${name}, which is set but not \
+             valid UTF-8 — spell it `~` if it's your home dir, else give it a UTF-8 value"
+        ),
+    }
+}
+
+/// Substitute `$VAR` and `${VAR}` from the process environment. Undefined / empty /
+/// non-UTF-8 → loud error (see [`resolve_var`]). `$$` escapes a literal `$`; a stray `$`
+/// that begins no reference is also a loud error, never a silent literal — in a boundary
+/// path it's a typo worth catching. `[A-Za-z_][A-Za-z0-9_]*` is the accepted name shape.
 fn expand_env_vars(s: &str) -> anyhow::Result<String> {
     fn is_start(c: char) -> bool {
         c.is_ascii_alphabetic() || c == '_'
@@ -2010,16 +2040,8 @@ fn expand_env_vars(s: &str) -> anyhow::Result<String> {
         c.is_ascii_alphanumeric() || c == '_'
     }
     fn lookup(out: &mut String, name: &str, full: &str) -> anyhow::Result<()> {
-        match std::env::var(name) {
-            Ok(val) => {
-                out.push_str(&val);
-                Ok(())
-            }
-            Err(_) => bail!(
-                "path {full:?} references environment variable ${name}, which is not set \
-                 — set it, or write the literal path"
-            ),
-        }
+        out.push_str(&resolve_var(name, full, std::env::var(name))?);
+        Ok(())
     }
 
     let mut out = String::with_capacity(s.len());
@@ -2030,6 +2052,11 @@ fn expand_env_vars(s: &str) -> anyhow::Result<String> {
             continue;
         }
         match chars.peek().copied() {
+            // `$$` is the escape for a literal `$` — the only way to put one in a path.
+            Some('$') => {
+                chars.next();
+                out.push('$');
+            }
             Some('{') => {
                 chars.next(); // consume '{'
                 let mut name = String::new();
@@ -2073,8 +2100,13 @@ fn expand_env_vars(s: &str) -> anyhow::Result<String> {
                 }
                 lookup(&mut out, &name, s)?;
             }
-            // A lone '$' (end of string, or followed by a non-name char) is literal.
-            _ => out.push('$'),
+            // A `$` that begins no reference and isn't escaped is a loud error, not a
+            // silent literal — a stray `$` in a boundary path (`$1`, `$ `, a mistyped
+            // `${...}`, a trailing `$`) is a typo, and keeping it silently would mask it.
+            _ => bail!(
+                "path {s:?} has a stray '$' — write `$$` for a literal '$', or \
+                 `$NAME` / `${{NAME}}` to expand a variable"
+            ),
         }
     }
     Ok(out)
@@ -2145,6 +2177,11 @@ mod tests {
             // loud parse error (not the misleading "not set" the env lookup would give).
             "${1bad}".to_string(),     // can't start with a digit
             "${A/B}".to_string(),      // `/` is not a name char
+            // A stray `$` that begins no reference is a typo in a boundary path, refused
+            // rather than kept as a silent literal. Write `$$` for a real literal `$`.
+            "/a/$ b".to_string(),      // `$` followed by a space
+            "/cost/$100".to_string(),  // `$` followed by a digit
+            "trailing$".to_string(),   // `$` at end of string
         ] {
             assert!(
                 expand_env_vars(&bad).is_err(),
@@ -2153,20 +2190,36 @@ mod tests {
         }
     }
 
-    /// A `$` that doesn't begin a valid reference is left literal (shell-style), and a
-    /// path with no `$` at all is untouched. A bare `$1` / `$$` is *not* a reference (the
-    /// next char isn't a name-start), so it passes through — only the braced `${...}` form
-    /// treats a bad name as an error.
+    /// `$$` is the escape for a literal `$` — the only way to put one in a path — and a
+    /// path with no `$` is untouched. (A stray, unescaped `$` errors; that's covered by
+    /// `expand_env_vars_undefined_or_malformed_is_loud`.)
     #[test]
-    fn expand_env_vars_leaves_bare_dollar_and_plain_paths_alone() {
-        assert_eq!(expand_env_vars("/a/$ b").unwrap(), "/a/$ b");
-        assert_eq!(expand_env_vars("/cost/$100").unwrap(), "/cost/$100");
-        // `$$` where neither `$` is followed by a name-start char stays literal. (A `$`
-        // *is* a name-start nowhere, so `$$x` would instead try to expand `$x` — the
-        // second `$` is literal, the `x` names a var; that's deliberate, not tested here.)
-        assert_eq!(expand_env_vars("$$ ").unwrap(), "$$ ");
-        assert_eq!(expand_env_vars("trailing$").unwrap(), "trailing$");
+    fn expand_env_vars_double_dollar_escapes_a_literal_dollar() {
+        assert_eq!(expand_env_vars("a$$b").unwrap(), "a$b");
+        assert_eq!(expand_env_vars("/cost/$$100").unwrap(), "/cost/$100");
+        assert_eq!(expand_env_vars("$$").unwrap(), "$");
         assert_eq!(expand_env_vars("/data/fixtures").unwrap(), "/data/fixtures");
+    }
+
+    /// `resolve_var` refuses the two set-but-unusable cases that would silently misplace
+    /// the boundary — empty value (`$EMPTY/` → `/`) and non-UTF-8 — while a normal value
+    /// passes. Pure, so this has teeth without mutating process env (which would race the
+    /// parallel suite, and is `unsafe` besides).
+    #[test]
+    fn resolve_var_refuses_empty_and_non_utf8() {
+        use std::env::VarError;
+        use std::ffi::OsString;
+
+        assert_eq!(resolve_var("X", "$X", Ok("/tmp/scratch".into())).unwrap(), "/tmp/scratch");
+        assert!(
+            resolve_var("X", "$X", Ok(String::new())).is_err(),
+            "a set-but-empty variable must be refused — an empty segment re-anchors the path"
+        );
+        assert!(resolve_var("X", "$X", Err(VarError::NotPresent)).is_err());
+        assert!(
+            resolve_var("X", "$X", Err(VarError::NotUnicode(OsString::from("x")))).is_err(),
+            "a set-but-non-UTF-8 variable must be refused (not reported as 'not set')"
+        );
     }
 
     /// `expand_path` composes env expansion *then* tilde: `$HOME` and `~` reach the same

--- a/src/config.rs
+++ b/src/config.rs
@@ -1987,7 +1987,9 @@ fn expand_tilde(s: &str) -> PathBuf {
 /// surprising (crashing beats data corruption): a typo'd `$TMPDR` fails at load, not by
 /// quietly granting `/`. Env expansion runs *first* so a leading `~` in a variable's
 /// *value* is still expanded (`MYDIR=~/data; allow_paths=["$MYDIR"]` works), and so the
-/// tilde step keeps operating on an `OsString` `$HOME` (non-UTF-8 homes survive). This is
+/// tilde step still resolves `~` through an `OsString` `$HOME` — a non-UTF-8 home survives
+/// *via the `~` form* (`expand_tilde` uses `var_os`); `$HOME` spelled out goes through
+/// UTF-8 `std::env::var`, so on the rare non-UTF-8 home, write `~`. This is
 /// what lets a user write the environment-portable `allow_paths = ["$TMPDIR"]` /
 /// `["$XDG_RUNTIME_DIR/scratch"]` instead of hardcoding a host-specific `/tmp`. A bare
 /// `$` not forming a reference (followed by a non-name char) is left literal, shell-style;
@@ -2036,6 +2038,18 @@ fn expand_env_vars(s: &str) -> anyhow::Result<String> {
                     if nc == '}' {
                         closed = true;
                         break;
+                    }
+                    // Validate as we collect, so `${/tmp}` is a clear "invalid name"
+                    // error rather than the misleading "not set" the env lookup would
+                    // give — and so both reference forms agree on what a name is. (The
+                    // braced form *is* an explicit expansion request, so a bad name is an
+                    // error here, unlike a bare `$1` which is simply not a reference.)
+                    let ok = if name.is_empty() { is_start(nc) } else { is_continue(nc) };
+                    if !ok {
+                        bail!(
+                            "path {s:?} has an invalid character {nc:?} in a ${{...}} \
+                             reference — names are [A-Za-z_][A-Za-z0-9_]*"
+                        );
                     }
                     name.push(nc);
                 }
@@ -2107,6 +2121,10 @@ mod tests {
         assert_eq!(expand_env_vars("${HOME}/src").unwrap(), format!("{home}/src"));
         // A reference mid-path, and back-to-back text.
         assert_eq!(expand_env_vars("/x/${HOME}y").unwrap(), format!("/x/{home}y"));
+        // Adjacent references concatenate; the second `$` ends the first name and starts
+        // a new reference (`is_continue` ⊇ `is_start`, so the name loop is well-behaved).
+        assert_eq!(expand_env_vars("$HOME$HOME").unwrap(), format!("{home}{home}"));
+        assert_eq!(expand_env_vars("${HOME}${HOME}").unwrap(), format!("{home}{home}"));
     }
 
     /// An undefined variable is a loud error, not a silent empty segment — the property
@@ -2119,10 +2137,14 @@ mod tests {
         assert!(std::env::var(unset).is_err(), "test precondition: {unset} unset");
 
         for bad in [
-            format!("${unset}"),
-            format!("${{{unset}}}"),
+            format!("${unset}"),       // bare form, undefined
+            format!("${{{unset}}}"),   // braced form, undefined
             "${UNTERMINATED".to_string(),
             "${}".to_string(),
+            // The braced form is an explicit expansion request, so an invalid name is a
+            // loud parse error (not the misleading "not set" the env lookup would give).
+            "${1bad}".to_string(),     // can't start with a digit
+            "${A/B}".to_string(),      // `/` is not a name char
         ] {
             assert!(
                 expand_env_vars(&bad).is_err(),
@@ -2132,11 +2154,18 @@ mod tests {
     }
 
     /// A `$` that doesn't begin a valid reference is left literal (shell-style), and a
-    /// path with no `$` at all is untouched.
+    /// path with no `$` at all is untouched. A bare `$1` / `$$` is *not* a reference (the
+    /// next char isn't a name-start), so it passes through — only the braced `${...}` form
+    /// treats a bad name as an error.
     #[test]
     fn expand_env_vars_leaves_bare_dollar_and_plain_paths_alone() {
         assert_eq!(expand_env_vars("/a/$ b").unwrap(), "/a/$ b");
         assert_eq!(expand_env_vars("/cost/$100").unwrap(), "/cost/$100");
+        // `$$` where neither `$` is followed by a name-start char stays literal. (A `$`
+        // *is* a name-start nowhere, so `$$x` would instead try to expand `$x` — the
+        // second `$` is literal, the `x` names a var; that's deliberate, not tested here.)
+        assert_eq!(expand_env_vars("$$ ").unwrap(), "$$ ");
+        assert_eq!(expand_env_vars("trailing$").unwrap(), "trailing$");
         assert_eq!(expand_env_vars("/data/fixtures").unwrap(), "/data/fixtures");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -989,17 +989,19 @@ impl Config {
         let tools = merge_tools(server.tools.unwrap_or_default());
         let default_cast = server.cast.unwrap_or_else(|| "anthropic".to_string());
         let log = server.log.unwrap_or_else(|| "kaibo=info".to_string());
-        // Tilde-expand `root` and `allow_paths` (file *and* env layers both land here
-        // as strings), so a hand-edited `~/src` resolves to `$HOME/src` like key files
-        // and `[context]` paths already do — rather than a literal `~` that fails
-        // canonicalization at startup. Absolute/relative paths pass through unchanged.
-        let root = server.root.as_deref().map(expand_tilde);
+        // Expand `$VAR`/`${VAR}` and a leading `~` in `root` / `allow_paths` (file *and*
+        // env layers both land here as strings), so a hand-edited `~/src` or the portable
+        // `$TMPDIR` / `$XDG_RUNTIME_DIR/scratch` resolves per-environment rather than a
+        // literal token that fails canonicalization at startup. An undefined variable is a
+        // loud load error (`expand_path`), not a silent empty segment. Absolute/relative
+        // paths with no `~`/`$` pass through unchanged.
+        let root = server.root.as_deref().map(expand_path).transpose()?;
         let allow_paths = server
             .allow_paths
             .unwrap_or_default()
             .iter()
-            .map(|s| expand_tilde(s))
-            .collect();
+            .map(|s| expand_path(s))
+            .collect::<anyhow::Result<Vec<_>>>()?;
         let follow_worktrees = server.follow_worktrees.unwrap_or(true);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default());
@@ -1979,6 +1981,91 @@ fn expand_tilde(s: &str) -> PathBuf {
     PathBuf::from(s)
 }
 
+/// Expand `$VAR` / `${VAR}` references *and* a leading `~`, in that order — the
+/// portable path form for `root` / `allow_paths`. An undefined variable is a **loud
+/// error**, never a silent empty segment that would point the read boundary somewhere
+/// surprising (crashing beats data corruption): a typo'd `$TMPDR` fails at load, not by
+/// quietly granting `/`. Env expansion runs *first* so a leading `~` in a variable's
+/// *value* is still expanded (`MYDIR=~/data; allow_paths=["$MYDIR"]` works), and so the
+/// tilde step keeps operating on an `OsString` `$HOME` (non-UTF-8 homes survive). This is
+/// what lets a user write the environment-portable `allow_paths = ["$TMPDIR"]` /
+/// `["$XDG_RUNTIME_DIR/scratch"]` instead of hardcoding a host-specific `/tmp`. A bare
+/// `$` not forming a reference (followed by a non-name char) is left literal, shell-style;
+/// a path that genuinely contains `$name` would be read as a reference — an accepted,
+/// documented limitation (no escaping yet).
+fn expand_path(s: &str) -> anyhow::Result<PathBuf> {
+    Ok(expand_tilde(&expand_env_vars(s)?))
+}
+
+/// Substitute `$VAR` and `${VAR}` from the process environment. Undefined → loud error
+/// (see [`expand_path`]). A `$` that doesn't begin a `{` or a valid name char is emitted
+/// verbatim. `[A-Za-z_][A-Za-z0-9_]*` is the accepted name shape, matching POSIX.
+fn expand_env_vars(s: &str) -> anyhow::Result<String> {
+    fn is_start(c: char) -> bool {
+        c.is_ascii_alphabetic() || c == '_'
+    }
+    fn is_continue(c: char) -> bool {
+        c.is_ascii_alphanumeric() || c == '_'
+    }
+    fn lookup(out: &mut String, name: &str, full: &str) -> anyhow::Result<()> {
+        match std::env::var(name) {
+            Ok(val) => {
+                out.push_str(&val);
+                Ok(())
+            }
+            Err(_) => bail!(
+                "path {full:?} references environment variable ${name}, which is not set \
+                 — set it, or write the literal path"
+            ),
+        }
+    }
+
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek().copied() {
+            Some('{') => {
+                chars.next(); // consume '{'
+                let mut name = String::new();
+                let mut closed = false;
+                for nc in chars.by_ref() {
+                    if nc == '}' {
+                        closed = true;
+                        break;
+                    }
+                    name.push(nc);
+                }
+                if !closed {
+                    bail!("path {s:?} has an unterminated ${{...}} reference");
+                }
+                if name.is_empty() {
+                    bail!("path {s:?} has an empty ${{}} reference");
+                }
+                lookup(&mut out, &name, s)?;
+            }
+            Some(nc) if is_start(nc) => {
+                let mut name = String::new();
+                while let Some(&nc) = chars.peek() {
+                    if is_continue(nc) {
+                        name.push(nc);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                lookup(&mut out, &name, s)?;
+            }
+            // A lone '$' (end of string, or followed by a non-name char) is literal.
+            _ => out.push('$'),
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2005,6 +2092,67 @@ mod tests {
                 "{verbatim:?} must pass through unchanged"
             );
         }
+    }
+
+    // --- expand_env_vars / expand_path ---------------------------------------
+
+    /// `$VAR` and `${VAR}` resolve from the environment; both spellings agree. Uses
+    /// `HOME` (always set in the test env) as the live variable so the test doesn't
+    /// mutate process env — which would race the parallel suite.
+    #[test]
+    fn expand_env_vars_resolves_both_spellings() {
+        let home = std::env::var("HOME").expect("HOME set in test env");
+
+        assert_eq!(expand_env_vars("$HOME/src").unwrap(), format!("{home}/src"));
+        assert_eq!(expand_env_vars("${HOME}/src").unwrap(), format!("{home}/src"));
+        // A reference mid-path, and back-to-back text.
+        assert_eq!(expand_env_vars("/x/${HOME}y").unwrap(), format!("/x/{home}y"));
+    }
+
+    /// An undefined variable is a loud error, not a silent empty segment — the property
+    /// that keeps a typo'd `$TMPDR` from quietly widening the read boundary. Covers the
+    /// bare form, the braced form, and the malformed `${` / `${}` shapes.
+    #[test]
+    fn expand_env_vars_undefined_or_malformed_is_loud() {
+        // A name we can be confident is unset in any sane test environment.
+        let unset = "KAIBO_DEFINITELY_UNSET_VAR_9Q";
+        assert!(std::env::var(unset).is_err(), "test precondition: {unset} unset");
+
+        for bad in [
+            format!("${unset}"),
+            format!("${{{unset}}}"),
+            "${UNTERMINATED".to_string(),
+            "${}".to_string(),
+        ] {
+            assert!(
+                expand_env_vars(&bad).is_err(),
+                "{bad:?} must fail loudly, not expand to a silent gap"
+            );
+        }
+    }
+
+    /// A `$` that doesn't begin a valid reference is left literal (shell-style), and a
+    /// path with no `$` at all is untouched.
+    #[test]
+    fn expand_env_vars_leaves_bare_dollar_and_plain_paths_alone() {
+        assert_eq!(expand_env_vars("/a/$ b").unwrap(), "/a/$ b");
+        assert_eq!(expand_env_vars("/cost/$100").unwrap(), "/cost/$100");
+        assert_eq!(expand_env_vars("/data/fixtures").unwrap(), "/data/fixtures");
+    }
+
+    /// `expand_path` composes env expansion *then* tilde: `$HOME` and `~` reach the same
+    /// place, and `~` still works when no variable is present (the boundary knobs depend
+    /// on both forms resolving).
+    #[test]
+    fn expand_path_does_env_then_tilde() {
+        let home = std::env::var("HOME").expect("HOME set in test env");
+        let home = home.trim_end_matches('/');
+
+        assert_eq!(expand_path("~/src").unwrap(), PathBuf::from(format!("{home}/src")));
+        assert_eq!(expand_path("$HOME/src").unwrap(), PathBuf::from(format!("{home}/src")));
+        assert_eq!(expand_path("/data/fixtures").unwrap(), PathBuf::from("/data/fixtures"));
+        // Undefined variable propagates as an error through expand_path, not a panic.
+        assert!(expand_path("$KAIBO_DEFINITELY_UNSET_VAR_9Q/x").is_err());
     }
 
     // --- built-in equivalence -------------------------------------------------

--- a/src/server.rs
+++ b/src/server.rs
@@ -646,7 +646,9 @@ impl KaiboHandler {
                 "path {} resolves to {}, which is outside the allowed set [{}]. \
                  To widen the boundary: pass --allow-path DIR on the command line, \
                  set KAIBO_ALLOW_PATHS=DIR (colon-separated), or add \
-                 `[server] allow_paths = [\"DIR\"]` in config.toml.",
+                 `[server] allow_paths = [\"DIR\"]` in config.toml. The config and env \
+                 forms expand `$VAR` / `${{VAR}}` and a leading `~`, so a scratch dir \
+                 reads portably as `\"$TMPDIR\"` / `\"$XDG_RUNTIME_DIR/...\"`.",
                 raw.display(),
                 canon.display(),
                 trees.join(", "),
@@ -1744,7 +1746,16 @@ default.
 (`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
 the secret stays outside it. Tell me which env vars to set or files to write, and let \
 me put the keys in myself.
-5. When the file is written, remind me to reconnect the kaibo MCP server so it re-reads \
+5. (Optional) Read scope. By default kaibo reads only the project tree it's pointed at \
+(plus linked git worktrees), and it only ever *reads* — never writes. If a workflow \
+hands kaibo artifacts to read from a scratch space — a diff, a generated file, a log \
+dropped in a temp dir — name that space in `[server] allow_paths` so it's in bounds. \
+Prefer the host-portable form `allow_paths = [\"$TMPDIR\"]` or \
+`[\"$XDG_RUNTIME_DIR/scratch\"]` over a hardcoded `/tmp` — `$VAR` / `${VAR}` and a \
+leading `~` expand in these paths, resolving per machine. Ask me whether I want a scratch \
+space readable before adding one: it widens what the team can see (read-only, but still a \
+real boundary), so it's a deliberate opt-in, not a default.
+6. When the file is written, remind me to reconnect the kaibo MCP server so it re-reads \
 the config and keys — both load once at startup.";
 
 /// The prompts kaibo advertises (`list_prompts`). Currently just `configure`.


### PR DESCRIPTION
## Why

"Can a user easily allow kaibo to read `/tmp`?" The widening knobs already existed (`--allow-path` / `KAIBO_ALLOW_PATHS` / `[server] allow_paths`), but the *path* you had to write was host-specific — a literal `/tmp` is wrong on macOS (per-user `/var/folders/...`) and on sandboxed Linux (`$XDG_RUNTIME_DIR`). kaibo already followed XDG for its config file but carried no XDG/POSIX awareness into the read boundary.

## What

`root` / `allow_paths` now expand `$VAR` / `${VAR}` on top of the leading `~` they already did, so a scratch space resolves per-host:

```toml
[server]
allow_paths = ["~/src", "$TMPDIR", "$XDG_RUNTIME_DIR/kaibo"]
```

The full surface ships together so a user meets the idiom wherever they hit the boundary:
- **Core** — `expand_path` / `expand_env_vars` in `config.rs`, wired into the `root` / `allow_paths` merge. Env-first-then-tilde ordering; an **undefined variable is a loud load error**, never a silent gap that could misplace the boundary.
- **`configure` prompt** — gained an opt-in read-scope step teaching the portable `$TMPDIR` / `$XDG_RUNTIME_DIR` form and the read-only-but-real tradeoff.
- **Containment error** — now names the portable form when a path lands out of bounds.
- **Docs** — `docs/config.md` documents expansion + the scratch-read workflow; `CHANGELOG.md`, `docs/devlog.md` updated.

## Decisions

- **General `$VAR` over a curated temp-var set or `--allow-tmp` knob** — least-surprising to shell users, costs no more, and `$TMPDIR`/`$XDG_RUNTIME_DIR`/`$HOME` all fall out.
- **Scoped to the boundary knobs.** `[context]` `user_files` and key-file paths stay tilde-only (they're infallible today; converting means threading `Result` through their loaders) — logged in `docs/issues.md` as consistency follow-up rather than smuggled in.
- **Opt-in, never default.** Widening to a shared, world-writable `/tmp` is a real (read-only) boundary move, so kaibo never adds it for you.

## Review (cross-family, per house rule)

- **DeepSeek V4 Pro** (`consult` over the diff — kaibo dogfooding its own review path): cleared the security properties (undefined-var-is-loud holds; canonicalize + `is_dir` + `starts_with` stay the defense in depth). Three low-risk findings folded in commit `dd8cc13`: `${...}` name validation, a doc-comment accuracy fix, and added parser tests (adjacent refs, literal `$$`, brace-name validation).
- **Gemini 3.1 Pro** (batch lane): ⏳ in flight — will fold any further findings before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)