### PR TITLE
Expand $VAR/${VAR} uniformly: user_files and api_key_file, not just root/allow_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,9 +88,13 @@ the git log. Each later release appends a new section at the top.
   and still land on the project. The scope handshake and `kaibo://config` tag the
   root as inferred. An `--allow-path` that excludes the cwd leaves no default root —
   kaibo never defaults to a path its own containment check would reject.
-- **`~` *and* `$VAR` / `${VAR}` expand in `[server] root` and `allow_paths`**
-  (config-file and `KAIBO_*` env layers), matching the tilde handling key files and
-  `[context]` paths already get. Set `allow_paths = ["~/src"]` once and every project
+- **`~` *and* `$VAR` / `${VAR}` expand in every config path — `[server] root`,
+  `allow_paths`, `[context] user_files`, and a backend's `api_key_file`** (config-file
+  and `KAIBO_*` env layers). One uniform rule: you never have to remember "env vars work
+  here but not there." `user_files = ["$XDG_CONFIG_HOME/notes.md"]` and
+  `api_key_file = "$XDG_CONFIG_HOME/keys/anthropic"` now resolve per-environment instead
+  of failing on a literal `$` (those two were previously tilde-only). Set
+  `allow_paths = ["~/src"]` once and every project
   under it is in-bounds — with cwd inferred as the default root, you stop thinking about
   `path` entirely. (Previously a literal `~` was taken verbatim and failed
   canonicalization at startup.) Environment variables make a scratch space portable:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -215,18 +215,6 @@ the scripted `CompletionClient` (`test_support.rs`) is the natural guard.
 
 ## P3 — Infra, perf, polish
 
-### Path expansion is inconsistent: `$VAR` only in `root` / `allow_paths`
-`expand_path` (`config.rs`) expands `$VAR` / `${VAR}` and a leading `~` for the boundary
-knobs (`root`, `allow_paths`), but `[context]` `user_files` (`merge_context`) and the
-key-file paths (`api_key_file`) still go through `expand_tilde` — tilde only. So
-`user_files = ["$XDG_CONFIG_HOME/notes.md"]` silently fails to expand where `allow_paths`
-would. Scoped out of the temp-read change deliberately (those two callers are infallible
-today; switching them to `expand_path` means threading `Result` through `merge_context`
-and the credential loader). Extend them to `expand_path` for one uniform rule — then a user
-never has to remember "env vars work here but not there." Low risk, mechanical; the only
-care is keeping the undefined/empty/non-UTF-8 errors loud at load (and that the extended
-callers get the same `$$`-escape + stray-`$`-is-error rules `expand_env_vars` enforces).
-
 ### Expand the `kaibo://config` `[runtime]` section beyond followed worktrees
 The config resource grew a `[runtime]` table for state that's *computed at read
 time* rather than configured — currently `follow_worktrees` (the knob) and

--- a/src/config.rs
+++ b/src/config.rs
@@ -898,7 +898,9 @@ impl Config {
         // `Result`. Absolute/plain paths pass through unchanged.
         for b in backends.values_mut() {
             if let Some(f) = b.api_key_file.as_deref() {
-                b.api_key_file = Some(expand_path(f)?.to_string_lossy().into_owned());
+                let expanded = expand_path(f)?;
+                let what = format!("backend {:?} api_key_file", b.name);
+                b.api_key_file = Some(expanded_to_utf8(expanded, &what)?);
             }
         }
 
@@ -2018,6 +2020,19 @@ fn expand_path(s: &str) -> anyhow::Result<PathBuf> {
     Ok(expand_tilde(&expand_env_vars(s)?))
 }
 
+/// Convert an [`expand_path`] result back to an owned `String` for the few fields stored
+/// as text (a backend's `api_key_file`), failing **loudly** on a non-UTF-8 result rather
+/// than lossily mangling it. The `~` form expands `$HOME` through `var_os`, so a non-UTF-8
+/// home survives into the `PathBuf` (see `expand_path`'s note); a `to_string_lossy` there
+/// would replace those bytes with U+FFFD and the key file would mis-resolve as "absent" —
+/// a silent corruption. Paths kept as `PathBuf` (`root`/`allow_paths`/`user_files`) don't
+/// need this; they carry the bytes intact.
+fn expanded_to_utf8(p: PathBuf, what: &str) -> anyhow::Result<String> {
+    p.into_os_string().into_string().map_err(|os| {
+        anyhow!("{what} expanded to a non-UTF-8 path ({os:?}); write it in UTF-8")
+    })
+}
+
 /// Resolve one variable lookup to its value, refusing the two set-but-unusable cases that
 /// would otherwise misplace the read boundary *silently*. Pure (the lookup result is passed
 /// in) so the boundary-relevant rejections are unit-testable without mutating process env.
@@ -2254,6 +2269,25 @@ mod tests {
         assert_eq!(expand_path("/data/fixtures").unwrap(), PathBuf::from("/data/fixtures"));
         // Undefined variable propagates as an error through expand_path, not a panic.
         assert!(expand_path("$KAIBO_DEFINITELY_UNSET_VAR_9Q/x").is_err());
+    }
+
+    /// The expanded-path → `String` conversion rejects a non-UTF-8 result loudly rather
+    /// than lossily mangling it (a non-UTF-8 `$HOME` reached via a `~` path would become
+    /// U+FFFD bytes and mis-resolve at key time — a silent corruption we refuse). A normal
+    /// path round-trips byte-for-byte.
+    #[cfg(unix)]
+    #[test]
+    fn expanded_to_utf8_rejects_non_utf8_loudly() {
+        use std::os::unix::ffi::OsStringExt;
+        let bad = PathBuf::from(std::ffi::OsString::from_vec(vec![b'/', 0xFF, 0xFE]));
+        assert!(
+            expanded_to_utf8(bad, "test").is_err(),
+            "a non-UTF-8 expanded path must fail loudly, not lossily convert"
+        );
+        assert_eq!(
+            expanded_to_utf8(PathBuf::from("/home/u/.key"), "test").unwrap(),
+            "/home/u/.key"
+        );
     }
 
     // --- uniform $VAR expansion: [context] user_files + backend api_key_file ----

--- a/src/config.rs
+++ b/src/config.rs
@@ -305,7 +305,8 @@ pub struct Backend {
     pub base_url: Option<String>,
     /// Env var to read the API key from (checked before `api_key_file`).
     pub api_key_env: Option<String>,
-    /// Key-file path (`~` expanded). Used when the env var is unset/blank.
+    /// Key-file path, stored already `$VAR`/`~`-expanded (resolved once at load in
+    /// `from_toml_str`). Used when the env var is unset/blank.
     pub api_key_file: Option<String>,
     /// When true, a missing key falls back to a placeholder bearer token instead of
     /// erroring (the keyless local-server case).
@@ -342,8 +343,9 @@ impl Backend {
             }
         }
 
-        // then a configured key file, *if it exists*.
-        if let Some(file) = self.api_key_file.as_deref().map(expand_tilde) {
+        // then a configured key file, *if it exists*. The path was `$VAR`/`~`-expanded
+        // once at load (see `from_toml_str`), so it's used verbatim here.
+        if let Some(file) = self.api_key_file.as_deref().map(PathBuf::from) {
             if file.exists() {
                 // env already handled above, so pass None — `resolve` reads the file
                 // and errors loudly on empty/unreadable (for keyed AND keyless).
@@ -396,8 +398,9 @@ impl Backend {
                 }
             }
         }
-        // then a configured key file, if it exists (contents unread — see above).
-        if let Some(file) = self.api_key_file.as_deref().map(expand_tilde) {
+        // then a configured key file, if it exists (contents unread — see above). The
+        // path was `$VAR`/`~`-expanded once at load, so it's used verbatim here.
+        if let Some(file) = self.api_key_file.as_deref().map(PathBuf::from) {
             if file.exists() {
                 return KeyStatus::Present;
             }
@@ -886,6 +889,19 @@ impl Config {
             }
         }
 
+        // Expand `$VAR`/`${VAR}` and a leading `~` in each backend's `api_key_file` — the
+        // same uniform rule `root`/`allow_paths` get, so a portable `$XDG_CONFIG_HOME/key`
+        // (or the built-in `~/.gemini-api-key`) resolves per-environment. Done once here,
+        // loudly on an undefined/empty/non-UTF-8 variable, so the use-sites
+        // (`resolve_key`/`key_status`) read an already-resolved path and stay infallible —
+        // `key_status` feeds the offline cast-usability classifiers, which can't take a
+        // `Result`. Absolute/plain paths pass through unchanged.
+        for b in backends.values_mut() {
+            if let Some(f) = b.api_key_file.as_deref() {
+                b.api_key_file = Some(expand_path(f)?.to_string_lossy().into_owned());
+            }
+        }
+
         // Backend aliases: built-ins first, then file-declared. Collisions are loud,
         // per level.
         let mut backend_aliases: BTreeMap<String, String> = BTreeMap::new();
@@ -1004,7 +1020,7 @@ impl Config {
             .collect::<anyhow::Result<Vec<_>>>()?;
         let follow_worktrees = server.follow_worktrees.unwrap_or(true);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
-        let context = merge_context(raw.context.unwrap_or_default());
+        let context = merge_context(raw.context.unwrap_or_default())?;
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;
         let orientation = merge_orientation(raw.orientation.unwrap_or_default())?;
         let mut sandbox = merge_sandbox(raw.sandbox.unwrap_or_default());
@@ -1652,11 +1668,14 @@ fn merge_telemetry(raw: RawTelemetry) -> Result<TelemetryConfig> {
 
 /// Resolve `[context]`. A *missing* `project_files` keeps the built-in
 /// `["AGENTS.md"]` default (vendor-neutral, opt-out by an explicit empty list);
-/// `user_files` default to empty and are tilde-expanded here so `assemble` is
-/// pure filesystem work. The files themselves are read lazily, per call, against
-/// the resolved root — not here — so a config load never touches a project.
-fn merge_context(raw: RawContext) -> ContextConfig {
-    ContextConfig {
+/// `user_files` default to empty and are `$VAR`/`~`-expanded here (via `expand_path`,
+/// the same uniform rule `root`/`allow_paths` get) so `assemble` is pure filesystem
+/// work and a portable `$XDG_CONFIG_HOME/notes.md` resolves per-environment. An
+/// undefined/empty/non-UTF-8 variable is a loud load error, not a silent gap. The files
+/// themselves are read lazily, per call, against the resolved root — not here — so a
+/// config load never touches a project.
+fn merge_context(raw: RawContext) -> anyhow::Result<ContextConfig> {
+    Ok(ContextConfig {
         project_files: raw
             .project_files
             .unwrap_or_else(|| vec!["AGENTS.md".to_string()]),
@@ -1664,9 +1683,9 @@ fn merge_context(raw: RawContext) -> ContextConfig {
             .user_files
             .unwrap_or_default()
             .iter()
-            .map(|s| expand_tilde(s))
-            .collect(),
-    }
+            .map(|s| expand_path(s))
+            .collect::<anyhow::Result<Vec<_>>>()?,
+    })
 }
 
 /// Resolve `[prompts]`. Each override is taken verbatim (full replace), but an
@@ -2235,6 +2254,64 @@ mod tests {
         assert_eq!(expand_path("/data/fixtures").unwrap(), PathBuf::from("/data/fixtures"));
         // Undefined variable propagates as an error through expand_path, not a panic.
         assert!(expand_path("$KAIBO_DEFINITELY_UNSET_VAR_9Q/x").is_err());
+    }
+
+    // --- uniform $VAR expansion: [context] user_files + backend api_key_file ----
+    //
+    // The boundary knobs (`root`/`allow_paths`) already take `$VAR`; these two paths
+    // lagged on tilde-only. One uniform rule means a user never has to remember "env
+    // vars work here but not there." Uses `$HOME` (always set) so no test mutates env.
+
+    /// `[context] user_files` expands `$VAR` *and* `~`, not tilde alone — so a portable
+    /// `$XDG_CONFIG_HOME/notes.md` resolves rather than landing as a literal token.
+    #[test]
+    fn user_files_expand_env_vars_not_just_tilde() {
+        let home = std::env::var("HOME").expect("HOME set in test env");
+        let home = home.trim_end_matches('/');
+        let cfg =
+            Config::from_toml_str("[context]\nuser_files = [\"$HOME/notes.md\", \"~/other.md\"]")
+                .unwrap();
+        assert_eq!(
+            cfg.context.user_files,
+            vec![
+                PathBuf::from(format!("{home}/notes.md")),
+                PathBuf::from(format!("{home}/other.md")),
+            ]
+        );
+    }
+
+    /// A backend's `api_key_file` expands `$VAR` too, resolved once at load (so the
+    /// use-sites stay infallible) and stored expanded.
+    #[test]
+    fn api_key_file_expands_env_vars_not_just_tilde() {
+        let home = std::env::var("HOME").expect("HOME set in test env");
+        let home = home.trim_end_matches('/');
+        let cfg =
+            Config::from_toml_str("[backends.anthropic]\napi_key_file = \"$HOME/.akey\"").unwrap();
+        let b = cfg.resolve_backend("anthropic").unwrap();
+        assert_eq!(b.api_key_file.as_deref(), Some(format!("{home}/.akey").as_str()));
+    }
+
+    /// An undefined variable in either path is a loud load error — never a silent gap
+    /// that would point a key read or a context file at the wrong place.
+    #[test]
+    fn undefined_var_in_user_files_or_api_key_file_is_loud_at_load() {
+        let unset = "KAIBO_DEFINITELY_UNSET_VAR_9Q";
+        assert!(std::env::var(unset).is_err(), "test precondition: {unset} unset");
+        assert!(
+            Config::from_toml_str(&format!(
+                "[context]\nuser_files = [\"${unset}/notes.md\"]"
+            ))
+            .is_err(),
+            "undefined var in user_files must fail at load"
+        );
+        assert!(
+            Config::from_toml_str(&format!(
+                "[backends.anthropic]\napi_key_file = \"${unset}/k\""
+            ))
+            .is_err(),
+            "undefined var in api_key_file must fail at load"
+        );
     }
 
     // --- built-in equivalence -------------------------------------------------

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,7 +13,7 @@
 //!   project root and canonicalize-checked to stay *within* it — a configured
 //!   `../escape` (or a symlink out) is refused, so the same containment that
 //!   bounds the read-only shell also bounds what gets injected.
-//! - **`user_files`** are absolute (tilde already expanded at config merge) and
+//! - **`user_files`** are absolute (`$VAR`/`~` already expanded at config merge) and
 //!   **read-required**: the operator named this file deliberately, so a missing
 //!   one is a loud error, not a silent skip. These live *outside* the sandbox's
 //!   allowed set on purpose — they're read here in trusted Rust at the server

--- a/src/context.rs
+++ b/src/context.rs
@@ -32,13 +32,13 @@ use anyhow::{bail, Context, Result};
 /// Resolved `[context]` configuration: which files to splice into preambles.
 /// Built by `config.rs::merge_context` from the on-disk `[context]` table (with
 /// `project_files` defaulting to `["AGENTS.md"]`); `user_files` arrive already
-/// tilde-expanded so `assemble` does pure filesystem work.
+/// `$VAR`/`~`-expanded so `assemble` does pure filesystem work.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ContextConfig {
     /// Root-relative files read if present (absent is normal). Default
     /// `["AGENTS.md"]`. Each must canonicalize to at-or-under the project root.
     pub project_files: Vec<String>,
-    /// Absolute files (tilde already expanded) read unconditionally — a missing
+    /// Absolute files (`$VAR`/`~` already expanded) read unconditionally — a missing
     /// one is an error, since the operator declared it. Default empty.
     pub user_files: Vec<PathBuf>,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2016,9 +2016,10 @@ fn render_config_resource(
         /// the value — the operator configured this pointer.
         #[serde(skip_serializing_if = "Option::is_none")]
         api_key_env: Option<String>,
-        /// Key file path as configured (`~` unexpanded; expansion happens at
-        /// key-resolution time). Used when the env var is unset/blank.
-        /// The PATH, not its contents.
+        /// Key file path, resolved (`$VAR`/`~` expanded once at config load), so this
+        /// shows the absolute path kaibo actually reads — consistent with how
+        /// `allowed_paths`/`default_root` render resolved here. Used when the env var is
+        /// unset/blank. The PATH, not its contents.
         #[serde(skip_serializing_if = "Option::is_none")]
         api_key_file: Option<String>,
         /// True when a missing key falls back to a placeholder (keyless endpoint).


### PR DESCRIPTION
## What

`$VAR` / `${VAR}` (not just a leading `~`) now expand in **`[context] user_files`** and a backend's **`api_key_file`**, matching what `[server] root` and `allow_paths` already do via `expand_path`. One uniform rule — a user never has to remember "env vars work here but not there." So `user_files = ["$XDG_CONFIG_HOME/notes.md"]` and `api_key_file = "$XDG_CONFIG_HOME/keys/anthropic"` resolve per-environment instead of failing on a literal `$`.

## How

- **`user_files`** — `merge_context` now returns `Result` and maps through `expand_path`; an undefined/empty/non-UTF-8 var is a loud load error. Covers the file and `KAIBO_USER_FILES` env layers (both flow through `merge_context`). CLI `--user-context-file` stays un-expanded by design — the shell expands CLI args, exactly as CLI `--allow-path`/`--root` already behave.
- **`api_key_file`** — expanded **once at load** (a `backends.values_mut()` pass after backend validation) and stored resolved, so the two use-sites (`resolve_key`, `key_status`) read a ready path and stay infallible. This matters because `key_status` feeds the offline cast-usability classifiers (`cast_usability`, `image_capable_casts`) which return enums, not `Result`s — threading a fallible expand through them would change their shape. Path-string work is pure (no file read), so use-time laziness is unaffected.

## Cross-family review found a corruption bug (second commit)

A Gemini review of the diff caught that the first cut stored the path via `to_string_lossy()`, which would **silently corrupt** a non-UTF-8 path: a non-UTF-8 `$HOME` reached via a `~` form expands through `var_os`, and lossy conversion mangles it to U+FFFD, so the key file mis-resolves as "absent." Fixed to convert through `into_string()` and fail **loudly** at load instead — the project's crash-over-corruption ethos, and what the issue asked for. Extracted `expanded_to_utf8` so the rejection is unit-tested from a synthesized non-UTF-8 `PathBuf` (no env mutation). The `$HOME` spelled-out form was already safe.

## Tests

Failing-first: `$VAR` expansion in both `user_files` and `api_key_file`, an undefined var failing at load for both, and the non-UTF-8 helper rejecting loudly. Full suite green (21 binaries), clippy clean.

Closes the path-expansion-inconsistency item in `docs/issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)