### PR TITLE
Provider failure policy: clean tool errors, retry hints, documented no-retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ the git log. Each later release appends a new section at the top.
   config, per-role reasoning effort, generous completion-token headroom).
 - **Multi-turn sessions** via `session_id`, and optional OTLP/HTTP trace export
   (`[telemetry]`, off by default).
+- **A failed provider doesn't fail your turn.** When a model or its provider misbehaves
+  (a 429/529 overload, a connection reset, a wedged backend that hits the
+  `request_timeout`), `consult`/`oneshot` return a *clean tool-result error* naming the
+  cast and the underlying detail — so the calling agent reads "the consult failed, here's
+  why" and proceeds without the second opinion, instead of its own tool call failing at
+  the protocol layer. kaibo does not retry (a consult is optional augmentation); the
+  policy is documented in the README FAQ and `docs/config.md`.
 - **Single self-contained binary** per platform; Linux builds are fully static
   (musl). TLS is rustls + ring — no OpenSSL, no aws-lc, no C toolchain.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,8 +121,11 @@ the git log. Each later release appends a new section at the top.
   `request_timeout`), `consult`/`oneshot` return a *clean tool-result error* naming the
   cast and the underlying detail — so the calling agent reads "the consult failed, here's
   why" and proceeds without the second opinion, instead of its own tool call failing at
-  the protocol layer. kaibo does not retry (a consult is optional augmentation); the
-  policy is documented in the README FAQ and `docs/config.md`.
+  the protocol layer. The message is tailored to the failure: a *transient* condition
+  (overload / rate-limit / timeout) invites a manual retry the agent can drive, a
+  non-transient one (auth / bad request) doesn't, and a kaibo-side error is named as such
+  rather than blamed on the provider. kaibo does not retry automatically (a consult is
+  optional augmentation); the policy is documented in the README FAQ and `docs/config.md`.
 - **Single self-contained binary** per platform; Linux builds are fully static
   (musl). TLS is rustls + ring — no OpenSSL, no aws-lc, no C toolchain.
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,18 @@ APIs, with keys you supply. kaish itself reaches nothing: no network, no credent
 Telemetry is off by default and, when on, only opens an *outbound* OTLP connection
 you configure.
 
+**What happens if a provider is overloaded or down (a 429/529, a reset, a wedged
+backend)?** kaibo does **not** retry — a single completion is bounded by the backend's
+`request_timeout` (default 15 min, the wall-clock for one model call) and a ≤10s
+`connect_timeout` that fails a dead endpoint fast. When a provider fails, the consult
+returns a **clean tool-result error** (`is_error`) naming the cast and the underlying
+detail, rather than a protocol-level error — because a consult is an *optional* second
+opinion, so your agent should read "the consult failed, here's why" and proceed without
+it (or call again), not have its own turn fail. Retrying is the calling agent's decision;
+if a provider is reliably slow, raise that backend's `request_timeout_secs`. (Automatic
+retry/backoff belongs in the HTTP layer — tracked as an upstream `rig` contribution in
+[`docs/issues.md`](docs/issues.md).)
+
 **What's the cost?** `consult` spends tokens on the provider behind the chosen cast. A
 family-mixing cast (cheap local explorer + hosted synth) keeps the broad, token-heavy
 sweeping cheap and pays the strong model only for the answer. The agent conversations

--- a/README.md
+++ b/README.md
@@ -301,10 +301,13 @@ backend)?** kaibo does **not** retry — a single completion is bounded by the b
 returns a **clean tool-result error** (`is_error`) naming the cast and the underlying
 detail, rather than a protocol-level error — because a consult is an *optional* second
 opinion, so your agent should read "the consult failed, here's why" and proceed without
-it (or call again), not have its own turn fail. Retrying is the calling agent's decision;
-if a provider is reliably slow, raise that backend's `request_timeout_secs`. (Automatic
-retry/backoff belongs in the HTTP layer — tracked as an upstream `rig` contribution in
-[`docs/issues.md`](docs/issues.md).)
+it (or call again), not have its own turn fail. The message is **tailored to the
+failure**: a transient condition (overload, rate-limit, timeout, reset) says so and
+invites you to retry the call, so the calling agent can drive the retry; a non-transient
+error (auth, bad request) doesn't, since a retry won't help; and a kaibo-side failure is
+named as such rather than blamed on the provider. If a provider is reliably slow, raise
+that backend's `request_timeout_secs`. (Automatic retry/backoff belongs in the HTTP layer
+— tracked as an upstream `rig` contribution in [`docs/issues.md`](docs/issues.md).)
 
 **What's the cost?** `consult` spends tokens on the provider behind the chosen cast. A
 family-mixing cast (cheap local explorer + hosted synth) keeps the broad, token-heavy

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,6 +91,20 @@ Connection knobs only — models never live here:
   single completion. `0` is rejected at load (it would time out every call
   instantly).
 
+  **Failure policy (no retry, by design).** kaibo does not retry a failed provider
+  call — there is no backoff and no `max_retries` knob. A 429/503/529 overload, a
+  connection reset, a partial stream, or a wedged backend that hits `request_timeout`
+  all fail the single completion, and `consult`/`oneshot` surface that as a **clean
+  tool-result error** (`is_error`) naming the cast and the underlying detail. The
+  rationale: a consult is an *optional* augmentation, so the calling agent should read
+  the failure and proceed without the second opinion (or call again) rather than have
+  its own tool call fail at the protocol layer. Retrying is the caller's decision; for a
+  reliably-slow backend, raise its `request_timeout_secs` rather than expecting kaibo to
+  paper over it. Automatic retry/backoff belongs in the shared HTTP layer (rig already
+  ships an `ExponentialBackoff`, wired only into its streaming path today) — landing it
+  for the non-streaming completion path is tracked as an upstream contribution in
+  `docs/issues.md`, not hand-rolled here.
+
 ### Casts: `[casts.<name>]`
 
 A role table. Each slot is a `"backend/model-id"` string (the common case — the

--- a/docs/config.md
+++ b/docs/config.md
@@ -98,9 +98,13 @@ Connection knobs only — models never live here:
   tool-result error** (`is_error`) naming the cast and the underlying detail. The
   rationale: a consult is an *optional* augmentation, so the calling agent should read
   the failure and proceed without the second opinion (or call again) rather than have
-  its own tool call fail at the protocol layer. Retrying is the caller's decision; for a
-  reliably-slow backend, raise its `request_timeout_secs` rather than expecting kaibo to
-  paper over it. Automatic retry/backoff belongs in the shared HTTP layer (rig already
+  its own tool call fail at the protocol layer. The message is classified so the agent
+  can drive the right next step: a *transient* condition (overload / rate-limit /
+  timeout / reset) invites a manual retry, a non-transient one (auth / bad request) does
+  not, and a kaibo-side failure is named as such. (Classification is a heuristic on the
+  provider's error *vocabulary*, not the HTTP status — rig surfaces the response body,
+  not the code.) Retrying is the caller's decision; for a reliably-slow backend, raise
+  its `request_timeout_secs` rather than expecting kaibo to paper over it. Automatic retry/backoff belongs in the shared HTTP layer (rig already
   ships an `ExponentialBackoff`, wired only into its streaming path today) — landing it
   for the non-streaming completion path is tracked as an upstream contribution in
   `docs/issues.md`, not hand-rolled here.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -214,6 +214,15 @@ a small cap, transient-status classification). If/when rig lands it, kaibo inher
 retry for free and the FAQ/`config.md` policy text updates to match. Until then, the
 documented no-retry-fail-clean behavior stands and is the honest answer.
 
+Related cleanup (DeepSeek review, 2026-06-23): the synth's kaish kernel is spawned
+*lazily inside* the consult tool-loop (the toolset factory), so a kernel-build failure
+lands in the same error shadow as a provider error. `consultation_failed` now classifies
+it as `Internal` (named as a kaibo-side failure, not blamed on the provider) so it's no
+longer *mislabelled* — but the cleaner fix is to spawn the driver's kernel in the handler
+*before* the `consult()` call (the way `orientation` already does) and map a spawn failure
+to `McpError::internal_error`, matching `run_kaish`. Low priority (kernel build is
+in-process and reliable); the classification covers the user-facing symptom today.
+
 ## P3 — Infra, perf, polish
 
 ### Path expansion is inconsistent: `$VAR` only in `root` / `allow_paths`

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -195,23 +195,24 @@ close tag) in the one wrapper so batch and oneshot inherit it together; the `pat
 attribute is server-controlled (the caller's path string), not a second injection point of
 concern. Lower priority than a real delimiter the model is told to trust.
 
-### Review the provider retry + failure policy (and document it)
-We don't have a stated, audited answer for what a `consult`/`oneshot`
-call does when a provider misbehaves mid-flight: a 429/529 overload, a connection
-reset, a partial stream, or a wedged-but-connected backend. Today the only explicit
-guard is the per-backend `request_timeout_secs` (default 900, `config.md`) that bounds
-a *single* completion — but whether rig retries with backoff, how many times, and
-whether a terminal provider error surfaces to the caller as a clean tool error (so the
-host agent can proceed *without* the consultation) versus failing the whole call is
-unverified. Surfaced in README review (an SRE reviewer asked "what happens on a
-DeepSeek 529?" and we couldn't answer from the docs).
+### Upstream a retry/backoff for rig's non-streaming completion path
+The provider failure *policy* is now stated, audited, and documented (README FAQ +
+`docs/config.md`, shipped): kaibo does **no** retry; one completion is bounded by the
+backend `request_timeout`/`connect_timeout`, and a provider failure surfaces as a clean
+**tool-result error** (`is_error`, `server.rs::consultation_failed`) the host can proceed
+past rather than an opaque `internal_error`. What's left is the *mechanism* we chose not
+to hand-roll: automatic retry/backoff for transient overload (429/503/529/reset).
 
-Do: trace the actual path through `consult.rs` → the rig client (`tls.rs`/client
-construction) → reqwest; confirm or add retry/backoff with a cap; make a terminal
-failure a clean, named tool error rather than an opaque internal_error; then document
-the policy in the README FAQ (it currently only promises "a down provider surfaces a
-clean error" loosely) and `docs/config.md`. A failing-first test that injects a 529 via
-the scripted `CompletionClient` (`test_support.rs`) is the natural guard.
+The decision (with Amy, 2026-06-23) was **not** to build a retry loop inside kaibo —
+that belongs in the shared HTTP layer, and hand-rolling it cuts against the anti-fork
+grain (cf. the TTS "wait for rig" call). rig *already ships* `ExponentialBackoff` /
+`RetryPolicy` (`rig-core 0.38 http_client/retry.rs`) but wires it **only into SSE
+streaming** (`http_client/sse.rs::with_retry_policy`); the non-streaming completion path
+kaibo uses gets none. So the right move is an **upstream rig contribution**: wire the
+existing retry policy into the non-streaming completion call (idempotent provider calls,
+a small cap, transient-status classification). If/when rig lands it, kaibo inherits
+retry for free and the FAQ/`config.md` policy text updates to match. Until then, the
+documented no-retry-fail-clean behavior stands and is the honest answer.
 
 ## P3 — Infra, perf, polish
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2343,21 +2343,90 @@ fn consult_result(answer: String, report: String, include_report: bool) -> CallT
     result
 }
 
+/// How a runtime consultation failure should be framed to the calling agent — derived
+/// from the error chain by [`classify_failure`].
+#[derive(Debug, PartialEq, Eq)]
+enum FailureKind {
+    /// A transient provider condition (overload / rate-limit / timeout / reset). Worth a
+    /// caller-driven manual retry.
+    TransientProvider,
+    /// A non-transient model/provider error (auth, bad request). Retrying won't help.
+    Provider,
+    /// A kaibo-*side* failure (e.g. the synth's kaish kernel failed to build) — not the
+    /// provider's fault, so we must not say it was.
+    Internal,
+}
+
+/// Classify a consultation failure from its error chain. This is a **heuristic on the
+/// error text**, by necessity: rig collapses the HTTP status into the response *body*
+/// (`CompletionError::ProviderError(text)` carries Anthropic's `overloaded_error` JSON, a
+/// Gemini `RESOURCE_EXHAUSTED`, etc. — not the number `529`), so we match the providers'
+/// transient *vocabulary* rather than a status code. The model loop wraps its errors as
+/// `"model loop failed: …"` (`consult.rs`); an error chain lacking that marker came from
+/// *before* a model ran (a kaish kernel build inside the toolset factory), so it's a
+/// kaibo-side failure, not the provider's.
+fn classify_failure(err: &anyhow::Error) -> FailureKind {
+    let s = format!("{err:#}").to_lowercase();
+    let from_model_loop = s.contains("model loop failed") || s.contains("model used all");
+    if !from_model_loop {
+        return FailureKind::Internal;
+    }
+    // Transient vocabulary across Anthropic / Gemini / OpenAI / DeepSeek bodies and the
+    // transport layer (reqwest timeouts/resets from our own `request_timeout`).
+    const TRANSIENT: &[&str] = &[
+        "overload",        // Anthropic 529 overloaded_error, Gemini
+        "rate limit",      // generic
+        "rate_limit",      // OpenAI/DeepSeek/Anthropic error `type`s
+        "ratelimit",
+        "resource_exhausted", // Gemini 429
+        "too many requests",  // 429 reason phrase
+        "timed out",          // reqwest / gateway
+        "timeout",
+        "connection reset",
+        "reset by peer",
+        "connection closed",
+        "broken pipe",
+        "temporarily",     // "temporarily unavailable"
+        "unavailable",     // 503 / Gemini UNAVAILABLE
+        "try again",
+    ];
+    if TRANSIENT.iter().any(|t| s.contains(t)) {
+        FailureKind::TransientProvider
+    } else {
+        FailureKind::Provider
+    }
+}
+
 /// Surface a *runtime* consultation failure as a **tool-result error** (`is_error =
 /// true`) rather than a protocol-level `internal_error`. A consult is an *optional*
-/// augmentation: when a provider misbehaves (overload, reset, or a wedged backend that
-/// hits the `request_timeout`), the calling agent should read a clear message and proceed
-/// *without* the second opinion — not have its own tool call fail at the JSON-RPC layer.
-/// The message names the tool, the cast, and the underlying detail so the host can decide
-/// whether to retry. kaibo does **not** retry on its own (one completion is bounded by the
-/// backend's `request_timeout`/`connect_timeout`); see the failure-policy FAQ and
-/// `docs/config.md`. Setup errors *before* the model call — an unknown cast, an attachment
-/// outside the boundary, a missing key — stay `McpError`, since those are the caller's to
-/// fix, not transient.
+/// augmentation: the calling agent should read a clear message and proceed *without* the
+/// second opinion — not have its own tool call fail at the JSON-RPC layer. The framing is
+/// tailored by [`classify_failure`] so the agent can drive the right next step: a
+/// transient overload/timeout invites a manual retry (kaibo does **not** retry on its own
+/// — one completion is bounded by the backend's `request_timeout`/`connect_timeout`; see
+/// the failure-policy FAQ and `docs/config.md`), a non-transient provider error doesn't,
+/// and a kaibo-side failure is named honestly rather than blamed on the provider. Setup
+/// errors *before* the model call — unknown cast, an attachment outside the boundary, a
+/// missing key — stay `McpError`, since those are the caller's to fix.
 fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) -> CallToolResult {
+    let detail = format!("{err:#}");
+    let guidance = match classify_failure(&err) {
+        FailureKind::TransientProvider => {
+            "This looks like a transient provider condition (overload, rate limit, or \
+             timeout). kaibo does not retry automatically — you may retry this call, or \
+             proceed without the consultation."
+        }
+        FailureKind::Provider => {
+            "The model or its provider rejected the request; retrying is unlikely to help \
+             — proceed without the consultation, or check the cast and config."
+        }
+        FailureKind::Internal => {
+            "This is a kaibo-side error (not the provider) — please report it; you can \
+             still proceed without the consultation."
+        }
+    };
     CallToolResult::error(vec![Content::text(format!(
-        "{tool} could not complete (cast `{cast}`): {err:#}. The model or its provider \
-         failed — kaibo does not retry, so proceed without this consultation or try again."
+        "{tool} could not complete (cast `{cast}`): {detail}. {guidance}"
     ))])
 }
 
@@ -2977,13 +3046,13 @@ mod tests {
             .clone()
     }
 
-    /// A runtime consultation failure (a provider overload/reset/timeout from the model
-    /// loop) surfaces as a **tool-result error** — `is_error = true` carrying the provider
-    /// detail — not a protocol-level `internal_error`. That's what lets the calling agent
-    /// read "the consult failed, here's why" and proceed without the second opinion.
+    /// A runtime consultation failure surfaces as a **tool-result error** (`is_error =
+    /// true`) carrying the detail — not a protocol-level `internal_error` — so the calling
+    /// agent reads "the consult failed, here's why" and proceeds without the second
+    /// opinion. The message names the tool and cast and preserves the underlying chain.
     #[test]
     fn consultation_failed_is_a_tool_error_carrying_the_detail() {
-        let err = anyhow::anyhow!("model loop failed: backend returned 529 overloaded");
+        let err = anyhow::anyhow!("model loop failed: ProviderError: overloaded_error");
         let result = consultation_failed("consult", "deepseek", err);
         assert_eq!(
             result.is_error,
@@ -2994,8 +3063,63 @@ mod tests {
         assert!(text.contains("consult"), "names the tool: {text}");
         assert!(text.contains("deepseek"), "names the cast: {text}");
         assert!(
-            text.contains("529 overloaded"),
-            "preserves the provider detail so the host can decide: {text}"
+            text.contains("overloaded_error"),
+            "preserves the underlying detail so the host can decide: {text}"
+        );
+    }
+
+    /// A *transient* provider condition (overload / rate-limit / timeout / reset) is
+    /// classified as retryable, so the message invites the calling agent to drive a manual
+    /// retry. We match the providers' transient *vocabulary*, not a status number: rig
+    /// collapses the HTTP status into the response *body* (`ProviderError(text)`), so the
+    /// numeric code isn't reliably present.
+    #[test]
+    fn transient_provider_failure_suggests_a_manual_retry() {
+        for body in [
+            "model loop failed: ProviderError: {\"type\":\"overloaded_error\"}",
+            "model loop failed: ProviderError: rate_limit_error",
+            "model loop failed: HttpError: error sending request: operation timed out",
+            "model loop failed: HttpError: connection reset by peer",
+            "model loop failed: ProviderError: RESOURCE_EXHAUSTED",
+        ] {
+            let result = consultation_failed("consult", "gemini", anyhow::anyhow!(body));
+            let text = answer_text(&result).to_lowercase();
+            assert!(
+                text.contains("retry"),
+                "a transient failure should invite a manual retry: {body} -> {text}"
+            );
+        }
+    }
+
+    /// A *non-transient* provider error (auth / bad request) does not invite a retry —
+    /// retrying won't help — but is still a clean tool-result error.
+    #[test]
+    fn non_transient_provider_failure_does_not_suggest_retry() {
+        let err = anyhow::anyhow!("model loop failed: ProviderError: invalid_request_error");
+        let text = answer_text(&consultation_failed("consult", "anthropic", err));
+        assert!(
+            !text.to_lowercase().contains("you may retry")
+                && !text.to_lowercase().contains("retry this call"),
+            "a non-transient error must not invite a retry: {text}"
+        );
+    }
+
+    /// A kaibo-*side* failure (a kaish kernel build, not the model loop) must not be
+    /// blamed on the provider — the message names it as a kaibo internal error. (DeepSeek
+    /// review, 2026-06-23: the synth's kernel spawns inside the consult error shadow, so a
+    /// spawn failure would otherwise read as "the provider failed, proceed without it".)
+    #[test]
+    fn internal_failure_is_not_blamed_on_the_provider() {
+        let err = anyhow::anyhow!("failed to build read-only kaish kernel: out of memory");
+        let text = answer_text(&consultation_failed("consult", "deepseek", err));
+        let lower = text.to_lowercase();
+        assert!(
+            lower.contains("kaibo"),
+            "a kaibo-side failure is named as such, not the provider's fault: {text}"
+        );
+        assert!(
+            !lower.contains("provider failed") && !lower.contains("provider rejected"),
+            "must not claim the provider failed: {text}"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1073,7 +1073,7 @@ impl KaiboHandler {
             session = session.is_some(),
         );
         progress.emit(PhaseEvent::PhaseStarted { phase: "consult" });
-        let out = consult(
+        let out = match consult(
             &input.question,
             input.context.as_deref(),
             root,
@@ -1084,7 +1084,12 @@ impl KaiboHandler {
         )
         .instrument(span)
         .await
-        .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        {
+            Ok(out) => out,
+            // A provider/model-loop failure is a clean tool-result error the host can
+            // proceed past, not a JSON-RPC internal_error. See `consultation_failed`.
+            Err(e) => return Ok(consultation_failed("consult", &cast.name, e)),
+        };
         progress.emit(PhaseEvent::PhaseFinished { phase: "consult" });
 
         // Provenance: name the cast and the models that answered, so a caller (a
@@ -1147,10 +1152,14 @@ impl KaiboHandler {
 
         let span = tracing::info_span!("oneshot", cast = %cast.name, model = %arm.model);
         progress.emit(PhaseEvent::PhaseStarted { phase: "oneshot" });
-        let answer = oneshot(&input.prompt, &attachments, &arm, &cfg)
+        let answer = match oneshot(&input.prompt, &attachments, &arm, &cfg)
             .instrument(span)
             .await
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        {
+            Ok(answer) => answer,
+            // A provider failure is a clean tool-result error, same as `consult`.
+            Err(e) => return Ok(consultation_failed("oneshot", &cast.name, e)),
+        };
         progress.emit(PhaseEvent::PhaseFinished { phase: "oneshot" });
 
         let answer = with_provenance(answer, &cast.name, &[("model", &arm.model)]);
@@ -2334,6 +2343,24 @@ fn consult_result(answer: String, report: String, include_report: bool) -> CallT
     result
 }
 
+/// Surface a *runtime* consultation failure as a **tool-result error** (`is_error =
+/// true`) rather than a protocol-level `internal_error`. A consult is an *optional*
+/// augmentation: when a provider misbehaves (overload, reset, or a wedged backend that
+/// hits the `request_timeout`), the calling agent should read a clear message and proceed
+/// *without* the second opinion — not have its own tool call fail at the JSON-RPC layer.
+/// The message names the tool, the cast, and the underlying detail so the host can decide
+/// whether to retry. kaibo does **not** retry on its own (one completion is bounded by the
+/// backend's `request_timeout`/`connect_timeout`); see the failure-policy FAQ and
+/// `docs/config.md`. Setup errors *before* the model call — an unknown cast, an attachment
+/// outside the boundary, a missing key — stay `McpError`, since those are the caller's to
+/// fix, not transient.
+fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(format!(
+        "{tool} could not complete (cast `{cast}`): {err:#}. The model or its provider \
+         failed — kaibo does not retry, so proceed without this consultation or try again."
+    ))])
+}
+
 /// Append a one-line provenance footer naming the cast and the model(s) that
 /// produced `answer`. The point is legibility: a caller — a cross-model study most
 /// of all — should see *which* model answered without cross-referencing
@@ -2948,6 +2975,28 @@ mod tests {
             .expect("consult answer is text content")
             .text
             .clone()
+    }
+
+    /// A runtime consultation failure (a provider overload/reset/timeout from the model
+    /// loop) surfaces as a **tool-result error** — `is_error = true` carrying the provider
+    /// detail — not a protocol-level `internal_error`. That's what lets the calling agent
+    /// read "the consult failed, here's why" and proceed without the second opinion.
+    #[test]
+    fn consultation_failed_is_a_tool_error_carrying_the_detail() {
+        let err = anyhow::anyhow!("model loop failed: backend returned 529 overloaded");
+        let result = consultation_failed("consult", "deepseek", err);
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "a provider failure is a tool-result error, not a success"
+        );
+        let text = answer_text(&result);
+        assert!(text.contains("consult"), "names the tool: {text}");
+        assert!(text.contains("deepseek"), "names the cast: {text}");
+        assert!(
+            text.contains("529 overloaded"),
+            "preserves the provider detail so the host can decide: {text}"
+        );
     }
 
     /// Provenance footer: the answer keeps its text, and the cast plus every labelled


### PR DESCRIPTION
## The audited answer we lacked

Traced the full path (`consult.rs` → rig client → reqwest). Findings:
- **kaibo does no retry.** rig ships `ExponentialBackoff` but wires it only into SSE streaming; kaibo's prompt loop is non-streaming, so a 429/529/reset fails the single completion immediately — bounded only by `request_timeout` (900s) + a ≤10s `connect_timeout`.
- **Terminal errors surfaced opaquely.** Every `consult`/`oneshot` error mapped through `McpError::internal_error` — not the "clean error the host can proceed past" the README loosely promised.

## What changed

A runtime provider/model-loop failure now returns a **tool-result error** (`is_error=true`) the calling agent can read and proceed past — a consult is *optional* augmentation, so it shouldn't fail the host's turn. Setup errors *before* the model call (bad cast, attachment outside the boundary, missing key) stay `McpError`.

The message is **classified** (`classify_failure`) so the agent can drive the right next step:
- **Transient** (overload / rate-limit / timeout / reset) → invites a manual retry.
- **Non-transient** (auth / bad request) → no retry suggestion (won't help).
- **kaibo-side** (e.g. a kaish kernel build failure) → named as kaibo's, not blamed on the provider.

We can't read the HTTP status — rig collapses it into the response *body* (`ProviderError` carries Anthropic's `overloaded_error` JSON / Gemini `RESOURCE_EXHAUSTED`, not `529`) — so classification matches the providers' transient *vocabulary*, and the `"model loop failed"` marker distinguishes a model-loop error from a pre-model kaibo-side one.

## Decisions

- **No kaibo-side retry** (with Amy): retry/backoff belongs in the shared HTTP layer, not forked into this one consumer (same anti-fork call as TTS). Re-homed in `docs/issues.md` as an upstream `rig` contribution — wire its existing `ExponentialBackoff` into the non-streaming completion path.
- **Retry hint over silent retry** (Amy): tell the agent it *can* retry a transient failure and let it drive, rather than holding the call open.

## Review

Cross-family review (DeepSeek) of the first flat-message cut found that the synth's kaish kernel spawns inside the consult error shadow, so a kernel-build failure would be mislabelled as a provider failure. The classifier's `Internal` class fixes the user-facing symptom; the cleaner structural fix (spawn the kernel in the handler, like `orientation`) is noted in `docs/issues.md`.

## Tests / docs

Failing-first tests for all three classes (the loop already surfaced provider errors as `Err`; these pin the server's clean-tool-error mapping + classification). Policy documented in the README FAQ and `docs/config.md`. Full suite green (21 binaries), clippy clean.

Closes the provider-retry/failure-policy item in `docs/issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)