### PR TITLE
Read attachments through the kaish VFS — close the check-then-open TOCTOU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,5 +131,11 @@ the git log. Each later release appends a new section at the top.
   output, 64 MB scratch — over-cap fails loudly, never a silent drop), and the model
   loops stop at turn limits, so a runaway consultation can't melt the machine or the
   budget. All configurable.
+- **Attachments are read through the read-only VFS.** A named attachment's bytes are
+  read *through* the same read-only kaish mount the shell uses (rooted at the file's
+  containing allowed tree), not a separate `std::fs` read after the containment check.
+  The VFS refuses to follow a symlink out of the allowed tree at read time, so a path
+  swapped for an out-of-tree symlink *after* the check is rejected structurally rather
+  than by racing a re-check — the boundary holds regardless of timing.
 
 [0.2.0]: https://github.com/tobert/kaibo/releases/tag/v0.2.0

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -172,6 +172,29 @@ otherwise sound. The attacker model stays narrow (a self-attack: a concurrent wr
 caller's own workspace, sub-millisecond window). Worth closing for symmetry when the model
 justifies it, but lower priority than the attachment read that one-shot-followed a symlink.
 
+### Attachment reads have no streaming/cumulative resource bounds (DoS, self-attack)
+Surfaced by the Gemini Pro batch review of the VFS-read change (2026-06-23). These are
+**pre-existing** (the old `std::fs::read` + `.collect()` path had them too) and all in the
+self-attack model (the caller owns the request and the workspace), so they're DoS, not
+confidentiality — but the attachment surface should be bounded structurally like the rest:
+- **Per-file size cap is check-then-read, not streaming.** `resolve_attachments` checks
+  `std::fs::metadata` length against `read_ceiling`, then `worker.read_file` slurps the whole
+  file with **no byte cap** (`Job::Read` deliberately skips the script-output cap). A file
+  swapped for a huge one *after* the metadata check is read whole into a `Vec<u8>` → OOM. Fix
+  wants a *streaming* cap in the read path (a `read_file` that takes a limit and aborts past
+  `limit+1`), which needs a `KaishWorker`/kaish-vfs API that bounds the read — not just a
+  pre-check. (`classify` enforces the cap only *after* the full read, too late for memory.)
+- **A special file (FIFO/device) swapped in can hang the read.** `is_file()` rejects a FIFO
+  at check time, but a regular file swapped for a FIFO before the read blocks
+  `worker.read_file` indefinitely (single worker thread; `request_timeout` covers only the
+  model call, not attachment resolution). Wants an `O_NONBLOCK`/`tokio::time::timeout` bound
+  on the read.
+- **No cumulative cap across attachments.** Each file passes the per-file ceiling, but
+  `paths.len()` and the running total of `out` bytes are unbounded — N×(under-cap) files load
+  N× into memory. Wants a hard cap on attachment count and a cumulative byte budget.
+Low priority (self-attack DoS), but cheap to land together as an "attachment resource bounds"
+pass. The streaming cap is the one with real teeth and needs the kaish-vfs read API.
+
 ### The `<file>` attachment wrapper doesn't escape its body
 `Attachment::wrapped_text` (`attach.rs`) wraps a text attachment as
 `<file path="…">{body}</file>` without escaping `body`, so a file that itself contains a

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -152,36 +152,25 @@ completes, while a pure-script spin still dies at 30s.
 
 ## P2 — Focused fixes & hardening
 
-### Path containment is check-then-open (a narrow TOCTOU)
-Both `resolve_root` and `resolve_attachments` (`server.rs`) check containment on the
-*canonical* path and then open/read it as a separate step — a classic check-then-open
-window. A concurrent writer could swap the canonical path for an outside-pointing symlink
-between the `contained` check and the read, escaping the boundary. Surfaced by the
-cross-family review of the batch `attach` feature (DeepSeek, 2026-06-22), which judged the
-boundary otherwise sound. The attacker model keeps it narrow: kaibo cannot write the
-workspace, so the race needs a concurrent writer to the very tree the calling agent owns
-(a self-attack), inside a sub-millisecond window. `resolve_root` is the less-exposed of
-the two — it hands the canonical path to the kaish kernel, which opens a directory fd and
-works through it — while the attachment path reads a file one-shot with `std::fs::read`
-and discards the fd.
+### Path containment check-then-open in `resolve_root` (the attachment half is closed)
+The attachment half **shipped**: `resolve_attachments` (`server.rs`) now reads *through the
+read-only kaish VFS* (`worker.read_file` on a `KaishWorker` rooted at the attachment's
+containing tree, one worker per distinct tree), not `std::fs::read`. The VFS resolves within
+its mount and refuses to follow a symlink out of the allowed tree, so a path swapped for an
+out-of-tree symlink after the friendly early check is rejected at the mount layer regardless
+of timing — the check-then-open window closes structurally. Teeth: `tests/attach.rs`
+proves the read goes through a worker mounted at the *correct* containing tree (a wrong
+mount fails the read), atop the `mount_layer_symlink_*` battery that proves the VFS refuses
+escapes. (No flaky racy TOCTOU test, per the project's no-flaky-tests stance.)
 
-**Likely structural fix: read attachments *through the kaish VFS*, not `std::fs::read`** —
-the project's own "read-only is structural" mechanism, and `view_image` already does
-exactly this (`view_image.rs`: `worker.read_file(&canon)` on a `KaishWorker`, the same
-read-only mount `run_kaish` uses). The VFS resolves within its mount and **refuses to
-follow a symlink out of the allowed tree** (proved by `tests/containment.rs`'s
-`mount_layer_symlink_in_allowed_pointing_outside`), so a swapped escaping symlink is
-rejected regardless of timing — the window closes structurally, and it's portable (no
-`/proc`, no `O_NOFOLLOW` per-platform dance). `resolve_attachments` keeps its
-`std`-level canonicalize + `contained` check for the friendly early error; the *read*
-moves to the worker. Open wrinkle to settle when we build it: `resolve_attachments` spans
-multiple allowed trees + followed worktrees, while a `KaishWorker` is rooted at one tree —
-so either root a worker per containing tree, or reuse the worker `batch_submit` would
-already have. A flaky racy "prove the TOCTOU" test isn't worth it (the project hates flaky
-tests); the deterministic proof is that the VFS refuses the escaping read — extend the
-mount-layer test to the attachment path. Deferred until the attacker model (a workspace
-writable by someone other than the caller) is real, but it's *more correct* regardless, so
-likely worth doing on its own merits. Documented in `resolve_attachments`' doc-comment.
+**Still open — `resolve_root`.** It also checks containment on the canonical path then hands
+it to the kaish kernel as the mount root, a separate step. It's the *less-exposed* half: the
+kernel opens the root as a directory fd and works through it (vs. the old one-shot
+`std::fs::read` the attachment path used), and the mount itself re-resolves reads. Surfaced
+by the batch `attach` cross-family review (DeepSeek, 2026-06-22), which judged the boundary
+otherwise sound. The attacker model stays narrow (a self-attack: a concurrent writer to the
+caller's own workspace, sub-millisecond window). Worth closing for symmetry when the model
+justifies it, but lower priority than the attachment read that one-shot-followed a symlink.
 
 ### The `<file>` attachment wrapper doesn't escape its body
 `Attachment::wrapped_text` (`attach.rs`) wraps a text attachment as

--- a/src/server.rs
+++ b/src/server.rs
@@ -630,10 +630,32 @@ impl KaiboHandler {
     /// `.git`), so a foreign dir can't forge its way in. The single containment
     /// predicate — `resolve_root` and `resolve_attachments` both defer to it.
     fn contained(&self, canon: &std::path::Path) -> bool {
-        if self.allowed_set.iter().any(|tree| canon.starts_with(tree)) {
-            return true;
+        self.containing_tree(canon).is_some()
+    }
+
+    /// The allowed tree (or followed-worktree root) that contains `canon`, or `None` when
+    /// it's outside the boundary — the *which-tree* sibling of [`contained`](Self::contained)
+    /// (which is just `is_some()` on this). A static `allow_path` wins over a followed
+    /// worktree, matching the precedence in `contained`'s original form. The returned root
+    /// is what an attachment read mounts a read-only kaish worker at, so the VFS refuses a
+    /// symlink escaping *that* tree (see [`resolve_attachments`](Self::resolve_attachments)).
+    fn containing_tree(&self, canon: &std::path::Path) -> Option<PathBuf> {
+        if let Some(tree) = self.allowed_set.iter().find(|tree| canon.starts_with(tree)) {
+            return Some(tree.clone());
         }
-        self.config.follow_worktrees && self.is_followed_worktree(canon)
+        if self.config.follow_worktrees {
+            for tree in self.allowed_set.iter() {
+                if let Some(common) = crate::worktree::common_git_dir(tree) {
+                    if let Some(wt) = crate::worktree::vouched_worktrees(&common)
+                        .into_iter()
+                        .find(|wt| canon.starts_with(wt))
+                    {
+                        return Some(wt);
+                    }
+                }
+            }
+        }
+        None
     }
 
     /// The shared "outside the allowed set" rejection, naming the boundary and the three
@@ -691,8 +713,8 @@ impl KaiboHandler {
     /// read and encoded server-side so the bytes never transit the calling agent's
     /// context. Each path obeys the *same* boundary as a session root — canonicalize
     /// (symlinks + `..` resolved), require a regular file, then the shared
-    /// [`contained`](Self::contained) check (allowed set + followed worktrees) — so
-    /// attachments can't read outside the workspace any more than `run_kaish` can.
+    /// [`containing_tree`](Self::containing_tree) check (allowed set + followed worktrees)
+    /// — so attachments can't read outside the workspace any more than `run_kaish` can.
     ///
     /// Failures are loud and per-path: a missing file, a directory, an over-cap or
     /// non-text/non-image file is a clear `invalid_params`, never a silent skip — an
@@ -700,15 +722,18 @@ impl KaiboHandler {
     /// size ceiling is enforced *before* reading (via the file's metadata) so a giant
     /// file is refused without first slurping it into memory.
     ///
-    /// Containment is checked on the *canonical* path, then the read follows — a
-    /// check-then-open TOCTOU window, the same class `resolve_root` carries (and tracked
-    /// in `docs/issues.md`). The attacker model makes it narrow: kaibo cannot write the
-    /// workspace, so swapping the canonical path for an outside-pointing symlink in the
-    /// sub-millisecond window needs a *concurrent* writer to the very workspace the
-    /// calling agent owns — a self-attack. Closing it structurally (open `O_NOFOLLOW`,
-    /// `fstat` the fd, contain via `/proc/self/fd`, read from the fd) is deferred until
-    /// the attacker model justifies it.
-    pub fn resolve_attachments(
+    /// **The read goes through the read-only kaish VFS, not `std::fs::read`** — the same
+    /// mechanism `view_image` uses. The canonicalize + containment check above is the
+    /// *friendly early error*; the read itself is mounted on a [`KaishWorker`] rooted at
+    /// the attachment's containing tree, whose VFS re-resolves at read time and refuses to
+    /// follow a symlink out of that tree (proved by `tests/containment.rs`'s
+    /// `mount_layer_symlink_*` battery). That closes the check-then-open TOCTOU window the
+    /// old `std::fs::read` left open — a path swapped for an out-of-tree symlink after the
+    /// check is rejected at the mount layer regardless of timing, structurally rather than
+    /// by racing a re-check. One worker is spawned per *distinct* containing tree and
+    /// reused across attachments under it, so the common case (files under one project
+    /// root) builds a single worker.
+    pub async fn resolve_attachments(
         &self,
         paths: &[String],
     ) -> Result<Vec<crate::attach::Attachment>, McpError> {
@@ -716,77 +741,76 @@ impl KaiboHandler {
         // The pre-read ceiling: whichever encoding cap is larger. `classify` applies the
         // precise per-encoding cap after sniffing; this just bounds the read itself.
         let read_ceiling = DEFAULT_MAX_TEXT_BYTES.max(DEFAULT_MAX_IMAGE_BYTES);
-        paths
-            .iter()
-            .map(|p| {
-                let raw = std::path::PathBuf::from(p);
-                let canon = std::fs::canonicalize(&raw).map_err(|e| {
-                    McpError::invalid_params(
-                        format!("attachment {} could not be resolved: {e}", raw.display()),
-                        None,
-                    )
-                })?;
-                // A regular file, not a directory — symmetric with resolve_root's dir
-                // check, the mirror image (we inline a file's bytes, not mount a tree).
-                let meta = std::fs::metadata(&canon).map_err(|e| {
-                    McpError::invalid_params(
-                        format!("attachment {} could not be read: {e}", canon.display()),
-                        None,
-                    )
-                })?;
-                if !meta.is_file() {
-                    return Err(McpError::invalid_params(
-                        format!("attachment {} is not a regular file", canon.display()),
-                        None,
-                    ));
-                }
-                // Same boundary as a session root.
-                if !self.contained(&canon) {
-                    return Err(self.containment_error(&raw, &canon));
-                }
-                // Bound the read by the absolute ceiling before slurping.
-                if meta.len() > read_ceiling as u64 {
-                    return Err(McpError::invalid_params(
-                        format!(
-                            "attachment {} is {} bytes, over the {read_ceiling}-byte limit",
-                            canon.display(),
-                            meta.len()
-                        ),
-                        None,
-                    ));
-                }
-                let bytes = std::fs::read(&canon).map_err(|e| {
-                    McpError::invalid_params(
-                        format!("attachment {} could not be read: {e}", canon.display()),
-                        None,
-                    )
-                })?;
-                // Label the attachment with the caller's path (what they typed), not the
-                // canonical one — it's their reference and it's what the model should see.
+        // One read-only worker per distinct containing tree, reused across attachments
+        // under it (a worker owns a thread + kernel build, so we don't want one per file).
+        let mut workers: std::collections::HashMap<PathBuf, KaishWorker> =
+            std::collections::HashMap::new();
+        let mut out = Vec::with_capacity(paths.len());
+        for p in paths {
+            let raw = std::path::PathBuf::from(p);
+            let canon = std::fs::canonicalize(&raw).map_err(|e| {
+                McpError::invalid_params(
+                    format!("attachment {} could not be resolved: {e}", raw.display()),
+                    None,
+                )
+            })?;
+            // A regular file, not a directory — symmetric with resolve_root's dir
+            // check, the mirror image (we inline a file's bytes, not mount a tree).
+            let meta = std::fs::metadata(&canon).map_err(|e| {
+                McpError::invalid_params(
+                    format!("attachment {} could not be read: {e}", canon.display()),
+                    None,
+                )
+            })?;
+            if !meta.is_file() {
+                return Err(McpError::invalid_params(
+                    format!("attachment {} is not a regular file", canon.display()),
+                    None,
+                ));
+            }
+            // Same boundary as a session root — and the tree to root the VFS read at.
+            let tree = self
+                .containing_tree(&canon)
+                .ok_or_else(|| self.containment_error(&raw, &canon))?;
+            // Bound the read by the absolute ceiling before slurping.
+            if meta.len() > read_ceiling as u64 {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "attachment {} is {} bytes, over the {read_ceiling}-byte limit",
+                        canon.display(),
+                        meta.len()
+                    ),
+                    None,
+                ));
+            }
+            // Read *through the VFS* rooted at the containing tree — see the doc-comment.
+            // A swapped escaping symlink is refused at the mount, not read through.
+            if !workers.contains_key(&tree) {
+                let worker = KaishWorker::spawn_with(&tree, self.config.sandbox.clone())
+                    .map_err(|e| {
+                        McpError::internal_error(
+                            format!("attachment reader for {}: {e:#}", tree.display()),
+                            None,
+                        )
+                    })?;
+                workers.insert(tree.clone(), worker);
+            }
+            let bytes = workers[&tree].read_file(canon.clone()).await.map_err(|e| {
+                McpError::invalid_params(
+                    format!("attachment {} could not be read: {e:#}", canon.display()),
+                    None,
+                )
+            })?;
+            // Label the attachment with the caller's path (what they typed), not the
+            // canonical one — it's their reference and it's what the model should see.
+            out.push(
                 classify(p, &bytes, DEFAULT_MAX_TEXT_BYTES, DEFAULT_MAX_IMAGE_BYTES)
-                    .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
-            })
-            .collect()
+                    .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?,
+            );
+        }
+        Ok(out)
     }
 
-    /// True when `canon` falls inside a git worktree that an already-allowed repo
-    /// vouches for. The trusted side does the vouching: for each allowed tree we
-    /// resolve *its* common git dir and enumerate the worktrees that common dir
-    /// names; `canon` is admitted only if it sits inside one. We never read
-    /// `canon`'s own `.git`, so a forged pointer there can't smuggle a foreign path
-    /// in. Pure file reads on the (rare) containment-miss path — see
-    /// [`crate::worktree`].
-    fn is_followed_worktree(&self, canon: &std::path::Path) -> bool {
-        self.allowed_set.iter().any(|tree| {
-            crate::worktree::common_git_dir(tree)
-                .map(|common| {
-                    crate::worktree::vouched_worktrees(&common)
-                        .iter()
-                        .any(|wt| canon.starts_with(wt))
-                })
-                .unwrap_or(false)
-        })
-    }
 
     /// The worktrees the follow feature currently admits *beyond* the static allowed
     /// set — for the `kaibo://config` runtime section, so the live boundary stays
@@ -1129,7 +1153,7 @@ impl KaiboHandler {
         let arm = self.arm(&cast, ModelRole::Synth)?;
         // Read + containment-check the attachments (same boundary as a session root); the
         // bytes are inlined server-side so they never transit the calling agent's context.
-        let attachments = self.resolve_attachments(&input.attach)?;
+        let attachments = self.resolve_attachments(&input.attach).await?;
         // Gate image attachments on the model's vision capability (shared with batch).
         self.gate_image_attachments(arm.caps.vision, &attachments, &arm.model, &cast.name)?;
         let progress = progress_sink(peer, &meta);
@@ -1383,7 +1407,7 @@ impl KaiboHandler {
         // Read + containment-check the attachments before anything hits the network: a
         // bad path is a clean refusal, not a half-submitted batch. The bytes are inlined
         // server-side so they never transit the calling agent's context.
-        let attachments = self.resolve_attachments(&input.attach)?;
+        let attachments = self.resolve_attachments(&input.attach).await?;
         // Gate image attachments on the synth model's vision capability before the
         // provider is built — so a vision misconfig needs no key to report.
         self.gate_image_attachments(caps.vision, &attachments, &model, &cast.name)?;

--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -38,8 +38,8 @@ fn fake_png() -> Vec<u8> {
 // --- happy paths: a workspace file inlines ----------------------------------
 
 /// A UTF-8 file inside the workspace resolves to a Text attachment carrying its body.
-#[test]
-fn workspace_text_file_inlines_as_text() {
+#[tokio::test]
+async fn workspace_text_file_inlines_as_text() {
     let root = tempdir().unwrap();
     let file = root.path().join("README.md");
     fs::write(&file, "# kaibo\nhello\n").unwrap();
@@ -47,6 +47,7 @@ fn workspace_text_file_inlines_as_text() {
 
     let atts = handler
         .resolve_attachments(&[file.to_string_lossy().to_string()])
+        .await
         .expect("an in-workspace text file must inline");
     assert_eq!(atts.len(), 1);
     match &atts[0] {
@@ -56,8 +57,8 @@ fn workspace_text_file_inlines_as_text() {
 }
 
 /// A workspace image resolves to an Image attachment with the sniffed mime.
-#[test]
-fn workspace_image_file_inlines_as_image() {
+#[tokio::test]
+async fn workspace_image_file_inlines_as_image() {
     let root = tempdir().unwrap();
     let file = root.path().join("logo.png");
     fs::write(&file, fake_png()).unwrap();
@@ -65,6 +66,7 @@ fn workspace_image_file_inlines_as_image() {
 
     let atts = handler
         .resolve_attachments(&[file.to_string_lossy().to_string()])
+        .await
         .expect("an in-workspace image must inline");
     match &atts[0] {
         Attachment::Image { mime, .. } => assert_eq!(*mime, "image/png"),
@@ -76,8 +78,8 @@ fn workspace_image_file_inlines_as_image() {
 
 /// An attachment whose path resolves *outside* the allowed set is refused, naming the
 /// boundary and a widening knob — the same rejection a session root gets.
-#[test]
-fn attachment_outside_allowed_set_is_rejected() {
+#[tokio::test]
+async fn attachment_outside_allowed_set_is_rejected() {
     let allowed = tempdir().unwrap();
     let outside = tempdir().unwrap();
     let secret = outside.path().join("secret.txt");
@@ -86,6 +88,7 @@ fn attachment_outside_allowed_set_is_rejected() {
 
     let err = handler
         .resolve_attachments(&[secret.to_string_lossy().to_string()])
+        .await
         .expect_err("a file outside the workspace must be refused");
     let msg = format!("{err:?}");
     assert!(
@@ -97,8 +100,8 @@ fn attachment_outside_allowed_set_is_rejected() {
 /// A symlink *inside* the workspace whose target is outside is refused: `canonicalize`
 /// resolves the link, so the containment check sees the real outside path. This proves
 /// the boundary is canonicalize-based, not string-prefix-based — the read-escape teeth.
-#[test]
-fn attachment_symlink_escaping_workspace_is_rejected() {
+#[tokio::test]
+async fn attachment_symlink_escaping_workspace_is_rejected() {
     let allowed = tempdir().unwrap();
     let outside = tempdir().unwrap();
     let secret = outside.path().join("secret.txt");
@@ -109,6 +112,7 @@ fn attachment_symlink_escaping_workspace_is_rejected() {
 
     let err = handler
         .resolve_attachments(&[link.to_string_lossy().to_string()])
+        .await
         .expect_err("a symlink whose target is outside must be refused");
     let msg = format!("{err:?}");
     assert!(
@@ -119,8 +123,8 @@ fn attachment_symlink_escaping_workspace_is_rejected() {
 
 /// A directory is not a regular file — refused, since attachments inline a file's bytes
 /// rather than mount a tree (the mirror image of `resolve_root`'s dir requirement).
-#[test]
-fn attachment_directory_is_rejected() {
+#[tokio::test]
+async fn attachment_directory_is_rejected() {
     let root = tempdir().unwrap();
     let sub = root.path().join("sub");
     fs::create_dir(&sub).unwrap();
@@ -128,6 +132,7 @@ fn attachment_directory_is_rejected() {
 
     let err = handler
         .resolve_attachments(&[sub.to_string_lossy().to_string()])
+        .await
         .expect_err("a directory must be refused");
     assert!(
         format!("{err:?}").contains("not a regular file"),
@@ -137,8 +142,8 @@ fn attachment_directory_is_rejected() {
 
 /// A binary file that is neither valid UTF-8 nor a recognized image is refused rather
 /// than inlined as mojibake — crash over corruption, even from inside the workspace.
-#[test]
-fn attachment_binary_inside_workspace_is_refused() {
+#[tokio::test]
+async fn attachment_binary_inside_workspace_is_refused() {
     let root = tempdir().unwrap();
     let file = root.path().join("mystery.bin");
     fs::write(&file, [0x00, 0xFF, 0xFE, 0xFD]).unwrap();
@@ -146,11 +151,45 @@ fn attachment_binary_inside_workspace_is_refused() {
 
     let err = handler
         .resolve_attachments(&[file.to_string_lossy().to_string()])
+        .await
         .expect_err("non-text non-image binary must be refused");
     assert!(
         format!("{err:?}").contains("neither valid UTF-8"),
         "rejection must explain the encoding gap, got: {err:?}"
     );
+}
+
+// --- the VFS read path: per-tree worker rooting --------------------------------
+
+/// An attachment in a *second* allowed tree (not the default root) reads correctly. This
+/// exercises the new read path's tree selection: `resolve_attachments` reads through a
+/// kaish worker rooted at the attachment's *containing* allowed tree, so picking the right
+/// one is load-bearing — a worker rooted at the wrong tree would fail the VFS read
+/// (the file sits outside its mount). Proves the read goes through the VFS, mounted right.
+#[tokio::test]
+async fn attachment_in_a_second_allowed_tree_reads_through_its_own_worker() {
+    let root = tempdir().unwrap();
+    let other = tempdir().unwrap();
+    let file = other.path().join("notes.md");
+    fs::write(&file, "# notes\nsecond-tree-body\n").unwrap();
+
+    // Two allowed trees: the default root and a second --allow-path.
+    let mut config = Config::builtin();
+    config.root = Some(root.path().to_path_buf());
+    config.allow_paths = vec![other.path().to_path_buf()];
+    let handler = KaiboHandler::new(config).expect("handler builds");
+
+    let atts = handler
+        .resolve_attachments(&[file.to_string_lossy().to_string()])
+        .await
+        .expect("a file in a second allowed tree must inline");
+    match &atts[0] {
+        Attachment::Text { body, .. } => assert!(
+            body.contains("second-tree-body"),
+            "body read through the second tree's worker: {body}"
+        ),
+        other => panic!("expected Text, got {other:?}"),
+    }
 }
 
 // --- vision gate: an image to a blind synth is refused offline ----------------


### PR DESCRIPTION
## The window

`resolve_attachments` canonicalized + containment-checked a path, then read it with a *separate* `std::fs::read`. A concurrent writer could swap the path for an out-of-tree symlink between the check and the read — a classic check-then-open TOCTOU. Flagged by the batch `attach` cross-family review (DeepSeek, 2026-06-22). The attacker model is narrow (a self-attack on the caller's own workspace, sub-millisecond window), but the read-only boundary is meant to be **structural**, not honor-system.

## The fix

Keep the `std` canonicalize + containment check as the *friendly early error*, but move the **read** through the read-only kaish VFS — `worker.read_file(canon)` on a `KaishWorker` rooted at the attachment's containing tree, exactly how `view_image` already reads. The VFS re-resolves at read time and refuses to follow a symlink out of its mount (the `mount_layer_symlink_*` battery proves this), so a swapped escaping symlink is rejected regardless of timing. The window closes structurally — no `/proc`, no `O_NOFOLLOW` per-platform dance.

- New `containing_tree(canon)` returns which allowed tree (or followed worktree) holds a path; `contained()` is now `is_some()` over it, and that tree is the worker's mount root.
- One worker per **distinct** containing tree, reused across attachments under it (the common case — files under one project root — builds a single worker).
- `resolve_attachments` became `async` (both call sites already are).

## Teeth

`tests/attach.rs` proves a file in a *second* allowed tree reads only when the worker mounts the **correct** containing tree — verified by breaking tree selection and watching the read fail (a file outside the worker's mount is unreadable, which is the escape-refusal property). Per the project's no-flaky-tests stance, there's no racy TOCTOU test; the deterministic proof is structural (the VFS refuses escapes + the read goes through it). `resolve_root`'s lesser check-then-open (it hands the canonical path to the kernel as a mount root, working through an fd) stays open and is re-scoped in `docs/issues.md` as the lower-priority remaining half.

## Review

Per Amy's direction, the full source (`server.rs`, `sandbox.rs`, `tests/attach.rs`) is out for a careful unwind-and-analyze pass on a **Gemini Pro batch** (cross-family, different lineage). Findings will land as a follow-up commit here, as with the other hardening PRs. Full suite green (21 binaries), clippy clean.

Closes the attachment half of the path-containment TOCTOU item in `docs/issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)