### PR TITLE
Bound the attachment surface: per-call count + cumulative-byte caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,10 @@ the git log. Each later release appends a new section at the top.
 - **Bounded resource use.** Each kaish script is capped (30 s wall-clock, 8 KB
   output, 64 MB scratch — over-cap fails loudly, never a silent drop), and the model
   loops stop at turn limits, so a runaway consultation can't melt the machine or the
-  budget. All configurable.
+  budget. All configurable. Attachments are bounded too: a per-file size cap, plus a
+  per-call cap on attachment *count* (64) and *cumulative* bytes (32 MiB), so a stray
+  thousand-file glob or many small files summing to an out-of-memory read is refused
+  loudly before anything is slurped in.
 - **Attachments are read through the read-only VFS.** A named attachment's bytes are
   read *through* the same read-only kaish mount the shell uses (rooted at the file's
   containing allowed tree), not a separate `std::fs` read after the containment check.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -172,28 +172,31 @@ otherwise sound. The attacker model stays narrow (a self-attack: a concurrent wr
 caller's own workspace, sub-millisecond window). Worth closing for symmetry when the model
 justifies it, but lower priority than the attachment read that one-shot-followed a symlink.
 
-### Attachment reads have no streaming/cumulative resource bounds (DoS, self-attack)
+### Attachment per-file streaming cap + FIFO-hang (DoS, self-attack) — count/total caps shipped
 Surfaced by the Gemini Pro batch review of the VFS-read change (2026-06-23). These are
-**pre-existing** (the old `std::fs::read` + `.collect()` path had them too) and all in the
-self-attack model (the caller owns the request and the workspace), so they're DoS, not
-confidentiality — but the attachment surface should be bounded structurally like the rest:
+**pre-existing** and all in the self-attack model (the caller owns the request and the
+workspace), so they're DoS, not confidentiality. The cheap batch-level bounds **shipped**
+(`attach::check_attachment_bounds`, wired into `resolve_attachments`): a hard cap on
+attachment *count* (`DEFAULT_MAX_ATTACHMENTS` = 64, checked before canonicalizing the list)
+and a *cumulative* byte budget (`DEFAULT_MAX_TOTAL_BYTES` = 32 MiB, the running total
+checked before each read so a batch of individually-legal files can't sum to an OOM). Two
+remain, both needing more than a pre-check:
 - **Per-file size cap is check-then-read, not streaming.** `resolve_attachments` checks
   `std::fs::metadata` length against `read_ceiling`, then `worker.read_file` slurps the whole
   file with **no byte cap** (`Job::Read` deliberately skips the script-output cap). A file
-  swapped for a huge one *after* the metadata check is read whole into a `Vec<u8>` → OOM. Fix
-  wants a *streaming* cap in the read path (a `read_file` that takes a limit and aborts past
-  `limit+1`), which needs a `KaishWorker`/kaish-vfs API that bounds the read — not just a
-  pre-check. (`classify` enforces the cap only *after* the full read, too late for memory.)
+  swapped for a huge one *after* the metadata check is read whole into a `Vec<u8>` → OOM,
+  bounded now only by the 32 MiB cumulative cap (so the blast radius shrank, but a single
+  swapped file up to that budget still slurps). The real fix is a *streaming* cap in the read
+  path (a `read_file` that takes a limit and aborts past `limit+1`), which needs a
+  `KaishWorker`/kaish-vfs API that bounds the read. (`classify` enforces the per-encoding cap
+  only *after* the full read, too late for memory.)
 - **A special file (FIFO/device) swapped in can hang the read.** `is_file()` rejects a FIFO
   at check time, but a regular file swapped for a FIFO before the read blocks
   `worker.read_file` indefinitely (single worker thread; `request_timeout` covers only the
   model call, not attachment resolution). Wants an `O_NONBLOCK`/`tokio::time::timeout` bound
-  on the read.
-- **No cumulative cap across attachments.** Each file passes the per-file ceiling, but
-  `paths.len()` and the running total of `out` bytes are unbounded — N×(under-cap) files load
-  N× into memory. Wants a hard cap on attachment count and a cumulative byte budget.
-Low priority (self-attack DoS), but cheap to land together as an "attachment resource bounds"
-pass. The streaming cap is the one with real teeth and needs the kaish-vfs read API.
+  on the read. Judged rare (decided 2026-06-23) — parked unless it bites.
+Low priority (self-attack DoS). The streaming cap is the one with real teeth and needs the
+kaish-vfs read API.
 
 ### Upstream a retry/backoff for rig's non-streaming completion path
 The provider failure *policy* is now stated, audited, and documented (README FAQ +

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -42,6 +42,16 @@ use std::sync::LazyLock;
 /// every prompt (the `[context]` no-cap mistake in `docs/issues.md` is the lesson).
 pub const DEFAULT_MAX_TEXT_BYTES: usize = 1 << 20; // 1 MiB
 
+/// Hard cap on the *number* of attachments in one call. The per-file caps bound a single
+/// file; this bounds the batch — a caller that names a thousand files (a stray glob, say)
+/// is a mistake to surface, not silently absorb. Generous; split a larger batch.
+pub const DEFAULT_MAX_ATTACHMENTS: usize = 64;
+
+/// Hard cap on the *cumulative* raw bytes of all attachments in one call — the batch-level
+/// sibling of the per-file caps, so N under-cap files can't sum to an out-of-memory read.
+/// Generous (several max-size files fit) but bounded.
+pub const DEFAULT_MAX_TOTAL_BYTES: u64 = 1 << 25; // 32 MiB across all attachments in a call
+
 /// Cap on an attached *image*'s raw (pre-base64) bytes — reuses
 /// [`crate::view_image::DEFAULT_MAX_IMAGE_BYTES`] so a read image and an attached one
 /// share one ceiling.
@@ -61,6 +71,34 @@ pub enum Attachment {
         mime: &'static str,
         data_b64: String,
     },
+}
+
+/// Refuse an attachment batch that busts the count or cumulative-byte budget — loud, never
+/// a silent drop (a dropped attachment the caller named would be a corrupt answer). Pure
+/// and cap-injected (the same shape as [`classify`]) so the bounds are unit-testable
+/// without cap-sized fixtures. Called twice in `resolve_attachments`: once on `count`
+/// alone (with `total = 0`) to fail fast *before* canonicalizing a huge path list, then on
+/// the real cumulative `total` (a saturating sum of metadata sizes) *before* any file is
+/// read — so an oversized batch never slurps into memory.
+pub fn check_attachment_bounds(
+    count: usize,
+    total_bytes: u64,
+    max_count: usize,
+    max_total: u64,
+) -> Result<()> {
+    if count > max_count {
+        bail!(
+            "too many attachments: {count} named, but at most {max_count} can ride one \
+             call — split the batch or attach fewer files"
+        );
+    }
+    if total_bytes > max_total {
+        bail!(
+            "attachments total {total_bytes} bytes, over the {max_total}-byte budget for \
+             one call — attach fewer or smaller files (each file's own size cap still applies)"
+        );
+    }
+    Ok(())
 }
 
 /// Neutralize any `<file>`-tag lookalike in an attachment body so it can't read as a
@@ -288,6 +326,37 @@ mod tests {
         let err = classify("notes.txt", &big, 32, DEFAULT_MAX_IMAGE_BYTES)
             .expect_err("a text file over the cap must be refused, not truncated");
         assert!(err.to_string().contains("text cap"), "names the cap: {err}");
+    }
+
+    /// The batch-level bounds refuse too many files and too many cumulative bytes, before
+    /// any read — the per-file caps don't cover "1,000 small files" or "N under-cap files
+    /// summing to an OOM". Saturating sum so a crafted size can't wrap past the budget.
+    #[test]
+    fn attachment_bounds_refuse_too_many_or_too_large() {
+        // Within bounds: ok (and the budget is an inclusive max).
+        assert!(check_attachment_bounds(3, 60, 64, 1 << 25).is_ok());
+        assert!(
+            check_attachment_bounds(1, 10, 64, 10).is_ok(),
+            "exactly at budget is fine"
+        );
+        assert!(
+            check_attachment_bounds(0, 0, 64, 1 << 25).is_ok(),
+            "empty is fine"
+        );
+
+        // Count cap: one too many is refused, naming the limit (total irrelevant here).
+        let err = check_attachment_bounds(65, 0, 64, 1 << 25).expect_err("65 > 64 refused");
+        assert!(
+            err.to_string().contains("too many attachments"),
+            "names the count cap: {err}"
+        );
+
+        // Cumulative cap: count is fine, but the bytes bust the budget.
+        let err = check_attachment_bounds(2, 12, 64, 10).expect_err("12 > 10 refused");
+        assert!(
+            err.to_string().contains("budget"),
+            "names the byte budget: {err}"
+        );
     }
 
     /// A body that itself contains the literal close delimiter can't terminate the

--- a/src/server.rs
+++ b/src/server.rs
@@ -719,8 +719,11 @@ impl KaiboHandler {
     /// Failures are loud and per-path: a missing file, a directory, an over-cap or
     /// non-text/non-image file is a clear `invalid_params`, never a silent skip — an
     /// attachment the caller named but we dropped would be a corrupt answer. An absolute
-    /// size ceiling is enforced *before* reading (via the file's metadata) so a giant
-    /// file is refused without first slurping it into memory.
+    /// per-file size ceiling is enforced *before* reading (via the file's metadata) so a
+    /// giant file is refused without first slurping it into memory; a batch-level count cap
+    /// and cumulative-byte budget ([`check_attachment_bounds`](crate::attach::check_attachment_bounds))
+    /// bound the *whole call* the same way — a stray thousand-file glob, or many
+    /// individually-legal files summing to an OOM, is refused before the offending read.
     ///
     /// **The read goes through the read-only kaish VFS, not `std::fs::read`** — the same
     /// mechanism `view_image` uses. The canonicalize + containment check above is the
@@ -737,15 +740,24 @@ impl KaiboHandler {
         &self,
         paths: &[String],
     ) -> Result<Vec<crate::attach::Attachment>, McpError> {
-        use crate::attach::{classify, DEFAULT_MAX_IMAGE_BYTES, DEFAULT_MAX_TEXT_BYTES};
+        use crate::attach::{
+            check_attachment_bounds, classify, DEFAULT_MAX_ATTACHMENTS, DEFAULT_MAX_IMAGE_BYTES,
+            DEFAULT_MAX_TEXT_BYTES, DEFAULT_MAX_TOTAL_BYTES,
+        };
         // The pre-read ceiling: whichever encoding cap is larger. `classify` applies the
         // precise per-encoding cap after sniffing; this just bounds the read itself.
         let read_ceiling = DEFAULT_MAX_TEXT_BYTES.max(DEFAULT_MAX_IMAGE_BYTES);
+        // Fail fast on count *before* canonicalizing the whole list (a stray glob could
+        // name thousands). The cumulative-byte budget is enforced per file below as the
+        // running total grows — before each read, so an oversized batch never slurps in.
+        check_attachment_bounds(paths.len(), 0, DEFAULT_MAX_ATTACHMENTS, DEFAULT_MAX_TOTAL_BYTES)
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
         // One read-only worker per distinct containing tree, reused across attachments
         // under it (a worker owns a thread + kernel build, so we don't want one per file).
         let mut workers: std::collections::HashMap<PathBuf, KaishWorker> =
             std::collections::HashMap::new();
         let mut out = Vec::with_capacity(paths.len());
+        let mut total_bytes: u64 = 0;
         for p in paths {
             let raw = std::path::PathBuf::from(p);
             let canon = std::fs::canonicalize(&raw).map_err(|e| {
@@ -783,6 +795,17 @@ impl KaiboHandler {
                     None,
                 ));
             }
+            // Cumulative budget across the batch, checked *before* this file's read so a
+            // batch of individually-legal files can't sum to an out-of-memory read. The
+            // running total saturates so a crafted size can't wrap past the budget.
+            total_bytes = total_bytes.saturating_add(meta.len());
+            check_attachment_bounds(
+                out.len() + 1,
+                total_bytes,
+                DEFAULT_MAX_ATTACHMENTS,
+                DEFAULT_MAX_TOTAL_BYTES,
+            )
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
             // Read *through the VFS* rooted at the containing tree — see the doc-comment.
             // A swapped escaping symlink is refused at the mount, not read through.
             if !workers.contains_key(&tree) {

--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -192,6 +192,24 @@ async fn attachment_in_a_second_allowed_tree_reads_through_its_own_worker() {
     }
 }
 
+/// Too many attachments in one call is refused up front — the batch-level count cap,
+/// checked before any filesystem work (a stray glob shouldn't canonicalize thousands of
+/// paths). The cap is `DEFAULT_MAX_ATTACHMENTS` (64); 65 dummy paths trip it before any
+/// of them is even resolved, so they needn't exist.
+#[tokio::test]
+async fn too_many_attachments_is_refused() {
+    let handler = handler_rooted_at(tempdir().unwrap().path());
+    let many: Vec<String> = (0..65).map(|i| format!("/nonexistent/f{i}.txt")).collect();
+    let err = handler
+        .resolve_attachments(&many)
+        .await
+        .expect_err("more than the count cap must be refused");
+    assert!(
+        format!("{err:?}").contains("too many attachments"),
+        "refusal names the count cap, got: {err:?}"
+    );
+}
+
 // --- vision gate: an image to a blind synth is refused offline ----------------
 
 /// `batch_submit` with an image attachment on a synth model pinned vision-blind is


### PR DESCRIPTION
## What

`resolve_attachments` capped each *file*'s size but had no limit on the *number* of attachments or their *cumulative* bytes — a stray thousand-file glob, or many individually-legal files summing past memory, would all be read. This adds two batch-level bounds with loud errors.

New `attach::check_attachment_bounds(count, total, max_count, max_total)` — pure and cap-injected (the `classify` shape) so the thresholds are unit-tested without cap-sized fixtures. `resolve_attachments` calls it twice:
- **up front** on count alone, *before* canonicalizing the list — a huge list fails fast with no wasted syscalls;
- **per file** on the saturating running total, *before* each read — so an oversized batch is refused before the offending slurp.

Defaults: **64** attachments, **32 MiB** cumulative. Generous, loud when busted.

## Scope (deliberately not everything Gemini Pro flagged)

This closes the two cheap, all-in-kaibo items from the Gemini Pro review of #16. Left deferred (re-scoped in `docs/issues.md`):
- **streaming per-file cap** — the real OOM-on-swap teeth; needs a kaish-vfs `read_file` that bounds the read, not just a pre-check. The cumulative cap shrinks its blast radius in the meantime.
- **FIFO/special-file read timeout** — judged rare; parked unless it bites.

These are pre-existing and self-attacks (the caller owns the request + workspace), so DoS not confidentiality — but the count cap also catches the honest-accident case (a stray glob).

## Review

Cross-family pass (DeepSeek) over the diff: **no bugs** — confirmed the ordering (budget check before the VFS read), strict-`>` boundary (exactly-at-budget passes), saturating sum, and that the early/per-iteration double call can't drift. Unit test covers the count + cumulative thresholds; an integration test trips the count cap with 65 paths (refused before any I/O). Full suite green (21 binaries), clippy clean.

Closes the count/cumulative half of the attachment-resource-bounds item in `docs/issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)