### PR TITLE
Degrade orientation to a directory map for large repos, not a refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,16 @@ the git log. Each later release appends a new section at the top.
 - **Operator ignore files** via a `[kaish.ignore]` config stanza.
 - **Thinking on by default,** with model-aware request shaping (per-provider thinking
   config, per-role reasoning effort, generous completion-token headroom).
+- **Repo orientation in the preamble.** Before a `consult`/`explore` investigates,
+  kaibo splices the project's layout into the exploring preamble so the model starts
+  *knowing* where things are instead of spending its first turns discovering them.
+  Small repos get the complete file list; larger ones (over `[orientation]
+  full_list_max_files`, default 256) get a depth-limited **directory map** (`dir/  N
+  files` lines, `tree_max_depth` deep, default 4) instead of a refused call; a repo
+  too large for even that map gets a short note pointing at discovery tools. The map
+  is never silently skipped and a big repo is never an error — orientation is an
+  enhancement, so its absence just costs the model a few discovery turns it always
+  could have taken.
 - **Multi-turn sessions** via `session_id`, and optional OTLP/HTTP trace export
   (`[telemetry]`, off by default).
 - **A failed provider doesn't fail your turn.** When a model or its provider misbehaves

--- a/docs/config.md
+++ b/docs/config.md
@@ -544,7 +544,8 @@ Agentless/Aider, made free — no model in the loop).
 ```toml
 [orientation]
 enabled = true               # default; set false to turn the map off
-full_list_max_files = 256    # ≤ this → inject the full list; above → refuse the call
+full_list_max_files = 256    # ≤ this → inject the full file list; above → directory map
+tree_max_depth = 4           # how deep the fallback directory map descends
 ```
 
 How it works: the server runs the kernel's **own** `glob -a --json '**/*'` server-side
@@ -553,12 +554,20 @@ would get (same VFS, same ignore rules), so the map can't disagree with what the
 explorer's own `glob`/`grep` sees. `-a` includes hidden config (`.github/`, `.cargo/`);
 the ignore filter still drops `.git`/`target`.
 
-Size-gated, by file count:
+Size-gated, with a graceful descent — orientation is an *enhancement* (the model always
+has `glob`/`grep`/`explore′`), so its absence is never fatal and the call is never refused
+for being large:
 - **≤ `full_list_max_files`** → the complete file list is spliced in.
-- **above it** → the call is **refused loudly** (`internal_error` naming the knob).
-  A big repo is an explicit error, not a silent partial dump — raise the limit, set `enabled = false`,
-  or point a cast that explores via `grep` at it. (`full_list_max_files = 0` is a load
-  error: it would refuse every repo; disable instead.)
+- **above it** → a **directory map**: the same files folded into a depth-limited tree of
+  `dir/  N files` lines, descending `tree_max_depth` levels (deeper files stay counted at
+  the deepest shown directory). The names are traded for structure; the model recovers them
+  with `glob 'DIR/**/*'` / `grep -rn`.
+- **above it *and* the directory map would itself exceed `full_list_max_files` lines** (a very
+  large or very wide repo) → a short **discover-as-you-go note** naming the discovery tools.
+  Skipped maps are logged (`tracing::warn`), not silent.
+
+`full_list_max_files = 0` is a load error (it would refuse every repo — disable instead), as is
+`tree_max_depth = 0` (it would render an empty map).
 
 It rides the **exploring** phases only — the `consult` driver and its nested
 `explore′` sweep. The toolless `oneshot` reads no project, so it gets no map. Like

--- a/src/config.rs
+++ b/src/config.rs
@@ -1392,16 +1392,18 @@ struct RawPrompts {
 }
 
 /// The `[orientation]` stanza — the static repo-map injected into the exploring
-/// preamble. Both fields optional; defaults are on with a 256-file ceiling. See
-/// [`OrientationConfig`].
+/// preamble. All fields optional; defaults are on with a 256-file ceiling and a
+/// 4-level fallback tree. See [`OrientationConfig`].
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawOrientation {
     /// Inject the map at all. Default `true`.
     enabled: Option<bool>,
-    /// File-count ceiling for the full-list form; over it, a call is refused.
-    /// Default `256`.
+    /// File-count ceiling for the full-list form; over it, the map falls back to a
+    /// directory tree. Default `256`.
     full_list_max_files: Option<usize>,
+    /// How many directory levels the fallback tree descends. Default `4`.
+    tree_max_depth: Option<usize>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1714,7 +1716,9 @@ fn merge_prompts(raw: RawPrompts) -> Result<PromptOverrides> {
 
 /// Resolve `[orientation]`. A zero `full_list_max_files` would refuse *every* repo
 /// (no project has zero files), which is never the intent — disable it via
-/// `enabled = false` instead. Loud at load rather than a baffling per-call error.
+/// `enabled = false` instead. A zero `tree_max_depth` would render an empty
+/// directory map, which is equally pointless. Both are loud at load rather than a
+/// baffling per-call result.
 fn merge_orientation(raw: RawOrientation) -> Result<OrientationConfig> {
     let d = OrientationConfig::default();
     let full_list_max_files = raw.full_list_max_files.unwrap_or(d.full_list_max_files);
@@ -1724,9 +1728,17 @@ fn merge_orientation(raw: RawOrientation) -> Result<OrientationConfig> {
              every repo; set `enabled = false` to turn the map off instead"
         );
     }
+    let tree_max_depth = raw.tree_max_depth.unwrap_or(d.tree_max_depth);
+    if tree_max_depth == 0 {
+        bail!(
+            "[orientation] tree_max_depth must be > 0 — a zero depth renders an empty \
+             directory map; set `enabled = false` to turn the map off instead"
+        );
+    }
     Ok(OrientationConfig {
         enabled: raw.enabled.unwrap_or(d.enabled),
         full_list_max_files,
+        tree_max_depth,
     })
 }
 

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -11,24 +11,38 @@
 //! includes hidden config like `.github/`/`.cargo/`; the ignore filter still drops
 //! `.git`/`target`.)
 //!
-//! Size-gated: at or under `full_list_max_files` the whole list is injected; past it
-//! the call is refused loudly (the directory-tree fallback for larger repos is the
-//! next increment — for now, big repos are an explicit error, not a silent dump).
+//! Size-gated, with a graceful descent — orientation is an *enhancement* (the model
+//! always has `glob`/`grep`/`explore′` regardless), so its absence must never be
+//! fatal. At or under `full_list_max_files` the whole file list is injected. Above
+//! it the flat list would be too big, so we fall back to a **directory map**: the
+//! same files folded into a depth-limited tree of dir → file-count lines, which
+//! gives the model the layout without the line budget of every path. If even that
+//! map would exceed the line budget (a very large or very wide repo), orientation
+//! degrades to a short note pointing the model at discovery-as-you-go — logged, not
+//! silent. The call is never refused for being large; that was the old behavior and
+//! it turned a missing nicety into a hard failure.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use crate::sandbox::{KaishWorker, SandboxConfig};
 
-/// Resolved `[orientation]` config: whether to inject the repo map, and the
-/// file-count ceiling for the full-list form.
+/// Resolved `[orientation]` config: whether to inject the repo map, the file-count
+/// ceiling that switches the full list to a directory map, and how deep that map
+/// descends.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrientationConfig {
     pub enabled: bool,
-    /// At or under this many files, inject the complete list. Above it, the call is
-    /// refused (dir-tree fallback not yet built).
+    /// At or under this many files, inject the complete file list. Above it, fall
+    /// back to a directory map. Doubles as the line budget for that map: if the map
+    /// would render more directory lines than this, orientation degrades to a note.
     pub full_list_max_files: usize,
+    /// How many directory levels the fallback map descends before folding deeper
+    /// files into the count of the deepest shown directory. Keeps a deep monorepo's
+    /// map bounded.
+    pub tree_max_depth: usize,
 }
 
 impl Default for OrientationConfig {
@@ -36,14 +50,16 @@ impl Default for OrientationConfig {
         Self {
             enabled: true,
             full_list_max_files: 256,
+            tree_max_depth: 4,
         }
     }
 }
 
 impl OrientationConfig {
     /// Build the orientation block for `root`, or `None` when disabled or the repo
-    /// is empty. Errors (loudly) when the repo is larger than `full_list_max_files`
-    /// — that's a configuration decision the operator should see, not a silent skip.
+    /// is empty. Never errors on size — a large repo gets a directory map, and a
+    /// repo too large for even that gets a discover-as-you-go note (logged). The
+    /// only hard errors are a failed kernel spawn or unparseable enumeration.
     pub async fn assemble(&self, root: &Path, sandbox: SandboxConfig) -> Result<Option<String>> {
         if !self.enabled {
             return Ok(None);
@@ -55,16 +71,26 @@ impl OrientationConfig {
             return Ok(None);
         }
         let n = files.len();
-        if n > self.full_list_max_files {
-            bail!(
-                "this project has {n} files, over [orientation] full_list_max_files \
-                 ({}). The directory-tree map for larger repos isn't built yet — raise \
-                 the limit, set [orientation] enabled = false, or point a cast that \
-                 explores via `grep` at it.",
-                self.full_list_max_files
-            );
+        if n <= self.full_list_max_files {
+            return Ok(Some(render_full_list(&files)));
         }
-        Ok(Some(render(&files)))
+        // Too many files for a flat list — fold into a directory map.
+        let tree = DirNode::from_paths(&files);
+        let dir_lines = tree.rendered_dir_count(1, self.tree_max_depth);
+        if dir_lines > self.full_list_max_files {
+            // Even the directory map exceeds the line budget — a very large or very
+            // wide repo. Degrade to a note rather than dump (or refuse). Loud in the
+            // log so the operator can see the map was skipped and why.
+            tracing::warn!(
+                files = n,
+                directories = dir_lines,
+                budget = self.full_list_max_files,
+                "orientation: repo too large for a directory map; injecting a \
+                 discover-as-you-go note instead"
+            );
+            return Ok(Some(render_too_large_note(n, dir_lines)));
+        }
+        Ok(Some(render_tree(&tree, n, self.tree_max_depth)))
     }
 }
 
@@ -92,10 +118,11 @@ async fn list_files(worker: &KaishWorker) -> Result<Vec<String>> {
     Ok(files)
 }
 
-/// Render the file list into the injected block. The framing tells the model the
-/// map is complete (so it skips discovery) and points it at the reads it should do
-/// instead — the whole point is to convert "what's here?" turns into direct reads.
-fn render(files: &[String]) -> String {
+/// Render the complete file list into the injected block. The framing tells the
+/// model the map is complete (so it skips discovery) and points it at the reads it
+/// should do instead — the whole point is to convert "what's here?" turns into
+/// direct reads.
+fn render_full_list(files: &[String]) -> String {
     let mut s = String::with_capacity(64 + files.iter().map(|f| f.len() + 1).sum::<usize>());
     s.push_str(
         "PROJECT FILES. The project's complete file list (read-only; hidden config \
@@ -109,6 +136,121 @@ fn render(files: &[String]) -> String {
         s.push('\n');
     }
     s
+}
+
+/// Render the depth-limited directory map for a repo too large to list flat. Each
+/// line is a directory and the total file count under it; the framing tells the
+/// model the names were traded for structure and how to recover them (`glob` a
+/// directory, `grep -rn` to locate, `cat -n` to read).
+fn render_tree(root: &DirNode, total_files: usize, max_depth: usize) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "PROJECT STRUCTURE. This project has {total_files} files — too many to list \
+         individually, so here is its directory map (read-only; build/VCS dirs \
+         excluded). Each line is a directory and the number of files under it. Go \
+         straight to the directories the question touches: `grep -rn PATTERN DIR/` to \
+         find where something lives, then `cat -n DIR/FILE` to read it; `glob \
+         'DIR/**/*'` lists a directory's files when you need exact names.\n"
+    ));
+    if root.direct_files > 0 {
+        s.push_str(&format!(
+            "  ./  {}\n",
+            count_phrase(root.direct_files)
+        ));
+    }
+    root.render_children("", 1, max_depth, &mut s);
+    s
+}
+
+/// Render the discover-as-you-go note for a repo too large for even a directory map.
+/// Positive, action-first framing: name the tools that find structure on demand
+/// rather than dwelling on the absence of a map.
+fn render_too_large_note(total_files: usize, directories: usize) -> String {
+    format!(
+        "PROJECT STRUCTURE. This project is very large ({total_files} files across \
+         {directories}+ directories) — too big for a file or directory map. Discover \
+         the layout as you go: `glob '**/*.rs'` (or another extension) to list files \
+         of a kind, `grep -rln PATTERN` to find where something lives, then `cat -n \
+         FILE` to read it.\n"
+    )
+}
+
+/// "1 file" / "N files" — pluralized so the map reads naturally.
+fn count_phrase(n: usize) -> String {
+    if n == 1 {
+        "1 file".to_string()
+    } else {
+        format!("{n} files")
+    }
+}
+
+/// A node in the directory tree: files directly in this directory, and named child
+/// directories. Built purely from the file path list — no second enumeration, so it
+/// can never disagree with the full-list form.
+#[derive(Default)]
+struct DirNode {
+    direct_files: usize,
+    children: BTreeMap<String, DirNode>,
+}
+
+impl DirNode {
+    /// Fold a list of `/`-separated relative file paths into a tree. The final
+    /// component is the file (counted on its directory); the rest are directories.
+    fn from_paths(files: &[String]) -> DirNode {
+        let mut root = DirNode::default();
+        for f in files {
+            let comps: Vec<&str> = f.split('/').filter(|c| !c.is_empty()).collect();
+            root.insert(&comps);
+        }
+        root
+    }
+
+    fn insert(&mut self, comps: &[&str]) {
+        match comps {
+            [] => {}
+            [_file] => self.direct_files += 1,
+            [dir, rest @ ..] => self
+                .children
+                .entry((*dir).to_string())
+                .or_default()
+                .insert(rest),
+        }
+    }
+
+    /// Total files at or under this node.
+    fn total_files(&self) -> usize {
+        self.direct_files + self.children.values().map(DirNode::total_files).sum::<usize>()
+    }
+
+    /// How many directory lines `render_children` would emit at this depth/limit —
+    /// the line-budget check, computed without building the string.
+    fn rendered_dir_count(&self, depth: usize, max_depth: usize) -> usize {
+        if depth > max_depth {
+            return 0;
+        }
+        self.children
+            .values()
+            .map(|c| 1 + c.rendered_dir_count(depth + 1, max_depth))
+            .sum()
+    }
+
+    /// Emit `prefix-qualified DIR/  N files` lines, descending until `max_depth`.
+    /// Past the depth limit, deeper files stay folded into a directory's total
+    /// count (which already includes them) — the structure is summarized, not lost.
+    fn render_children(&self, prefix: &str, depth: usize, max_depth: usize, s: &mut String) {
+        if depth > max_depth {
+            return;
+        }
+        for (name, child) in &self.children {
+            let path = format!("{prefix}{name}/");
+            let indent = "  ".repeat(depth);
+            s.push_str(&format!(
+                "{indent}{path}  {}\n",
+                count_phrase(child.total_files())
+            ));
+            child.render_children(&path, depth + 1, max_depth, s);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -143,24 +285,88 @@ mod tests {
         assert!(out.contains("README.md"), "lists the readme: {out}");
     }
 
-    /// Over the file-count ceiling, the call is refused loudly (not a silent skip).
+    /// Over the file-count ceiling, the flat list gives way to a directory map —
+    /// dir → file-count lines — instead of refusing the call. Orientation is an
+    /// enhancement; a large repo must still get one.
     #[tokio::test]
-    async fn refuses_a_repo_over_the_limit() {
+    async fn summarizes_a_repo_over_the_limit_as_a_dir_map() {
+        let dir = tempdir().unwrap();
+        // 6 files across two directories, over a ceiling of 3.
+        write(dir.path(), "src/a.rs", "x\n");
+        write(dir.path(), "src/b.rs", "x\n");
+        write(dir.path(), "src/c.rs", "x\n");
+        write(dir.path(), "docs/one.md", "x\n");
+        write(dir.path(), "docs/two.md", "x\n");
+        write(dir.path(), "README.md", "x\n");
+        let canon = std::fs::canonicalize(dir.path()).unwrap();
+        let cfg = OrientationConfig {
+            enabled: true,
+            full_list_max_files: 3,
+            tree_max_depth: 4,
+        };
+        let out = cfg
+            .assemble(&canon, SandboxConfig::default())
+            .await
+            .unwrap()
+            .expect("a large repo still yields a map");
+        assert!(out.contains("PROJECT STRUCTURE"), "framed as structure: {out}");
+        assert!(out.contains("src/  3 files"), "src dir + count: {out}");
+        assert!(out.contains("docs/  2 files"), "docs dir + count: {out}");
+        // The flat names are traded for structure — no individual source file listed.
+        assert!(!out.contains("a.rs"), "names are folded into counts: {out}");
+        // The root file is reflected in the root line, singular-pluralized.
+        assert!(out.contains("./  1 file"), "root file counted: {out}");
+    }
+
+    /// The directory map descends only `tree_max_depth` levels; files deeper than
+    /// that stay folded into the deepest shown directory's total count, so a deep
+    /// tree can't blow the budget.
+    #[tokio::test]
+    async fn dir_map_respects_max_depth() {
         let dir = tempdir().unwrap();
         for i in 0..5 {
-            write(dir.path(), &format!("f{i}.txt"), "x\n");
+            write(dir.path(), &format!("a/b/c/deep{i}.rs"), "x\n");
         }
         let canon = std::fs::canonicalize(dir.path()).unwrap();
         let cfg = OrientationConfig {
             enabled: true,
-            full_list_max_files: 3, // below the 5 we wrote
+            full_list_max_files: 3,
+            tree_max_depth: 2,
         };
-        let err = cfg
+        let out = cfg
             .assemble(&canon, SandboxConfig::default())
             .await
-            .unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("full_list_max_files"), "names the knob: {msg}");
+            .unwrap()
+            .expect("yields a map");
+        assert!(out.contains("a/  5 files"), "depth-1 dir + total: {out}");
+        assert!(out.contains("a/b/  5 files"), "depth-2 dir + total: {out}");
+        assert!(!out.contains("a/b/c/"), "depth-3 dir folded away: {out}");
+    }
+
+    /// When even the directory map would exceed the line budget (more directories
+    /// than `full_list_max_files`), orientation degrades to a discover-as-you-go
+    /// note — never a refusal, never a dump.
+    #[tokio::test]
+    async fn very_wide_repo_degrades_to_a_note() {
+        let dir = tempdir().unwrap();
+        // 5 sibling directories, each one file — 5 dir lines, over a ceiling of 2.
+        for i in 0..5 {
+            write(dir.path(), &format!("d{i}/f.rs"), "x\n");
+        }
+        let canon = std::fs::canonicalize(dir.path()).unwrap();
+        let cfg = OrientationConfig {
+            enabled: true,
+            full_list_max_files: 2,
+            tree_max_depth: 4,
+        };
+        let out = cfg
+            .assemble(&canon, SandboxConfig::default())
+            .await
+            .unwrap()
+            .expect("still yields a note");
+        assert!(out.contains("very large"), "framed as too-large: {out}");
+        assert!(out.contains("Discover"), "points at discovery: {out}");
+        assert!(!out.contains("d0/"), "no directory lines dumped: {out}");
     }
 
     /// Disabled → no map, no work.
@@ -172,6 +378,7 @@ mod tests {
         let cfg = OrientationConfig {
             enabled: false,
             full_list_max_files: 256,
+            tree_max_depth: 4,
         };
         assert_eq!(
             cfg.assemble(&canon, SandboxConfig::default())

--- a/src/server.rs
+++ b/src/server.rs
@@ -853,8 +853,10 @@ impl KaiboHandler {
     /// Assemble the static repo-orientation map for this call against the resolved
     /// `root` — the `[orientation]` block injected into the exploring preamble. Runs
     /// the kernel's own `glob` server-side (no model turn). A repo over the file
-    /// ceiling is a loud `internal_error` (the operator chose that limit), per
-    /// `OrientationConfig::assemble`. Only the *exploring* tools call this.
+    /// ceiling gets a directory map, and one too large for even that gets a short
+    /// discover-as-you-go note — never a refusal, per `OrientationConfig::assemble`.
+    /// Errors here are real failures (kernel spawn, unparseable enumeration), not
+    /// size. Only the *exploring* tools call this.
     async fn orientation(&self, root: &std::path::Path) -> Result<Option<Arc<str>>, McpError> {
         self.config
             .orientation

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1587,21 +1587,37 @@ fn an_empty_slot_preamble_is_a_loud_error() {
 
 // --- [orientation] static repo map --------------------------------------------
 
-/// No `[orientation]` table → on by default, 256-file ceiling.
+/// No `[orientation]` table → on by default, 256-file ceiling, depth-4 fallback.
 #[test]
 fn orientation_defaults_on_with_256_ceiling() {
     let c = Config::builtin();
     assert!(c.orientation.enabled);
     assert_eq!(c.orientation.full_list_max_files, 256);
+    assert_eq!(c.orientation.tree_max_depth, 4);
 }
 
-/// The table tunes both knobs.
+/// The table tunes every knob.
 #[test]
 fn orientation_table_tunes_enabled_and_ceiling() {
-    let c = Config::from_toml_str("[orientation]\nenabled = false\nfull_list_max_files = 1000\n")
-        .unwrap();
+    let c = Config::from_toml_str(
+        "[orientation]\nenabled = false\nfull_list_max_files = 1000\ntree_max_depth = 6\n",
+    )
+    .unwrap();
     assert!(!c.orientation.enabled);
     assert_eq!(c.orientation.full_list_max_files, 1000);
+    assert_eq!(c.orientation.tree_max_depth, 6);
+}
+
+/// A zero `tree_max_depth` is a loud load error — it would render an empty
+/// directory map; disable instead.
+#[test]
+fn a_zero_tree_depth_is_a_loud_error() {
+    let err = Config::from_toml_str("[orientation]\ntree_max_depth = 0\n")
+        .expect_err("a zero depth must be rejected");
+    assert!(
+        format!("{err:#}").contains("tree_max_depth"),
+        "names the knob: {err:#}"
+    );
 }
 
 /// A zero ceiling is a loud load error — it would refuse every repo; disable


### PR DESCRIPTION
## What

Replaces the old loud refusal for repos over `[orientation] full_list_max_files` with a graceful descent, so orientation is never a hard failure.

Orientation is an *enhancement* — the exploring model always has `glob`/`grep`/`explore′`, so a missing map only costs it a few discovery turns it could always have taken. The old behavior turned that nicety into a hard failure: a repo over the ceiling refused the call outright. That's the wrong shape for an enhancement.

## Behavior

- **≤ `full_list_max_files`** → complete flat file list (unchanged).
- **above it** → depth-limited **directory map** (`dir/  N files` lines, descending `tree_max_depth` levels, default 4). Names traded for structure; the model recovers them with `glob`/`grep`.
- **map would itself exceed the line budget** (very wide or deep repo) → short **discover-as-you-go note**. Logged via `tracing::warn`, never silent.

A new `tree_max_depth` knob (default 4) controls descent. Like `full_list_max_files`, a zero value is a loud load error (it would render an empty map) — disable the feature instead.

The tree is built purely from the file-path list already enumerated for the flat form — no second enumeration, so the map can never disagree with what the explorer's own `glob` sees. The line-budget check reuses the same `DirNode` via `rendered_dir_count` rather than rendering-then-measuring.

## Tests

- `summarizes_a_repo_over_the_limit_as_a_dir_map` — large repo yields a dir map, names folded into counts, root file counted.
- `dir_map_respects_max_depth` — files deeper than `tree_max_depth` stay folded into the deepest shown directory's total.
- `very_wide_repo_degrades_to_a_note` — too many dir lines → discover note, no refusal, no dump.
- `a_zero_tree_depth_is_a_loud_error` + updated config-table/default tests.

## Review

Cross-family reviewed via kaibo/deepseek (different lineage than the Claude that wrote it): no correctness bugs — depth-folding, line-count parity between `rendered_dir_count` and `render_children`, and config wiring all verified. One by-design note: the root `./` line sits outside the directory-line budget (≤1-line overshoot), consistent with the doc framing the budget as directory lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)