### PR TITLE
Async consult: submit/wait surface, attach-on-consult, and a watchable live view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,23 @@ the git log. Each later release appends a new section at the top.
   (with a vision-capable synth model). Paths obey the same workspace boundary as
   everything else (worktrees included); a file outside it, a directory, an oversized
   file, or a binary that isn't a known image is refused with a clear error.
+- **`wait`** — block briefly and productively for your async work instead of
+  blind-polling `get`. Fire off consults and batches, do your other work, then `wait`
+  when you're ready to spend a minute on kaibo: it blocks up to `timeout_secs` (you
+  choose — no clamp; interruptible) and returns as soon as something lands, or on a clean
+  timeout. By default it hands back what kaibo flags as worth your attention (a job
+  finished/failed, a research-limit) plus which consult jobs are still running; pass
+  `level: "info"` to also pull the watchable narrative — each kaish command, sweep, and
+  milestone the agents ran — into your context. Name batch handles in `handles` to fold a
+  one-shot poll of them in too. Nothing wakes you (you choose when to block) and it isn't
+  the source of truth — `get`/`list` are; a clean empty return just means nothing new yet.
+  This pairs with launching work in parallel: submit several, do everything else, then
+  `wait` to merge the outputs.
+- **Async consults are watchable again.** A `consult_submit` job now streams its liveness
+  (each kaish command, sweep, and milestone) onto kaibo's logging channel — the live
+  "watch it work" view a synchronous `consult` always had, restored for the async path.
+  It rides kaibo's level convention (Info = the narrative; Warn = "the calling model
+  should see this"), so a watching client sees the show and `wait` pulls the salient bits.
 - **`get` / `cancel` / `list`** — one shared surface to collect, stop, and survey
   *both* kinds of async work, told apart by the handle: a batch handle is
   `backend/provider-id`, a consult job is `job-N`. `get <handle>` returns a progress/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ the git log. Each later release appends a new section at the top.
   answer carries a provenance footer naming the cast and the models that produced it.
   Args: `question`, `context`, `path`, `cast`, `session_id`, `include_report`, and
   per-call `explorer_model` / `synth_model` (+ `_backend`) overrides.
+- **`consult_submit`** — the *async sibling* of `consult` (as batch is to `oneshot`):
+  start a consultation in the background and get back a handle (`job-N`) instead of
+  holding your turn open while a deep investigation runs. Same investigation, same args
+  as `consult`. Built for running several consults at once — a cross-model study submits
+  one per `cast` and collects them all — or for not blocking on a long answer: submit, go
+  do other work, collect later. Jobs are in-memory and live only for the server session
+  (no restart survival), evicted by capacity like sessions. Replaces the pattern of
+  spawning a throwaway sub-agent just to hold a blocking `consult` open. On completion a
+  job emits a soft notification on the MCP logging channel (a clue for a client watching
+  the log stream) — advisory only, since no MCP primitive wakes the calling agent;
+  collecting by handle stays the contract.
 - **`oneshot`** — a thin, direct second opinion from a model outside your family:
   prompt in, answer out, no codebase access and no tools, exactly one upstream
   request. The counterpart to `consult` for when you already own the context (you've
@@ -39,10 +50,10 @@ the git log. Each later release appends a new section at the top.
   `gpt-image` / DALL·E, or a local Stable-Diffusion server). Its `cast` parameter
   advertises the casts that actually carry a usable image slot as a schema enum, so a
   host agent picks one off the schema — as discoverable as the consultation tools.
-- **Batch (`batch_submit` / `batch_get` / `batch_cancel` / `batch_list`)** — the
-  *offline, async sibling* of `oneshot`: submit a list of tool-less prompts, get a
-  handle, poll it, read every answer when the provider's batch lane finishes — no call
-  held open per answer. Built for fanning many prompts (or one hard question you'll wait on) at a
+- **Batch (`batch_submit`)** — the *offline, async sibling* of `oneshot`: submit a list
+  of tool-less prompts, get a handle, then collect it with the shared `get`/`cancel`/
+  `list` verbs (see below) — read every answer when the provider's batch lane finishes,
+  no call held open per answer. Built for fanning many prompts (or one hard question you'll wait on) at a
   top-tier model: it maxes the knobs (forces high thinking effort + a generous token
   budget) regardless of how the cast was tuned for interactive use, and a per-call
   `model`/`backend` override lets you batch a Pro/Opus tier a cast otherwise synths
@@ -55,8 +66,8 @@ the git log. Each later release appends a new section at the top.
   its latency is free. Gated by `--no-batch` (one flag over every verb). Batch carries its
   own system preamble fit to the offline lane — one complete, self-contained response with
   no follow-up, told to spend on depth — overridable via `[prompts].batch` like the other
-  phases. While a batch runs, `batch_get` reminds you to go do other work and check back
-  rather than wait on it. Lost a handle? `batch_list` re-discovers the batches a backend
+  phases. While a batch runs, `get` reminds you to go do other work and check back
+  rather than wait on it. Lost a handle? `list` re-discovers the batches a backend
   still holds (newest first, each with its handle, status, and progress), so a batch is
   never orphaned — defaulting across every batch-capable backend, or scoped to one with
   `backend`. **`attach`** lets you name workspace files to inline as shared context for
@@ -66,6 +77,18 @@ the git log. Each later release appends a new section at the top.
   (with a vision-capable synth model). Paths obey the same workspace boundary as
   everything else (worktrees included); a file outside it, a directory, an oversized
   file, or a binary that isn't a known image is refused with a clear error.
+- **`get` / `cancel` / `list`** — one shared surface to collect, stop, and survey
+  *both* kinds of async work, told apart by the handle: a batch handle is
+  `backend/provider-id`, a consult job is `job-N`. `get <handle>` returns a progress/
+  status line while the work runs and the full result when it lands; `cancel <handle>`
+  stops it; `list` shows everything in flight — your in-memory consult jobs plus the
+  batches each backend still holds — each with a ready-to-use handle. One mental model
+  for everything you submit. The verbs stay available as long as either `consult` or
+  batch is enabled (gated off only when both are). `list` trims its batch section to the
+  **last 24 hours** by default — a provider keeps months of finished batches and dumping
+  them all just burns tokens, while anything older is done and still collectible by its
+  handle; it reports how many it hid and takes `all: true` for the full history (true
+  orphan recovery). Consult jobs are always shown in full.
 - **`view_image`** — vision-capable consultation phases can read an image *file* from
   the workspace into model context (screenshots, diagrams, assets already in the tree).
 - **Multi-provider model teams.** Anthropic, DeepSeek, and Gemini natively, plus a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,13 @@ the git log. Each later release appends a new section at the top.
   family answers with `cast`. Optionally seed it with `context` (a change summary or
   pasted source), trusted as starting evidence while it investigates for more. The
   answer carries a provenance footer naming the cast and the models that produced it.
-  Args: `question`, `context`, `path`, `cast`, `session_id`, `include_report`, and
-  per-call `explorer_model` / `synth_model` (+ `_backend`) overrides.
+  Args: `question`, `context`, `path`, `cast`, `session_id`, `attach`, `include_report`,
+  and per-call `explorer_model` / `synth_model` (+ `_backend`) overrides. **`attach`**
+  names workspace files (under the project root) to put in front of the investigation —
+  unlike the tool-less tools' attach, kaibo does *not* inline them; it names them in the
+  prompt and the consult model reads them itself with the shell when it's ready, in full,
+  building its own narrative. "Review this diff" is `attach: ["changes.diff"]` with no
+  paste; the files just have to live under the root the consult reads (a worktree counts).
 - **`consult_submit`** — the *async sibling* of `consult` (as batch is to `oneshot`):
   start a consultation in the background and get back a handle (`job-N`) instead of
   holding your turn open while a deep investigation runs. Same investigation, same args

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "chrono",
  "clap",
  "kaish-kernel",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 lru = "0.18"
+# RFC3339 parsing for the `list` recency filter only — already in the tree (kaish-kernel
+# / rmcp / schemars). Parsing needs just `alloc`; "now" comes from `SystemTime`, so the
+# `clock` feature (and its iana-time-zone dep) stays off.
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 
 # OpenTelemetry traces (opt-in, off by default — see src/telemetry.rs + config.rs).
 # rig-core already emits the GenAI span tree (invoke_agent → chat → tool, with

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,58 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-24 — Async consult (`consult_submit`), unified collect verbs, and a 24h `list` trim
+
+The seed was a self-observation: Claude (the caller) was spawning throwaway sub-agents
+*just* to hold a blocking `consult` open in the background. That's the missing primitive
+hand-rolled out of the only async construct an agent has — and a bad version of it (a full
+agent context for zero reasoning, lossy relay of the answer, no progress visibility). So:
+make `consult` submittable.
+
+**Async needs in-process state, not disk persistence.** The instinct was "we'll need
+persistence at that point." We didn't. `batch` gets async *for free* because the work lives
+at the provider and the handle *is* the provider's id — but a consult's tool loop runs
+*inside* kaibo, so an async consult has to hold the live loop in-process. That's
+statefulness, not durability. For a stdio server whose lifetime *is* the caller's session,
+disk buys nothing — a restart has no context to resume into. So `JobStore` (`src/jobs.rs`)
+is a clone of the `SessionStore` pattern: `Arc<Mutex<LruCache>>`, capacity-LRU, no TTL,
+diskless. A job dies with the session, exactly as the sub-agent it replaces did.
+
+**The scratch-collision worry was unfounded.** Pre-work assumption: concurrent consults
+share the `/` `MemoryFs` scratch. They don't — `consult.rs` already spawns a fresh
+`KaishWorker` (own kernel + scratch) per call, so the isolation was always per-call. No
+isolation work was needed; read-only project + per-call scratch already pay for it.
+
+**Collapsed the management verbs by handle shape, not an op-enum.** Rather than
+`consult_get`/`consult_cancel` paralleling `batch_get`/`batch_cancel`/`batch_list`, the
+collect verbs unified into one `get`/`cancel`/`list` that route on the handle (`/` ⇒ batch
+`backend/id`, else consult `job-N`). Rejected the one-tool-with-`op`-enum collapse:
+tool-calling models dispatch reliably by *tool*, far less by an enum arg, and the per-op
+required-args differ (get/cancel need a handle, list doesn't). Net 6→5 async tools, one
+mental model ("submit returns a handle; get/cancel/list manage handles"), and consult
+gained a `list` it never had. The verbs gate on `batch || consult` (present while either
+is on), and `list`'s batch section degrades to a *note* when no batch backend is
+configured rather than sinking the consult-jobs section — a local-only setup is the common
+case there.
+
+**`list` recency filter: status, reframed as time.** Amy flagged the batch list dumping
+42 entries (token waste). The literal "drop old stuff" reading barely helps — almost all
+42 were *recent* but *terminal* (done). The waste is finished batches, not old ones. But a
+24h window captures it anyway: the offline SLA is ≤24h, so a batch older than a day is
+done and still collectible by its handle. So default-trim to the last 24h (Amy's call),
+`all: true` for orphan archaeology, and an undateable batch is *kept* not hidden (losing
+sight of a batch is worse than a line). **Brought in `chrono`** for the RFC3339 parse
+rather than hand-rolling calendar math — Amy's preference, and it's already in the tree
+(kaish-kernel / rmcp / schemars), used parse-only so its `clock` feature stays off and no
+new dep (or aws-lc) rides in.
+
+**Completion notification is a clue, not a trigger — proven live.** A finished job emits an
+`info` `tracing` event that rides the existing tracing→MCP `notifications/message` bridge.
+But we tested it: the notification does *not* surface into Claude Code's agent loop (it
+goes to the client's log/debug view). So it's advisory — useful for a human watching logs
+or a client that surfaces them; the calling agent still closes the loop by remembering its
+handle and polling. No MCP primitive wakes the agent, and we didn't pretend otherwise.
+
 ## 2026-06-22 — `$VAR` expansion in `root` / `allow_paths`, for portable scratch reads
 
 Amy asked the real question behind "can a user easily allow kaibo to read `/tmp`?": the

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -152,6 +152,16 @@ completes, while a pure-script spin still dies at 30s.
 
 ## P2 — Focused fixes & hardening
 
+### Flaky: `omitted_path_zero_config_infers_cwd_as_default_root` (cwd race)
+`tests/containment.rs:222` reads the process-wide `std::env::current_dir()` and asserts
+the handler infers it as the default root. It fails intermittently (~1 in 5 full
+`cargo test` runs) and passes in isolation and on re-run — a parallel-execution race on
+the shared process cwd, not a logic bug (untouched by the async-consult work). Fix is to
+make the test not depend on the ambient cwd — drive it through an explicit root/config
+fixture, or serialize the cwd-reading tests. Low priority; it's a test-quality issue, the
+boundary itself is sound.
+
+
 ### Async consult (`consult_submit` + shared `get`/`cancel`/`list`) — follow-ups
 The async-consult surface shipped (`src/jobs.rs` `JobStore`, `consult_submit` in
 `server.rs`, the unified handle-dispatched `get`/`cancel`/`list`). Open polish:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -152,6 +152,31 @@ completes, while a pure-script spin still dies at 30s.
 
 ## P2 — Focused fixes & hardening
 
+### Async consult (`consult_submit` + shared `get`/`cancel`/`list`) — follow-ups
+The async-consult surface shipped (`src/jobs.rs` `JobStore`, `consult_submit` in
+`server.rs`, the unified handle-dispatched `get`/`cancel`/`list`). Open polish:
+- **Dedicated `job_capacity` knob.** Jobs currently reuse `defaults.session_capacity`
+  for their LRU cap (`server.rs`, `JobStore::new` call). Fine for a trial — both are
+  diskless client-keyed registries — but a job result is heavier than a `QaTurn`, so a
+  separate `[defaults] job_capacity` (+ `KAIBO_JOB_CAPACITY`) is the honest knob. Mirror
+  `session_capacity`'s plumbing in `config.rs`.
+- **Progress into the job.** `consult_submit` runs on a `NullSink`, so `get` reports only
+  "running, Ns" — not sweep/turn beats. A buffering `ProgressSink` stored on the job
+  (drained by `get`) would restore the visibility a synchronous `consult` streams. Cheap,
+  high-value; the reason the subagent-wrapper pattern felt opaque.
+- **Completion notification is log-only (by necessity).** A finished job emits an `info`
+  `tracing` event onto the MCP `notifications/message` bridge (`mcp_log`). Confirmed live:
+  Claude Code does *not* surface that into the agent's loop (it's a client log/debug
+  signal), and no MCP primitive wakes the caller — so it's a clue for a human/log-watching
+  client, not a trigger. Don't build polling-avoidance on it. If a client that *does*
+  surface server notifications to its agent shows up, this already works for it.
+- **Independent gate.** The async trio shares the `--no-consult` flag; a `--no-consult-async`
+  (or splitting submit vs. blocking) is the per-tool-gate ideal if anyone wants only one
+  shape. Low priority — they're one capability.
+- **Restart survival is intentionally out of scope.** Jobs die with the session (stdio
+  lifetime = caller session), matching the subagent pattern they replace. Persisting them
+  to disk is a *different product* (kaibo-as-daemon); don't add it without that decision.
+
 ### Path containment check-then-open in `resolve_root` (the attachment half is closed)
 The attachment half **shipped**: `resolve_attachments` (`server.rs`) now reads *through the
 read-only kaish VFS* (`worker.read_file` on a `KaishWorker` rooted at the attachment's

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -329,6 +329,19 @@ fn parse_list_item(v: &Value) -> Result<BatchListItem> {
     })
 }
 
+/// Parse an RFC3339 timestamp to Unix epoch seconds — the shapes our batch providers
+/// emit (Anthropic `2026-06-22T15:40:08.480837+00:00`, Gemini
+/// `2026-06-24T15:53:10.062475197Z`). `chrono` (already in the tree via kaish-kernel /
+/// rmcp / schemars) handles the offset and fractional seconds; we only *parse* with it
+/// and read "now" from `SystemTime`, so its `clock` feature stays off and no new
+/// transitive dep rides in. Returns `None` on anything it can't read, so the `list`
+/// recency filter *keeps* (never silently drops) an item it can't date.
+pub fn rfc3339_to_epoch(s: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp())
+}
+
 /// Parse the list endpoint's `{ data: [...], has_more }` page into items (in the order
 /// the provider returned them — newest first) plus the `has_more` flag, so a caller
 /// learns a truncated page is truncated instead of mistaking it for the whole set.
@@ -423,7 +436,7 @@ fn parse_results_jsonl(body: &str) -> Result<Vec<BatchAnswer>> {
 pub fn render_poll(poll: &BatchPoll, label: &str) -> String {
     match poll {
         BatchPoll::Pending { completed, total } => {
-            format!("Batch in progress — {completed}/{total} requests done. No need to wait on it — go do other work and `batch_get` this id again later (it can take minutes to hours; the handle keeps).")
+            format!("Batch in progress — {completed}/{total} requests done. No need to wait on it — go do other work and `get` this handle again later (it can take minutes to hours; the handle keeps).")
         }
         BatchPoll::Cancelling => {
             "Batch is being canceled; poll again for the final per-item results.".to_string()
@@ -447,7 +460,7 @@ pub fn render_poll(poll: &BatchPoll, label: &str) -> String {
     }
 }
 
-/// Render a `batch_list` result for the calling agent. Each entry is a ready-to-use
+/// Render the batches section of `list` for the calling agent. Each entry is a ready-to-use
 /// `(handle, item)`; `errors` are per-backend failures (a backend with no key or an
 /// unreachable endpoint is reported, not silently skipped — one bad backend never
 /// hides the rest); `truncated` names backends whose page hit `has_more` (so a partial
@@ -472,7 +485,7 @@ pub fn render_list(
         }
     }
     if !entries.is_empty() {
-        s.push_str("\n\nPoll one with `batch_get <handle>`; cancel with `batch_cancel <handle>`.");
+        s.push_str("\n\nPoll one with `get <handle>`; cancel with `cancel <handle>`.");
     }
     if !truncated.is_empty() {
         s.push_str(&format!(
@@ -1108,7 +1121,7 @@ impl BatchProvider for GeminiBatch {
 // --- Dispatch --------------------------------------------------------------
 
 /// Does this provider kind have a batch lane? The single source of truth — dispatch
-/// ([`submitter`]/[`poller`]), `batch_list`'s backend filter, and refusal messages all
+/// ([`submitter`]/[`poller`]), `list`'s backend filter, and refusal messages all
 /// defer to it, so adding a provider is a one-line change here. Keep the `matches!` arm in
 /// step with the per-kind impls below.
 pub fn batch_supported(kind: ProviderKind) -> bool {
@@ -1269,6 +1282,50 @@ mod tests {
     use super::*;
     use crate::config::{Defaults, ModelSlot};
 
+    #[test]
+    fn rfc3339_epoch_known_anchors() {
+        // The Unix epoch itself, and a hand-verified anchor (2000-01-01 = 946684800).
+        assert_eq!(rfc3339_to_epoch("1970-01-01T00:00:00Z"), Some(0));
+        assert_eq!(rfc3339_to_epoch("2000-01-01T00:00:00Z"), Some(946_684_800));
+    }
+
+    #[test]
+    fn rfc3339_epoch_handles_provider_shapes() {
+        // Anthropic (`+00:00`, microseconds) and Gemini (`Z`, nanoseconds) — the
+        // fraction is ignored, both are UTC, so each equals its whole-second instant.
+        assert_eq!(
+            rfc3339_to_epoch("2026-06-22T15:40:08.480837+00:00"),
+            rfc3339_to_epoch("2026-06-22T15:40:08Z"),
+        );
+        assert_eq!(
+            rfc3339_to_epoch("2026-06-24T15:53:10.062475197Z"),
+            rfc3339_to_epoch("2026-06-24T15:53:10Z"),
+        );
+    }
+
+    #[test]
+    fn rfc3339_epoch_applies_the_offset() {
+        // 01:00 at +01:00 is the same instant as 00:00 UTC — UTC = civil − offset.
+        assert_eq!(
+            rfc3339_to_epoch("2000-01-01T01:00:00+01:00"),
+            rfc3339_to_epoch("2000-01-01T00:00:00Z"),
+        );
+        // A negative offset pushes the instant later in UTC.
+        assert_eq!(
+            rfc3339_to_epoch("2000-01-01T00:00:00-05:00"),
+            Some(946_684_800 + 5 * 3600),
+        );
+    }
+
+    #[test]
+    fn rfc3339_epoch_rejects_garbage() {
+        // Unparseable input is None, so the recency filter keeps the item rather than
+        // silently dropping a batch it couldn't date.
+        assert_eq!(rfc3339_to_epoch("not-a-timestamp"), None);
+        assert_eq!(rfc3339_to_epoch("2026-06-24"), None);
+        assert_eq!(rfc3339_to_epoch(""), None);
+    }
+
     fn anthropic_backend() -> Backend {
         Backend {
             name: "anthropic".into(),
@@ -1374,8 +1431,14 @@ mod tests {
                 prompt: "second".into(),
             },
         ];
-        let body =
-            anthropic_batch_body("claude-sonnet-4-6", max_tokens, "be terse", &params, &[], &items);
+        let body = anthropic_batch_body(
+            "claude-sonnet-4-6",
+            max_tokens,
+            "be terse",
+            &params,
+            &[],
+            &items,
+        );
         let reqs = body["requests"].as_array().expect("requests array");
         assert_eq!(reqs.len(), 2);
         assert_eq!(reqs[0]["custom_id"], "0");
@@ -1413,14 +1476,26 @@ mod tests {
                 prompt: "and this".into(),
             },
         ];
-        let body = anthropic_batch_body("claude-sonnet-4-6", 1024, "sys", &None, &attachments, &items);
+        let body = anthropic_batch_body(
+            "claude-sonnet-4-6",
+            1024,
+            "sys",
+            &None,
+            &attachments,
+            &items,
+        );
         let content = &body["requests"][0]["params"]["messages"][0]["content"];
-        let blocks = content.as_array().expect("attachments make content a block array");
+        let blocks = content
+            .as_array()
+            .expect("attachments make content a block array");
         // [text-attachment, image-attachment, prompt]
         assert_eq!(blocks.len(), 3);
         assert_eq!(blocks[0]["type"], "text");
         assert!(
-            blocks[0]["text"].as_str().unwrap().contains("path=\"README.md\""),
+            blocks[0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("path=\"README.md\""),
             "the text block wraps the file: {}",
             blocks[0]["text"]
         );
@@ -1781,7 +1856,10 @@ mod tests {
             .expect("parts array");
         assert_eq!(parts.len(), 3);
         assert!(
-            parts[0]["text"].as_str().unwrap().contains("path=\"diff.patch\""),
+            parts[0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("path=\"diff.patch\""),
             "the text part wraps the file: {}",
             parts[0]["text"]
         );
@@ -2016,7 +2094,10 @@ mod tests {
         let id = provider.submit("sys", &[], &items).await.unwrap();
         assert_eq!(id, "msgbatch_test");
         assert_eq!(provider.submits()[0].0, "sys");
-        assert!(provider.submits()[0].1.is_empty(), "no attachments in this flow");
+        assert!(
+            provider.submits()[0].1.is_empty(),
+            "no attachments in this flow"
+        );
         assert!(matches!(
             provider.poll(&id).await.unwrap(),
             BatchPoll::Pending { .. }

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -31,8 +31,8 @@ use anyhow::{anyhow, Context, Result};
 use rig_core::agent::{HookAction, PromptHook};
 use rig_core::client::CompletionClient;
 use rig_core::completion::message::{
-    AssistantContent, Image, ImageMediaType, MimeType, ToolChoice, ToolResult,
-    ToolResultContent, UserContent,
+    AssistantContent, Image, ImageMediaType, MimeType, ToolChoice, ToolResult, ToolResultContent,
+    UserContent,
 };
 use rig_core::completion::{CompletionModel, Message, Prompt, PromptError, ToolDefinition};
 use rig_core::providers::{anthropic, deepseek, gemini, openai};
@@ -849,6 +849,13 @@ pub struct ConsultConfig {
     /// resolved root (only for the exploring tools — `explore`/`consult`); `Default`
     /// is `None`, so offline tests run the unchanged preamble.
     pub orientation: Option<Arc<str>>,
+    /// Caller-attached files, as **root-relative paths the model reads itself** via the
+    /// shell — *not* inlined bytes. Unlike `oneshot`/`batch` attach (toolless, so kaibo
+    /// inlines), `consult` has kaish, so attach just *names* the files in the driver's
+    /// prompt and lets the model `cat` them when it's ready — no upfront IO, the model
+    /// builds its narrative its own way. The server validates each path lands under the
+    /// consult's root (so the shell can reach it) before filling this. `Default` is empty.
+    pub attachments: Vec<String>,
 }
 
 impl Default for ConsultConfig {
@@ -862,6 +869,7 @@ impl Default for ConsultConfig {
             house_rules: None,
             prompts: PromptOverrides::default(),
             orientation: None,
+            attachments: Vec::new(),
         }
     }
 }
@@ -1565,9 +1573,14 @@ pub async fn oneshot(
 /// and steers the model to re-confirm any span a prior answer cited: the exploration
 /// runs fresh every turn (we never replay the stored report — it'd be stale), so the
 /// code is the ground truth, not the old answer.
-pub fn consult_user_prompt(question: &str, context: Option<&str>, history: &[QaTurn]) -> String {
+pub fn consult_user_prompt(
+    question: &str,
+    context: Option<&str>,
+    history: &[QaTurn],
+    attached: &[String],
+) -> String {
     let context = context.map(str::trim).filter(|c| !c.is_empty());
-    if history.is_empty() && context.is_none() {
+    if history.is_empty() && context.is_none() && attached.is_empty() {
         return question.to_string();
     }
     let mut prompt = String::new();
@@ -1601,6 +1614,17 @@ pub fn consult_user_prompt(question: &str, context: Option<&str>, history: &[QaT
              question reaches that it didn't cover. Where the code you read and the \
              context genuinely disagree, the code wins.\n\n",
         ));
+    }
+    if !attached.is_empty() {
+        prompt.push_str(
+            "The caller attached these files as central to the question — read them in \
+             full with the shell as you build your answer (`cat -n PATH`). They live \
+             under the project root, so a relative path reads directly:\n",
+        );
+        for f in attached {
+            prompt.push_str(&format!("- {f}\n"));
+        }
+        prompt.push('\n');
     }
     prompt.push_str(&format!("Now answer the current question:\n\n{question}"));
     prompt
@@ -1756,7 +1780,7 @@ pub(crate) async fn consult_session_turn(
         Some((store, id)) => store.history(id),
         None => Vec::new(),
     };
-    let user_prompt = consult_user_prompt(question, context, &history);
+    let user_prompt = consult_user_prompt(question, context, &history, &cfg.attachments);
 
     let out = consult_with(&user_prompt, root, explorer, synth, cfg).await?;
 
@@ -2151,9 +2175,18 @@ mod tests {
         assert_eq!(reqs.len(), 1, "oneshot is exactly one upstream request");
         // The text file rode inline as `<file>`-wrapped context, ahead of the prompt.
         let ut = &reqs[0].user_text;
-        assert!(ut.contains("<file path=\"README.md\">"), "text file inlined as context: {ut}");
-        assert!(ut.contains("hello world"), "the file body rode inline: {ut}");
-        assert!(ut.contains("review these"), "the prompt is still present: {ut}");
+        assert!(
+            ut.contains("<file path=\"README.md\">"),
+            "text file inlined as context: {ut}"
+        );
+        assert!(
+            ut.contains("hello world"),
+            "the file body rode inline: {ut}"
+        );
+        assert!(
+            ut.contains("review these"),
+            "the prompt is still present: {ut}"
+        );
         // The image rode as a native image part, not flattened into text.
         assert!(
             saw_image.load(Ordering::SeqCst),
@@ -2184,12 +2217,24 @@ mod tests {
                 Ok(text_response("done"))
             })
             .build();
-        oneshot("just ask", &[], &arm(&client, MODEL), &ConsultConfig::default())
-            .await
-            .unwrap();
+        oneshot(
+            "just ask",
+            &[],
+            &arm(&client, MODEL),
+            &ConsultConfig::default(),
+        )
+        .await
+        .unwrap();
         let reqs = client.requests_for(MODEL);
-        assert_eq!(reqs[0].user_text.trim(), "just ask", "bare prompt, no wrapper");
-        assert!(!saw_image.load(Ordering::SeqCst), "no attachment, no image part");
+        assert_eq!(
+            reqs[0].user_text.trim(),
+            "just ask",
+            "bare prompt, no wrapper"
+        );
+        assert!(
+            !saw_image.load(Ordering::SeqCst),
+            "no attachment, no image part"
+        );
     }
 
     /// An image-only attach with an empty prompt sends *just* the image part — no empty
@@ -3622,8 +3667,38 @@ mod tests {
     #[test]
     fn empty_history_yields_the_bare_question() {
         assert_eq!(
-            consult_user_prompt("Where is the sandbox enforced?", None, &[]),
+            consult_user_prompt("Where is the sandbox enforced?", None, &[], &[]),
             "Where is the sandbox enforced?"
+        );
+    }
+
+    /// Attached files are named in the prompt (for the model to `cat` itself) and steered
+    /// to read them in full — and they're listed before the question, like context.
+    #[test]
+    fn attached_files_are_named_for_the_model_to_read() {
+        let prompt = consult_user_prompt(
+            "Does the diff weaken the sandbox?",
+            None,
+            &[],
+            &["changes.diff".to_string(), "src/sandbox.rs".to_string()],
+        );
+        assert!(
+            prompt.contains("changes.diff"),
+            "names each attached file:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("src/sandbox.rs"),
+            "names each attached file:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("cat -n"),
+            "steers the model to read them with the shell:\n{prompt}"
+        );
+        let listed = prompt.find("changes.diff").unwrap();
+        let question = prompt.find("Does the diff weaken").unwrap();
+        assert!(
+            listed < question,
+            "attachments precede the question:\n{prompt}"
         );
     }
 
@@ -3635,7 +3710,7 @@ mod tests {
             QaTurn::new("What is kaish?", "A read-only shell (src/sandbox.rs)."),
             QaTurn::new("Who calls it?", "consult drives it (src/consult.rs)."),
         ];
-        let prompt = consult_user_prompt("And explore?", None, &history);
+        let prompt = consult_user_prompt("And explore?", None, &history, &[]);
 
         for needle in [
             "What is kaish?",

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,0 +1,371 @@
+//! In-memory async-`consult` job registry — backs `consult_submit` and the shared
+//! `get` / `cancel` / `list` verbs (which also serve batch handles).
+//!
+//! The async counterpart to the synchronous `consult`: `consult_submit` returns a job
+//! id immediately, the consultation runs as a spawned task, and `get` collects the
+//! answer when it lands. This is the *same* diskless, persistence-shaped state as
+//! [`crate::session::SessionStore`] — an `Arc<Mutex<LruCache>>`, capacity-LRU, no TTL,
+//! the mutex never held across an `.await` — only the value is a job's live status
+//! instead of a conversation thread. kaibo writes nothing to disk: a job lives for the
+//! session and dies with the process, exactly as the spawned sub-agent it replaces did.
+//!
+//! The store is deliberately ignorant of *what* a job is. It spawns any
+//! `Future<Output = Result<JobResult, String>>` and tracks its terminal state, so the
+//! consult-specific rendering (provenance footer, failure classification) stays in
+//! `server.rs` and this module stays offline-testable with trivial futures.
+//!
+//! **Eviction is capacity-LRU, like sessions** — a job is dropped only when a newer
+//! submit pushes it past the cap as the least-recently-used; touching it (`get`/
+//! `cancel`) promotes it. A still-*running* job that gets evicted is not aborted: the
+//! spawned task owns its own `Arc` of the status cell, so it runs to completion against
+//! a cell nobody will read, then drops — no panic, no orphaned handle, no disk.
+
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use lru::LruCache;
+use tokio::task::AbortHandle;
+
+/// A completed consultation, ready to render back to the calling agent. `answer`
+/// already carries its provenance footer; `report` is the explorer's aggregated
+/// report when the submit asked for it (`include_report`), else `None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JobResult {
+    pub answer: String,
+    pub report: Option<String>,
+}
+
+/// Where a job is in its lifecycle, as one `get` sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobState {
+    /// The spawned task is still working.
+    Running,
+    /// The consultation finished and produced an answer.
+    Done(JobResult),
+    /// The consultation failed; the string is the already-rendered failure text
+    /// (detail + guidance), so the tool layer wraps it without re-classifying.
+    Failed(String),
+    /// `cancel` aborted the task before it finished.
+    Canceled,
+}
+
+/// A point-in-time view of a job for rendering: its state plus the metadata a poll
+/// line wants (which cast/models, how long it's been running).
+#[derive(Debug, Clone)]
+pub struct JobSnapshot {
+    pub state: JobState,
+    pub label: String,
+    pub age: Duration,
+}
+
+/// What `cancel` did, so the tool layer can word the reply honestly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CancelOutcome {
+    /// The job was running and is now aborted + marked canceled.
+    Canceled,
+    /// The job had already reached a terminal state — nothing to abort.
+    AlreadyFinished,
+    /// No such job id (never existed, or evicted).
+    Unknown,
+}
+
+/// One job: a shared status cell the spawned task writes, plus the handle to abort it
+/// and the metadata for rendering. The `state` is its own `Arc<Mutex<_>>` rather than
+/// living under the store's map lock, so the task can finish (and set its result)
+/// without contending for the whole registry — and survives the entry's eviction.
+struct Job {
+    state: Arc<Mutex<JobState>>,
+    abort: AbortHandle,
+    label: String,
+    started: Instant,
+}
+
+/// A cap-based LRU of async consultations, keyed by a kaibo-minted job id (`job-N`).
+#[derive(Clone)]
+pub struct JobStore {
+    inner: Arc<Mutex<LruCache<String, Arc<Job>>>>,
+    next_id: Arc<AtomicU64>,
+}
+
+impl JobStore {
+    /// A store holding at most `capacity` jobs (running + finished-but-uncollected).
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(LruCache::new(capacity))),
+            next_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    /// Spawn `fut` as a job and return its id immediately. `label` is the human-facing
+    /// cast/model summary a poll line shows. The future's `Ok`/`Err` becomes the job's
+    /// terminal `Done`/`Failed` state; an abort (via [`cancel`](Self::cancel)) leaves it
+    /// `Canceled` because the task never runs its tail.
+    pub fn submit<F>(&self, label: impl Into<String>, fut: F) -> String
+    where
+        F: Future<Output = Result<JobResult, String>> + Send + 'static,
+    {
+        let n = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let id = format!("job-{n}");
+
+        let state = Arc::new(Mutex::new(JobState::Running));
+        let task_state = state.clone();
+        let task_id = id.clone();
+        let handle = tokio::spawn(async move {
+            let outcome = fut.await;
+            let mut s = task_state.lock().expect("job state mutex poisoned");
+            // Only land the result if a `cancel` didn't race in while we were
+            // finishing — a caller who asked to cancel gets `Canceled`, not a
+            // surprise late answer.
+            if matches!(*s, JobState::Running) {
+                let succeeded = outcome.is_ok();
+                *s = match outcome {
+                    Ok(result) => JobState::Done(result),
+                    Err(text) => JobState::Failed(text),
+                };
+                drop(s); // release the state lock before the log emit
+
+                // Soft completion signal: a `tracing` event under the `kaibo` target rides
+                // the existing tracing→MCP `notifications/message` bridge (`mcp_log`), so a
+                // client watching the log stream gets a nudge to collect. Advisory only —
+                // no MCP primitive wakes the agent, so polling stays the contract; this is
+                // the clue, not a trigger. (A canceled job never reaches here — its task is
+                // aborted — so we don't ping for it.)
+                if succeeded {
+                    tracing::info!(job = %task_id, "async job finished — collect it with `get`");
+                } else {
+                    tracing::warn!(job = %task_id, "async job failed — `get` it for the reason");
+                }
+            }
+        });
+
+        let job = Arc::new(Job {
+            state,
+            abort: handle.abort_handle(),
+            label: label.into(),
+            started: Instant::now(),
+        });
+        self.lock().put(id.clone(), job);
+        id
+    }
+
+    /// Snapshot a job's state for rendering — `None` if the id is unknown (never
+    /// existed, or evicted). Touching the job promotes it to most-recently-used.
+    pub fn get(&self, id: &str) -> Option<JobSnapshot> {
+        let job = self.lock().get(id).cloned()?;
+        let state = job.state.lock().expect("job state mutex poisoned").clone();
+        Some(JobSnapshot {
+            state,
+            label: job.label.clone(),
+            age: job.started.elapsed(),
+        })
+    }
+
+    /// Abort a running job and mark it `Canceled`. Idempotent on an already-canceled
+    /// job; reports `AlreadyFinished` for one that already produced a result or failure.
+    /// Promotes the job (a cancel means you still hold the handle).
+    pub fn cancel(&self, id: &str) -> CancelOutcome {
+        let Some(job) = self.lock().get(id).cloned() else {
+            return CancelOutcome::Unknown;
+        };
+        let mut state = job.state.lock().expect("job state mutex poisoned");
+        match *state {
+            JobState::Running => {
+                job.abort.abort();
+                *state = JobState::Canceled;
+                CancelOutcome::Canceled
+            }
+            JobState::Canceled => CancelOutcome::Canceled,
+            JobState::Done(_) | JobState::Failed(_) => CancelOutcome::AlreadyFinished,
+        }
+    }
+
+    /// Snapshot every live job, most-recently-touched first — the order the unified
+    /// `list` shows them. A read: it promotes nothing and takes no job's state lock for
+    /// longer than the clone.
+    pub fn list(&self) -> Vec<(String, JobSnapshot)> {
+        self.lock()
+            .iter()
+            .map(|(id, job)| {
+                let state = job.state.lock().expect("job state mutex poisoned").clone();
+                (
+                    id.clone(),
+                    JobSnapshot {
+                        state,
+                        label: job.label.clone(),
+                        age: job.started.elapsed(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Number of live jobs in the registry. For tests and diagnostics.
+    pub fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    /// True when no jobs are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The only work done under this lock is `LruCache` ops on owned values, which
+    /// don't panic, so poisoning is effectively unreachable — treat it as the
+    /// build-time bug it would be rather than masking it. Mirrors [`SessionStore`].
+    fn lock(&self) -> std::sync::MutexGuard<'_, LruCache<String, Arc<Job>>> {
+        self.inner.lock().expect("job store mutex poisoned")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cap(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).unwrap()
+    }
+
+    fn done(answer: &str) -> JobResult {
+        JobResult {
+            answer: answer.to_string(),
+            report: None,
+        }
+    }
+
+    /// Poll `get` until the job leaves `Running`, or panic after a generous bound — the
+    /// spawned task needs a runtime tick to land its result, so tests can't read it
+    /// synchronously right after `submit`. Returns the terminal state.
+    async fn await_terminal(store: &JobStore, id: &str) -> JobState {
+        for _ in 0..1000 {
+            match store.get(id).map(|s| s.state) {
+                Some(JobState::Running) | None => tokio::task::yield_now().await,
+                Some(terminal) => return terminal,
+            }
+        }
+        panic!("job {id} never left Running");
+    }
+
+    #[tokio::test]
+    async fn unknown_job_has_no_snapshot() {
+        let store = JobStore::new(cap(4));
+        assert!(store.get("job-404").is_none());
+        assert_eq!(store.cancel("job-404"), CancelOutcome::Unknown);
+        assert!(store.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_ready_future_lands_as_done() {
+        let store = JobStore::new(cap(4));
+        let id = store.submit("cast `x`", async { Ok(done("the answer")) });
+        assert_eq!(
+            await_terminal(&store, &id).await,
+            JobState::Done(done("the answer"))
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failing_future_lands_as_failed() {
+        let store = JobStore::new(cap(4));
+        let id = store.submit("cast `x`", async { Err("provider exploded".to_string()) });
+        assert_eq!(
+            await_terminal(&store, &id).await,
+            JobState::Failed("provider exploded".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn an_in_flight_job_reads_as_running_then_done() {
+        let store = JobStore::new(cap(4));
+        // Gate the future on a channel the test holds, so "Running" is observable
+        // deterministically rather than by racing the scheduler.
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let id = store.submit("cast `x`", async move {
+            let _ = rx.await;
+            Ok(done("eventually"))
+        });
+        assert_eq!(
+            store.get(&id).map(|s| s.state),
+            Some(JobState::Running),
+            "a gated job must read as Running before it's released"
+        );
+        tx.send(()).unwrap();
+        assert_eq!(
+            await_terminal(&store, &id).await,
+            JobState::Done(done("eventually"))
+        );
+    }
+
+    #[tokio::test]
+    async fn submitting_past_capacity_evicts_the_least_recently_used() {
+        let store = JobStore::new(cap(2));
+        let a = store.submit("a", async { Ok(done("a")) });
+        let b = store.submit("b", async { Ok(done("b")) });
+        // Touch `a` so `b` becomes the least-recently-used.
+        let _ = store.get(&a);
+        let c = store.submit("c", async { Ok(done("c")) });
+
+        assert!(
+            store.get(&b).is_none(),
+            "b was the LRU and should be evicted"
+        );
+        assert!(
+            store.get(&a).is_some(),
+            "a was just touched and must survive"
+        );
+        assert!(store.get(&c).is_some(), "c is newest");
+        assert_eq!(store.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn cancel_aborts_a_running_job_and_marks_it_canceled() {
+        let store = JobStore::new(cap(4));
+        // A future that would run forever if not aborted — its tail must never land.
+        let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let id = store.submit("cast `x`", async move {
+            let _ = rx.await;
+            Ok(done("should never be seen"))
+        });
+        assert_eq!(store.cancel(&id), CancelOutcome::Canceled);
+        assert_eq!(store.get(&id).map(|s| s.state), Some(JobState::Canceled));
+        // Give the runtime ticks; an aborted task must not overwrite Canceled.
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            store.get(&id).map(|s| s.state),
+            Some(JobState::Canceled),
+            "an aborted task must never clobber the Canceled state with a late result"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_on_a_finished_job_reports_already_finished() {
+        let store = JobStore::new(cap(4));
+        let id = store.submit("cast `x`", async { Ok(done("fast")) });
+        let _ = await_terminal(&store, &id).await;
+        assert_eq!(store.cancel(&id), CancelOutcome::AlreadyFinished);
+    }
+
+    #[tokio::test]
+    async fn list_returns_every_live_job_newest_first() {
+        let store = JobStore::new(cap(4));
+        let a = store.submit("cast `a`", async { Ok(done("a")) });
+        let b = store.submit("cast `b`", async { Ok(done("b")) });
+        let listed: Vec<String> = store.list().into_iter().map(|(id, _)| id).collect();
+        // Most-recently-submitted first: b before a.
+        assert_eq!(listed, vec![b, a]);
+    }
+
+    #[tokio::test]
+    async fn ids_are_unique_and_monotonic() {
+        let store = JobStore::new(cap(8));
+        let a = store.submit("a", async { Ok(done("a")) });
+        let b = store.submit("b", async { Ok(done("b")) });
+        assert_ne!(a, b);
+        assert_eq!(a, "job-1");
+        assert_eq!(b, "job-2");
+    }
+}

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -16,9 +16,12 @@
 //!
 //! **Eviction is capacity-LRU, like sessions** — a job is dropped only when a newer
 //! submit pushes it past the cap as the least-recently-used; touching it (`get`/
-//! `cancel`) promotes it. A still-*running* job that gets evicted is not aborted: the
-//! spawned task owns its own `Arc` of the status cell, so it runs to completion against
-//! a cell nobody will read, then drops — no panic, no orphaned handle, no disk.
+//! `cancel`) promotes it. A still-*running* job that gets evicted is **aborted** (its
+//! `Job` drop aborts the task): once the store drops a job its id is unreachable
+//! (`get`/`cancel` return not-found), so letting an orphaned consult run on would just
+//! burn provider tokens against a cell nobody can read. The spawned task owns its own
+//! `Arc` of the status cell, so the cell stays valid until the task actually stops —
+//! no panic, no disk.
 
 use std::future::Future;
 use std::num::NonZeroUsize;
@@ -83,6 +86,52 @@ struct Job {
     started: Instant,
 }
 
+impl Drop for Job {
+    /// Abort the task when its `Job` is dropped — i.e. when the store evicts it (LRU) or
+    /// the whole store goes away. Dropping an `AbortHandle` does *not* abort the task on
+    /// its own, so without this an evicted-but-still-running consult would run to
+    /// completion against an unreachable cell, burning provider tokens for an answer no
+    /// `get` can ever return. A finished or already-canceled job's abort is a harmless
+    /// no-op. `get`/`cancel`/`list` only clone the `Arc<Job>` transiently under the store
+    /// lock, so this fires on the *last* reference — true unreachability — not on a poll.
+    fn drop(&mut self) {
+        self.abort.abort();
+    }
+}
+
+/// A drop guard for the spawned task: if the task's future ends *without* landing a
+/// result — a panic (we build `panic = unwind`, so tokio catches it and the state would
+/// otherwise sit at `Running` forever) or an abort that drops the future at its await
+/// point — record a terminal failure instead of leaving `get` to report "still running"
+/// with no end. The task disarms it on the normal path so it never overwrites a real
+/// outcome. On an *abort* the cell is usually unreachable anyway (canceled, or evicted),
+/// so the write is harmless; on a *panic* of a still-live job it's the difference between
+/// an eternal hang and an honest failure.
+struct FinishGuard {
+    state: Arc<Mutex<JobState>>,
+    armed: bool,
+}
+
+impl Drop for FinishGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Reached only on an unwind/abort before the task disarmed us. Lock the state
+        // (the task holds no lock at its await point, so no deadlock) and fail it iff it
+        // never reached a terminal state.
+        if let Ok(mut s) = self.state.lock() {
+            if matches!(*s, JobState::Running) {
+                *s = JobState::Failed(
+                    "the consultation task ended without completing (it panicked or was \
+                     aborted)"
+                        .to_string(),
+                );
+            }
+        }
+    }
+}
+
 /// A cap-based LRU of async consultations, keyed by a kaibo-minted job id (`job-N`).
 #[derive(Clone)]
 pub struct JobStore {
@@ -114,31 +163,43 @@ impl JobStore {
         let task_state = state.clone();
         let task_id = id.clone();
         let handle = tokio::spawn(async move {
+            // Armed until the future returns: if it panics or is aborted at its await
+            // point, this guard records a terminal failure instead of leaving the job
+            // stuck `Running`. Disarmed once `fut.await` returns normally below.
+            let mut guard = FinishGuard {
+                state: task_state.clone(),
+                armed: true,
+            };
             let outcome = fut.await;
-            let mut s = task_state.lock().expect("job state mutex poisoned");
-            // Only land the result if a `cancel` didn't race in while we were
-            // finishing — a caller who asked to cancel gets `Canceled`, not a
-            // surprise late answer.
-            if matches!(*s, JobState::Running) {
-                let succeeded = outcome.is_ok();
-                *s = match outcome {
-                    Ok(result) => JobState::Done(result),
-                    Err(text) => JobState::Failed(text),
-                };
-                drop(s); // release the state lock before the log emit
+            {
+                let mut s = task_state.lock().expect("job state mutex poisoned");
+                // Only land the result if a `cancel` didn't race in while we were
+                // finishing — a caller who asked to cancel gets `Canceled`, not a
+                // surprise late answer.
+                if matches!(*s, JobState::Running) {
+                    let succeeded = outcome.is_ok();
+                    *s = match outcome {
+                        Ok(result) => JobState::Done(result),
+                        Err(text) => JobState::Failed(text),
+                    };
+                    drop(s); // release the state lock before the log emit
 
-                // Soft completion signal: a `tracing` event under the `kaibo` target rides
-                // the existing tracing→MCP `notifications/message` bridge (`mcp_log`), so a
-                // client watching the log stream gets a nudge to collect. Advisory only —
-                // no MCP primitive wakes the agent, so polling stays the contract; this is
-                // the clue, not a trigger. (A canceled job never reaches here — its task is
-                // aborted — so we don't ping for it.)
-                if succeeded {
-                    tracing::info!(job = %task_id, "async job finished — collect it with `get`");
-                } else {
-                    tracing::warn!(job = %task_id, "async job failed — `get` it for the reason");
+                    // Completion signal at **Warn** — kaibo's "the calling model should
+                    // see this" level (not severity): a finished/failed job is exactly
+                    // what a `wait` drains by default, and the `mcp_log` bridge also
+                    // mirrors it to a watching client. Still advisory — no MCP primitive
+                    // wakes the agent, so polling/`wait` stays the contract. (A canceled
+                    // job never reaches here — its task is aborted — no ping for it.)
+                    if succeeded {
+                        tracing::warn!(target: "kaibo::jobs", job = %task_id, "async job finished — collect it with `get`");
+                    } else {
+                        tracing::warn!(target: "kaibo::jobs", job = %task_id, "async job failed — `get` it for the reason");
+                    }
                 }
             }
+            // The future returned (no panic) — disarm so the guard's Drop is a no-op and
+            // can't overwrite the outcome (or a raced `Canceled`).
+            guard.armed = false;
         });
 
         let job = Arc::new(Job {
@@ -347,6 +408,46 @@ mod tests {
         let id = store.submit("cast `x`", async { Ok(done("fast")) });
         let _ = await_terminal(&store, &id).await;
         assert_eq!(store.cancel(&id), CancelOutcome::AlreadyFinished);
+    }
+
+    #[tokio::test]
+    async fn eviction_aborts_a_still_running_job() {
+        use std::sync::atomic::{AtomicBool, Ordering as AOrd};
+        let store = JobStore::new(cap(1));
+        // job-1's tail sets this flag *if* it ever runs to completion. It shouldn't —
+        // eviction must abort it before the gate is released.
+        let ran_tail = Arc::new(AtomicBool::new(false));
+        let flag = ran_tail.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let _evicted = store.submit("a", async move {
+            let _ = rx.await;
+            flag.store(true, AOrd::SeqCst);
+            Ok(done("a"))
+        });
+        // A second submit at cap 1 evicts the first → its `Job` drops → task aborts.
+        let _b = store.submit("b", async { Ok(done("b")) });
+        // Release the gate; an aborted task must never run its tail.
+        let _ = tx.send(());
+        for _ in 0..200 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !ran_tail.load(AOrd::SeqCst),
+            "an evicted running job must be aborted, not run to completion (token waste)"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_panicking_task_lands_as_failed_not_stuck_running() {
+        // tokio catches the spawned task's panic (we don't await its JoinHandle); without
+        // the FinishGuard the state would sit at Running forever. The guard turns the
+        // unwind into a terminal Failed, so `await_terminal` resolves instead of spinning.
+        let store = JobStore::new(cap(4));
+        let id = store.submit("cast `x`", async { panic!("boom in the consult loop") });
+        assert!(
+            matches!(await_terminal(&store, &id).await, JobState::Failed(_)),
+            "a panicking task must land as Failed, not hang in Running forever"
+        );
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod credentials;
 pub mod explorer;
 pub mod generate_image;
 pub mod image_gen;
+pub mod jobs;
 pub mod kaish_syntax;
 pub mod mcp_log;
 pub mod orientation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,11 @@ async fn main() -> Result<()> {
     // before then — startup — buffer here and flush when draining begins, so the
     // client sees them too.
     let (log_tx, log_rx) = tokio::sync::mpsc::unbounded_channel();
+    // The pull-side ring: the bridge layer tees kaibo-target records here so the `wait`
+    // tool can drain them on demand (the same records it streams to the client). Created
+    // before the subscriber so the layer and the handler share one ring. Bounded — old
+    // records age out; it's a convenience, not the authoritative job state.
+    let notifications = mcp_log::NotificationBuffer::new(512);
     // Per-layer filters, not one global EnvFilter. The OTLP layer must see rig's
     // `rig::*` spans — the GenAI trace tree is the whole point — while stderr and
     // the MCP bridge stay scoped to the `kaibo` target. A single global filter would
@@ -173,7 +178,11 @@ async fn main() -> Result<()> {
                 .with_writer(std::io::stderr)
                 .with_filter(kaibo_filter()),
         )
-        .with(McpBridgeLayer::new(log_tx).with_filter(kaibo_filter()))
+        .with(
+            McpBridgeLayer::new(log_tx)
+                .with_buffer(notifications.clone())
+                .with_filter(kaibo_filter()),
+        )
         .init();
 
     // A zero-tool server is a misconfiguration, not a mode: refuse it loudly here,
@@ -220,7 +229,7 @@ async fn main() -> Result<()> {
         );
     }
 
-    let handler = KaiboHandler::new(config)?;
+    let handler = KaiboHandler::new(config)?.with_notifications(notifications);
     // Log the resolved (canonicalized) allowed set so the operator can verify the
     // containment boundary without inspecting config files.
     tracing::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,9 @@ struct Args {
     #[arg(long)]
     no_generate_image: bool,
 
-    /// Don't advertise the batch tools (`batch_submit`/`batch_get`/`batch_cancel`).
+    /// Don't advertise `batch_submit`. The shared `get`/`cancel`/`list` verbs remain as
+    /// long as `consult` is on (they also collect consult jobs); they drop only when both
+    /// `--no-batch` and `--no-consult` are set.
     #[arg(long)]
     no_batch: bool,
 

--- a/src/mcp_log.rs
+++ b/src/mcp_log.rs
@@ -193,22 +193,58 @@ impl NotificationBuffer {
         floor: u8,
         limit: usize,
     ) -> Vec<LogRecord> {
+        // The simple form: drain and return at one floor, no side-channel.
+        self.wait_drain_with(timeout, floor, floor, limit, |_| {})
+            .await
+    }
+
+    /// The streaming core behind [`wait_drain`]: drain every record at or above
+    /// `drain_floor`, hand each to `on_drained` (the `wait` tool streams the Info-level
+    /// narrative to the client's progress channel here), and *return* those at or above
+    /// `return_floor` (capped at `limit`). It blocks until a returnable record lands or
+    /// the deadline passes — so a default `wait` streams the narrative the whole time and
+    /// returns only when something the model should act on (a completion) arrives.
+    ///
+    /// `drain_floor` ≤ `return_floor`: the caller drains *down to* what it streams (Info)
+    /// while returning only the salient (Warn+). A drained-but-not-returned record is
+    /// consumed — it was delivered via `on_drained` — so the narrative isn't left to pile
+    /// up once it's been streamed.
+    pub async fn wait_drain_with<F: FnMut(&LogRecord)>(
+        &self,
+        timeout: std::time::Duration,
+        drain_floor: u8,
+        return_floor: u8,
+        limit: usize,
+        mut on_drained: F,
+    ) -> Vec<LogRecord> {
         let deadline = tokio::time::Instant::now() + timeout;
+        let mut collected: Vec<LogRecord> = Vec::new();
         loop {
-            let got = self.drain(floor, limit);
-            if !got.is_empty() {
-                return got;
+            for rec in self.drain(drain_floor, usize::MAX) {
+                on_drained(&rec);
+                if rank(rec.level) >= return_floor && collected.len() < limit {
+                    collected.push(rec);
+                }
+            }
+            if !collected.is_empty() {
+                return collected;
             }
             // Register the wake future *before* re-checking, so a push between the drain
             // above and the await below leaves a permit rather than being missed.
             let notified = self.notify.notified();
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
-                return self.drain(floor, limit);
+                for rec in self.drain(drain_floor, usize::MAX) {
+                    on_drained(&rec);
+                    if rank(rec.level) >= return_floor && collected.len() < limit {
+                        collected.push(rec);
+                    }
+                }
+                return collected;
             }
             tokio::select! {
                 _ = notified => {}
-                _ = tokio::time::sleep(remaining) => return self.drain(floor, limit),
+                _ = tokio::time::sleep(remaining) => {}
             }
         }
     }
@@ -302,7 +338,11 @@ impl McpBridgeLayer {
 impl<S: Subscriber> Layer<S> for McpBridgeLayer {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let meta = event.metadata();
-        if !meta.target().starts_with(KAIBO_TARGET) {
+        // Exactly `kaibo` or a `kaibo::` submodule — boundary-checked so a hypothetical
+        // `kaibox` target can't slip onto the bridge. (The per-layer EnvFilter already
+        // scopes to `kaibo`, so this is belt-and-suspenders.)
+        let target = meta.target();
+        if target != KAIBO_TARGET && !target.starts_with("kaibo::") {
             return;
         }
         let mut visitor = FieldVisitor::default();
@@ -431,6 +471,33 @@ mod tests {
             1,
             "the unmatched Info record is left in the ring"
         );
+    }
+
+    #[tokio::test]
+    async fn wait_drain_with_streams_everything_but_returns_only_the_salient() {
+        let buf = NotificationBuffer::new(8);
+        buf.push(rec(LoggingLevel::Info, "kaish a"));
+        buf.push(rec(LoggingLevel::Warning, "job done"));
+        buf.push(rec(LoggingLevel::Info, "kaish b"));
+
+        let mut streamed = Vec::new();
+        let returned = buf
+            .wait_drain_with(
+                std::time::Duration::from_secs(5),
+                rank(LoggingLevel::Info), // drain down to Info (to stream)
+                rank(LoggingLevel::Warning), // return only the Warn-bar records
+                20,
+                |r| streamed.push(r.message.clone()),
+            )
+            .await;
+
+        // The human side (on_drained) sees the whole narrative, in order…
+        assert_eq!(streamed, vec!["kaish a", "job done", "kaish b"]);
+        // …while the model's return is just the promote-to-model record.
+        assert_eq!(returned.len(), 1);
+        assert_eq!(returned[0].message, "job done");
+        // Everything drained is consumed — the streamed narrative isn't left to pile up.
+        assert!(buf.is_empty());
     }
 
     #[test]

--- a/src/mcp_log.rs
+++ b/src/mcp_log.rs
@@ -122,6 +122,114 @@ impl LogRecord {
     }
 }
 
+/// A bounded, in-memory ring of recent [`LogRecord`]s — the pull side of the bridge.
+/// The same events the [`McpBridgeLayer`] streams to a watching client are teed here so
+/// the calling model can *drain* them on demand via the `wait` tool, filtered to the
+/// level it cares about (Warn+ by default — kaibo's "the model should see this" bar).
+///
+/// Capacity-bounded (oldest dropped), per session, deliver-once: a drained record is
+/// removed. It is **not** load-bearing — `get`/`list` stay the authoritative source of a
+/// job's state; a record that ages out just means the model uses `get`. `Clone` shares
+/// one `Arc<Mutex<_>>` + `Notify`, so the layer (which pushes) and the handler (which
+/// drains) hold the same ring. The mutex is only ever held for `VecDeque` ops, never
+/// across an `.await`.
+#[derive(Clone)]
+pub struct NotificationBuffer {
+    inner: Arc<std::sync::Mutex<std::collections::VecDeque<LogRecord>>>,
+    notify: Arc<tokio::sync::Notify>,
+    cap: usize,
+}
+
+impl NotificationBuffer {
+    /// A ring holding at most `cap` records.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(
+                std::collections::VecDeque::with_capacity(cap),
+            )),
+            notify: Arc::new(tokio::sync::Notify::new()),
+            cap,
+        }
+    }
+
+    /// Append a record, dropping the oldest if at capacity, and wake one waiter. Called
+    /// from the sync layer, so it never blocks or awaits. `notify_one` stores a permit if
+    /// no one is waiting yet, so a push that races a `wait`'s registration isn't missed.
+    fn push(&self, record: LogRecord) {
+        {
+            let mut q = self.lock();
+            if q.len() == self.cap {
+                q.pop_front();
+            }
+            q.push_back(record);
+        }
+        self.notify.notify_one();
+    }
+
+    /// Remove and return up to `limit` records at or above `floor` (a [`rank`]), oldest
+    /// first; records below `floor` stay in the ring (a later lower-floor drain, or the
+    /// cap, takes them). Deliver-once: a returned record is gone.
+    pub fn drain(&self, floor: u8, limit: usize) -> Vec<LogRecord> {
+        let mut q = self.lock();
+        let mut taken = Vec::new();
+        let mut kept = std::collections::VecDeque::with_capacity(q.len());
+        for rec in q.drain(..) {
+            if taken.len() < limit && rank(rec.level) >= floor {
+                taken.push(rec);
+            } else {
+                kept.push_back(rec);
+            }
+        }
+        *q = kept;
+        taken
+    }
+
+    /// Block up to `timeout` for records at or above `floor`, returning as soon as any
+    /// land (up to `limit`) or the deadline passes (then a final drain, possibly empty).
+    /// The clean-exit contract: never an error, never an indefinite hang.
+    pub async fn wait_drain(
+        &self,
+        timeout: std::time::Duration,
+        floor: u8,
+        limit: usize,
+    ) -> Vec<LogRecord> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let got = self.drain(floor, limit);
+            if !got.is_empty() {
+                return got;
+            }
+            // Register the wake future *before* re-checking, so a push between the drain
+            // above and the await below leaves a permit rather than being missed.
+            let notified = self.notify.notified();
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return self.drain(floor, limit);
+            }
+            tokio::select! {
+                _ = notified => {}
+                _ = tokio::time::sleep(remaining) => return self.drain(floor, limit),
+            }
+        }
+    }
+
+    /// Records currently buffered. For tests and the `wait` footer.
+    pub fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    /// True when the ring is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, std::collections::VecDeque<LogRecord>> {
+        self.inner
+            .lock()
+            .expect("notification buffer mutex poisoned")
+    }
+}
+
 /// Collects an event's fields into a JSON map, pulling the special `message` field
 /// out as a plain string. Everything else is captured with its `Debug`/typed value
 /// so structured logging (`tracing::info!(provider = %p, …)`) survives onto the wire.
@@ -172,11 +280,22 @@ impl Visit for FieldVisitor {
 /// doesn't flood the MCP client with dependency noise.
 pub struct McpBridgeLayer {
     tx: UnboundedSender<LogRecord>,
+    /// The pull-side ring, teed alongside the push channel: the same record streamed to
+    /// the client is buffered for the `wait` tool to drain. `None` when no buffer is
+    /// wired (e.g. a test subscriber).
+    buffer: Option<NotificationBuffer>,
 }
 
 impl McpBridgeLayer {
     pub fn new(tx: UnboundedSender<LogRecord>) -> Self {
-        Self { tx }
+        Self { tx, buffer: None }
+    }
+
+    /// Tee each mirrored record into `buffer` as well as the client channel, so the
+    /// calling model can drain it via `wait`.
+    pub fn with_buffer(mut self, buffer: NotificationBuffer) -> Self {
+        self.buffer = Some(buffer);
+        self
     }
 }
 
@@ -194,6 +313,11 @@ impl<S: Subscriber> Layer<S> for McpBridgeLayer {
             message: visitor.message.unwrap_or_default(),
             fields: visitor.fields,
         };
+        // Tee to the pull-side ring (for `wait`) before the push channel (for the
+        // streaming client). Both are infallible/non-blocking — never panic in a log path.
+        if let Some(buffer) = &self.buffer {
+            buffer.push(record.clone());
+        }
         // A closed channel means the drain task is gone (shutdown) — drop silently;
         // there is nowhere left to deliver, and we must never panic in a log path.
         let _ = self.tx.send(record);
@@ -223,6 +347,91 @@ pub async fn drain(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rec(level: LoggingLevel, message: &str) -> LogRecord {
+        LogRecord {
+            level,
+            target: "kaibo::test".into(),
+            message: message.into(),
+            fields: Map::new(),
+        }
+    }
+
+    #[test]
+    fn buffer_drain_filters_by_level_and_leaves_the_rest() {
+        let buf = NotificationBuffer::new(8);
+        buf.push(rec(LoggingLevel::Info, "kaish a"));
+        buf.push(rec(LoggingLevel::Warning, "job done"));
+        buf.push(rec(LoggingLevel::Info, "kaish b"));
+
+        // Default drain at the Warn floor takes only the promote-to-model record; the
+        // Info narrative stays for a lower-floor drain.
+        let warn = buf.drain(rank(LoggingLevel::Warning), 20);
+        assert_eq!(warn.len(), 1);
+        assert_eq!(warn[0].message, "job done");
+        assert_eq!(buf.len(), 2, "the two Info records stay");
+
+        // A later Info-floor drain gets them, oldest-first.
+        let info = buf.drain(rank(LoggingLevel::Info), 20);
+        let msgs: Vec<_> = info.iter().map(|r| r.message.as_str()).collect();
+        assert_eq!(msgs, vec!["kaish a", "kaish b"]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn buffer_drops_oldest_past_capacity() {
+        let buf = NotificationBuffer::new(2);
+        buf.push(rec(LoggingLevel::Warning, "1"));
+        buf.push(rec(LoggingLevel::Warning, "2"));
+        buf.push(rec(LoggingLevel::Warning, "3")); // evicts "1"
+        let got: Vec<_> = buf
+            .drain(rank(LoggingLevel::Info), 20)
+            .into_iter()
+            .map(|r| r.message)
+            .collect();
+        assert_eq!(got, vec!["2".to_string(), "3".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn wait_drain_returns_when_a_record_lands() {
+        let buf = NotificationBuffer::new(8);
+        let pusher = buf.clone();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            pusher.push(rec(LoggingLevel::Warning, "landed"));
+        });
+        let got = buf
+            .wait_drain(
+                std::time::Duration::from_secs(5),
+                rank(LoggingLevel::Warning),
+                20,
+            )
+            .await;
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].message, "landed");
+    }
+
+    #[tokio::test]
+    async fn wait_drain_times_out_clean_and_empty() {
+        let buf = NotificationBuffer::new(8);
+        // Only an Info record, but we wait at the Warn floor — nothing matches, so it
+        // must time out cleanly (empty), never hang or error. A short real timeout keeps
+        // the test fast without tokio's test-util time control.
+        buf.push(rec(LoggingLevel::Info, "narrative"));
+        let got = buf
+            .wait_drain(
+                std::time::Duration::from_millis(80),
+                rank(LoggingLevel::Warning),
+                20,
+            )
+            .await;
+        assert!(got.is_empty(), "no Warn+ record ⇒ clean empty return");
+        assert_eq!(
+            buf.len(),
+            1,
+            "the unmatched Info record is left in the ring"
+        );
+    }
 
     #[test]
     fn tracing_levels_map_to_mcp_levels() {

--- a/src/mcp_log.rs
+++ b/src/mcp_log.rs
@@ -20,6 +20,22 @@
 //! before any layer sees them, so MCP verbosity can't exceed stderr's. Fine while
 //! the operator drives both with one filter; a per-layer filter is the upgrade if
 //! someone needs MCP-debug over an info stderr.
+//!
+//! **kaibo's level convention — audience, not severity.** Within the `kaibo` target
+//! tree, levels route a record to *who needs it*, not how dire it is:
+//! - **Error** — a real kaibo error: to the watching client, to the calling model's
+//!   `wait` drain, and to stderr.
+//! - **Warn = "the calling model should see this"** — salient/actionable (a job
+//!   finished or failed, the research budget ran out), *not* a dire warning. This is
+//!   the level `wait` returns to the model by default. Any kaibo code (and kaish, via
+//!   a future hook) marks something for the model's attention by emitting it at Warn.
+//! - **Info** — the watchable narrative: each kaish command, sweep, and milestone (see
+//!   [`TracingSink`](crate::progress::TracingSink)). The user's live "watch it work"
+//!   view; the model only pulls it into `wait` on request.
+//! - **Debug** — the true firehose, off by default.
+//!
+//! The convention is safe to assert here because [`KAIBO_TARGET`] filtering means
+//! rig/reqwest's *severity*-sense `warn!`s never reach this bridge — only kaibo's own.
 
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -82,6 +82,43 @@ impl ProgressSink for NullSink {
     fn emit(&self, _event: PhaseEvent) {}
 }
 
+/// A [`ProgressSink`] that maps each [`PhaseEvent`] onto kaibo's `tracing` stream under
+/// the `kaibo::consult` target. An *async* phase has no live MCP peer to push progress
+/// notifications to, so this is how it stays legible: the `mcp_log` bridge mirrors these
+/// `tracing` events to a watching client (the live "watch it work" view sync `consult`
+/// gave), and the notification ring buffer tees them for `wait`.
+///
+/// Levels follow kaibo's convention — **Warn = "promote to the calling model"**, Info =
+/// the watchable narrative — *not* severity:
+/// - `KaishRun`, the sweep events, and phase start/finish → **Info**: each shell command
+///   and milestone, the user's continuous view.
+/// - `TurnCapReached` → **Warn**: the caller should know the research budget ran out and
+///   the answer was written early, so it surfaces in the model's `wait` drain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TracingSink;
+
+impl ProgressSink for TracingSink {
+    fn emit(&self, event: PhaseEvent) {
+        // `event.message()` is the same tidy one-liner sync consult streamed; reuse it so
+        // the two channels read identically. The level branch is the only divergence.
+        let msg = event.message();
+        if promotes_to_caller(&event) {
+            tracing::warn!(target: "kaibo::consult", "{msg}");
+        } else {
+            tracing::info!(target: "kaibo::consult", "{msg}");
+        }
+    }
+}
+
+/// Does this event clear kaibo's **Warn** bar — "the calling model should see this"? Only
+/// the research-limit beat does today (the answer was written early, which changes how a
+/// caller reads it); the rest are the Info-level narrative. Split out as a pure predicate
+/// so the convention is testable without a `tracing` subscriber (whose capture tests are
+/// flaky — see project memory).
+fn promotes_to_caller(event: &PhaseEvent) -> bool {
+    matches!(event, PhaseEvent::TurnCapReached)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,6 +187,46 @@ mod tests {
     fn null_sink_swallows_events() {
         // No panic, no state — the no-op contract.
         NullSink.emit(PhaseEvent::SweepFinished);
+    }
+
+    /// The Warn-bar convention: only `TurnCapReached` promotes to the calling model; the
+    /// rest are the Info-level narrative. Pure predicate, so no flaky `tracing` capture.
+    #[test]
+    fn only_the_research_limit_promotes_to_the_caller() {
+        assert!(promotes_to_caller(&PhaseEvent::TurnCapReached));
+        for event in [
+            PhaseEvent::PhaseStarted { phase: "consult" },
+            PhaseEvent::PhaseFinished { phase: "consult" },
+            PhaseEvent::SweepStarted {
+                question: "q".into(),
+            },
+            PhaseEvent::SweepFinished,
+            PhaseEvent::KaishRun {
+                script: "cat -n x".into(),
+            },
+        ] {
+            assert!(
+                !promotes_to_caller(&event),
+                "{event:?} is Info-narrative, not a caller promotion"
+            );
+        }
+    }
+
+    #[test]
+    fn tracing_sink_handles_every_variant_without_panic() {
+        // The thin adapter must take every event (levels are verified live / by the pure
+        // predicate above, not by a flaky subscriber-capture test).
+        let sink = TracingSink;
+        sink.emit(PhaseEvent::PhaseStarted { phase: "consult" });
+        sink.emit(PhaseEvent::KaishRun {
+            script: "grep -rn TODO .".into(),
+        });
+        sink.emit(PhaseEvent::SweepStarted {
+            question: "where?".into(),
+        });
+        sink.emit(PhaseEvent::SweepFinished);
+        sink.emit(PhaseEvent::TurnCapReached);
+        sink.emit(PhaseEvent::PhaseFinished { phase: "consult" });
     }
 
     /// `Arc<dyn ProgressSink>` must be `Debug` (it rides inside `ConsultConfig`,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1965,6 +1965,8 @@ impl KaiboHandler {
     async fn wait(
         &self,
         Parameters(input): Parameters<WaitInput>,
+        peer: Peer<RoleServer>,
+        meta: Meta,
     ) -> Result<CallToolResult, McpError> {
         // No silent clamp — a model picks its own block; only an absurd value is refused,
         // loudly. The client's tool-call timeout and the user's interrupt are the real
@@ -1981,12 +1983,52 @@ impl KaiboHandler {
                 ));
             }
         }
-        let floor = wait_level_floor(input.level.as_deref())?;
+        let return_floor = wait_level_floor(input.level.as_deref())?;
         let limit = input.limit.unwrap_or(20);
         let timeout = std::time::Duration::from_secs(input.timeout_secs.unwrap_or(60));
 
-        // Block on the activity stream (consult progress + completions) up to the timeout.
-        let records = self.notifications.wait_drain(timeout, floor, limit).await;
+        // The live view for the *human*: while this call is open, stream the Info-level
+        // narrative (each kaish command, sweep, milestone) as `notifications/progress` on
+        // this call's token, so the client renders it in real time — the channel sync
+        // `consult` used, reopened on demand. Independent of what we *return* to the model
+        // (Warn+ by default): the human watches the show, the model gets the salient bits.
+        let info_floor = crate::mcp_log::rank(LoggingLevel::Info);
+        let token = progress_token(&meta);
+        // Drain down to whichever is lower — Info (to stream) when a token is present,
+        // else just the return floor (don't consume narrative no one is watching).
+        let drain_floor = if token.is_some() {
+            info_floor.min(return_floor)
+        } else {
+            return_floor
+        };
+        let seq = AtomicU64::new(0);
+        let records = self
+            .notifications
+            .wait_drain_with(timeout, drain_floor, return_floor, limit, |rec| {
+                // Stream Info+ to the human's progress channel; the model's return is the
+                // separate `return_floor` collection inside `wait_drain_with`.
+                if let Some(token) = &token {
+                    if crate::mcp_log::rank(rec.level) >= info_floor {
+                        let param = ProgressNotificationParam {
+                            progress_token: token.clone(),
+                            progress: seq.fetch_add(1, Ordering::Relaxed) as f64,
+                            total: None,
+                            message: Some(format!(
+                                "[{}] {}",
+                                wait_level_label(rec.level),
+                                rec.message
+                            )),
+                        };
+                        let peer = peer.clone();
+                        // Fire-and-forget, like `ProgressReporter`: don't make the drain
+                        // loop await a notification it doesn't depend on.
+                        tokio::spawn(async move {
+                            let _ = peer.notify_progress(param).await;
+                        });
+                    }
+                }
+            })
+            .await;
 
         // Gentle batch poll: a batch is provider-side with no push, so fold in a one-shot
         // status for any batch handle named. Non-batch handles are ignored here (consult
@@ -1994,6 +2036,13 @@ impl KaiboHandler {
         let mut batch_lines = Vec::new();
         for h in &input.handles {
             if !is_batch_handle(h) {
+                continue;
+            }
+            // Respect batch gating, like `get`/`cancel` — don't poll a batch handle on a
+            // server that has batch turned off. A per-handle note, not a hard error: it
+            // never sinks the rest of the `wait`.
+            if let Err(e) = self.ensure_batch_enabled(h) {
+                batch_lines.push(format!("{h} — {}", e.message));
                 continue;
             }
             let line = match parse_batch_handle(h) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -326,6 +326,36 @@ pub struct ListInput {
     pub all: bool,
 }
 
+/// Arguments to the `wait` tool. See [`ConsultInput`] for the `deny_unknown_fields`
+/// rationale.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct WaitInput {
+    /// How long to block, in seconds (default 60). You choose — kaibo does not clamp it;
+    /// your client's own tool-call timeout and your ability to interrupt are the real
+    /// bounds. For a very long park, prefer calling `wait` again each time it returns
+    /// over one giant block. A value over 3600 is a loud error, not a silent trim.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+
+    /// Max records to return (default 20, newest activity last).
+    #[serde(default)]
+    pub limit: Option<usize>,
+
+    /// The lowest level to return to you: `warn` (default — what kaibo flags as "the
+    /// calling model should see this": a job finished or failed, a research-limit), `info`
+    /// (also the watchable narrative — each kaish command, sweep, milestone), `error`, or
+    /// `debug` (the firehose). Not severity — `warn` is the salience bar, not a problem.
+    #[serde(default)]
+    pub level: Option<String>,
+
+    /// Optional handles to also check this call: a batch handle (`backend/provider-id`)
+    /// is polled once and its current status appended (consult jobs already surface via
+    /// the activity stream). Omit to just drain the activity stream + see running jobs.
+    #[serde(default)]
+    pub handles: Vec<String>,
+}
+
 /// Arguments to the `run_kaish` tool. See [`ConsultInput`] for the
 /// `deny_unknown_fields` rationale.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -362,6 +392,12 @@ pub struct KaiboHandler {
     /// shared `get`/`cancel`/`list`). Same `Arc<Mutex<LruCache>>` shape as `sessions`, so
     /// the per-request handler clones all share one registry (see [`JobStore`]).
     jobs: JobStore,
+    /// The pull-side notification ring the `wait` tool drains — the same kaibo-target
+    /// records the `mcp_log` bridge streams to the client, teed for on-demand pull.
+    /// `new` seeds an unwired default (nothing pushes to it); `main` swaps in the shared
+    /// ring via [`with_notifications`](Self::with_notifications) so the bridge layer feeds
+    /// it. `Clone` shares one ring (see [`NotificationBuffer`](crate::mcp_log::NotificationBuffer)).
+    notifications: crate::mcp_log::NotificationBuffer,
     /// The client's MCP log floor (a [`mcp_log::rank`]), written by `logging/setLevel`
     /// and read by the log-drain task. `Arc<AtomicU8>` so every per-request handler
     /// clone — and the drain task in `main` — share the one cell; a `setLevel` on any
@@ -461,6 +497,7 @@ impl KaiboHandler {
             (gating.batch || gating.consult, "get"),
             (gating.batch || gating.consult, "cancel"),
             (gating.batch || gating.consult, "list"),
+            (gating.batch || gating.consult, "wait"),
         ] {
             if !enabled {
                 assert!(
@@ -561,11 +598,23 @@ impl KaiboHandler {
             tool_schemas: Arc::new(builtin_schemas()?),
             sessions,
             jobs,
+            // An unwired default — nothing pushes to it until `main` swaps in the shared
+            // ring the bridge layer feeds (see `with_notifications`). So a handler built
+            // for a test has a valid, empty buffer and `wait` simply drains nothing.
+            notifications: crate::mcp_log::NotificationBuffer::new(512),
             mcp_log_level: Arc::new(AtomicU8::new(mcp_log::rank(mcp_log::DEFAULT_LEVEL))),
             allowed_set: Arc::new(allowed),
             default_root: Arc::new(default_root),
             default_root_inferred,
         })
+    }
+
+    /// Swap in the shared notification ring `main` also handed the bridge layer, so the
+    /// `wait` tool drains the records the layer pushes. A builder (not a `new` param) to
+    /// keep `new(config)` unchanged for the many call sites and tests.
+    pub fn with_notifications(mut self, buffer: crate::mcp_log::NotificationBuffer) -> Self {
+        self.notifications = buffer;
+        self
     }
 
     /// A handle to the shared MCP log floor, for the drain task in `main` to read.
@@ -1895,6 +1944,79 @@ impl KaiboHandler {
         )]))
     }
 
+    #[tool(
+        description = "Block briefly for your async work to make progress, then return \
+            what happened — the way to *productively park* instead of blind-polling `get`. \
+            Fire off consults (`consult_submit`) and batches (`batch_submit`), do your \
+            other work (your own sub-agents included), then call `wait` when you're ready \
+            to spend a minute on kaibo: it blocks up to `timeout_secs` (you choose; no \
+            clamp — you can always interrupt) and returns as soon as something lands, or \
+            on a clean timeout. By default it hands back the records kaibo flagged for you \
+            (a job finished or failed, a research-limit) plus which consult jobs are still \
+            running; pass `level:\"info\"` to also pull the watchable narrative (each kaish \
+            command, sweep, and milestone the agents ran) into your context. Name batch \
+            handles in `handles` to fold their current status in too (kaibo polls them \
+            once). Nothing here wakes you — you choose when to block — and it's not the \
+            source of truth: `get`/`list` are. A clean empty return just means nothing new \
+            yet; `wait` again to keep parking. Args: timeout_secs (optional, default 60), \
+            limit (optional, default 20), level (optional: warn|info|error|debug), handles \
+            (optional list to also poll)."
+    )]
+    async fn wait(
+        &self,
+        Parameters(input): Parameters<WaitInput>,
+    ) -> Result<CallToolResult, McpError> {
+        // No silent clamp — a model picks its own block; only an absurd value is refused,
+        // loudly. The client's tool-call timeout and the user's interrupt are the real
+        // ceilings (see `WaitInput::timeout_secs`).
+        if let Some(t) = input.timeout_secs {
+            if t > 3600 {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "timeout_secs {t} is over 3600 (1h) — pass a smaller value, or \
+                         call `wait` again each time it returns; a single block is capped \
+                         by your client's tool-call timeout anyway."
+                    ),
+                    None,
+                ));
+            }
+        }
+        let floor = wait_level_floor(input.level.as_deref())?;
+        let limit = input.limit.unwrap_or(20);
+        let timeout = std::time::Duration::from_secs(input.timeout_secs.unwrap_or(60));
+
+        // Block on the activity stream (consult progress + completions) up to the timeout.
+        let records = self.notifications.wait_drain(timeout, floor, limit).await;
+
+        // Gentle batch poll: a batch is provider-side with no push, so fold in a one-shot
+        // status for any batch handle named. Non-batch handles are ignored here (consult
+        // jobs surface through the stream + the running-jobs footer).
+        let mut batch_lines = Vec::new();
+        for h in &input.handles {
+            if !is_batch_handle(h) {
+                continue;
+            }
+            let line = match parse_batch_handle(h) {
+                Ok((backend, id)) => match self.batch_poller(backend) {
+                    Ok(provider) => match provider.poll(id).await {
+                        Ok(poll) => format!("{h} — {}", batch_poll_brief(&poll)),
+                        Err(e) => format!("{h} — poll failed: {e:#}"),
+                    },
+                    Err(e) => format!("{h} — {}", e.message),
+                },
+                Err(e) => format!("{h} — {}", e.message),
+            };
+            batch_lines.push(line);
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(render_wait(
+            &records,
+            &batch_lines,
+            &self.jobs,
+            timeout,
+        ))]))
+    }
+
     /// Refuse a batch-shaped handle when batch is gated off — `get`/`cancel` survive as
     /// long as *either* capability is on, so a handle can arrive for a disabled one.
     fn ensure_batch_enabled(&self, handle: &str) -> Result<(), McpError> {
@@ -2866,6 +2988,92 @@ fn is_batch_handle(handle: &str) -> bool {
     handle.contains('/')
 }
 
+/// Map a `wait` `level` string to a [`mcp_log::rank`] floor. `warn` (the default) is
+/// kaibo's "the calling model should see this" bar — salience, not severity.
+fn wait_level_floor(level: Option<&str>) -> Result<u8, McpError> {
+    let l = match level.unwrap_or("warn").to_ascii_lowercase().as_str() {
+        "debug" => LoggingLevel::Debug,
+        "info" => LoggingLevel::Info,
+        "warn" | "warning" => LoggingLevel::Warning,
+        "error" => LoggingLevel::Error,
+        other => {
+            return Err(McpError::invalid_params(
+                format!("level must be one of debug|info|warn|error, got {other:?}"),
+                None,
+            ))
+        }
+    };
+    Ok(crate::mcp_log::rank(l))
+}
+
+/// A short, readable tag for a record's level in `wait` output.
+fn wait_level_label(level: LoggingLevel) -> &'static str {
+    match level {
+        LoggingLevel::Debug => "debug",
+        LoggingLevel::Info => "info",
+        LoggingLevel::Notice => "note",
+        LoggingLevel::Warning => "warn",
+        LoggingLevel::Error
+        | LoggingLevel::Critical
+        | LoggingLevel::Alert
+        | LoggingLevel::Emergency => "error",
+    }
+}
+
+/// One-line status for a batch poll, for the `wait` footer — not the full results (`get`
+/// the handle for those).
+fn batch_poll_brief(poll: &crate::batch::BatchPoll) -> String {
+    match poll {
+        crate::batch::BatchPoll::Pending { completed, total } => {
+            format!("running, {completed}/{total} done")
+        }
+        crate::batch::BatchPoll::Cancelling => "canceling".to_string(),
+        crate::batch::BatchPoll::Done(answers) => {
+            format!("complete — {} result(s); `get` it", answers.len())
+        }
+        crate::batch::BatchPoll::Failed { state, .. } => format!("ended ({state})"),
+    }
+}
+
+/// Render a `wait` result: the drained activity records (each tagged by level), any
+/// gentle batch-poll lines, and a footer naming the consult jobs still running.
+fn render_wait(
+    records: &[crate::mcp_log::LogRecord],
+    batch_lines: &[String],
+    jobs: &JobStore,
+    timeout: std::time::Duration,
+) -> String {
+    let mut s = String::new();
+    if records.is_empty() && batch_lines.is_empty() {
+        s.push_str(&format!("Nothing new in {}s.", timeout.as_secs()));
+    } else {
+        for r in records {
+            s.push_str(&format!("[{}] {}\n", wait_level_label(r.level), r.message));
+        }
+        for b in batch_lines {
+            s.push_str(b);
+            s.push('\n');
+        }
+    }
+    let running: Vec<String> = jobs
+        .list()
+        .into_iter()
+        .filter(|(_, snap)| matches!(snap.state, JobState::Running))
+        .map(|(id, _)| id)
+        .collect();
+    s.push('\n');
+    if running.is_empty() {
+        s.push_str("No consult jobs still running.");
+    } else {
+        s.push_str(&format!("Still running: {}.", running.join(", ")));
+    }
+    s.push_str(
+        " `get <handle>` to collect a finished one, `list` for the full picture, or \
+         `wait` again to keep parking.",
+    );
+    s
+}
+
 /// The default `list` recency window: 24h. A provider's offline SLA is ≤24h, so an
 /// older batch is done and still collectible by its handle — trimming it saves the
 /// caller tokens without losing anything actionable.
@@ -3067,6 +3275,54 @@ mod tests {
             "the refusal names the boundary: {}",
             err.message
         );
+    }
+
+    #[test]
+    fn wait_level_floor_parses_the_salience_words_and_rejects_junk() {
+        use crate::mcp_log::rank;
+        // Default is the Warn bar — "the calling model should see this".
+        assert_eq!(wait_level_floor(None).unwrap(), rank(LoggingLevel::Warning));
+        assert_eq!(
+            wait_level_floor(Some("info")).unwrap(),
+            rank(LoggingLevel::Info)
+        );
+        assert_eq!(
+            wait_level_floor(Some("WARN")).unwrap(),
+            rank(LoggingLevel::Warning)
+        );
+        assert_eq!(
+            wait_level_floor(Some("error")).unwrap(),
+            rank(LoggingLevel::Error)
+        );
+        assert!(
+            wait_level_floor(Some("loud")).is_err(),
+            "an unknown level is a loud error, not a silent default"
+        );
+    }
+
+    #[test]
+    fn render_wait_tags_records_and_footers_running_jobs() {
+        let jobs = JobStore::new(std::num::NonZeroUsize::new(4).unwrap());
+        let recs = vec![crate::mcp_log::LogRecord {
+            level: LoggingLevel::Warning,
+            target: "kaibo::jobs".into(),
+            message: "async job finished — collect it with `get`".into(),
+            fields: serde_json::Map::new(),
+        }];
+        let out = render_wait(&recs, &[], &jobs, std::time::Duration::from_secs(60));
+        assert!(out.contains("[warn]"), "tags the record's level: {out}");
+        assert!(
+            out.contains("async job finished"),
+            "carries the message: {out}"
+        );
+        assert!(
+            out.contains("No consult jobs still running"),
+            "footer reports none running: {out}"
+        );
+
+        // No records, no batch lines → the clean empty line, naming the wait length.
+        let empty = render_wait(&[], &[], &jobs, std::time::Duration::from_secs(30));
+        assert!(empty.contains("Nothing new in 30s"), "clean empty: {empty}");
     }
 
     fn batch_item(created_at: Option<&str>) -> crate::batch::BatchListItem {

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,7 +40,7 @@ use crate::kaish_syntax::{
     kaibo_instructions_with_scope, kaibo_sandbox_doc, render_builtin_help, render_topic, topics,
 };
 use crate::mcp_log;
-use crate::progress::{NullSink, PhaseEvent, ProgressSink};
+use crate::progress::{NullSink, PhaseEvent, ProgressSink, TracingSink};
 use crate::sandbox::{builtin_schemas, KaishWorker};
 use crate::session::SessionStore;
 
@@ -185,6 +185,18 @@ pub struct ConsultInput {
     /// (an empty report is itself the signal that the consult delegated no sweep).
     #[serde(default)]
     pub include_report: bool,
+
+    /// Workspace files to put in front of the investigation — absolute or relative
+    /// (relative reads from the project root) paths that must live **under the project
+    /// root** so the consult can reach them through its read-only shell. Unlike
+    /// `oneshot`/`batch` attach, kaibo does **not** inline these — it names them in the
+    /// investigation prompt and the consult model reads them itself (`cat -n`) when it's
+    /// ready, in full, building its own narrative. Use it to hand the consult a focus —
+    /// "review this diff" with `["changes.diff"]` (write it under the repo first), or the
+    /// specific files a question centers on — without pasting their bytes into your
+    /// context. A path outside the root, a directory, or a missing file is a clear error.
+    #[serde(default)]
+    pub attach: Vec<String>,
 }
 
 /// Arguments to the unified `get` / `cancel` tools: one handle that addresses either
@@ -724,6 +736,66 @@ impl KaiboHandler {
         )
     }
 
+    /// Validate caller-named `consult` attachments and return them as **root-relative
+    /// paths the model reads itself** — no bytes are read here, unlike
+    /// [`resolve_attachments`](Self::resolve_attachments), which inlines for the tool-less
+    /// tools. Each path must canonicalize to a regular file *under the consult's `root`*,
+    /// because the consult reads it through a kaish worker rooted there; an out-of-root
+    /// path is refused with guidance. The returned relative paths are what the model
+    /// `cat`s and what [`consult_user_prompt`](crate::consult::consult_user_prompt) names
+    /// in the driver prompt — deferring the IO to the model's own reads.
+    fn resolve_consult_attachments(
+        root: &std::path::Path,
+        attach: &[String],
+    ) -> Result<Vec<String>, McpError> {
+        let mut out = Vec::with_capacity(attach.len());
+        for p in attach {
+            let raw = std::path::PathBuf::from(p);
+            // A relative path reads from the project root (where the model's shell starts).
+            let joined = if raw.is_absolute() {
+                raw.clone()
+            } else {
+                root.join(&raw)
+            };
+            let canon = std::fs::canonicalize(&joined).map_err(|e| {
+                McpError::invalid_params(
+                    format!("attached file {} could not be resolved: {e}", raw.display()),
+                    None,
+                )
+            })?;
+            let meta = std::fs::metadata(&canon).map_err(|e| {
+                McpError::invalid_params(
+                    format!("attached file {} could not be read: {e}", canon.display()),
+                    None,
+                )
+            })?;
+            if !meta.is_file() {
+                return Err(McpError::invalid_params(
+                    format!("attached file {} is not a regular file", canon.display()),
+                    None,
+                ));
+            }
+            // Must be under the consult's root — the tree its read-only shell is mounted
+            // at, so anything outside it the model simply can't `cat`. (oneshot/batch
+            // attach inline from anywhere in the allowed set; consult reads in situ.)
+            let rel = canon.strip_prefix(root).map_err(|_| {
+                McpError::invalid_params(
+                    format!(
+                        "attached file {} resolves outside the project root {} — consult \
+                         reads attachments through its shell, so they must live under the \
+                         project. Paste it into `context`, or use `oneshot`/`batch` attach \
+                         (which inline a file from anywhere in the allowed set).",
+                        raw.display(),
+                        root.display(),
+                    ),
+                    None,
+                )
+            })?;
+            out.push(rel.display().to_string());
+        }
+        Ok(out)
+    }
+
     /// Refuse image attachments to a vision-blind model, naming the cast so the caller
     /// can pick a vision-capable one. Shared by the tool-less attach surfaces (`batch` and
     /// `oneshot`) so the refusal reads identically and lives in one place; a blind model
@@ -1073,10 +1145,13 @@ impl KaiboHandler {
             (optional; a change summary or pasted source to seed the investigation — \
             trusted as starting evidence), path (project dir; optional if the server \
             has a default root), cast (optional), session_id (optional; opaque \
-            conversation key), include_report (optional; attach the explorer's report \
-            as structured_content for debugging the hand-off), and optional \
-            explorer_model / synth_model overrides (a model id, sent verbatim; add \
-            explorer_backend / synth_backend to retarget the slot's backend). For a \
+            conversation key), attach (optional; workspace files under the project root \
+            to put in front of the investigation — kaibo names them and the model reads \
+            them itself with the shell, no inlining, so 'review this diff' is \
+            attach:[\"changes.diff\"] with no paste), include_report (optional; attach \
+            the explorer's report as structured_content for debugging the hand-off), and \
+            optional explorer_model / synth_model overrides (a model id, sent verbatim; \
+            add explorer_backend / synth_backend to retarget the slot's backend). For a \
             thin answer with no codebase access, use `oneshot` instead."
     )]
     async fn consult(
@@ -1121,6 +1196,9 @@ impl KaiboHandler {
             house_rules: self.house_rules(&root)?,
             prompts: self.resolved_prompts(&cast),
             orientation: self.orientation(&root).await?,
+            // Validated to live under `root` (the model reads them via its shell); not
+            // inlined — consult defers the IO to its own `cat`s. See [`ConsultInput::attach`].
+            attachments: Self::resolve_consult_attachments(&root, &input.attach)?,
         };
 
         // Multi-turn: a session_id binds this turn to a thread (replay prior turns,
@@ -1176,7 +1254,7 @@ impl KaiboHandler {
             collect later — the async sibling of `consult`, the way `batch_submit` is to \
             `oneshot`. Same investigation (a capable model drives the read-only kaish \
             shell, reads spans, delegates sweeps, answers with `file:line` citations), \
-            same args as `consult` (question, context, path, cast, session_id, \
+            same args as `consult` (question, context, path, cast, session_id, attach, \
             include_report, model/backend overrides) — it just hands back a handle \
             instead of holding your turn open while it thinks. Reach for it to run \
             several consults at once (a cross-model study: submit one per cast, collect \
@@ -1221,12 +1299,17 @@ impl KaiboHandler {
                 .unwrap_or(defaults.explorer_max_turns),
             synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
             sandbox: self.config.sandbox.clone(),
-            // An async job streams to no live peer — progress is collected via
-            // `get`'s status line, not the MCP progress channel.
-            progress: Arc::new(NullSink),
+            // An async job has no live MCP peer to push progress notifications to, so
+            // route its liveness onto the `tracing` stream: the `mcp_log` bridge mirrors
+            // it to a watching client (the live view sync `consult` had) and the
+            // notification buffer tees it for `wait`. See [`TracingSink`].
+            progress: Arc::new(TracingSink),
             house_rules: self.house_rules(&root)?,
             prompts: self.resolved_prompts(&cast),
             orientation: self.orientation(&root).await?,
+            // Validated to live under `root` (the model reads them via its shell); not
+            // inlined — consult defers the IO to its own `cat`s. See [`ConsultInput::attach`].
+            attachments: Self::resolve_consult_attachments(&root, &input.attach)?,
         };
 
         // Owned captures for the `'static` spawned task. The session store is `Clone`
@@ -1326,10 +1409,12 @@ impl KaiboHandler {
             synth_max_turns: defaults.synth_max_turns,
             sandbox: self.config.sandbox.clone(),
             progress: progress.clone(),
-            // oneshot reads no project: no house rules, no repo map, no shell.
+            // oneshot reads no project: no house rules, no repo map, no shell — and no
+            // consult-style attachments (it inlines its `attach` files via `oneshot()`).
             house_rules: None,
             prompts: self.resolved_prompts(&cast),
             orientation: None,
+            attachments: Vec::new(),
         };
 
         let span = tracing::info_span!("oneshot", cast = %cast.name, model = %arm.model);
@@ -1785,8 +1870,12 @@ impl KaiboHandler {
                     let hidden = if input.all {
                         0
                     } else {
+                        // Read the clock once, not once per item.
+                        let now = now_epoch_secs();
                         let before = entries.len();
-                        entries.retain(|(_, it)| is_recent_batch(it));
+                        entries.retain(|(_, it)| {
+                            batch_within_window(it, now, BATCH_RECENCY_WINDOW_SECS)
+                        });
                         before - entries.len()
                     };
                     sections.push(crate::batch::render_list(&entries, &errors, &truncated));
@@ -2782,21 +2871,23 @@ fn is_batch_handle(handle: &str) -> bool {
 /// caller tokens without losing anything actionable.
 const BATCH_RECENCY_WINDOW_SECS: i64 = 24 * 3600;
 
-/// Was this batch created within the last 24h? The default `list` recency filter. A
-/// batch kaibo can't date (no or unparseable `created_at`) counts as recent, so it's
-/// shown rather than silently hidden — losing sight of a batch is worse than an extra
-/// line. "Now" is read from `SystemTime`, so chrono's `clock` feature stays off.
-fn is_recent_batch(it: &crate::batch::BatchListItem) -> bool {
-    let now = std::time::SystemTime::now()
+/// Unix epoch seconds now, for the `list` recency window — read once per `list` call and
+/// passed into [`batch_within_window`], not re-read per item. A pre-epoch system clock
+/// (impossible in practice) reads as 0, which keeps everything: fail-open, never hide a
+/// batch on a clock glitch. From `SystemTime`, so chrono's `clock` feature stays off.
+fn now_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    batch_within_window(it, now, BATCH_RECENCY_WINDOW_SECS)
+        .unwrap_or(0)
 }
 
-/// The pure core of [`is_recent_batch`], with `now` injected so the keep/drop boundary is
-/// testable without the clock. Undateable → kept; a future timestamp (clock skew) yields
-/// a negative age, still within the window, so also kept.
+/// Is this batch within `window_secs` of `now_epoch`? The `list` recency filter, with
+/// `now` injected so the keep/drop boundary is testable without the clock and the clock
+/// is read once per call rather than per item. A batch kaibo can't date (no or
+/// unparseable `created_at`) is kept, not silently hidden — losing sight of a batch is
+/// worse than an extra line; a future timestamp (clock skew) yields a negative age, still
+/// within the window, so also kept.
 fn batch_within_window(it: &crate::batch::BatchListItem, now_epoch: i64, window_secs: i64) -> bool {
     match it
         .created_at
@@ -2941,6 +3032,42 @@ mod tests {
     use super::*;
     use rmcp::model::{NumberOrString, PromptMessageContent};
     use rmcp::ServerHandler;
+
+    /// consult `attach` validates files are under the consult root (so the model's shell
+    /// can `cat` them) and returns them as relative paths; a file outside the root — even
+    /// a real, readable one — is refused, since the shell couldn't reach it. The root here
+    /// stands in for any tree, including a followed worktree (which `resolve_root` returns
+    /// as the root verbatim).
+    #[test]
+    fn consult_attach_keeps_under_root_relative_and_rejects_outside() {
+        let root = tempfile::tempdir().unwrap();
+        let root_canon = std::fs::canonicalize(root.path()).unwrap();
+        std::fs::create_dir(root_canon.join("src")).unwrap();
+        std::fs::write(root_canon.join("src/jobs.rs"), b"// in tree").unwrap();
+
+        // A relative path resolves to its root-relative form (what the model `cat`s).
+        let rel =
+            KaiboHandler::resolve_consult_attachments(&root_canon, &["src/jobs.rs".to_string()])
+                .expect("an in-tree file resolves");
+        assert_eq!(rel, vec!["src/jobs.rs".to_string()]);
+
+        // A file outside the root is refused, even though it exists and is readable.
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = std::fs::canonicalize(outside.path())
+            .unwrap()
+            .join("x.diff");
+        std::fs::write(&outside_file, b"diff").unwrap();
+        let err = KaiboHandler::resolve_consult_attachments(
+            &root_canon,
+            &[outside_file.display().to_string()],
+        )
+        .expect_err("an out-of-root file must be refused");
+        assert!(
+            err.message.contains("outside the project root"),
+            "the refusal names the boundary: {}",
+            err.message
+        );
+    }
 
     fn batch_item(created_at: Option<&str>) -> crate::batch::BatchListItem {
         crate::batch::BatchListItem {

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,10 +29,13 @@ use serde_json::json;
 use tracing::Instrument;
 
 use crate::config::{Backend, Cast, Config, ModelRole, ModelSlot};
-use crate::consult::{consult, oneshot, Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides};
+use crate::consult::{
+    consult, oneshot, Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides,
+};
 use crate::explorer::format_output;
 use crate::generate_image::GenerateImageInput;
 use crate::image_gen::ImageGen;
+use crate::jobs::{CancelOutcome, JobResult, JobSnapshot, JobState, JobStore};
 use crate::kaish_syntax::{
     kaibo_instructions_with_scope, kaibo_sandbox_doc, render_builtin_help, render_topic, topics,
 };
@@ -184,6 +187,19 @@ pub struct ConsultInput {
     pub include_report: bool,
 }
 
+/// Arguments to the unified `get` / `cancel` tools: one handle that addresses either
+/// kind of async work. See [`ConsultInput`] for the `deny_unknown_fields` rationale.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct HandleInput {
+    /// The handle of the async work to act on. Two shapes, told apart by the `/`:
+    /// a **batch** handle from `batch_submit` is `backend/provider-id` (e.g.
+    /// `anthropic/msgbatch_…`, durable — survives a restart); a **consult** handle from
+    /// `consult_submit` is `job-N` (e.g. `job-1`, in-memory — lives only for this server
+    /// session). kaibo routes by the handle, so you pass the same one you were given.
+    pub handle: String,
+}
+
 /// Arguments to the `oneshot` tool. See [`ConsultInput`] for the
 /// `deny_unknown_fields` rationale. No `path`: oneshot reads no project — it's a
 /// thin, toolless completion, so the caller owns any context the model needs.
@@ -275,25 +291,27 @@ pub struct BatchSubmitInput {
     pub backend: Option<String>,
 }
 
-/// Arguments to `batch_list`: an optional backend to scope the listing to.
+/// Arguments to the unified `list`: an optional backend to scope the *batch* portion
+/// of the listing to. Live consult jobs (in-memory, not backend-bound) are always
+/// listed regardless.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct BatchListInput {
+pub struct ListInput {
     /// Which backend (name or alias) to list batches from. Omit to list across every
     /// configured batch-capable backend — the orphan-recovery default when you've lost a
-    /// handle and don't recall which backend ran it.
+    /// handle and don't recall which backend ran it. Does not affect the consult-jobs
+    /// section, which is always shown.
     #[serde(default)]
     pub backend: Option<String>,
-}
 
-/// Arguments to `batch_get` / `batch_cancel`: the opaque handle `batch_submit`
-/// returned (`"backend/provider-id"`).
-#[derive(Debug, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct BatchHandleInput {
-    /// The batch handle kaibo returned from `batch_submit` (e.g.
-    /// `anthropic/msgbatch_…`). kaibo holds no state — the handle is the whole address.
-    pub batch_id: String,
+    /// Show *all* batches, including ones created more than 24h ago. By default the
+    /// batches section is trimmed to the last 24 hours (a provider keeps months of
+    /// finished batches, and dumping them all just burns tokens — the offline SLA is
+    /// ≤24h, so anything older is done and still collectible by its handle). Set
+    /// `all: true` for the full history — true orphan recovery of an old batch. A batch
+    /// kaibo can't date (no timestamp) is always shown, never silently hidden.
+    #[serde(default)]
+    pub all: bool,
 }
 
 /// Arguments to the `run_kaish` tool. See [`ConsultInput`] for the
@@ -328,6 +346,10 @@ pub struct KaiboHandler {
     /// Multi-turn `consult` sessions. Internally an `Arc<Mutex<_>>`, so the
     /// per-request handler clones all share one cache (see [`SessionStore`]).
     sessions: SessionStore,
+    /// In-flight + collectable async consultations (`consult_submit`, collected via the
+    /// shared `get`/`cancel`/`list`). Same `Arc<Mutex<LruCache>>` shape as `sessions`, so
+    /// the per-request handler clones all share one registry (see [`JobStore`]).
+    jobs: JobStore,
     /// The client's MCP log floor (a [`mcp_log::rank`]), written by `logging/setLevel`
     /// and read by the log-drain task. `Arc<AtomicU8>` so every per-request handler
     /// clone — and the drain task in `main` — share the one cell; a `setLevel` on any
@@ -409,14 +431,24 @@ impl KaiboHandler {
         // exists before dropping it — a stale name is a build-time bug we want loud.
         for (enabled, name) in [
             (gating.consult, "consult"),
+            // `consult_submit` is the async sibling of `consult` — same capability, a
+            // submit/collect surface rather than a blocking one — so it shares the
+            // `consult` gate. (docs/issues.md tracks a dedicated flag if anyone needs
+            // only one shape.) The verbs that *collect* its handles (`get`/`cancel`/
+            // `list`) are shared with batch and gated below.
+            (gating.consult, "consult_submit"),
             (gating.oneshot, "oneshot"),
             (gating.run_kaish, "run_kaish"),
             (gating.generate_image, "generate_image"),
-            // One `--no-batch` flag drops all batch routes together.
+            // `--no-batch` drops `batch_submit`; the shared collect verbs live below.
             (gating.batch, "batch_submit"),
-            (gating.batch, "batch_get"),
-            (gating.batch, "batch_cancel"),
-            (gating.batch, "batch_list"),
+            // `get`/`cancel`/`list` manage *both* batch and consult handles, so they
+            // stay as long as *either* capability is on, and drop only when both are
+            // gated off. Routing by handle shape inside each verb refuses a handle whose
+            // own capability is disabled.
+            (gating.batch || gating.consult, "get"),
+            (gating.batch || gating.consult, "cancel"),
+            (gating.batch || gating.consult, "list"),
         ] {
             if !enabled {
                 assert!(
@@ -495,7 +527,11 @@ impl KaiboHandler {
             .into_iter()
             .map(|(name, _)| name)
             .collect();
-        inject_cast_enum(&mut tool_router, &["consult", "oneshot"], &usable);
+        inject_cast_enum(
+            &mut tool_router,
+            &["consult", "consult_submit", "oneshot"],
+            &usable,
+        );
         // `generate_image` selects the `image` slot, not explorer/synth, so its menu is
         // a different filter — casts with a usable image slot, not `usable_casts`. Same
         // advisory enum so image gen is as discoverable as consultation.
@@ -503,11 +539,16 @@ impl KaiboHandler {
         inject_cast_enum(&mut tool_router, &["generate_image"], &image_casts);
 
         let sessions = SessionStore::new(config.defaults.session_capacity);
+        // Async-consult jobs reuse the session capacity for now — both are diskless,
+        // client-keyed, capacity-LRU registries. (docs/issues.md tracks giving jobs
+        // their own `job_capacity` knob.)
+        let jobs = JobStore::new(config.defaults.session_capacity);
         Ok(Self {
             config: Arc::new(config),
             tool_router,
             tool_schemas: Arc::new(builtin_schemas()?),
             sessions,
+            jobs,
             mcp_log_level: Arc::new(AtomicU8::new(mcp_log::rank(mcp_log::DEFAULT_LEVEL))),
             allowed_set: Arc::new(allowed),
             default_root: Arc::new(default_root),
@@ -662,7 +703,11 @@ impl KaiboHandler {
     /// widening knobs. Used wherever [`contained`](Self::contained) says no, so the
     /// caller always learns where the edge is and how to move it.
     fn containment_error(&self, raw: &std::path::Path, canon: &std::path::Path) -> McpError {
-        let trees: Vec<String> = self.allowed_set.iter().map(|p| p.display().to_string()).collect();
+        let trees: Vec<String> = self
+            .allowed_set
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
         McpError::invalid_params(
             format!(
                 "path {} resolves to {}, which is outside the allowed set [{}]. \
@@ -786,8 +831,8 @@ impl KaiboHandler {
             // Read *through the VFS* rooted at the containing tree — see the doc-comment.
             // A swapped escaping symlink is refused at the mount, not read through.
             if !workers.contains_key(&tree) {
-                let worker = KaishWorker::spawn_with(&tree, self.config.sandbox.clone())
-                    .map_err(|e| {
+                let worker =
+                    KaishWorker::spawn_with(&tree, self.config.sandbox.clone()).map_err(|e| {
                         McpError::internal_error(
                             format!("attachment reader for {}: {e:#}", tree.display()),
                             None,
@@ -810,7 +855,6 @@ impl KaiboHandler {
         }
         Ok(out)
     }
-
 
     /// The worktrees the follow feature currently admits *beyond* the static allowed
     /// set — for the `kaibo://config` runtime section, so the live boundary stays
@@ -1128,6 +1172,120 @@ impl KaiboHandler {
     }
 
     #[tool(
+        description = "Start a `consult` in the background and get back a job id to \
+            collect later — the async sibling of `consult`, the way `batch_submit` is to \
+            `oneshot`. Same investigation (a capable model drives the read-only kaish \
+            shell, reads spans, delegates sweeps, answers with `file:line` citations), \
+            same args as `consult` (question, context, path, cast, session_id, \
+            include_report, model/backend overrides) — it just hands back a handle \
+            instead of holding your turn open while it thinks. Reach for it to run \
+            several consults at once (a cross-model study: submit one per cast, collect \
+            them all) or when a deep consult would otherwise block you: submit, go do \
+            other work, then `get <job-id>` for the answer. Stop one early with \
+            `cancel <job-id>`; see everything in flight with `list`. Returns a job id like \
+            `job-1`; the job lives for this server session only (no restart survival — \
+            collect it before you reconnect). For an answer right now in one call, use \
+            `consult`."
+    )]
+    async fn consult_submit(
+        &self,
+        Parameters(input): Parameters<ConsultInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let root = self.resolve_root(input.path)?;
+        // Resolve cast + per-call overrides + arms exactly as `consult` does — all the
+        // refusable work (bad cast, bad path, missing key) happens *here*, synchronously,
+        // so a bad submit is a clean error, not a job that fails on poll.
+        let mut cast = self.resolve_cast(input.cast)?;
+        self.apply_model_override(
+            &mut cast,
+            ModelRole::Explorer,
+            input.explorer_model.as_deref(),
+            input.explorer_backend.as_deref(),
+            "explorer_model",
+            "explorer_backend",
+        )?;
+        self.apply_model_override(
+            &mut cast,
+            ModelRole::Synth,
+            input.synth_model.as_deref(),
+            input.synth_backend.as_deref(),
+            "synth_model",
+            "synth_backend",
+        )?;
+        let explorer = self.arm(&cast, ModelRole::Explorer)?;
+        let synth = self.arm(&cast, ModelRole::Synth)?;
+        let defaults = &self.config.defaults;
+        let cfg = ConsultConfig {
+            explorer_max_turns: input
+                .explorer_max_turns
+                .unwrap_or(defaults.explorer_max_turns),
+            synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
+            sandbox: self.config.sandbox.clone(),
+            // An async job streams to no live peer — progress is collected via
+            // `get`'s status line, not the MCP progress channel.
+            progress: Arc::new(NullSink),
+            house_rules: self.house_rules(&root)?,
+            prompts: self.resolved_prompts(&cast),
+            orientation: self.orientation(&root).await?,
+        };
+
+        // Owned captures for the `'static` spawned task. The session store is `Clone`
+        // (an `Arc` inside), so the task holds its own handle and rebuilds the borrow
+        // (`&store, &id`) inside the async block where both live.
+        let question = input.question.clone();
+        let context = input.context.clone();
+        let sessions = self.sessions.clone();
+        let session_id = input.session_id.clone();
+        let include_report = input.include_report;
+        let cast_name = cast.name.clone();
+        let explorer_model = explorer.model.clone();
+        let synth_model = synth.model.clone();
+        let label =
+            format!("cast `{cast_name}` (explorer `{explorer_model}`, synth `{synth_model}`)");
+
+        let job_id = self.jobs.submit(label, async move {
+            let session = session_id.as_ref().map(|id| (&sessions, id.as_str()));
+            match consult(
+                &question,
+                context.as_deref(),
+                root,
+                &explorer,
+                &synth,
+                &cfg,
+                session,
+            )
+            .await
+            {
+                Ok(out) => {
+                    let answer = with_provenance(
+                        out.answer,
+                        &cast_name,
+                        &[
+                            ("explorer", explorer_model.as_str()),
+                            ("synth", synth_model.as_str()),
+                        ],
+                    );
+                    Ok(JobResult {
+                        answer,
+                        report: include_report.then_some(out.report),
+                    })
+                }
+                // Render the failure to its final text here (classification + guidance),
+                // so `get` wraps a ready string without re-deriving anything.
+                Err(e) => Err(consultation_failure_text("consult", &cast_name, e)),
+            }
+        });
+
+        let msg = format!(
+            "Submitted consultation `{job_id}` on cast `{}`. It runs in the \
+             background — go do other work and `get {job_id}` for the answer; \
+             `cancel {job_id}` stops it. Nothing to wait on now.",
+            cast.name
+        );
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    }
+
+    #[tool(
         description = "Ask a model *outside your own family* a thin, direct question \
             — prompt in, answer out, no codebase access and no tools. The counterpart \
             to `consult`: use `oneshot` when you already own the context (you've pasted \
@@ -1328,7 +1486,7 @@ impl KaiboHandler {
         crate::batch::poller(backend).map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
     }
 
-    /// The set of backend names `batch_list` should query. An explicit `backend` scopes
+    /// The set of backend names `list` should query. An explicit `backend` scopes
     /// to that one (resolved by name/alias, and refused loudly if its kind has no batch
     /// lane). Omitted, it's every configured batch-capable backend, sorted — the orphan-
     /// recovery default. No batch-capable backend at all is a clear parameter error, not an
@@ -1384,12 +1542,13 @@ impl KaiboHandler {
             get a clear refusal naming the batch-capable backends). `kaibo://config` lists \
             the casts. Args: prompts (required, a list), cast \
             (optional), model + backend (optional synth override — handy to batch a \
-            Pro/Opus tier a cast synths cheaper interactively). Returns a handle; poll \
-            it with `batch_get`, stop it with `batch_cancel`. This is a fire-and-forget \
+            Pro/Opus tier a cast synths cheaper interactively). Returns a handle \
+            (`backend/provider-id`); poll it with `get <handle>`, stop it with \
+            `cancel <handle>`, find a lost one with `list`. This is a fire-and-forget \
             lane: submit, then go do other work — don't sit in a wait/sleep loop holding \
             your turn open. A batch can take minutes to hours (the provider's offline \
             SLA is up to 24h), and the handle is durable — it survives a server restart \
-            — so come back and `batch_get` later rather than blocking on it now."
+            — so come back and `get` it later rather than blocking on it now."
     )]
     pub async fn batch_submit(
         &self,
@@ -1453,8 +1612,8 @@ impl KaiboHandler {
         let handle = format!("{backend_name}/{provider_id}");
         let msg = format!(
             "Submitted batch `{handle}` — {} prompt(s) on cast `{}` (model `{}`). \
-             Poll it with `batch_get` (it'll show progress, then per-item answers when \
-             done); stop it with `batch_cancel`.",
+             Poll it with `get {handle}` (it'll show progress, then per-item answers when \
+             done); stop it with `cancel {handle}`.",
             items.len(),
             cast.name,
             model
@@ -1463,103 +1622,217 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Poll a batch by the handle `batch_submit` returned. While it runs \
-            you get a progress line; once it's done you get every item's answer (each \
-            labelled by its index), with per-item failures surfaced rather than dropped. \
-            kaibo holds no state — the handle is the whole address, so this works across \
-            a server restart. Poll occasionally, not in a tight loop: if it's still \
-            pending, go do other work and check back later rather than sleeping on it — \
-            the handle keeps, so there's no rush and nothing to lose. Args: batch_id \
-            (the handle from `batch_submit`)."
+        description = "Collect a submitted async job by its handle — the one surface for \
+            both `batch_submit` and `consult_submit`. kaibo tells the two apart by the \
+            handle: a **batch** handle is `backend/provider-id` (durable; this polls the \
+            provider, returning a progress line while it runs and every item's answer — \
+            labelled by index, per-item failures surfaced — once it's done), and a \
+            **consult** handle is `job-N` (in-memory, this session; returns a status line \
+            while it investigates, then the full grounded answer with its provenance \
+            footer, or the failure reason). Either way: collect occasionally, not in a \
+            tight loop — if it's still working, go do other work and check back; nothing \
+            is lost by waiting. Args: handle (from `batch_submit` or `consult_submit`)."
     )]
-    async fn batch_get(
+    async fn get(
         &self,
-        Parameters(input): Parameters<BatchHandleInput>,
+        Parameters(input): Parameters<HandleInput>,
     ) -> Result<CallToolResult, McpError> {
-        let (backend_name, provider_id) = parse_batch_handle(&input.batch_id)?;
-        let provider = self.batch_poller(backend_name)?;
-        let span = tracing::info_span!("batch_get", handle = %input.batch_id);
-        let poll = provider
-            .poll(provider_id)
-            .instrument(span)
-            .await
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
-        let label = format!("{backend_name} · {provider_id}");
-        Ok(CallToolResult::success(vec![Content::text(
-            crate::batch::render_poll(&poll, &label),
-        )]))
+        if is_batch_handle(&input.handle) {
+            self.ensure_batch_enabled(&input.handle)?;
+            let (backend_name, provider_id) = parse_batch_handle(&input.handle)?;
+            let provider = self.batch_poller(backend_name)?;
+            let span = tracing::info_span!("get", handle = %input.handle);
+            let poll = provider
+                .poll(provider_id)
+                .instrument(span)
+                .await
+                .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+            let label = format!("{backend_name} · {provider_id}");
+            return Ok(CallToolResult::success(vec![Content::text(
+                crate::batch::render_poll(&poll, &label),
+            )]));
+        }
+        self.ensure_consult_enabled(&input.handle)?;
+        match self.jobs.get(&input.handle) {
+            Some(snap) => Ok(render_job(&input.handle, snap)),
+            None => Err(McpError::invalid_params(
+                format!(
+                    "no consultation job `{}` — it may have finished and been evicted by \
+                     newer submits, been canceled, or never existed. Consult job ids look \
+                     like `job-1` and live only for this server session.",
+                    input.handle
+                ),
+                None,
+            )),
+        }
     }
 
     #[tool(
-        description = "Cancel a running batch by its handle. The provider stops scheduling \
-            new requests; any already in flight finish. Poll with `batch_get` afterward \
-            for the final per-item results. Args: batch_id (the handle from \
-            `batch_submit`)."
+        description = "Stop a running async job by its handle — works for both kinds. A \
+            **batch** handle (`backend/provider-id`) tells the provider to stop scheduling \
+            new requests (any already in flight finish); `get` it afterward for the final \
+            per-item results. A **consult** handle (`job-N`) aborts the investigation; \
+            `get` it afterward and it reports canceled. A job that already finished is \
+            left alone. Args: handle (from `batch_submit` or `consult_submit`)."
     )]
-    async fn batch_cancel(
+    async fn cancel(
         &self,
-        Parameters(input): Parameters<BatchHandleInput>,
+        Parameters(input): Parameters<HandleInput>,
     ) -> Result<CallToolResult, McpError> {
-        let (backend_name, provider_id) = parse_batch_handle(&input.batch_id)?;
-        let provider = self.batch_poller(backend_name)?;
-        let span = tracing::info_span!("batch_cancel", handle = %input.batch_id);
-        provider
-            .cancel(provider_id)
-            .instrument(span)
-            .await
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "Requested cancellation of batch `{}`. Poll it with `batch_get` for the \
-             final per-item results.",
-            input.batch_id
-        ))]))
+        if is_batch_handle(&input.handle) {
+            self.ensure_batch_enabled(&input.handle)?;
+            let (backend_name, provider_id) = parse_batch_handle(&input.handle)?;
+            let provider = self.batch_poller(backend_name)?;
+            let span = tracing::info_span!("cancel", handle = %input.handle);
+            provider
+                .cancel(provider_id)
+                .instrument(span)
+                .await
+                .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "Requested cancellation of batch `{}`. `get` it for the final per-item \
+                 results.",
+                input.handle
+            ))]));
+        }
+        self.ensure_consult_enabled(&input.handle)?;
+        let msg = match self.jobs.cancel(&input.handle) {
+            CancelOutcome::Canceled => format!("Canceled consultation `{}`.", input.handle),
+            CancelOutcome::AlreadyFinished => format!(
+                "Consultation `{}` had already finished — `get` it for the answer.",
+                input.handle
+            ),
+            CancelOutcome::Unknown => {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "no consultation job `{}` to cancel — it may have finished and \
+                         been evicted, or never existed.",
+                        input.handle
+                    ),
+                    None,
+                ));
+            }
+        };
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
     }
 
     #[tool(
-        description = "List the batches a backend still knows about, newest first — the \
-            way back to a batch whose handle you've lost (kaibo holds no state, so the \
-            provider's own list is the source of truth). Each entry comes with its \
-            ready-to-use handle, status, and progress; feed one to `batch_get` or \
-            `batch_cancel`. Omit `backend` to list across every batch-capable backend; \
-            pass one (name or alias) to scope it. A backend that \
-            can't be reached (no key, endpoint down) is reported rather than hiding the \
-            rest, and a truncated page says so. Args: backend (optional)."
+        description = "List your async work — both the consult jobs in flight this session \
+            and the batches the providers still know about — each with a ready-to-use \
+            handle for `get` / `cancel`. The consult-jobs section is in-memory (this \
+            session only); the batches section is the way back to a batch whose handle you \
+            lost (kaibo holds no state — the provider's own list is the source of truth). \
+            By default the batches section shows only the **last 24 hours** — a provider \
+            keeps months of finished batches and listing them all just burns tokens, and \
+            anything older is done and still collectible by its handle; pass `all: true` \
+            for the full history (true orphan recovery of an old batch). `backend` scopes \
+            only the batches section (omit it to sweep every batch-capable backend); \
+            consult jobs are always shown in full. An unreachable backend is reported \
+            rather than hiding the rest. Args: backend (optional), all (optional, default \
+            false)."
     )]
-    async fn batch_list(
+    async fn list(
         &self,
-        Parameters(input): Parameters<BatchListInput>,
+        Parameters(input): Parameters<ListInput>,
     ) -> Result<CallToolResult, McpError> {
-        let backends = self.batch_backends(input.backend.as_deref())?;
-        let mut entries: Vec<(String, crate::batch::BatchListItem)> = Vec::new();
-        let mut errors: Vec<(String, String)> = Vec::new();
-        let mut truncated: Vec<String> = Vec::new();
-        for name in backends {
-            // Build the poller and list per backend, turning any failure into a
-            // per-backend note — one keyless or unreachable backend never sinks the
-            // whole listing (the per-item-failure ethos, at the backend grain).
-            let listed = match self.batch_poller(&name) {
-                Ok(provider) => {
-                    let span = tracing::info_span!("batch_list", backend = %name);
-                    provider.list().instrument(span).await
-                }
-                Err(e) => Err(anyhow::anyhow!("{}", e.message)),
-            };
-            match listed {
-                Ok((items, has_more)) => {
-                    if has_more {
-                        truncated.push(name.clone());
+        let mut sections: Vec<String> = Vec::new();
+
+        // Consult jobs first — in-memory, this session, always shown when consult is on.
+        if self.config.tools.consult {
+            sections.push(render_jobs_section(&self.jobs.list()));
+        }
+
+        // Batches — provider-side and durable; `backend` scopes this section only. A
+        // batch-resolution failure (no batch-capable backend, or a bad explicit
+        // `backend`) becomes a *section note*, not a hard error — so it never sinks the
+        // consult-jobs section above it. (A local-only setup with batch on but no
+        // hosted backend is the common case here.)
+        if self.config.tools.batch {
+            match self.batch_backends(input.backend.as_deref()) {
+                Ok(backends) => {
+                    let mut entries: Vec<(String, crate::batch::BatchListItem)> = Vec::new();
+                    let mut errors: Vec<(String, String)> = Vec::new();
+                    let mut truncated: Vec<String> = Vec::new();
+                    for name in backends {
+                        // One keyless or unreachable backend never sinks the whole
+                        // listing — turn its failure into a per-backend note (the
+                        // per-item-failure ethos, at the backend grain).
+                        let listed = match self.batch_poller(&name) {
+                            Ok(provider) => {
+                                let span = tracing::info_span!("list", backend = %name);
+                                provider.list().instrument(span).await
+                            }
+                            Err(e) => Err(anyhow::anyhow!("{}", e.message)),
+                        };
+                        match listed {
+                            Ok((items, has_more)) => {
+                                if has_more {
+                                    truncated.push(name.clone());
+                                }
+                                for it in items {
+                                    let handle = format!("{}/{}", name, it.provider_id);
+                                    entries.push((handle, it));
+                                }
+                            }
+                            Err(e) => errors.push((name, format!("{e:#}"))),
+                        }
                     }
-                    for it in items {
-                        let handle = format!("{}/{}", name, it.provider_id);
-                        entries.push((handle, it));
+                    // Trim to the last 24h by default — a provider keeps months of
+                    // finished batches, and dumping them all every call just burns the
+                    // caller's tokens. The SLA is ≤24h, so anything older is done and
+                    // still collectible by its handle; `all: true` shows the full history.
+                    // An undateable batch (no/garbled timestamp) is kept, never hidden.
+                    let hidden = if input.all {
+                        0
+                    } else {
+                        let before = entries.len();
+                        entries.retain(|(_, it)| is_recent_batch(it));
+                        before - entries.len()
+                    };
+                    sections.push(crate::batch::render_list(&entries, &errors, &truncated));
+                    if hidden > 0 {
+                        sections.push(format!(
+                            "({hidden} batch(es) older than 24h hidden — `list` with \
+                             `all: true` to see the full history.)"
+                        ));
                     }
                 }
-                Err(e) => errors.push((name, format!("{e:#}"))),
+                Err(e) => sections.push(format!("Batches: unavailable — {}", e.message)),
             }
         }
+
         Ok(CallToolResult::success(vec![Content::text(
-            crate::batch::render_list(&entries, &errors, &truncated),
+            sections.join("\n\n"),
         )]))
+    }
+
+    /// Refuse a batch-shaped handle when batch is gated off — `get`/`cancel` survive as
+    /// long as *either* capability is on, so a handle can arrive for a disabled one.
+    fn ensure_batch_enabled(&self, handle: &str) -> Result<(), McpError> {
+        if self.config.tools.batch {
+            return Ok(());
+        }
+        Err(McpError::invalid_params(
+            format!(
+                "`{handle}` looks like a batch handle (`backend/id`), but batch is \
+                 disabled on this server (--no-batch)."
+            ),
+            None,
+        ))
+    }
+
+    /// Refuse a consult-job handle (`job-N`) when consult is gated off.
+    fn ensure_consult_enabled(&self, handle: &str) -> Result<(), McpError> {
+        if self.config.tools.consult {
+            return Ok(());
+        }
+        Err(McpError::invalid_params(
+            format!(
+                "`{handle}` looks like a consult job (`job-N`), but consult is disabled \
+                 on this server (--no-consult)."
+            ),
+            None,
+        ))
     }
 }
 
@@ -2399,9 +2672,9 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
     // Transient vocabulary across Anthropic / Gemini / OpenAI / DeepSeek bodies and the
     // transport layer (reqwest timeouts/resets from our own `request_timeout`).
     const TRANSIENT: &[&str] = &[
-        "overload",        // Anthropic 529 overloaded_error, Gemini
-        "rate limit",      // generic
-        "rate_limit",      // OpenAI/DeepSeek/Anthropic error `type`s
+        "overload",   // Anthropic 529 overloaded_error, Gemini
+        "rate limit", // generic
+        "rate_limit", // OpenAI/DeepSeek/Anthropic error `type`s
         "ratelimit",
         "resource_exhausted", // Gemini 429
         "too many requests",  // 429 reason phrase
@@ -2411,8 +2684,8 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
         "reset by peer",
         "connection closed",
         "broken pipe",
-        "temporarily",     // "temporarily unavailable"
-        "unavailable",     // 503 / Gemini UNAVAILABLE
+        "temporarily", // "temporarily unavailable"
+        "unavailable", // 503 / Gemini UNAVAILABLE
         "try again",
     ];
     if TRANSIENT.iter().any(|t| s.contains(t)) {
@@ -2434,6 +2707,16 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
 /// errors *before* the model call — unknown cast, an attachment outside the boundary, a
 /// missing key — stay `McpError`, since those are the caller's to fix.
 fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(consultation_failure_text(
+        tool, cast, err,
+    ))])
+}
+
+/// The rendered failure text (detail + classified guidance) for a consultation that
+/// errored — the body of [`consultation_failed`], split out so the async path
+/// ([`consult_submit`]) can store a ready string in a [`JobState::Failed`] and the
+/// unified `get` wrap it without re-classifying.
+fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> String {
     let detail = format!("{err:#}");
     let guidance = match classify_failure(&err) {
         FailureKind::TransientProvider => {
@@ -2450,9 +2733,34 @@ fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) -> CallToolRe
              still proceed without the consultation."
         }
     };
-    CallToolResult::error(vec![Content::text(format!(
-        "{tool} could not complete (cast `{cast}`): {detail}. {guidance}"
-    ))])
+    format!("{tool} could not complete (cast `{cast}`): {detail}. {guidance}")
+}
+
+/// Render an async consultation job for the unified `get`: a status line while it runs,
+/// the grounded answer (and optional report) when it's done, the stored failure text on
+/// error, or a canceled notice. Mirrors the synchronous `consult` result shape so an
+/// agent reads the same thing whether it asked synchronously or collected a job.
+fn render_job(id: &str, snap: JobSnapshot) -> CallToolResult {
+    match snap.state {
+        JobState::Running => CallToolResult::success(vec![Content::text(format!(
+            "Consultation `{id}` is still running — {} ({}s elapsed). No need to wait: go \
+             do other work and `get` it again later.",
+            snap.label,
+            snap.age.as_secs(),
+        ))]),
+        JobState::Done(result) => {
+            let include_report = result.report.is_some();
+            consult_result(
+                result.answer,
+                result.report.unwrap_or_default(),
+                include_report,
+            )
+        }
+        JobState::Failed(text) => CallToolResult::error(vec![Content::text(text)]),
+        JobState::Canceled => CallToolResult::success(vec![Content::text(format!(
+            "Consultation `{id}` was canceled."
+        ))]),
+    }
 }
 
 /// Append a one-line provenance footer naming the cast and the model(s) that
@@ -2461,6 +2769,66 @@ fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) -> CallToolRe
 /// `kaibo://config`, since the answering model is the whole variable. `roles` is the
 /// labelled models for this tool (one for `oneshot`, explorer+synth for `consult`).
 /// Pure and offline-testable.
+/// Which kind of async work a handle addresses. A batch handle carries a `/`
+/// (`backend/provider-id`); a consult job id (`job-N`) never does, and a backend name
+/// carries no `/` either (enforced at config load), so the presence of a `/` is an
+/// unambiguous batch-vs-consult discriminator for the unified `get`/`cancel` verbs.
+fn is_batch_handle(handle: &str) -> bool {
+    handle.contains('/')
+}
+
+/// The default `list` recency window: 24h. A provider's offline SLA is ≤24h, so an
+/// older batch is done and still collectible by its handle — trimming it saves the
+/// caller tokens without losing anything actionable.
+const BATCH_RECENCY_WINDOW_SECS: i64 = 24 * 3600;
+
+/// Was this batch created within the last 24h? The default `list` recency filter. A
+/// batch kaibo can't date (no or unparseable `created_at`) counts as recent, so it's
+/// shown rather than silently hidden — losing sight of a batch is worse than an extra
+/// line. "Now" is read from `SystemTime`, so chrono's `clock` feature stays off.
+fn is_recent_batch(it: &crate::batch::BatchListItem) -> bool {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    batch_within_window(it, now, BATCH_RECENCY_WINDOW_SECS)
+}
+
+/// The pure core of [`is_recent_batch`], with `now` injected so the keep/drop boundary is
+/// testable without the clock. Undateable → kept; a future timestamp (clock skew) yields
+/// a negative age, still within the window, so also kept.
+fn batch_within_window(it: &crate::batch::BatchListItem, now_epoch: i64, window_secs: i64) -> bool {
+    match it
+        .created_at
+        .as_deref()
+        .and_then(crate::batch::rfc3339_to_epoch)
+    {
+        Some(created) => now_epoch - created <= window_secs,
+        None => true,
+    }
+}
+
+/// Render the consult-jobs section of `list`: the in-memory async consultations this
+/// session, newest-first, each with its handle and a one-line state. Empty is itself
+/// informative ("none"), so the section always renders.
+fn render_jobs_section(jobs: &[(String, JobSnapshot)]) -> String {
+    if jobs.is_empty() {
+        return "Consult jobs (this session): none.".to_string();
+    }
+    let mut s = String::from("Consult jobs (this session), newest first:");
+    for (id, snap) in jobs {
+        let state = match &snap.state {
+            JobState::Running => format!("running, {}s", snap.age.as_secs()),
+            JobState::Done(_) => "done — `get` it for the answer".to_string(),
+            JobState::Failed(_) => "failed — `get` it for the reason".to_string(),
+            JobState::Canceled => "canceled".to_string(),
+        };
+        s.push_str(&format!("\n  {id} — {} [{state}]", snap.label));
+    }
+    s.push_str("\n\nCollect one with `get <job-id>`; stop one with `cancel <job-id>`.");
+    s
+}
+
 /// Split a batch handle (`"backend/provider-id"`) the way `batch_submit` minted it.
 /// Splitting on the *first* `/` is unambiguous because a backend name carries no `/`
 /// (enforced at config load) — so the provider id keeps any slashes of its own (an
@@ -2574,6 +2942,56 @@ mod tests {
     use rmcp::model::{NumberOrString, PromptMessageContent};
     use rmcp::ServerHandler;
 
+    fn batch_item(created_at: Option<&str>) -> crate::batch::BatchListItem {
+        crate::batch::BatchListItem {
+            provider_id: "id".into(),
+            status: "ended".into(),
+            completed: 1,
+            total: 1,
+            created_at: created_at.map(str::to_string),
+        }
+    }
+
+    /// The `list` recency filter's keep/drop boundary, with `now` pinned so it doesn't
+    /// depend on the wall clock. `now` = 2026-06-24T18:00:00Z (epoch 1782756000).
+    #[test]
+    fn batch_recency_window_keeps_recent_and_undateable_drops_old() {
+        let now = crate::batch::rfc3339_to_epoch("2026-06-24T18:00:00Z").unwrap();
+        let window = 24 * 3600;
+
+        // 2h old → kept.
+        assert!(batch_within_window(
+            &batch_item(Some("2026-06-24T16:00:00Z")),
+            now,
+            window
+        ));
+        // 30h old → dropped.
+        assert!(!batch_within_window(
+            &batch_item(Some("2026-06-23T12:00:00Z")),
+            now,
+            window
+        ));
+        // Exactly at the 24h edge → kept (boundary is inclusive).
+        assert!(batch_within_window(
+            &batch_item(Some("2026-06-23T18:00:00Z")),
+            now,
+            window
+        ));
+        // Undateable (no timestamp, or garbage) → kept, never silently hidden.
+        assert!(batch_within_window(&batch_item(None), now, window));
+        assert!(batch_within_window(
+            &batch_item(Some("whenever")),
+            now,
+            window
+        ));
+        // Future timestamp (clock skew) → kept.
+        assert!(batch_within_window(
+            &batch_item(Some("2026-06-25T00:00:00Z")),
+            now,
+            window
+        ));
+    }
+
     /// A small stand-in builtin set so resource rendering is offline-testable.
     fn sample_schemas() -> Vec<ToolSchema> {
         vec![
@@ -2647,7 +3065,9 @@ mod tests {
             .and_then(|p| p.get("cast"))
             .and_then(|c| c.get("enum"))
             .and_then(|e| e.as_array())
-            .unwrap_or_else(|| panic!("generate_image cast param should carry an enum:\n{schema:#?}"))
+            .unwrap_or_else(|| {
+                panic!("generate_image cast param should carry an enum:\n{schema:#?}")
+            })
             .iter()
             .filter_map(|v| v.as_str())
             .collect();

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -58,6 +58,7 @@ fn consult_seed_context_is_framed_as_trusted_evidence() {
         "What blocks writes?",
         Some("src/sandbox.rs:95 read-only mount"),
         &[],
+        &[],
     );
 
     assert!(p.contains("What blocks writes?"), "question present");
@@ -88,11 +89,11 @@ fn consult_prompt_without_context_or_history_is_the_bare_question() {
     // steer lives in the consult preamble, not this prompt. Whitespace-only context
     // is no context — don't pretend there's evidence.
     assert_eq!(
-        consult_user_prompt("What blocks writes?", None, &[]),
+        consult_user_prompt("What blocks writes?", None, &[], &[]),
         "What blocks writes?"
     );
     assert_eq!(
-        consult_user_prompt("Q?", Some("  \n  "), &[]),
+        consult_user_prompt("Q?", Some("  \n  "), &[], &[]),
         "Q?",
         "blank context should behave like None"
     );

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -8,16 +8,18 @@ use std::process::Command;
 use kaibo::config::Config;
 use kaibo::server::{KaiboHandler, ToolGating};
 
-/// Every advertised tool, sorted (the order `advertised_tools` returns). The batch
-/// capability is four routes (`batch_submit`/`batch_get`/`batch_cancel`/`batch_list`)
-/// behind one `--no-batch` flag.
-const ALL_TOOLS: [&str; 8] = [
-    "batch_cancel",
-    "batch_get",
-    "batch_list",
+/// Every advertised tool, sorted (the order `advertised_tools` returns). `consult` and
+/// `batch` each carry a `*_submit` under their own flag; the collect verbs `get`/
+/// `cancel`/`list` are *shared* — they manage both kinds of handle and stay advertised
+/// as long as either capability is on, so they belong to neither flag exclusively.
+const ALL_TOOLS: [&str; 9] = [
     "batch_submit",
+    "cancel",
     "consult",
+    "consult_submit",
     "generate_image",
+    "get",
+    "list",
     "oneshot",
     "run_kaish",
 ];
@@ -37,11 +39,15 @@ fn default_advertises_all_tools() {
 
 #[test]
 fn each_flag_removes_exactly_its_own_tools() {
-    // Each flag and the tool route(s) it drops. `--no-batch` is one flag over the
-    // whole batch trio — they're one capability — so it lists all three.
+    // Each flag and the tool route(s) it drops *exclusively*. The shared collect verbs
+    // `get`/`cancel`/`list` belong to neither flag alone — gating one capability leaves
+    // them because the other still needs them — so they appear in no row's removed-set
+    // and are covered by the "every other tool remains" check below.
     let cases: [(&[&str], ToolGating); 5] = [
         (
-            &["consult"],
+            // `--no-consult` drops the blocking `consult` and the async `consult_submit`;
+            // `get`/`cancel`/`list` stay (batch still uses them).
+            &["consult", "consult_submit"],
             ToolGating {
                 consult: false,
                 ..Default::default()
@@ -69,7 +75,9 @@ fn each_flag_removes_exactly_its_own_tools() {
             },
         ),
         (
-            &["batch_submit", "batch_get", "batch_cancel", "batch_list"],
+            // `--no-batch` drops only `batch_submit`; `get`/`cancel`/`list` stay (consult
+            // still uses them).
+            &["batch_submit"],
             ToolGating {
                 batch: false,
                 ..Default::default()
@@ -91,6 +99,52 @@ fn each_flag_removes_exactly_its_own_tools() {
                 "{t} should remain, got {tools:?}"
             );
         }
+    }
+}
+
+/// The shared collect verbs (`get`/`cancel`/`list`) are gated by *either* capability:
+/// they stay while batch or consult is on, and drop only when both are off. A naive
+/// single-flag gate would fail the "stays with the other capability on" cases.
+#[test]
+fn shared_collect_verbs_track_both_capabilities() {
+    const VERBS: [&str; 3] = ["get", "cancel", "list"];
+
+    // consult on, batch off — the verbs still serve consult jobs.
+    let consult_only = advertised(ToolGating {
+        batch: false,
+        ..Default::default()
+    });
+    for v in VERBS {
+        assert!(
+            consult_only.contains(&v.to_string()),
+            "{v} must remain with consult on (it collects consult jobs)"
+        );
+    }
+
+    // batch on, consult off — the verbs still serve batches.
+    let batch_only = advertised(ToolGating {
+        consult: false,
+        ..Default::default()
+    });
+    for v in VERBS {
+        assert!(
+            batch_only.contains(&v.to_string()),
+            "{v} must remain with batch on (it collects batches)"
+        );
+    }
+
+    // Both off — nothing to collect, so the verbs drop. (run_kaish/oneshot keep the
+    // server a valid, non-empty surface.)
+    let neither = advertised(ToolGating {
+        batch: false,
+        consult: false,
+        ..Default::default()
+    });
+    for v in VERBS {
+        assert!(
+            !neither.contains(&v.to_string()),
+            "{v} must drop when both batch and consult are off"
+        );
     }
 }
 

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -10,9 +10,9 @@ use kaibo::server::{KaiboHandler, ToolGating};
 
 /// Every advertised tool, sorted (the order `advertised_tools` returns). `consult` and
 /// `batch` each carry a `*_submit` under their own flag; the collect verbs `get`/
-/// `cancel`/`list` are *shared* — they manage both kinds of handle and stay advertised
-/// as long as either capability is on, so they belong to neither flag exclusively.
-const ALL_TOOLS: [&str; 9] = [
+/// `cancel`/`list`/`wait` are *shared* — they manage both kinds of handle and stay
+/// advertised as long as either capability is on, so they belong to neither flag.
+const ALL_TOOLS: [&str; 10] = [
     "batch_submit",
     "cancel",
     "consult",
@@ -22,6 +22,7 @@ const ALL_TOOLS: [&str; 9] = [
     "list",
     "oneshot",
     "run_kaish",
+    "wait",
 ];
 
 fn advertised(gating: ToolGating) -> Vec<String> {
@@ -107,7 +108,7 @@ fn each_flag_removes_exactly_its_own_tools() {
 /// single-flag gate would fail the "stays with the other capability on" cases.
 #[test]
 fn shared_collect_verbs_track_both_capabilities() {
-    const VERBS: [&str; 3] = ["get", "cancel", "list"];
+    const VERBS: [&str; 4] = ["get", "cancel", "list", "wait"];
 
     // consult on, batch off — the verbs still serve consult jobs.
     let consult_only = advertised(ToolGating {


### PR DESCRIPTION
Turns kaibo's consultation into something a client model can drive *asynchronously and pleasantly* — submit work, do other things, collect later — and restores the live "watch it work" view that the synchronous path always had.

## Why

The seed was a self-observation: the calling agent was spawning throwaway sub-agents *just* to hold a blocking `consult` open in the background. That's the missing async primitive, hand-rolled badly. So: make consult submittable, and make the whole submit→collect surface coherent and low-friction for the model using it.

## What's in it

**Async consult**
- **`consult_submit`** — fire a consult, get a `job-N` handle. Backed by a diskless `JobStore` (the `SessionStore` pattern: `Arc<Mutex<LruCache>>`, capacity-LRU, no TTL). A job lives for the session and dies with it — no disk, because a stdio server's lifetime *is* the caller's session.

**One collect surface, by handle shape**
- **`get` / `cancel` / `list`** unify the old `batch_get/cancel/list` and the new consult handles, dispatched by handle (`backend/id` ⇒ batch, `job-N` ⇒ consult). Rejected an op-enum collapse — models dispatch by *tool*, not an enum arg. `list` trims its batch section to the last 24h (`all: true` for full history).
- **`wait`** — the productive park: block on your terms (you pick the timeout, no clamp), return what kaibo flags as worth acting on (a completion), and pull the kaish/sweep narrative into context with `level: "info"`. Fold in a one-shot batch poll via `handles`.

**`attach` on consult — deferred, not inlined**
- The tool-less tools inline an attachment's bytes; consult has a shell, so its `attach` just *names* the files in the prompt and lets the model `cat` them itself when ready, in full — no upfront IO. `consult(attach: ["changes.diff"])` reviews a diff with no paste. Files must live under the consult's root (a followed worktree counts).

**A watchable live view, and a level convention**
- An async consult streams its liveness (each kaish command, sweep, milestone) onto kaibo's `tracing` stream, and while a `wait` call is open kaibo mirrors that as `notifications/progress` — the exact channel sync consult used, so the client renders it live again.
- New kaibo-wide level convention — **audience, not severity**: **Warn** = "the calling model should see this", **Info** = the watchable narrative, **Debug** = firehose. Documented in `mcp_log.rs`; the `kaibo` target filter keeps external crates' severity-sense warns off the bridge.

## Review & verification

- **Cross-family review (the dogfood):** a **deepseek** `consult` and a **gemini** `batch` reviewed the diff. They caught real bugs the deep review missed — an LRU-evicted running job burning provider tokens (its `AbortHandle` drop doesn't abort), a panicking task hung at `Running` forever, and gating/target-filter nits — all fixed, each with a failing-first test. deepseek separately cleared the `NotificationBuffer`/`Notify` machinery of lost-wakeup races.
- **Tests:** all suites green; new coverage with proven teeth (buffer drain/level-filter/eviction/timeout, the cancel-vs-late-completion guard, the panic guard, the 24h recency boundary, attach under-root validation, the level predicate).
- **Invariants held:** `chrono` was added for the RFC3339 parse but used parse-only (no `clock` feature), so `cargo tree -i aws-lc-rs` stays empty — the C-free / static-binary TLS invariant is intact. Read-only sandbox untouched.
- **Live dogfood:** attach (the model read the diff itself), async submit, `wait` drain, and the live progress streaming all confirmed end to end.

CHANGELOG / devlog / issues updated. One pre-existing flaky cwd-race test is noted in issues (surfaced, not caused, by full-suite runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)