### PR TITLE
Async consult: image attachments + fix wait returning too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ the git log. Each later release appends a new section at the top.
   and per-call `explorer_model` / `synth_model` (+ `_backend`) overrides. **`attach`**
   names workspace files (under the project root) to put in front of the investigation —
   unlike the tool-less tools' attach, kaibo does *not* inline them; it names them in the
-  prompt and the consult model reads them itself with the shell when it's ready, in full,
-  building its own narrative. "Review this diff" is `attach: ["changes.diff"]` with no
-  paste; the files just have to live under the root the consult reads (a worktree counts).
+  prompt and the consult model opens each itself when it's ready, in full, building its own
+  narrative: a text file with the shell (`cat -n`), an **image** with its `view_image` tool.
+  An attached image therefore needs a vision-capable cast — kaibo refuses one to a
+  vision-blind synth up front (the same honest refusal `oneshot`/`batch` give) rather than
+  name a file the model could never open. The files just have to live under the root the
+  consult reads (a worktree counts).
 - **`consult_submit`** — the *async sibling* of `consult` (as batch is to `oneshot`):
   start a consultation in the background and get back a handle (`job-N`) instead of
   holding your turn open while a deep investigation runs. Same investigation, same args

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -51,13 +51,59 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
 - **Media moves by VFS path; base64 only at the edges** (provider wire, MCP
   content). Scratch `MemoryFs` is the working bus — bounded now that kaish landed
   `ByteBudget` (kaish-vfs, 2026-06-10; kaibo pickup tracked in the P2 entry below).
-  A future `--out-dir` adds a third mount: project **ro** / scratch **rw-bounded** /
-  `/out` **rw** mapped to a user-specified real directory, off by default.
-  Read-only-is-the-product survives precisely: the project mount stays ro; bytes
-  land on the real filesystem only where the user explicitly pointed. Failing-first
-  tests when it lands: writes outside `/out` refused; project ro even with out-dir set.
+  **RW mounts — design settled 2026-06-25 (w/ Amy), supersedes the inline-only
+  `--out-dir` plan.** Instead of a special-case artifact dir, kaibo gains a *general*
+  set of writable mounts: `rw_paths` (CLI `--rw-path` / `KAIBO_RW_PATHS` /
+  `[server] rw_paths`, default none) — the read-only `allow_paths` shape with the
+  mount flag flipped, reusing the same `$VAR` expansion + canonicalize + contain
+  machinery (`config.rs` `expand_env_vars`/`resolve_var`, `server.rs` containment).
+  Decisions that fell out of the conversation:
+  - **The invariant relocates, it doesn't weaken.** Not "kaibo is read-only" but
+    *kaibo never writes to the project under analysis; writes are confined to RW
+    mounts the user explicitly named (default none)*. The project mount stays ro
+    always — no flag, no per-tool exception. The CLAUDE.md "Read-only is the product"
+    invariant (lever 1) reworded to this when it lands; teeth-test unchanged (mount
+    the project writable, watch the denial tests fail).
+  - **Uniform, not staged per tool.** The RW mounts wire the *same* into every kaish
+    kernel — `run_kaish`, the `consult` driver, the `explore′` sub-agent — one
+    `build_sandbox`. Rejected a "consult stays read-only" carve-out: a user who
+    configures an RW space expects kaibo to use it, and per-tool RW rules are a
+    cognitive tax on both human and agent. consult *does* get RW — and this is the
+    substrate for future RW kaibo tasks (the arc image-gen → image2image → … already
+    traces it).
+  - **Longest-prefix routing makes nested RW-in-ro a feature**, not a footgun:
+    `~/src/$repo/scratch` RW inside the `~/src/$repo` ro project routes correctly —
+    the scratch subtree writable, the rest of the repo ro (it's already how
+    `VfsRouter` resolves `/` MemoryFs vs. the project mount). The hard safety
+    invariant is **canonicalize-before-route** (resolve `..`/symlinks *then*
+    longest-match): `scratch/../secret` and a symlink in `scratch/` → out-of-subtree
+    both canonicalize onto the ro project mount and the write is refused. Failing-first
+    write-escape test mirrors the read-escape battery; confirm kaish's VFS
+    canonicalizes-then-routes for *write* ops, not just reads.
+  - **No byte budget on real-FS mounts** — the filesystem is the backstop (its own
+    limits; tmpfs its own size); kaibo reimplementing quota would be worse (blind to
+    external/concurrent writers) and against the don't-fork-the-platform grain. ENOSPC
+    must surface as a *loud* kaish write error and we never deliver a truncated
+    artifact as valid (the delivery path sniffs MIME, so a half-written PNG fails
+    decode). The `/` `MemoryFs` scratch *keeps* its `ByteBudget` — RAM has no
+    filesystem to stop an OOM — so "RAM scratch bounded, real-FS mounts unbounded" is
+    a principled asymmetry; comment it in `sandbox.rs` so it isn't "unified" away.
+  - **Danger is surfaced, not blocked** (broad RW is the user's call — they could set
+    `~/src` RW and ask kaibo to *code*). Warn loudly on broad named roots (`$HOME`,
+    `/`, a dir with many pre-existing files); refuse only the catastrophic (an empty
+    `$VAR` segment is already a load error; an RW mount at `/`). `/configure` steers
+    to `$TMPDIR` / `$XDG_CACHE_HOME/kaibo`. **Surfacing channels are an open design
+    point (2026-06-25, in progress)** — stdio has no synchronous human so friction
+    must be *config-time*, runtime is surface-only: startup stderr warning, a
+    graduated config-time ack for the broadest roots, and/or a `kaibo://config`
+    `[runtime]` breadth field the agent can relay.
+  - **Prompt-injection note for the threat model:** consult-can-write means a consult
+    reading attacker-controlled repo content ("write X to /tmp/Y") can now *act* on
+    it — bounded to the named RW mount, can't escape or execute, can't touch the
+    project, but it's a real new instruction-following exposure to document honestly
+    when this lands.
 - **Delivery over MCP:** small images inline as `Content::image` (rmcp 0.16,
-  `model/content.rs:165`); large objects flush to `/out` and return as
+  `model/content.rs:165`); large objects flush to a RW mount and return as
   `RawContent::ResourceLink` (`model/content.rs:140`) instead of base64 blobs.
 - **Capabilities are data on the `ModelShape` seam** — SHIPPED
   2026-06-11: `ModelCaps` + the vision classifier (`consult.rs`), per-slot
@@ -78,13 +124,16 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
 **Sequencing:** (0) the backends/casts split — SHIPPED 2026-06-11. (1) vision-in —
 SHIPPED 2026-06-11, path-only. (2) **image-out — SHIPPED 2026-06-13** as the
 `generate_image` capability tool (live-verified; see the top Last pass), inline
-`Content::image` only. **Next: (3)** the deferred large-artifact + composition work —
-`--out-dir` (project **ro** / scratch **rw-bounded** / `/out` **rw**, off by default;
-failing-first tests: writes outside `/out` refused, project ro even with out-dir set)
-+ `ResourceLink` delivery for objects over the inline cap, and the kaish-builtin/VFS
-surface for *composition* (image2image, feeding a generated artifact to another tool in
-a `run_kaish` script). Those builtins need the per-builtin timeout (its own P1 entry)
-before a minutes-long model call. Additive after that.
+`Content::image` only. **Next: (3)** the general **RW mounts** above (the design that
+supersedes the inline-only `--out-dir`): `rw_paths` wired uniformly into every kernel,
+then `ResourceLink` delivery for artifacts over the inline cap (flush to a RW mount),
+then the kaish-builtin/VFS surface for *composition* (image2image, feeding a generated
+artifact to another tool in a `run_kaish` script). The composition builtins need the
+per-builtin timeout (its own P1 entry) before a minutes-long model call; artifact
+delivery to a RW mount doesn't, so it can land first. Failing-first tests when RW
+lands: write outside a named RW mount refused, project ro even with RW set,
+canonicalize-before-route write-escape (symlink/`..` out of an RW subtree refused),
+ENOSPC surfaces loud. Additive after that.
 
 **Open design points (for the production builtins):** session history records
 `[image: path, mime]` markers, not blobs; the input size cap is a `view_image` const

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -817,6 +817,23 @@ impl Arm {
 /// thinking budget, sampling) ride each [`Arm`] (they track the slot's model);
 /// what remains here are the loop bounds the caller may dial per request, the
 /// sandbox limits, and the progress sink.
+/// One caller-attached file, classified so the driver's prompt can route it to the
+/// right tool. `consult` never inlines an attachment's bytes — text files the model
+/// reads itself with `cat -n`, images it views with `view_image` (the image-analog of
+/// `cat`, present whenever the synth is vision-capable). The server sniffs each file's
+/// magic bytes to set `is_image`, so a `.png` named `.txt` (or vice versa) is routed by
+/// content, not extension — matching how `view_image` re-sniffs authoritatively at read.
+#[derive(Debug, Clone)]
+pub struct ConsultAttachment {
+    /// Root-relative path the model passes to `cat -n` or `view_image`.
+    pub path: String,
+    /// True when the file sniffed as a known image type — route it to `view_image`, not
+    /// the shell. A consult that carries an image attachment must run a vision-capable
+    /// synth (the server gates this up front, the same honest refusal `oneshot`/`batch`
+    /// give a blind model).
+    pub is_image: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct ConsultConfig {
     /// Bounds each cheap `explore′` sweep — it's cheap, let it rip.
@@ -849,13 +866,14 @@ pub struct ConsultConfig {
     /// resolved root (only for the exploring tools — `explore`/`consult`); `Default`
     /// is `None`, so offline tests run the unchanged preamble.
     pub orientation: Option<Arc<str>>,
-    /// Caller-attached files, as **root-relative paths the model reads itself** via the
-    /// shell — *not* inlined bytes. Unlike `oneshot`/`batch` attach (toolless, so kaibo
-    /// inlines), `consult` has kaish, so attach just *names* the files in the driver's
-    /// prompt and lets the model `cat` them when it's ready — no upfront IO, the model
-    /// builds its narrative its own way. The server validates each path lands under the
-    /// consult's root (so the shell can reach it) before filling this. `Default` is empty.
-    pub attachments: Vec<String>,
+    /// Caller-attached files, as **root-relative paths the model reads itself** — *not*
+    /// inlined bytes. Unlike `oneshot`/`batch` attach (toolless, so kaibo inlines),
+    /// `consult` has tools, so attach just *names* each file in the driver's prompt and
+    /// lets the model open it when it's ready: a text file with `cat -n`, an image with
+    /// `view_image` (per [`ConsultAttachment::is_image`]) — no upfront IO, the model builds
+    /// its narrative its own way. The server validates each path lands under the consult's
+    /// root and sniffs its type before filling this. `Default` is empty.
+    pub attachments: Vec<ConsultAttachment>,
 }
 
 impl Default for ConsultConfig {
@@ -1577,7 +1595,7 @@ pub fn consult_user_prompt(
     question: &str,
     context: Option<&str>,
     history: &[QaTurn],
-    attached: &[String],
+    attached: &[ConsultAttachment],
 ) -> String {
     let context = context.map(str::trim).filter(|c| !c.is_empty());
     if history.is_empty() && context.is_none() && attached.is_empty() {
@@ -1616,13 +1634,32 @@ pub fn consult_user_prompt(
         ));
     }
     if !attached.is_empty() {
+        let (images, texts): (Vec<&ConsultAttachment>, Vec<&ConsultAttachment>) =
+            attached.iter().partition(|a| a.is_image);
         prompt.push_str(
-            "The caller attached these files as central to the question — read them in \
-             full with the shell as you build your answer (`cat -n PATH`). They live \
-             under the project root, so a relative path reads directly:\n",
+            "The caller attached these files as central to the question. They live under \
+             the project root, so a relative path opens directly. Open each as you build \
+             your answer:\n",
         );
-        for f in attached {
-            prompt.push_str(&format!("- {f}\n"));
+        if !texts.is_empty() {
+            prompt.push_str(
+                "\nText files — read each in full with the shell (`cat -n PATH`):\n",
+            );
+            for a in &texts {
+                prompt.push_str(&format!("- {}\n", a.path));
+            }
+        }
+        if !images.is_empty() {
+            // Images are binary — `cat` refuses them; the model has a `view_image` tool
+            // (present because the synth is vision-capable, gated server-side) that hands
+            // it the actual picture. Route images there, never to the shell.
+            prompt.push_str(
+                "\nImages — view each with the `view_image` tool (`view_image PATH`), which \
+                 hands you the picture itself; don't `cat` an image:\n",
+            );
+            for a in &images {
+                prompt.push_str(&format!("- {}\n", a.path));
+            }
         }
         prompt.push('\n');
     }
@@ -3672,15 +3709,15 @@ mod tests {
         );
     }
 
-    /// Attached files are named in the prompt (for the model to `cat` itself) and steered
-    /// to read them in full — and they're listed before the question, like context.
+    /// Text attachments are named in the prompt (for the model to `cat` itself) and
+    /// steered to read them in full — and they're listed before the question, like context.
     #[test]
     fn attached_files_are_named_for_the_model_to_read() {
         let prompt = consult_user_prompt(
             "Does the diff weaken the sandbox?",
             None,
             &[],
-            &["changes.diff".to_string(), "src/sandbox.rs".to_string()],
+            &[text_attach("changes.diff"), text_attach("src/sandbox.rs")],
         );
         assert!(
             prompt.contains("changes.diff"),
@@ -3700,6 +3737,58 @@ mod tests {
             listed < question,
             "attachments precede the question:\n{prompt}"
         );
+    }
+
+    /// An image attachment must be routed to `view_image`, never to `cat` (which refuses
+    /// binary). With a mix, each file lands under the right instruction: text → `cat -n`,
+    /// image → `view_image`. This is the prompt half of the image-attach support; the
+    /// server gates a vision-blind synth before we ever get here.
+    #[test]
+    fn image_attachments_are_routed_to_view_image_not_cat() {
+        let prompt = consult_user_prompt(
+            "What does the banner show, and does it match the brand doc?",
+            None,
+            &[],
+            &[
+                image_attach("docs/brand/banner-teal.png"),
+                text_attach("docs/brand/README.md"),
+            ],
+        );
+        // The image is steered to view_image and explicitly kept away from the shell.
+        let view_at = prompt
+            .find("view_image")
+            .expect("image must be routed to view_image");
+        let img_at = prompt
+            .find("banner-teal.png")
+            .expect("image is named in the prompt");
+        // The image name sits under the view_image instruction, not the cat -n one.
+        let cat_at = prompt.find("cat -n").expect("text section names cat -n");
+        assert!(
+            view_at < img_at,
+            "the image is listed under the view_image instruction:\n{prompt}"
+        );
+        // The text file is under the cat -n section.
+        let readme_at = prompt
+            .find("README.md")
+            .expect("text file is named in the prompt");
+        assert!(
+            cat_at < readme_at,
+            "the text file is listed under the cat -n instruction:\n{prompt}"
+        );
+    }
+
+    fn text_attach(path: &str) -> ConsultAttachment {
+        ConsultAttachment {
+            path: path.to_string(),
+            is_image: false,
+        }
+    }
+
+    fn image_attach(path: &str) -> ConsultAttachment {
+        ConsultAttachment {
+            path: path.to_string(),
+            is_image: true,
+        }
     }
 
     /// With history, every prior turn appears, the current question appears, and the

--- a/src/mcp_log.rs
+++ b/src/mcp_log.rs
@@ -37,18 +37,18 @@
 //! The convention is safe to assert here because [`KAIBO_TARGET`] filtering means
 //! rig/reqwest's *severity*-sense `warn!`s never reach this bridge — only kaibo's own.
 
-use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
+use rmcp::RoleServer;
 use rmcp::model::{LoggingLevel, LoggingMessageNotificationParam};
 use rmcp::service::Peer;
-use rmcp::RoleServer;
 use serde_json::{Map, Value};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
-use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
 
 /// Only events under this target tree are mirrored to MCP — kaibo's own logs, never
 /// the chatter from `rig`/`reqwest`/`rmcp` a broad `RUST_LOG` would otherwise pull
@@ -182,6 +182,26 @@ impl NotificationBuffer {
         }
         *q = kept;
         taken
+    }
+
+    /// Seed a record straight into the ring, bypassing the `tracing` layer — for tests
+    /// that need a job's completion ping present without standing up a subscriber (whose
+    /// callsite-interest capture is flaky; see project memory). Same effect as a real
+    /// layer push, minus the client-channel tee.
+    #[cfg(test)]
+    pub(crate) fn push_record(&self, record: LogRecord) {
+        self.push(record);
+    }
+
+    /// Drop any buffered record carrying `job = <id>` — the completion ping a finished
+    /// job pushed (`jobs.rs`, at **Warn**). Once that job is collected via `get`, the ping
+    /// is stale news: left in the ring it would make the *next* `wait` return instantly on
+    /// old activity instead of blocking for something new (the "`wait` returns too fast"
+    /// bug). Idempotent — a ping a live `wait` already drained leaves nothing to remove —
+    /// and scoped to the one id, so an *uncollected* job's ping still wakes a later `wait`.
+    pub fn discard_job_pings(&self, id: &str) {
+        self.lock()
+            .retain(|rec| rec.fields.get("job").and_then(Value::as_str) != Some(id));
     }
 
     /// Block up to `timeout` for records at or above `floor`, returning as soon as any
@@ -498,6 +518,44 @@ mod tests {
         assert_eq!(returned[0].message, "job done");
         // Everything drained is consumed — the streamed narrative isn't left to pile up.
         assert!(buf.is_empty());
+    }
+
+    /// A finished job's completion ping (carrying `job=<id>`) is retired when that job is
+    /// collected — but only that job's ping. The bug it guards: a stale ping left in the
+    /// ring makes the next `wait` return instantly instead of blocking for new work.
+    #[test]
+    fn discard_job_pings_drops_only_the_named_jobs_ping() {
+        fn ping(job: &str) -> LogRecord {
+            let mut fields = Map::new();
+            fields.insert("job".into(), Value::String(job.into()));
+            LogRecord {
+                level: LoggingLevel::Warning,
+                target: "kaibo::jobs".into(),
+                message: format!("async job finished — collect it with `get` ({job})"),
+                fields,
+            }
+        }
+        let buf = NotificationBuffer::new(8);
+        buf.push(ping("job-1"));
+        buf.push(ping("job-2"));
+        buf.push(rec(LoggingLevel::Warning, "a jobless warn")); // no `job` field
+
+        buf.discard_job_pings("job-1");
+
+        // job-1's ping is gone; job-2's and the jobless warn survive (drain proves what's
+        // left and in what order).
+        let left: Vec<String> = buf
+            .drain(rank(LoggingLevel::Warning), 20)
+            .into_iter()
+            .map(|r| r.message)
+            .collect();
+        assert_eq!(
+            left,
+            vec![
+                "async job finished — collect it with `get` (job-2)".to_string(),
+                "a jobless warn".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -178,9 +178,10 @@ pub struct ConsultInput {
     pub include_report: bool,
 
     /// Workspace files (under the project root or a followed git worktree) to put in front
-    /// of the investigation. kaibo names them and the consult model reads them itself (not
-    /// inlined) — hand it the files a question centers on, or the whole files a change
-    /// touched. See `kaibo://tools`.
+    /// of the investigation. kaibo names them and the consult model opens them itself (not
+    /// inlined) — a text file with `cat -n`, an image with `view_image` (so an attached
+    /// image needs a vision-capable cast). Hand it the files a question centers on, or the
+    /// whole files a change touched. See `kaibo://tools`.
     #[serde(default)]
     pub attach: Vec<String>,
 }
@@ -746,7 +747,7 @@ impl KaiboHandler {
     fn resolve_consult_attachments(
         root: &std::path::Path,
         attach: &[String],
-    ) -> Result<Vec<String>, McpError> {
+    ) -> Result<Vec<crate::consult::ConsultAttachment>, McpError> {
         let mut out = Vec::with_capacity(attach.len());
         for p in attach {
             let raw = std::path::PathBuf::from(p);
@@ -790,9 +791,53 @@ impl KaiboHandler {
                     None,
                 )
             })?;
-            out.push(rel.display().to_string());
+            // Sniff the file's type so the driver prompt routes it to the right tool: a
+            // text file the model reads with `cat -n`, an image it views with `view_image`
+            // (which `cat` would refuse as binary). Classify by content, not extension — a
+            // 16-byte prefix covers every magic number `sniff_mime` knows; `view_image`
+            // re-sniffs the full bytes authoritatively through the VFS at view time, so
+            // this is just the routing hint, and an unreadable prefix simply reads as text.
+            let is_image = {
+                use std::io::Read;
+                let mut buf = [0u8; 16];
+                let n = std::fs::File::open(&canon)
+                    .and_then(|mut f| f.read(&mut buf))
+                    .unwrap_or(0);
+                crate::view_image::sniff_mime(&buf[..n]).is_some()
+            };
+            out.push(crate::consult::ConsultAttachment {
+                path: rel.display().to_string(),
+                is_image,
+            });
         }
         Ok(out)
+    }
+
+    /// Refuse an image attachment to a vision-blind consult synth — the consult analog of
+    /// [`gate_image_attachments`]. consult never inlines an image's bytes; it routes the
+    /// caller to view it with the `view_image` tool, which is only wired in when the synth
+    /// is vision-capable. So an image attached to a blind synth could never be seen —
+    /// refuse honestly up front, naming the cast, rather than name a file the model has no
+    /// way to open. Text attachments (and the no-attachment case) always pass.
+    fn gate_consult_image_attachments(
+        attachments: &[crate::consult::ConsultAttachment],
+        vision: bool,
+        model: &str,
+        cast: &str,
+    ) -> Result<(), McpError> {
+        if !vision && attachments.iter().any(|a| a.is_image) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "an image was attached, but the consult synth `{model}` on cast `{cast}` \
+                     can't see images — consult opens an attached image with its `view_image` \
+                     tool, which only a vision-capable synth carries. Use a vision-capable \
+                     cast, or attach only text files. `kaibo://config` lists each slot's \
+                     `vision`."
+                ),
+                None,
+            ));
+        }
+        Ok(())
     }
 
     /// Refuse image attachments to a vision-blind model, naming the cast so the caller
@@ -1195,6 +1240,11 @@ impl KaiboHandler {
         // onto the wire when the client supplied a token, else a no-op sink.
         let progress = progress_sink(peer, &meta);
         let defaults = &self.config.defaults;
+        // Resolve + classify attachments, then gate: an image needs a vision-capable synth
+        // (consult views it with `view_image`, which only a vision synth carries). Refuse
+        // here, before the loop, the same honest up-front refusal oneshot/batch give.
+        let attachments = Self::resolve_consult_attachments(&root, &input.attach)?;
+        Self::gate_consult_image_attachments(&attachments, synth.caps.vision, &synth.model, &cast.name)?;
         let cfg = ConsultConfig {
             explorer_max_turns: input
                 .explorer_max_turns
@@ -1205,9 +1255,7 @@ impl KaiboHandler {
             house_rules: self.house_rules(&root)?,
             prompts: self.resolved_prompts(&cast),
             orientation: self.orientation(&root).await?,
-            // Validated to live under `root` (the model reads them via its shell); not
-            // inlined — consult defers the IO to its own `cat`s. See [`ConsultInput::attach`].
-            attachments: Self::resolve_consult_attachments(&root, &input.attach)?,
+            attachments,
         };
 
         // Multi-turn: a session_id binds this turn to a thread (replay prior turns,
@@ -1296,6 +1344,10 @@ impl KaiboHandler {
         let explorer = self.arm(&cast, ModelRole::Explorer)?;
         let synth = self.arm(&cast, ModelRole::Synth)?;
         let defaults = &self.config.defaults;
+        // Resolve + classify + gate before spawning: a bad attach (or an image to a blind
+        // synth) is a clean synchronous refusal, not a job that fails on poll.
+        let attachments = Self::resolve_consult_attachments(&root, &input.attach)?;
+        Self::gate_consult_image_attachments(&attachments, synth.caps.vision, &synth.model, &cast.name)?;
         let cfg = ConsultConfig {
             explorer_max_turns: input
                 .explorer_max_turns
@@ -1310,9 +1362,7 @@ impl KaiboHandler {
             house_rules: self.house_rules(&root)?,
             prompts: self.resolved_prompts(&cast),
             orientation: self.orientation(&root).await?,
-            // Validated to live under `root` (the model reads them via its shell); not
-            // inlined — consult defers the IO to its own `cat`s. See [`ConsultInput::attach`].
-            attachments: Self::resolve_consult_attachments(&root, &input.attach)?,
+            attachments,
         };
 
         // Owned captures for the `'static` spawned task. The session store is `Clone`
@@ -2351,11 +2401,13 @@ pass back through *your* context. That's the whole point: keep your context lean
 kaibo carry the files. Two shapes, by tool:
 
 - **`consult` / `consult_submit` — named, not inlined.** The consult model has its own
-  shell, so kaibo simply *names* your attached files in the investigation prompt and the
-  model reads them itself (`cat -n`), in full, when it's ready. Hand it the files a
-  question centers on as a focus: `attach: [\"src/server.rs\", \"src/sandbox.rs\"]`. These
-  are text files it reads with the shell — for an image, reach for `oneshot` / `batch_submit`,
-  whose `attach` carries it as a native vision part.
+  tools, so kaibo simply *names* your attached files in the investigation prompt and the
+  model opens each itself, in full, when it's ready: a text file with the shell (`cat -n`),
+  an image with its `view_image` tool. Hand it the files a question centers on as a focus:
+  `attach: [\"src/server.rs\", \"docs/architecture.png\"]`. An attached image needs a
+  vision-capable cast — view_image only exists when the synth can see — so kaibo refuses an
+  image to a blind synth up front rather than name a file it could never open. (The
+  toolless `oneshot` / `batch_submit` instead *inline* an image as a native vision part.)
 - **`oneshot` / `batch_submit` — inlined.** These models are tool-less — they can't go
   read the repo — so kaibo splices the file bytes straight into the prompt. Give them the
   *whole* file(s): `[\"README.md\", \"src/server.rs\"]`, not a snippet. Top-tier models
@@ -3363,7 +3415,8 @@ mod tests {
         let rel =
             KaiboHandler::resolve_consult_attachments(&root_canon, &["src/jobs.rs".to_string()])
                 .expect("an in-tree file resolves");
-        assert_eq!(rel, vec!["src/jobs.rs".to_string()]);
+        assert_eq!(rel.len(), 1);
+        assert_eq!(rel[0].path, "src/jobs.rs");
 
         // A file outside the root is refused, even though it exists and is readable.
         let outside = tempfile::tempdir().unwrap();
@@ -3381,6 +3434,62 @@ mod tests {
             "the refusal names the boundary: {}",
             err.message
         );
+    }
+
+    /// consult `attach` sniffs each file's *content* (not its extension) so the driver
+    /// prompt routes it to the right tool: a text file to `cat -n`, an image to
+    /// `view_image`. A PNG signature classifies as an image even named `.txt`, and a UTF-8
+    /// file classifies as text even named `.png` — content is the ground truth, matching
+    /// how `view_image` re-sniffs at read time.
+    #[test]
+    fn consult_attach_classifies_images_by_content_not_extension() {
+        let root = tempfile::tempdir().unwrap();
+        let root_canon = std::fs::canonicalize(root.path()).unwrap();
+        // A real PNG magic number, deliberately misnamed `.txt`.
+        let png_sig = [0x89u8, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        std::fs::write(root_canon.join("shot.txt"), png_sig).unwrap();
+        // UTF-8 source, deliberately misnamed `.png`.
+        std::fs::write(root_canon.join("notes.png"), b"// just text").unwrap();
+
+        let out = KaiboHandler::resolve_consult_attachments(
+            &root_canon,
+            &["shot.txt".to_string(), "notes.png".to_string()],
+        )
+        .expect("both resolve");
+        let by_path = |p: &str| out.iter().find(|a| a.path == p).unwrap().is_image;
+        assert!(by_path("shot.txt"), "PNG bytes classify as image despite .txt");
+        assert!(
+            !by_path("notes.png"),
+            "UTF-8 bytes classify as text despite .png"
+        );
+    }
+
+    /// An image attached to a vision-blind consult synth is refused honestly up front —
+    /// consult would have no way to show it (no `view_image` without vision), so naming the
+    /// file would be a lie. A vision synth passes; text-only always passes either way.
+    #[test]
+    fn consult_image_attach_is_gated_on_synth_vision() {
+        let img = vec![crate::consult::ConsultAttachment {
+            path: "shot.png".to_string(),
+            is_image: true,
+        }];
+        let txt = vec![crate::consult::ConsultAttachment {
+            path: "notes.md".to_string(),
+            is_image: false,
+        }];
+        // Blind synth + image → refused, naming the cast and the vision requirement.
+        let err = KaiboHandler::gate_consult_image_attachments(&img, false, "deepseek-v4-pro", "deepseek")
+            .expect_err("an image to a blind synth must be refused");
+        assert!(
+            err.message.contains("can't see images") && err.message.contains("deepseek"),
+            "the refusal names the cause and the cast: {}",
+            err.message
+        );
+        // Vision synth + image → fine; blind synth + text-only → fine.
+        KaiboHandler::gate_consult_image_attachments(&img, true, "claude-sonnet-4-6", "anthropic")
+            .expect("a vision synth accepts an image");
+        KaiboHandler::gate_consult_image_attachments(&txt, false, "deepseek-v4-pro", "deepseek")
+            .expect("text-only needs no vision");
     }
 
     #[test]
@@ -3948,6 +4057,7 @@ mod tests {
             "126",             // the exit-code contract
             "worktree",        // attach/path reaches a followed git worktree
             "Reviewing a change", // prefer whole files over a diff for review
+            "view_image",      // consult opens an attached image with view_image
         ] {
             assert!(
                 text.contains(needle),

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,11 +5,12 @@
 
 use std::path::{Path, PathBuf};
 
-use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 use kaish_kernel::tools::ToolSchema;
+use rmcp::ErrorData as McpError;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
@@ -22,15 +23,14 @@ use rmcp::model::{
 };
 use rmcp::schemars::{self, JsonSchema};
 use rmcp::service::{Peer, RequestContext};
-use rmcp::ErrorData as McpError;
-use rmcp::{tool, tool_handler, tool_router, RoleServer};
+use rmcp::{RoleServer, tool, tool_handler, tool_router};
 use serde::Deserialize;
 use serde_json::json;
 use tracing::Instrument;
 
 use crate::config::{Backend, Cast, Config, ModelRole, ModelSlot};
 use crate::consult::{
-    consult, oneshot, Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides,
+    Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides, consult, oneshot,
 };
 use crate::explorer::format_output;
 use crate::generate_image::GenerateImageInput;
@@ -41,7 +41,7 @@ use crate::kaish_syntax::{
 };
 use crate::mcp_log;
 use crate::progress::{NullSink, PhaseEvent, ProgressSink, TracingSink};
-use crate::sandbox::{builtin_schemas, KaishWorker};
+use crate::sandbox::{KaishWorker, builtin_schemas};
 use crate::session::SessionStore;
 
 /// kaibo's resource URI namespace. Everything kaish-related hangs off `kaibo://kaish/`.
@@ -915,8 +915,8 @@ impl KaiboHandler {
         paths: &[String],
     ) -> Result<Vec<crate::attach::Attachment>, McpError> {
         use crate::attach::{
-            check_attachment_bounds, classify, DEFAULT_MAX_ATTACHMENTS, DEFAULT_MAX_IMAGE_BYTES,
-            DEFAULT_MAX_TEXT_BYTES, DEFAULT_MAX_TOTAL_BYTES,
+            DEFAULT_MAX_ATTACHMENTS, DEFAULT_MAX_IMAGE_BYTES, DEFAULT_MAX_TEXT_BYTES,
+            DEFAULT_MAX_TOTAL_BYTES, check_attachment_bounds, classify,
         };
         // The pre-read ceiling: whichever encoding cap is larger. `classify` applies the
         // precise per-encoding cap after sniffing; this just bounds the read itself.
@@ -924,8 +924,13 @@ impl KaiboHandler {
         // Fail fast on count *before* canonicalizing the whole list (a stray glob could
         // name thousands). The cumulative-byte budget is enforced per file below as the
         // running total grows — before each read, so an oversized batch never slurps in.
-        check_attachment_bounds(paths.len(), 0, DEFAULT_MAX_ATTACHMENTS, DEFAULT_MAX_TOTAL_BYTES)
-            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
+        check_attachment_bounds(
+            paths.len(),
+            0,
+            DEFAULT_MAX_ATTACHMENTS,
+            DEFAULT_MAX_TOTAL_BYTES,
+        )
+        .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
         // One read-only worker per distinct containing tree, reused across attachments
         // under it (a worker owns a thread + kernel build, so we don't want one per file).
         let mut workers: std::collections::HashMap<PathBuf, KaishWorker> =
@@ -1257,7 +1262,12 @@ impl KaiboHandler {
         // (consult views it with `view_image`, which only a vision synth carries). Refuse
         // here, before the loop, the same honest up-front refusal oneshot/batch give.
         let attachments = Self::resolve_consult_attachments(&root, &input.attach)?;
-        Self::gate_consult_image_attachments(&attachments, synth.caps.vision, &synth.model, &cast.name)?;
+        Self::gate_consult_image_attachments(
+            &attachments,
+            synth.caps.vision,
+            &synth.model,
+            &cast.name,
+        )?;
         let cfg = ConsultConfig {
             explorer_max_turns: input
                 .explorer_max_turns
@@ -1360,7 +1370,12 @@ impl KaiboHandler {
         // Resolve + classify + gate before spawning: a bad attach (or an image to a blind
         // synth) is a clean synchronous refusal, not a job that fails on poll.
         let attachments = Self::resolve_consult_attachments(&root, &input.attach)?;
-        Self::gate_consult_image_attachments(&attachments, synth.caps.vision, &synth.model, &cast.name)?;
+        Self::gate_consult_image_attachments(
+            &attachments,
+            synth.caps.vision,
+            &synth.model,
+            &cast.name,
+        )?;
         let cfg = ConsultConfig {
             explorer_max_turns: input
                 .explorer_max_turns
@@ -1783,7 +1798,18 @@ impl KaiboHandler {
         }
         self.ensure_consult_enabled(&input.handle)?;
         match self.jobs.get(&input.handle) {
-            Some(snap) => Ok(render_job(&input.handle, snap)),
+            Some(snap) => {
+                // Collecting a terminal job retires its completion ping from the `wait`
+                // ring — otherwise that stale Warn lingers and the next `wait` returns on
+                // it immediately instead of blocking for new work. A Running job has no
+                // ping yet; a Canceled one never emitted one — both are no-ops, so this is
+                // safe to call unconditionally, but we scope it to the terminal states the
+                // ping actually exists for.
+                if matches!(snap.state, JobState::Done(_) | JobState::Failed(_)) {
+                    self.notifications.discard_job_pings(&input.handle);
+                }
+                Ok(render_job(&input.handle, snap))
+            }
             None => Err(McpError::invalid_params(
                 format!(
                     "no consultation job `{}` — it may have finished and been evicted by \
@@ -3171,7 +3197,7 @@ fn wait_level_floor(level: Option<&str>) -> Result<u8, McpError> {
             return Err(McpError::invalid_params(
                 format!("level must be one of debug|info|warn|error, got {other:?}"),
                 None,
-            ))
+            ));
         }
     };
     Ok(crate::mcp_log::rank(l))
@@ -3409,8 +3435,8 @@ impl ProgressSink for ProgressReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::{NumberOrString, PromptMessageContent};
     use rmcp::ServerHandler;
+    use rmcp::model::{NumberOrString, PromptMessageContent};
 
     /// consult `attach` validates files are under the consult root (so the model's shell
     /// can `cat` them) and returns them as relative paths; a file outside the root — even
@@ -3470,7 +3496,10 @@ mod tests {
         )
         .expect("both resolve");
         let by_path = |p: &str| out.iter().find(|a| a.path == p).unwrap().is_image;
-        assert!(by_path("shot.txt"), "PNG bytes classify as image despite .txt");
+        assert!(
+            by_path("shot.txt"),
+            "PNG bytes classify as image despite .txt"
+        );
         assert!(
             !by_path("notes.png"),
             "UTF-8 bytes classify as text despite .png"
@@ -3491,8 +3520,13 @@ mod tests {
             is_image: false,
         }];
         // Blind synth + image → refused, naming the cast and the vision requirement.
-        let err = KaiboHandler::gate_consult_image_attachments(&img, false, "deepseek-v4-pro", "deepseek")
-            .expect_err("an image to a blind synth must be refused");
+        let err = KaiboHandler::gate_consult_image_attachments(
+            &img,
+            false,
+            "deepseek-v4-pro",
+            "deepseek",
+        )
+        .expect_err("an image to a blind synth must be refused");
         assert!(
             err.message.contains("can't see images") && err.message.contains("deepseek"),
             "the refusal names the cause and the cast: {}",
@@ -3801,6 +3835,78 @@ mod tests {
         );
     }
 
+    /// A job's completion ping (a Warn carrying `job=<id>`) sits in the `wait` ring until
+    /// drained. Collecting that job with `get` must retire its ping — otherwise the ping
+    /// lingers and the next `wait` returns on it instantly instead of blocking for new
+    /// work (the "`wait` returns too fast" bug). An *uncollected* job's ping is untouched,
+    /// so it still wakes a later `wait`.
+    #[tokio::test]
+    async fn get_on_a_terminal_job_retires_its_wait_ping() {
+        use crate::jobs::JobResult;
+        use crate::mcp_log::LogRecord;
+        use rmcp::model::LoggingLevel;
+
+        fn ping(job: &str) -> LogRecord {
+            let mut fields = serde_json::Map::new();
+            fields.insert("job".into(), serde_json::Value::String(job.into()));
+            LogRecord {
+                level: LoggingLevel::Warning,
+                target: "kaibo::jobs".into(),
+                message: format!("async job finished — collect it with `get` ({job})"),
+                fields,
+            }
+        }
+
+        let h = handler();
+        // Two finished jobs; we only collect the first.
+        let collected = h.jobs.submit("test", async {
+            Ok(JobResult {
+                answer: "answer".into(),
+                report: None,
+            })
+        });
+        let other = h.jobs.submit("test", async {
+            Ok(JobResult {
+                answer: "answer".into(),
+                report: None,
+            })
+        });
+        // Both must reach a terminal state before `get` will evict (Running has no ping).
+        for id in [&collected, &other] {
+            for _ in 0..1000 {
+                match h.jobs.get(id).map(|s| s.state) {
+                    Some(JobState::Running) | None => tokio::task::yield_now().await,
+                    Some(_) => break,
+                }
+            }
+        }
+        // Seed both pings, the way the finishing tasks' `tracing::warn!` would.
+        h.notifications.push_record(ping(&collected));
+        h.notifications.push_record(ping(&other));
+
+        h.get(Parameters(HandleInput {
+            handle: collected.clone(),
+        }))
+        .await
+        .expect("get collects the finished job");
+
+        // The collected job's ping is gone; the uncollected one's survives to wake a
+        // later `wait`.
+        let left: Vec<String> = h
+            .notifications
+            .drain(crate::mcp_log::rank(LoggingLevel::Warning), 20)
+            .into_iter()
+            .map(|r| {
+                r.fields
+                    .get("job")
+                    .and_then(|v| v.as_str())
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(left, vec![other], "only the uncollected job's ping remains");
+    }
+
     /// Progress is opt-in: with no `progressToken` in `_meta` we send nothing, so the
     /// sink must be the no-op. (A `consult` with no token is byte-for-byte its old
     /// silent self.)
@@ -4058,19 +4164,19 @@ mod tests {
         );
         let text = read_text(TOOLS_URI, &[]);
         for needle in [
-            "attach",          // the attachment guidance moved here
-            "inlined",         // the consult-vs-oneshot attach distinction
-            "whole file",      // the toolless-model whole-files steer
-            "verbatim",        // the model-id override semantics
-            "_backend",        // the retarget-the-slot mechanic
-            "job-N",           // the consult handle shape
+            "attach",              // the attachment guidance moved here
+            "inlined",             // the consult-vs-oneshot attach distinction
+            "whole file",          // the toolless-model whole-files steer
+            "verbatim",            // the model-id override semantics
+            "_backend",            // the retarget-the-slot mechanic
+            "job-N",               // the consult handle shape
             "backend/provider-id", // the batch handle shape
-            "fire-and-forget", // the async-workflow framing
-            "read-only",       // the kaish shell boundary
-            "126",             // the exit-code contract
-            "worktree",        // attach/path reaches a followed git worktree
-            "Reviewing a change", // prefer whole files over a diff for review
-            "view_image",      // consult opens an attached image with view_image
+            "fire-and-forget",     // the async-workflow framing
+            "read-only",           // the kaish shell boundary
+            "126",                 // the exit-code contract
+            "worktree",            // attach/path reaches a followed git worktree
+            "Reviewing a change",  // prefer whole files over a diff for review
+            "view_image",          // consult opens an attached image with view_image
         ] {
             assert!(
                 text.contains(needle),

--- a/src/server.rs
+++ b/src/server.rs
@@ -741,9 +741,10 @@ impl KaiboHandler {
     /// [`resolve_attachments`](Self::resolve_attachments), which inlines for the tool-less
     /// tools. Each path must canonicalize to a regular file *under the consult's `root`*,
     /// because the consult reads it through a kaish worker rooted there; an out-of-root
-    /// path is refused with guidance. The returned relative paths are what the model
-    /// `cat`s and what [`consult_user_prompt`](crate::consult::consult_user_prompt) names
-    /// in the driver prompt — deferring the IO to the model's own reads.
+    /// path is refused with guidance. The returned relative paths are what the model opens
+    /// itself — a text file with `cat -n`, an image with `view_image` — and what
+    /// [`consult_user_prompt`](crate::consult::consult_user_prompt) names in the driver
+    /// prompt, deferring the byte-level IO to the model's own reads.
     fn resolve_consult_attachments(
         root: &std::path::Path,
         attach: &[String],
@@ -794,9 +795,20 @@ impl KaiboHandler {
             // Sniff the file's type so the driver prompt routes it to the right tool: a
             // text file the model reads with `cat -n`, an image it views with `view_image`
             // (which `cat` would refuse as binary). Classify by content, not extension — a
-            // 16-byte prefix covers every magic number `sniff_mime` knows; `view_image`
-            // re-sniffs the full bytes authoritatively through the VFS at view time, so
-            // this is just the routing hint, and an unreadable prefix simply reads as text.
+            // 16-byte prefix covers every magic number `sniff_mime` knows.
+            //
+            // This prefix is read with `std::fs`, NOT through the kaish VFS the way
+            // `resolve_attachments` reads its bytes — a deliberate, bounded exception, not
+            // an oversight. There, the bytes are *inlined into the model's context*, so a
+            // raced symlink-swap could exfiltrate out-of-tree content to the model — which
+            // is exactly why that read is VFS-mounted (it re-resolves and refuses an
+            // escaping symlink). Here the 16 bytes never leave this function: they feed
+            // `sniff_mime` to a bool and are dropped. And kaibo's adversary is the *model*,
+            // which has no control over filesystem timing to drive a swap. The authoritative
+            // image read still goes through the read-only VFS in `view_image` at view time,
+            // re-sniffing the full bytes with full containment — so the worst case of a
+            // raced swap here is a misrouted hint (cat vs view_image) the model recovers
+            // from, never an escape or a leak. An unreadable prefix simply reads as text.
             let is_image = {
                 use std::io::Read;
                 let mut buf = [0u8; 16];
@@ -814,11 +826,12 @@ impl KaiboHandler {
     }
 
     /// Refuse an image attachment to a vision-blind consult synth — the consult analog of
-    /// [`gate_image_attachments`]. consult never inlines an image's bytes; it routes the
-    /// caller to view it with the `view_image` tool, which is only wired in when the synth
-    /// is vision-capable. So an image attached to a blind synth could never be seen —
-    /// refuse honestly up front, naming the cast, rather than name a file the model has no
-    /// way to open. Text attachments (and the no-attachment case) always pass.
+    /// [`gate_image_attachments`]. consult never inlines an image's bytes; the model opens
+    /// an attached image with the `view_image` tool, which is only wired into the toolset
+    /// when the synth is vision-capable (see `consult_tools`). So an image attached to a
+    /// blind synth could never be seen — refuse honestly up front, naming the cast, rather
+    /// than let the prompt name a file the model has no way to open. Text attachments (and
+    /// the no-attachment case) always pass.
     fn gate_consult_image_attachments(
         attachments: &[crate::consult::ConsultAttachment],
         vision: bool,

--- a/src/view_image.rs
+++ b/src/view_image.rs
@@ -229,13 +229,12 @@ impl Tool for ViewImage {
     }
 }
 
-/// Identify an image by its magic bytes (content, not extension — the model may name
-/// a path with the wrong suffix, and we're handing a `mimeType` straight to the
-/// provider). Returns the MIME string rig maps to its `ImageMediaType`, or `None`
-/// for anything we don't carry.
-/// Recognize an image's MIME type from its leading magic bytes (png/jpeg/gif/webp).
-/// Shared with the `generate_image` capability, which must label produced bytes the
-/// same way `view_image` labels read ones — one sniffer, one source of truth.
+/// Identify an image by its leading magic bytes (png/jpeg/gif/webp) — content, not
+/// extension, since the model may name a path with the wrong suffix and we hand a
+/// `mimeType` straight to the provider. Returns the MIME string rig maps to its
+/// `ImageMediaType`, or `None` for anything we don't carry. Shared with the
+/// `generate_image` capability, which must label produced bytes the same way
+/// `view_image` labels read ones — one sniffer, one source of truth.
 pub(crate) fn sniff_mime(bytes: &[u8]) -> Option<&'static str> {
     const PNG: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
     if bytes.starts_with(PNG) {


### PR DESCRIPTION
This branch carries two changes to the async consult/`wait` surface: image attachments to `consult`, and a fix for `wait` returning too early.

---

## 1. Support image attachments to consult (routed through view_image)

### Why

`consult`'s `attach` was text-only by construction — it *names* files for the model to `cat -n`, and an image hits kaish's binary refusal. But a vision-capable consult already carries a `view_image` tool (the image-analog of `cat`), so an attached image just needed to be routed there instead of the shell. Two concrete bugs before this: the prompt told the model to `cat` *every* attached file (misdirects an image), and there was **no vision gate** — an image attached to a vision-blind consult was silently uncatchable, with no honest refusal.

### What

Route an attached image through the `view_image` tool the consult already has — keeping consult's "name it, the model opens it when ready" philosophy, and treating an attached image identically to one the model discovers in the repo. (Chosen over eagerly inlining the image as a vision part on the first turn: that always spends the image tokens and adds a second delivery path; view_image is lazy and already solves per-provider transport.)

Three parts:
1. **Classify by content.** The server sniffs each attachment's magic bytes — a PNG named `.txt` is still an image, matching how `view_image` re-sniffs authoritatively at read time.
2. **Gate on vision.** An image to a vision-blind synth is refused up front, naming the cast — the same honest refusal `oneshot`/`batch` give. consult could never show it, so naming the file would be a lie.
3. **Route in the prompt.** `consult_user_prompt` now splits its list: text files under a `cat -n` instruction, images under a `view_image` one — never `cat`-ing a binary.

`ConsultConfig.attachments` carries the classification (`Vec<ConsultAttachment>`), threaded through both `consult` and `consult_submit`.

### Tests

- content-based classification (PNG-as-`.txt` → image, UTF-8-as-`.png` → text)
- the vision gate (blind synth + image → refused; vision synth + image → ok; text-only always ok)
- prompt routing (image under view_image, text under cat -n)
- the `kaibo://tools` doc test gains `view_image` as a needle

Note: the default `deepseek` cast is vision-blind, so image attach there now refuses with guidance — use a vision cast (`anthropic`/`gemini`).

---

## 2. Fix `wait` returning too early on a stale completion ping

### Why

`wait(timeout_secs=600)` was returning near-instantly instead of blocking. The cause was a stale wake signal left in the notification ring:

- A finished async job pushes a **Warn** "job finished/failed" ping into the shared notification ring (`jobs.rs`) — the wake signal a parked `wait` returns on.
- `get` collected a job from the `JobStore` **without ever draining that ping**, so it lingered in the 512-cap ring.
- The next `wait` then drained the stale ping and returned immediately. Net effect: the *first* `wait` on a job blocked correctly, but every later one returned too fast on the previous job's ping.

The `wait` timeout/`select!` arithmetic was never at fault — the empty-timeout path is sound and tested.

### What

`get` now retires a terminal job's ping when it collects it (the ping is stale news once the job is in hand). New `NotificationBuffer::discard_job_pings(id)`, called from `get` only for `Done`/`Failed` jobs (a `Running` job has no ping yet; a `Canceled` one never emitted one). Scoped to the one job id, so an **uncollected** job's ping still wakes a later `wait`, and idempotent — a ping a live `wait` already drained leaves nothing to remove.

### Tests

- the buffer method drops only the named job's ping, leaving others (incl. job-less Warns) intact
- `get` on a terminal job retires its ping while an uncollected job's survives — the integration seam where a regression would hide (the assertion compares against the surviving ping, so it fails if the eviction call is dropped)

---

Full suite green (272 lib tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
