### PR TITLE
Gate batch casts to the batch lane; rename openai built-in to openai-local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,28 @@ Local musl repro (no system zig needed): `pip install ziglang` in a venv,
 x86_64-unknown-linux-musl`. Verify the boundary with `cargo tree -i aws-lc-rs`
 (empty) and `ldd target/.../kaibo` (`not a dynamic executable`).
 
+## Writing for models
+
+Every prompt, preamble, tool description, and cheatsheet is text some model reads.
+When we touch one, we **re-read the whole block and judge it holistically** — not the
+diff in isolation. The ratchet is *compression* (改善): over time a block should carry
+more impact per token and avoid accreting clauses.
+
+Two audiences are optimized differently:
+
+- **Client-facing text** — the MCP server instructions and each tool's `description`
+  in `server.rs`, read by the *calling* agent. Density is existential here because it's
+  *resident* cost: the descriptions load into the caller's context every session
+  whether or not the tool is ever called — an unused tool still bills the user. We ask
+  people to spend a few tokens on kaibo in every session they connect us; each one has
+  to earn its place and be additive to their experience. Terse, concrete, no clause
+  that doesn't pay rent.
+- **Agent-facing text** — preambles, the kaish cheatsheet, the casts' answering
+  instructions, read by the commercial models *we* drive, with windows in the hundreds
+  of thousands to millions of tokens. Here verbosity is *licensed where it shapes
+  behavior*: say it a few ways, frame positively, be explicit (see **Driving the
+  models**). Verbose to install behavior, never verbose by default.
+
 ## Driving the models
 
 How kaibo talks to LLMs — Amy's defaults, made local so any agent here inherits them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,15 @@ the git log. Each later release appends a new section at the top.
   no state: the handle is the whole address, so poll/cancel survive a restart, and a
   failed item is surfaced per-item rather than dropped. Runs on **Anthropic and Gemini**
   backends (OpenAI batch is a tracked follow-on); a cast whose synth has no batch lane is
-  refused with a clear message naming the ones that do. For Gemini there's a ready-made
-  `gemini-batch` cast that synths Gemini **Pro** — the tier you reach for offline, where
-  its latency is free. Gated by `--no-batch` (one flag over every verb). Batch carries its
+  refused with a clear message naming the ones that do. Two ready-made batch casts ship:
+  `gemini-batch` (synth Gemini **Pro**) and `anthropic-batch` (synth Claude **Opus**) —
+  the tier you reach for offline, where its latency is free. Both declare **`batch = true`**,
+  which dedicates them to the batch lane: `batch_submit` takes a batch cast and the
+  interactive tools (`consult`/`oneshot`) refuse one — and vice versa — so a big,
+  offline-tuned model is never run interactively (slow, expensive) by accident. Mark your
+  own cast `batch = true` in `config.toml` (its synth must be a batch-capable backend; the
+  per-tool `cast` menu lists the casts each tool actually accepts). Gated by `--no-batch`
+  (one flag over every verb). Batch carries its
   own system preamble fit to the offline lane — one complete, self-contained response with
   no follow-up, told to spend on depth — overridable via `[prompts].batch` like the other
   phases. While a batch runs, `get` reminds you to go do other work and check back

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -53,11 +53,11 @@ composition, compositions choose connections.
 
 ```toml
 # --- backends: connections only. The four built-ins (anthropic, deepseek,
-#     gemini, openai) ship in code with today's key sources; a stanza here
+#     gemini, openai-local) ship in code with today's key sources; a stanza here
 #     retargets one or adds a new one. ---
 
 # (No stanza needed for the local llama.cpp default: `gemma` is a built-in
-#  alias of the `openai` backend, which already points at localhost:13305.
+#  alias of the `openai-local` backend, which already points at localhost:13305.
 #  Built-in alias names are reserved — `[backends.gemma]` would be a loud
 #  collision error, not a redefinition.)
 
@@ -104,7 +104,7 @@ Rules, in the loud-over-silent house style:
   user; git history is the record.
 - **Built-in equivalence:** four built-in backends + four same-named
   single-backend casts. Today's profile aliases — `claude`→`anthropic`,
-  `google`→`gemini`, `local`/`lemonade`/`gemma`/`gemma4`→`openai` — register
+  `google`→`gemini`, `local`/`lemonade`/`gemma`/`gemma4`→`openai-local` — register
   at *both* levels (cast aliases so `cast = "claude"` resolves, backend
   aliases so a slot ref `claude/<id>` resolves), and user stanzas can declare
   their own `aliases = [...]` at either level. A missing config file and

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -4,7 +4,7 @@
 # or point at it with --config <path> / KAIBO_CONFIG.
 #
 # EVERYTHING here is optional. With no config file at all, kaibo runs exactly as it
-# does today: four built-in BACKENDS (connections: anthropic/deepseek/gemini/openai)
+# does today: four built-in BACKENDS (connections: anthropic/deepseek/gemini/openai-local)
 # and four same-named single-backend CASTS (compositions: role → "backend/model-id")
 # ship in code; this file only OVERRIDES fields or ADDS backends and casts.
 # `[profiles]` is gone — a config that still carries it is a load error pointing at
@@ -206,7 +206,7 @@ kind = "gemini"
 api_key_env  = "GEMINI_API_KEY"
 api_key_file = "~/.gemini-api-key"
 
-[backends.openai]                            # aliases: local, lemonade, gemma, gemma4
+[backends.openai-local]                            # aliases: local, lemonade, gemma, gemma4
 kind = "openai"
 base_url = "http://localhost:13305/api/v1"   # also overridable via OPENAI_BASE_URL
 api_key_env  = "OPENAI_API_KEY"
@@ -217,7 +217,7 @@ key_optional = true                          # keyless local default → placeho
 #     A new backend must declare its `kind`; it seeds that kind's default key
 #     sources, then your fields apply on top. A new openai-kind backend must also
 #     set `base_url` (the OPENAI_BASE_URL / local-default fallback belongs to the
-#     built-in `openai` backend alone — a forgotten base_url is a load error, not
+#     built-in `openai-local` backend alone — a forgotten base_url is a load error, not
 #     a silent dial of the wrong server). ---
 
 # Hosted OpenAI, keyed.
@@ -272,7 +272,7 @@ synth    = "claude/claude-sonnet-4-6"       # the voice that answers — Claude 
 image    = "sd/sdxl-turbo"                  # image gen stays local — Stable Diffusion
 
 # --- Privacy posture: nothing leaves the box. `gemma` is the built-in alias for
-#     the local-default `openai` backend. ---
+#     the local-default `openai-local` backend. ---
 
 [casts.local-only]
 explorer = "gemma/Gemma-4-E4B-it-GGUF"

--- a/docs/config.md
+++ b/docs/config.md
@@ -69,7 +69,7 @@ Connection knobs only — models never live here:
   path) — this is what lets any number of openai-kind backends (hosted GPT, two
   local llama.cpp servers, an image server) be live at once, each its own name.
   A *new* openai-kind backend must set it: the `OPENAI_BASE_URL`/local-default
-  fallback belongs to the built-in `openai` backend alone, so a forgotten
+  fallback belongs to the built-in `openai-local` backend alone, so a forgotten
   `base_url` is a load error, not a silent dial of the wrong server. For the
   keyed kinds rig fixes the endpoint, so a `base_url` there is a config error,
   surfaced loudly — not silently ignored.
@@ -124,12 +124,13 @@ image    = "sd/sdxl-turbo"                  # image gen stays local
 
 # table form: id + capability pins + per-slot tunables
 # synth = { backend = "claude", id = "claude-opus-4-8", effort = "max" }
-# explorer = { backend = "openai", id = "Gemma-4-E4B-it", preamble = "..." }  # per-model prompt
+# explorer = { backend = "openai-local", id = "Gemma-4-E4B-it", preamble = "..." }  # per-model prompt
 ```
 
 - **Known roles:** `explorer`, `synth`, `image`, `tts`. A typo'd role (or a typo'd
   per-slot knob) is a loud load error, not a silent no-op. A cast may omit roles —
-  built-ins always carry explorer+synth; a user cast that omits one is valid
+  the four interactive built-ins carry explorer+synth, the batch built-ins carry
+  synth only; a user cast that omits a role is valid
   config, and the tool that needs the missing role fails loudly *at call time*,
   naming the gap ("cast `tts-box` has no synth slot"). Absent = capability absent.
   (Nothing consumes `image`/`tts` yet; they land with the production builtins.
@@ -202,27 +203,36 @@ The `[defaults]` knobs themselves:
 
 Four backends and four same-named single-backend casts ship **in code** and
 reproduce kaibo's historical behavior exactly, so a **missing config file is not
-an error**. One extra built-in cast ships too — `gemini-batch`, a Gemini cast whose
-synth is Pro, for the offline batch lane (see `batch_submit`). The TOML *merges over* this registry by name: set one field on a
-built-in to retarget it, or add brand-new backends and casts. The built-in alias
-names register at **both** levels — as cast aliases (so `cast = "claude"`
-resolves) and backend aliases (so a slot ref `claude/<id>` resolves) — and are
-reserved: naming a new backend or cast after one is a loud collision error.
+an error**. Two extra built-in casts ship for the offline batch lane —
+`gemini-batch` (synth Gemini Pro) and `anthropic-batch` (synth Claude Opus). Both
+declare `batch = true`, which staffs `batch_submit` *only*: the interactive tools
+(`consult`/`oneshot`) refuse a batch cast, and `batch_submit` refuses a non-batch
+cast, so a big offline-tuned model is never run interactively by accident (and vice
+versa). A batch cast carries **synth only** (batch is toolless) and its synth must
+sit on a batch-capable backend (Anthropic or Gemini) — declaring `batch = true`
+elsewhere is a loud load error. The TOML *merges over* this registry by name: set
+one field on a built-in to retarget it (the `batch` flag is sticky — retuning
+`gemini-batch`'s model leaves it batch), or add brand-new backends and casts. The
+built-in alias names register at **both** levels — as cast aliases (so
+`cast = "claude"` resolves) and backend aliases (so a slot ref `claude/<id>`
+resolves) — and are reserved: naming a new backend or cast after one is a loud
+collision error.
 
 | backend | kind | base_url | key env / file | aliases |
 |---|---|---|---|---|
 | `anthropic` | anthropic | — | `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` | `claude` |
 | `deepseek` | deepseek | — | `DEEPSEEK_API_KEY` / `~/.deepseek-key` | — |
 | `gemini` | gemini | — | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
-| `openai` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
+| `openai-local` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
 
-| cast | explorer | synth |
-|---|---|---|
-| `anthropic` | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-4-6` |
-| `deepseek` | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` |
-| `gemini` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-3.5-flash` |
-| `gemini-batch` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-pro-latest` |
-| `openai` | `openai/Gemma-4-E4B-it-GGUF` | `openai/Gemma-4-26B-A4B-it-GGUF` |
+| cast | explorer | synth | batch |
+|---|---|---|---|
+| `anthropic` | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-4-6` | |
+| `deepseek` | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` | |
+| `gemini` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-3.5-flash` | |
+| `openai-local` | `openai-local/Gemma-4-E4B-it-GGUF` | `openai-local/Gemma-4-26B-A4B-it-GGUF` | |
+| `gemini-batch` | — | `gemini/gemini-pro-latest` | ✓ |
+| `anthropic-batch` | — | `anthropic/claude-opus-4-8` | ✓ |
 
 ### The chimera payoff
 
@@ -511,7 +521,7 @@ model-aware; the prose is too). The per-model knob is `preamble` on the cast's
 
 ```toml
 [casts.local]
-explorer = { backend = "openai", id = "Gemma-4-E4B-it", preamble = "You are a careful reader; quote exact lines." }
+explorer = { backend = "openai-local", id = "Gemma-4-E4B-it", preamble = "You are a careful reader; quote exact lines." }
 synth    = "anthropic/claude-sonnet-4-6"   # no per-model prompt; uses [prompts] or built-in
 ```
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -589,3 +589,13 @@ question is whether the content/cost of a logs signal is worth it given traces
 already carry the prompts/completions. The session's `otlp-mcp` collector is the
 sink for a probe.
 
+
+### Flaky: `containment::omitted_path_zero_config_infers_cwd_as_default_root`
+Failed once under a full `cargo test`, passed in isolation and on the next full run.
+The test reads process-global `current_dir()`; containment.rs has two cwd-reading
+tests and the harness runs a binary's tests on parallel threads, so a cwd-sensitive
+assert can race. Not tied to any one feature (the batch-cast work that surfaced it
+touches no root logic). Fix candidates: serialize the cwd-reading tests (a shared
+mutex / `serial_test`), or have the test assert against an explicit root rather than
+the ambient cwd. Cross-reference [[tracing-callsite-interest-poisoning]] — same
+"global state shared across a binary's tests" failure class.

--- a/src/config.rs
+++ b/src/config.rs
@@ -728,6 +728,12 @@ impl Config {
         self.casts
             .iter()
             .filter(|(_, cast)| {
+                // A batch cast is refused by `generate_image` (it staffs `batch_submit`
+                // only), so never advertise it here even if it carries an image slot —
+                // the menu must match the gate.
+                if cast.batch {
+                    return false;
+                }
                 let Some(slot) = cast.slot(ModelRole::Image) else {
                     return false;
                 };
@@ -848,13 +854,13 @@ impl Config {
                     rb.apply_to(&mut b)?;
                     // A NEW openai-kind backend must say where it points: the
                     // use-time fallback (OPENAI_BASE_URL, else the local default)
-                    // belongs to the built-in `openai` backend alone — inherited
-                    // here it would silently dial the wrong server and fail as a
-                    // cryptic 404 mid-call instead of loudly at load.
+                    // belongs to the built-in `openai-local` backend alone —
+                    // inherited here it would silently dial the wrong server and fail
+                    // as a cryptic 404 mid-call instead of loudly at load.
                     if b.kind == ProviderKind::Openai && b.base_url.is_none() {
                         bail!(
                             "backend {name:?} (kind \"openai\") must set base_url — \
-                             only the built-in `openai` backend falls back to \
+                             only the built-in `openai-local` backend falls back to \
                              OPENAI_BASE_URL / the local default"
                         );
                     }
@@ -2683,7 +2689,7 @@ mod tests {
     /// `Unconfigured` ones — and reports each survivor's state so the handshake can tag
     /// a local one. With only an Anthropic key in the env, the keyed built-ins that lack
     /// keys (deepseek, gemini) drop out; anthropic and the Anthropic-synth `anthropic-batch`
-    /// are Ready and the keyless `openai` is LocalUnverified. (The roster spans both lanes;
+    /// are Ready and the keyless `openai-local` is LocalUnverified. (The roster spans both lanes;
     /// the per-tool `cast` enums partition it by `batch`.) This is the source of the
     /// truthful "## Casts" handshake list.
     #[test]
@@ -2723,16 +2729,24 @@ mod tests {
 
             [casts.wrongkind]
             image = { backend = "anthropic", id = "imagen-ish" }
+
+            # A batch cast with an otherwise-valid openai image slot: `generate_image`
+            # refuses batch casts, so the menu must NOT advertise it.
+            [casts.batchart]
+            batch = true
+            synth = "gemini/gemini-pro-latest"
+            image = { backend = "openai-local", id = "sd-xl" }
             "#,
         )
         .unwrap();
         // No env key at all: the openai image cast still qualifies (keyless local),
-        // the anthropic-backed one is excluded by kind, and the built-in agent-only
-        // casts (no image slot) never appear.
+        // the anthropic-backed one is excluded by kind, the batch cast is excluded by
+        // lane (refused by the tool), and the built-in agent-only casts (no image slot)
+        // never appear.
         assert_eq!(
             cfg.image_capable_casts(|_| None),
             vec!["art".to_string()],
-            "only the openai-backed image cast is image-capable"
+            "only the openai-backed, non-batch image cast is image-capable"
         );
         // An anthropic key in the env changes nothing — wrong kind stays excluded.
         let with_key = |k: &str| (k == "ANTHROPIC_API_KEY").then(|| "sk-test".to_string());

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,8 @@ impl Default for Defaults {
 /// The roles a cast's model slots can serve. Explorer and synth are the agent
 /// phases; the media roles (the pal-merge production models — see `docs/issues.md`
 /// "Media spine") are present only when configured: an absent slot means the
-/// capability is absent, not an error (built-in casts always carry explorer+synth).
+/// capability is absent, not an error (the four interactive built-in casts carry
+/// explorer+synth; the batch built-ins carry synth only).
 ///
 /// **`Tts` is a reserved, unwired seam.** It parses and resolves into a cast slot,
 /// but nothing consumes it — and won't until rig's provider coverage fills in: as
@@ -440,6 +441,13 @@ pub struct Cast {
     pub name: String,
     /// The role table: which slot serves each [`ModelRole`].
     pub slots: BTreeMap<ModelRole, ModelSlot>,
+    /// Positively declares this cast for the offline batch lane: `batch = true`
+    /// staffs `batch_submit` *only*. Its synth is a big, slow, expensive model tuned
+    /// for free batch latency (Gemini Pro, Claude Opus), so running it through an
+    /// interactive tool loop (`consult`/`oneshot`) is the wrong-and-costly mistake —
+    /// the gate refuses the mix in both directions (`server.rs`). Default `false`
+    /// (interactive); the batch-capable-synth requirement is checked at config load.
+    pub batch: bool,
 }
 
 impl Cast {
@@ -626,6 +634,14 @@ impl Config {
             "unknown cast {name:?}; known casts: {}",
             names.join(", ")
         ))
+    }
+
+    /// Whether `name` (a canonical cast name) is declared for the batch lane. Used to
+    /// partition the live roster onto the right tools' `cast` enums — batch casts to
+    /// `batch_submit`, the rest to the interactive tools. A name not in the registry
+    /// reads as non-batch (the caller already worked from canonical keys).
+    pub fn cast_is_batch(&self, name: &str) -> bool {
+        self.casts.get(name).is_some_and(|c| c.batch)
     }
 
     /// Resolve a backend by name or alias (the seam slot refs and per-call
@@ -923,7 +939,14 @@ impl Config {
             let cast = casts.entry(name.clone()).or_insert_with(|| Cast {
                 name: name.clone(),
                 slots: BTreeMap::new(),
+                batch: false,
             });
+            // `batch` is sticky: omitting it leaves a built-in batch cast batch (so a
+            // file can retune `gemini-batch`'s model without un-batching it); set it
+            // explicitly to declare or clear the lane.
+            if let Some(b) = rc.batch {
+                cast.batch = b;
+            }
             for (role, raw_slot) in rc.slots() {
                 let slot = raw_slot
                     .clone()
@@ -939,7 +962,7 @@ impl Config {
         // Resolve every slot's backend ref through the alias map (stored canonical),
         // and validate the slot. Unknown backend → loud error naming the known set.
         for cast in casts.values_mut() {
-            let Cast { name, slots } = cast;
+            let Cast { name, slots, batch } = cast;
             for (role, slot) in slots.iter_mut() {
                 if !backends.contains_key(&slot.backend) {
                     match backend_aliases.get(&slot.backend) {
@@ -985,6 +1008,28 @@ impl Config {
                         role.key(),
                         t.thinking_budget,
                         t.max_tokens
+                    );
+                }
+            }
+            // A batch cast is staffed by `batch_submit` — a toolless oneshot on the synth
+            // slot — so it MUST carry a synth slot whose backend actually has a batch API.
+            // Catch the misdeclaration loudly at load (a `batch = true` deepseek cast, say),
+            // not as a baffling refusal or a 400 at submit time.
+            if *batch {
+                let synth = slots.get(&ModelRole::Synth).ok_or_else(|| {
+                    anyhow!(
+                        "cast {name:?}: batch = true needs a synth slot \
+                         (batch_submit runs the synth model)"
+                    )
+                })?;
+                let kind = backends[&synth.backend].kind;
+                if !crate::batch::batch_supported(kind) {
+                    bail!(
+                        "cast {name:?}: batch = true but the synth backend {:?} ({}) has no \
+                         batch API — batch casts must synth a batch-capable backend ({})",
+                        synth.backend,
+                        kind.canonical_name(),
+                        crate::batch::supported_kinds_list(),
                     );
                 }
             }
@@ -1175,7 +1220,10 @@ fn builtin_aliases(name: &str) -> Vec<String> {
     let v: &[&str] = match name {
         "anthropic" => &["claude"],
         "gemini" => &["google"],
-        "openai" => &["local", "lemonade", "gemma", "gemma4"],
+        // The local-default built-in. `openai` is *not* an alias: that's the wire
+        // protocol's id, and leaving it free lets a user name their own backend
+        // `[backends.openai]` (e.g. the hosted API) without an alias collision.
+        "openai-local" => &["local", "lemonade", "gemma", "gemma4"],
         _ => &[],
     };
     v.iter().map(|s| s.to_string()).collect()
@@ -1208,7 +1256,7 @@ fn builtin_backends(defaults: &Defaults) -> BTreeMap<String, Backend> {
         ProviderKind::Openai,
     ] {
         let mut b = backend_template(kind, defaults);
-        b.name = kind.canonical_name().to_string();
+        b.name = kind.builtin_name().to_string();
         m.insert(b.name.clone(), b);
     }
     m
@@ -1225,7 +1273,7 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
         ProviderKind::Gemini,
         ProviderKind::Openai,
     ] {
-        let name = kind.canonical_name().to_string();
+        let name = kind.builtin_name().to_string();
         let (explorer, synth) = default_models(kind);
         // Only the agent roles are seeded: a media role (image, tts) appears in
         // the table only when a config asks for it — absent means the capability
@@ -1234,31 +1282,52 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
             (ModelRole::Explorer, ModelSlot::bare(&name, explorer)),
             (ModelRole::Synth, ModelSlot::bare(&name, synth)),
         ]);
-        m.insert(name.clone(), Cast { name, slots });
+        m.insert(
+            name.clone(),
+            Cast {
+                name,
+                slots,
+                batch: false,
+            },
+        );
     }
-    // gemini-batch: the offline lane's cast. Pro is near-unusable interactively (slow),
-    // so casts synth Flash; batch is exactly where the latency is free, so this cast
-    // synths Gemini Pro. Uses the `gemini-pro-latest` *alias* deliberately, not a pinned
-    // preview id: pinned Pro previews get retired out from under us (a live batch dogfood
-    // caught `gemini-3-pro-preview` 404ing mid-flight — submit accepted it, the per-item
-    // request failed at run time), so the latest-alias is the drift-resistant default.
-    // Override in config.toml to pin a specific Pro. Explorer stays the cheap flash-lite
-    // (batch is toolless and won't touch it, but the cast is usable for consult too).
+    // The offline batch lane's built-in casts (`batch = true`): staffed by a single
+    // big, slow, capable synth — the model whose latency is *free* in batch but
+    // near-unusable interactively. They carry synth only: batch is a toolless oneshot
+    // (no explorer sweep), and the interactive tools that used an explorer now refuse a
+    // batch cast outright, so an explorer slot here would be dead weight advertising a
+    // consult-usability the lane no longer has.
+    //
+    // gemini-batch synths Gemini Pro via the `gemini-pro-latest` *alias*, deliberately
+    // not a pinned preview id: pinned Pro previews get retired out from under us (a live
+    // batch dogfood caught `gemini-3-pro-preview` 404ing mid-flight — submit accepted it,
+    // the per-item request failed at run time), so the latest-alias is drift-resistant.
     let gemini_batch = "gemini-batch".to_string();
     m.insert(
         gemini_batch.clone(),
         Cast {
             name: gemini_batch,
-            slots: BTreeMap::from([
-                (
-                    ModelRole::Explorer,
-                    ModelSlot::bare("gemini", "gemini-flash-lite-latest"),
-                ),
-                (
-                    ModelRole::Synth,
-                    ModelSlot::bare("gemini", "gemini-pro-latest"),
-                ),
-            ]),
+            slots: BTreeMap::from([(
+                ModelRole::Synth,
+                ModelSlot::bare("gemini", "gemini-pro-latest"),
+            )]),
+            batch: true,
+        },
+    );
+    // anthropic-batch synths Claude Opus — the Anthropic analogue of Gemini Pro, the big
+    // model whose batch latency is free. Anthropic has no `-latest` alias convention, so
+    // the id is pinned (`claude-opus-4-8`); when it's retired, bump it here or pin a
+    // current Opus in config.toml.
+    let anthropic_batch = "anthropic-batch".to_string();
+    m.insert(
+        anthropic_batch.clone(),
+        Cast {
+            name: anthropic_batch,
+            slots: BTreeMap::from([(
+                ModelRole::Synth,
+                ModelSlot::bare("anthropic", "claude-opus-4-8"),
+            )]),
+            batch: true,
         },
     );
     m
@@ -1508,6 +1577,10 @@ impl RawBackend {
 #[serde(deny_unknown_fields)]
 struct RawCast {
     aliases: Option<Vec<String>>,
+    /// Declares the cast for the offline batch lane (`batch_submit` only). Absent
+    /// reads as `false` for a fresh cast; on a built-in batch cast it's omitted to
+    /// keep the existing flag, set explicitly to flip it. See [`Cast::batch`].
+    batch: Option<bool>,
     explorer: Option<RawSlot>,
     synth: Option<RawSlot>,
     image: Option<RawSlot>,
@@ -2381,17 +2454,122 @@ mod tests {
         assert!(!b.key_optional);
     }
 
-    /// All four built-in casts exist, each single-backend with explorer+synth.
+    /// All four interactive built-in casts exist, each single-backend with
+    /// explorer+synth, and none is flagged for the batch lane.
     #[test]
     fn all_four_builtin_casts_resolve() {
         let cfg = Config::builtin();
-        for name in ["anthropic", "deepseek", "gemini", "openai"] {
+        for name in ["anthropic", "deepseek", "gemini", "openai-local"] {
             let cast = cfg.resolve_cast(name).unwrap();
+            assert!(
+                !cast.batch,
+                "interactive built-in {name:?} must not be a batch cast"
+            );
             for role in [ModelRole::Explorer, ModelRole::Synth] {
                 let slot = cast.require_slot(role).unwrap();
                 assert_eq!(slot.backend, name, "built-in casts are single-backend");
             }
         }
+    }
+
+    /// The built-in batch casts positively declare `batch = true`, carry **synth only**
+    /// (batch is a toolless oneshot — an explorer slot would be dead weight), and synth a
+    /// batch-capable backend. Pins the lane's shape so an accidental explorer slot or a
+    /// dropped flag fails here.
+    #[test]
+    fn builtin_batch_casts_are_synth_only_and_flagged() {
+        let cfg = Config::builtin();
+        for (name, backend) in [("gemini-batch", "gemini"), ("anthropic-batch", "anthropic")] {
+            let cast = cfg.resolve_cast(name).unwrap();
+            assert!(cast.batch, "{name:?} must declare batch = true");
+            assert!(
+                cast.slot(ModelRole::Explorer).is_none(),
+                "{name:?} is a batch cast — toolless, so it carries no explorer slot"
+            );
+            let synth = cast.require_slot(ModelRole::Synth).unwrap();
+            assert_eq!(synth.backend, backend, "{name:?} synths its named backend");
+            assert!(
+                crate::batch::batch_supported(cfg.backends[&synth.backend].kind),
+                "{name:?} must synth a batch-capable backend"
+            );
+        }
+    }
+
+    /// A `batch = true` cast whose synth backend has no batch API is a misdeclaration —
+    /// caught loudly at config load, not as a 400 at submit time. The message names the
+    /// cast and the live batch-capable set.
+    #[test]
+    fn batch_cast_on_non_batch_backend_is_a_load_error() {
+        let err = Config::from_toml_str(
+            r#"
+            [casts.bad]
+            batch = true
+            synth = "deepseek/deepseek-v4-pro"
+            "#,
+        )
+        .expect_err("a batch cast on a non-batch backend must not load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("bad") && msg.contains("batch"),
+            "load error must name the cast and the batch problem, got: {msg}"
+        );
+    }
+
+    /// A `batch = true` cast with no synth slot can't run `batch_submit` (which runs the
+    /// synth model), so it's refused at load rather than failing cryptically on submit.
+    #[test]
+    fn batch_cast_without_synth_is_a_load_error() {
+        let err = Config::from_toml_str(
+            r#"
+            [casts.bad]
+            batch = true
+            explorer = "gemini/gemini-flash-lite-latest"
+            "#,
+        )
+        .expect_err("a batch cast with no synth slot must not load");
+        assert!(
+            format!("{err:#}").contains("synth"),
+            "load error must name the missing synth slot"
+        );
+    }
+
+    /// `batch` round-trips from `[casts.<name>]`: a fresh cast defaults non-batch, an
+    /// explicit `batch = true` (on a batch-capable synth) declares the lane, and the flag
+    /// is sticky over a built-in — retuning `gemini-batch`'s model leaves it batch.
+    #[test]
+    fn batch_flag_parses_defaults_false_and_is_sticky() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.fresh]
+            synth = "anthropic/claude-sonnet-4-6"
+
+            [casts.declared]
+            batch = true
+            synth = "anthropic/claude-opus-4-8"
+
+            [casts.gemini-batch]
+            synth = "gemini/gemini-3-pro-preview"
+            "#,
+        )
+        .unwrap();
+        assert!(
+            !cfg.resolve_cast("fresh").unwrap().batch,
+            "absent batch ⇒ false"
+        );
+        assert!(
+            cfg.resolve_cast("declared").unwrap().batch,
+            "batch = true ⇒ true"
+        );
+        let gb = cfg.resolve_cast("gemini-batch").unwrap();
+        assert!(
+            gb.batch,
+            "retuning a built-in batch cast leaves it batch (sticky)"
+        );
+        assert_eq!(
+            gb.require_slot(ModelRole::Synth).unwrap().id,
+            "gemini-3-pro-preview",
+            "the file override reached the synth slot"
+        );
     }
 
     // --- usability: the unconfigured-install signal ---------------------------
@@ -2407,7 +2585,7 @@ mod tests {
         api_key_file = "/nonexistent-kaibo-test/deepseek"
         [backends.gemini]
         api_key_file = "/nonexistent-kaibo-test/gemini"
-        [backends.openai]
+        [backends.openai-local]
         api_key_file = "/nonexistent-kaibo-test/openai"
     "#;
 
@@ -2447,7 +2625,7 @@ mod tests {
     #[test]
     fn cast_usability_local_unverified_for_keyless_placeholder() {
         let cfg = Config::from_toml_str(&format!(
-            "{NO_KEY_FILES}\n[casts.t]\nexplorer=\"openai/m1\"\nsynth=\"openai/m2\""
+            "{NO_KEY_FILES}\n[casts.t]\nexplorer=\"openai-local/m1\"\nsynth=\"openai-local/m2\""
         ))
         .unwrap();
         let cast = cfg.resolve_cast("t").unwrap();
@@ -2475,7 +2653,7 @@ mod tests {
     #[test]
     fn cast_usability_local_unverified_when_mixing_present_and_placeholder() {
         let cfg = Config::from_toml_str(&format!(
-            "{NO_KEY_FILES}\n[casts.t]\nexplorer=\"anthropic/m1\"\nsynth=\"openai/m2\""
+            "{NO_KEY_FILES}\n[casts.t]\nexplorer=\"anthropic/m1\"\nsynth=\"openai-local/m2\""
         ))
         .unwrap();
         let cast = cfg.resolve_cast("t").unwrap();
@@ -2504,8 +2682,10 @@ mod tests {
     /// `usable_casts` keeps only the casts that can reach a model — filtering out the
     /// `Unconfigured` ones — and reports each survivor's state so the handshake can tag
     /// a local one. With only an Anthropic key in the env, the keyed built-ins that lack
-    /// keys (deepseek, gemini) drop out; anthropic is Ready and the keyless `openai` is
-    /// LocalUnverified. This is the source of the truthful "## Casts" handshake list.
+    /// keys (deepseek, gemini) drop out; anthropic and the Anthropic-synth `anthropic-batch`
+    /// are Ready and the keyless `openai` is LocalUnverified. (The roster spans both lanes;
+    /// the per-tool `cast` enums partition it by `batch`.) This is the source of the
+    /// truthful "## Casts" handshake list.
     #[test]
     fn usable_casts_filters_unconfigured_and_reports_state() {
         let cfg = Config::from_toml_str(NO_KEY_FILES).unwrap();
@@ -2515,7 +2695,8 @@ mod tests {
             usable,
             vec![
                 ("anthropic".to_string(), CastUsability::Ready),
-                ("openai".to_string(), CastUsability::LocalUnverified),
+                ("anthropic-batch".to_string(), CastUsability::Ready),
+                ("openai-local".to_string(), CastUsability::LocalUnverified),
             ],
             "only keyed-and-present + keyless casts survive, with their state"
         );
@@ -2523,7 +2704,7 @@ mod tests {
         let none = cfg.usable_casts(|_| None);
         assert_eq!(
             none,
-            vec![("openai".to_string(), CastUsability::LocalUnverified)],
+            vec![("openai-local".to_string(), CastUsability::LocalUnverified)],
             "no env key ⇒ only the keyless local cast is usable"
         );
     }
@@ -2538,7 +2719,7 @@ mod tests {
         let cfg = Config::from_toml_str(
             r#"
             [casts.art]
-            image = { backend = "openai", id = "sd-xl" }
+            image = { backend = "openai-local", id = "sd-xl" }
 
             [casts.wrongkind]
             image = { backend = "anthropic", id = "imagen-ish" }
@@ -2567,12 +2748,12 @@ mod tests {
         assert_eq!(cfg.resolve_cast("claude").unwrap().name, "anthropic");
         assert_eq!(cfg.resolve_cast("google").unwrap().name, "gemini");
         for a in ["local", "lemonade", "gemma", "gemma4"] {
-            assert_eq!(cfg.resolve_cast(a).unwrap().name, "openai");
+            assert_eq!(cfg.resolve_cast(a).unwrap().name, "openai-local");
         }
         // Backend level.
         assert_eq!(cfg.resolve_backend("claude").unwrap().name, "anthropic");
         assert_eq!(cfg.resolve_backend("google").unwrap().name, "gemini");
-        assert_eq!(cfg.resolve_backend("local").unwrap().name, "openai");
+        assert_eq!(cfg.resolve_backend("local").unwrap().name, "openai-local");
         // And a slot ref written against an alias canonicalizes at load.
         let cfg = Config::from_toml_str(
             r#"
@@ -2634,8 +2815,8 @@ mod tests {
     /// form: only the FIRST `/` splits backend from id.
     #[test]
     fn slot_ref_splits_on_the_first_slash_only() {
-        let (backend, id) = parse_slot_ref("openai/Qwen/Qwen3-32B").unwrap();
-        assert_eq!(backend, "openai");
+        let (backend, id) = parse_slot_ref("openai-local/Qwen/Qwen3-32B").unwrap();
+        assert_eq!(backend, "openai-local");
         assert_eq!(id, "Qwen/Qwen3-32B");
         assert!(parse_slot_ref("no-slash-here").is_err());
         assert!(parse_slot_ref("/id-only").is_err());
@@ -2879,7 +3060,7 @@ mod tests {
         Config::from_toml_str(
             r#"
             [casts.x]
-            synth = { backend = "openai", id = "m", max_tokens = 1000, thinking_budget = 2000 }
+            synth = { backend = "openai-local", id = "m", max_tokens = 1000, thinking_budget = 2000 }
             "#,
         )
         .unwrap();

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -47,14 +47,31 @@ impl ProviderKind {
         matches!(self, ProviderKind::Openai)
     }
 
-    /// The canonical lower-case name of this kind — also the name of its built-in
-    /// backend and cast (so a bare `--cast anthropic` resolves to the built-ins).
+    /// The canonical lower-case name of this kind — the wire-protocol id used in
+    /// kind listings and error messages, and (for the keyed kinds) the name of the
+    /// built-in backend and cast, so a bare `--cast anthropic` resolves to the
+    /// built-ins. The OpenAI built-in's *name* diverges from this id — see
+    /// [`ProviderKind::builtin_name`].
     pub fn canonical_name(self) -> &'static str {
         match self {
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::DeepSeek => "deepseek",
             ProviderKind::Gemini => "gemini",
             ProviderKind::Openai => "openai",
+        }
+    }
+
+    /// The name of this kind's built-in backend and cast. Equals [`canonical_name`]
+    /// for the keyed providers, but the OpenAI-compatible built-in is named
+    /// `openai-local`: its default endpoint is a *local* keyless server (Gemma via an
+    /// OpenAI-compatible host), so the bare `openai` — which is really the wire
+    /// protocol's id — would misrepresent what the built-in points at. `openai` is
+    /// deliberately *not* an alias of it, so a user can name their own backend
+    /// `[backends.openai]` (a hosted endpoint) without colliding.
+    pub fn builtin_name(self) -> &'static str {
+        match self {
+            ProviderKind::Openai => "openai-local",
+            _ => self.canonical_name(),
         }
     }
 

--- a/src/generate_image.rs
+++ b/src/generate_image.rs
@@ -42,7 +42,7 @@ pub struct GenerateImageInput {
     /// What to draw. A plain-language description; passed verbatim to the image model.
     pub prompt: String,
 
-    /// Cast: a built-in name ("openai", …) or a cast from config.toml. The cast must
+    /// Cast: a built-in name ("openai-local", …) or a cast from config.toml. The cast must
     /// carry an `image` slot on an OpenAI-compatible backend. Omit to use the default
     /// cast.
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,9 @@ struct Args {
     no_follow_worktrees: bool,
 
     /// Default cast when a call omits it (a built-in name or a cast defined in
-    /// config.toml). Built-ins: anthropic | deepseek | gemini | openai (plus
-    /// aliases: claude, google, local, …). Replaces the old --provider flag
+    /// config.toml). Built-ins: anthropic | deepseek | gemini | openai-local
+    /// (plus aliases: claude, google, local, …) and the batch casts gemini-batch
+    /// | anthropic-batch. Replaces the old --provider flag
     /// (clap rejects the unknown flag loudly).
     #[arg(long)]
     cast: Option<String>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -527,11 +527,19 @@ impl KaiboHandler {
             .into_iter()
             .map(|(name, _)| name)
             .collect();
+        // A batch cast (`batch = true`) staffs `batch_submit` *only*, so the rosters split
+        // by lane: the interactive tools advertise the non-batch casts, `batch_submit`
+        // advertises the batch ones. The gate enforces the same split at call time; this
+        // just keeps the advertised menu honest so an agent doesn't pick a cast its tool
+        // will refuse.
+        let (batch_usable, interactive_usable): (Vec<String>, Vec<String>) =
+            usable.into_iter().partition(|n| config.cast_is_batch(n));
         inject_cast_enum(
             &mut tool_router,
             &["consult", "consult_submit", "oneshot"],
-            &usable,
+            &interactive_usable,
         );
+        inject_cast_enum(&mut tool_router, &["batch_submit"], &batch_usable);
         // `generate_image` selects the `image` slot, not explorer/synth, so its menu is
         // a different filter — casts with a usable image slot, not `usable_casts`. Same
         // advisory enum so image gen is as discoverable as consultation.
@@ -1101,6 +1109,46 @@ impl KaiboHandler {
             .map_err(|e| McpError::invalid_params(e.to_string(), None))
     }
 
+    /// Refuse an interactive tool (`consult`/`consult_submit`/`oneshot`/`generate_image`)
+    /// on a batch cast. A `batch = true` cast's synth is a big, slow, expensive model
+    /// tuned for free offline batch latency (Gemini Pro, Claude Opus); driving it through
+    /// an interactive tool loop is the wrong-and-costly mistake this gate exists to stop.
+    /// Points the caller at the lane that fits.
+    fn reject_batch_cast(&self, cast: &Cast, tool: &str) -> Result<(), McpError> {
+        if cast.batch {
+            return Err(McpError::invalid_params(
+                format!(
+                    "cast `{}` is a batch cast (batch = true) — submit it with `batch_submit`, \
+                     not `{tool}`. Its synth is a big, slow model tuned for free offline batch \
+                     latency; running it interactively would be slow and expensive. Pick a \
+                     non-batch cast for `{tool}`.",
+                    cast.name
+                ),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Refuse `batch_submit` on a non-batch cast — the other half of the lane split. A
+    /// batch cast must positively declare `batch = true`, so an ordinary interactive cast
+    /// is never silently batched (an accidental Opus/Pro batch is just as costly the other
+    /// way). Points the caller at the built-in batch casts.
+    fn require_batch_cast(&self, cast: &Cast) -> Result<(), McpError> {
+        if !cast.batch {
+            return Err(McpError::invalid_params(
+                format!(
+                    "cast `{}` is not a batch cast — `batch_submit` needs a cast that declares \
+                     `batch = true` (the built-ins `gemini-batch`, `anthropic-batch`, or your \
+                     own in config.toml). For an interactive answer, use `consult`/`oneshot`.",
+                    cast.name
+                ),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
     /// Apply a per-call model override to one of `cast`'s slots.
     ///
     /// The model id rides *verbatim* — an id containing `/` (HuggingFace-style
@@ -1236,6 +1284,7 @@ impl KaiboHandler {
         // Resolve the cast, layer per-call model overrides onto the clone, then
         // resolve each phase's slot into its own arm (client + request shape).
         let mut cast = self.resolve_cast(input.cast)?;
+        self.reject_batch_cast(&cast, "consult")?;
         self.apply_model_override(
             &mut cast,
             ModelRole::Explorer,
@@ -1348,6 +1397,7 @@ impl KaiboHandler {
         // refusable work (bad cast, bad path, missing key) happens *here*, synchronously,
         // so a bad submit is a clean error, not a job that fails on poll.
         let mut cast = self.resolve_cast(input.cast)?;
+        self.reject_batch_cast(&cast, "consult_submit")?;
         self.apply_model_override(
             &mut cast,
             ModelRole::Explorer,
@@ -1466,6 +1516,7 @@ impl KaiboHandler {
         meta: Meta,
     ) -> Result<CallToolResult, McpError> {
         let mut cast = self.resolve_cast(input.cast)?;
+        self.reject_batch_cast(&cast, "oneshot")?;
         self.apply_model_override(
             &mut cast,
             ModelRole::Synth,
@@ -1564,6 +1615,7 @@ impl KaiboHandler {
         Parameters(input): Parameters<GenerateImageInput>,
     ) -> Result<CallToolResult, McpError> {
         let mut cast = self.resolve_cast(input.cast.clone())?;
+        self.reject_batch_cast(&cast, "generate_image")?;
         // Optional per-call override on the image slot: `image_model` keeps the slot's
         // backend; `image_backend` retargets it (and works on a cast with no image slot
         // at all). The "pass the backend override arg" error now names a real arg.
@@ -1708,6 +1760,7 @@ impl KaiboHandler {
             ));
         }
         let mut cast = self.resolve_cast(input.cast)?;
+        self.require_batch_cast(&cast)?;
         self.apply_model_override(
             &mut cast,
             ModelRole::Synth,
@@ -3676,10 +3729,123 @@ mod tests {
                 .and_then(|e| e.as_array())
                 .unwrap_or_else(|| panic!("{tool}: cast param should carry an enum:\n{schema:#?}"));
             assert!(
-                variants.iter().any(|v| v == "openai"),
+                variants.iter().any(|v| v == "openai-local"),
                 "{tool}: cast enum should list the always-usable local cast, got {variants:?}"
             );
         }
+    }
+
+    /// The cast roster splits by lane on the advertised `cast` enums: the interactive
+    /// tools list non-batch casts, `batch_submit` lists batch casts — so an agent reading
+    /// the schema never offers a cast the tool will refuse. Driven through a keyless local
+    /// gemini backend so both a batch and an interactive cast are usable regardless of
+    /// which API keys the test env carries.
+    #[test]
+    fn cast_enums_split_by_lane() {
+        let h = handler_from_toml(
+            r#"
+            # A keyless (placeholder) batch-capable backend so both casts are "usable"
+            # offline — the partition is exercised with teeth, not trivially empty.
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.mybatch]
+            batch = true
+            synth = "gem/some-pro"
+
+            [casts.myinteractive]
+            explorer = "gem/some-lite"
+            synth = "gem/some-flash"
+            "#,
+        );
+        let enum_of = |tool: &str| -> Vec<String> {
+            h.tool_router
+                .get(tool)
+                .expect("tool advertised")
+                .input_schema
+                .get("properties")
+                .and_then(|p| p.get("cast"))
+                .and_then(|c| c.get("enum"))
+                .and_then(|e| e.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        for tool in ["consult", "consult_submit", "oneshot"] {
+            let casts = enum_of(tool);
+            assert!(
+                casts.iter().any(|c| c == "myinteractive"),
+                "{tool} enum should list the interactive cast, got {casts:?}"
+            );
+            assert!(
+                !casts.iter().any(|c| c == "mybatch"),
+                "{tool} enum must not list a batch cast, got {casts:?}"
+            );
+        }
+        let batch = enum_of("batch_submit");
+        assert!(
+            batch.iter().any(|c| c == "mybatch"),
+            "batch_submit enum should list the batch cast, got {batch:?}"
+        );
+        assert!(
+            !batch.iter().any(|c| c == "myinteractive"),
+            "batch_submit enum must not list an interactive cast, got {batch:?}"
+        );
+    }
+
+    /// The lane gate's two halves, tested directly: an interactive tool refuses a batch
+    /// cast (naming the cast and `batch_submit`), and `batch_submit` refuses a non-batch
+    /// cast — while each accepts the cast that fits its lane.
+    #[test]
+    fn lane_gate_refuses_the_wrong_lane() {
+        let h = handler();
+        let batch = h.config.resolve_cast("gemini-batch").unwrap().clone();
+        let interactive = h.config.resolve_cast("anthropic").unwrap().clone();
+
+        let err = h
+            .reject_batch_cast(&batch, "consult")
+            .expect_err("an interactive tool must refuse a batch cast");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("gemini-batch") && msg.contains("batch_submit"),
+            "refusal should name the cast and point at batch_submit, got: {msg}"
+        );
+        assert!(h.reject_batch_cast(&interactive, "consult").is_ok());
+
+        let err = h
+            .require_batch_cast(&interactive)
+            .expect_err("batch_submit must refuse a non-batch cast");
+        assert!(
+            format!("{err:?}").contains("not a batch cast"),
+            "refusal should explain the cast isn't a batch cast"
+        );
+        assert!(h.require_batch_cast(&batch).is_ok());
+    }
+
+    /// The gate is wired into the live `batch_submit` handler and fires *before* any
+    /// network: a non-batch cast is refused with no key and no provider call. (`consult`/
+    /// `oneshot` wire the mirror gate the same way, right after `resolve_cast`.)
+    #[tokio::test]
+    async fn batch_submit_handler_refuses_a_non_batch_cast() {
+        let h = handler();
+        let err = h
+            .batch_submit(Parameters(BatchSubmitInput {
+                prompts: vec!["q".to_string()],
+                attach: vec![],
+                cast: Some("anthropic".to_string()),
+                model: None,
+                backend: None,
+            }))
+            .await
+            .expect_err("batch_submit must refuse an interactive cast");
+        assert!(
+            format!("{err:?}").contains("not a batch cast"),
+            "the handler must reject before building any provider client"
+        );
     }
 
     /// `generate_image` advertises its own, *differently-filtered* roster: casts with a
@@ -3692,7 +3858,7 @@ mod tests {
             r#"
             # An openai `image` slot on the keyless local backend → image-capable.
             [casts.art]
-            image = { backend = "openai", id = "sd-xl" }
+            image = { backend = "openai-local", id = "sd-xl" }
 
             # An `image` slot on a non-openai backend → rig has no path → excluded.
             [casts.wrongkind]
@@ -3725,8 +3891,8 @@ mod tests {
             "a non-openai image cast has no rig path and must not be listed: {variants:?}"
         );
         assert!(
-            !variants.contains(&"openai"),
-            "the builtin `openai` cast has no image slot and must not be listed: {variants:?}"
+            !variants.contains(&"openai-local"),
+            "the builtin `openai-local` cast has no image slot and must not be listed: {variants:?}"
         );
     }
 
@@ -4519,7 +4685,7 @@ mod tests {
 
             # openai (toggle-less): sends neither effort nor budget; keeps sampling.
             [casts.oai]
-            synth = { backend = "openai", id = "gemma-local", thinking_budget = 8192, effort = "high", temperature = 0.7 }
+            synth = { backend = "openai-local", id = "gemma-local", thinking_budget = 8192, effort = "high", temperature = 0.7 }
 
             # Anthropic budget tier: takes budget_tokens, no effort; drops sampling under thinking.
             [casts.ant_budget]
@@ -4601,7 +4767,7 @@ mod tests {
             "config resource must show the allowed set:\n{body}"
         );
         // Backends and casts include the built-in four.
-        for name in ["anthropic", "deepseek", "gemini", "openai"] {
+        for name in ["anthropic", "deepseek", "gemini", "openai-local"] {
             assert!(
                 body.contains(&format!("[backends.{name}]")),
                 "config resource must list the {name} backend:\n{body}"
@@ -4945,7 +5111,7 @@ mod tests {
         let config = Config::from_toml_str(
             r#"
             [casts.pinned]
-            synth = { backend = "openai", id = "llava", vision = true, max_tokens = 999 }
+            synth = { backend = "openai-local", id = "llava", vision = true, max_tokens = 999 }
             "#,
         )
         .unwrap();
@@ -4954,7 +5120,7 @@ mod tests {
         h.override_model(&mut cast, ModelRole::Synth, "other-model", None)
             .unwrap();
         let slot = cast.slot(ModelRole::Synth).unwrap();
-        assert_eq!(slot.backend, "openai", "backend kept");
+        assert_eq!(slot.backend, "openai-local", "backend kept");
         assert_eq!(slot.id, "other-model");
         assert_eq!(slot.vision, None, "caps pin dropped — classifies fresh");
         assert_eq!(slot.max_tokens, None, "per-slot tunables dropped");
@@ -5000,7 +5166,7 @@ mod tests {
     #[test]
     fn an_org_prefixed_model_id_stays_on_the_slots_backend() {
         let h = handler();
-        let mut cast = h.resolve_cast(Some("openai".into())).unwrap();
+        let mut cast = h.resolve_cast(Some("openai-local".into())).unwrap();
         h.override_model(
             &mut cast,
             ModelRole::Explorer,
@@ -5009,7 +5175,10 @@ mod tests {
         )
         .unwrap();
         let slot = cast.slot(ModelRole::Explorer).unwrap();
-        assert_eq!(slot.backend, "openai", "the configured backend is kept");
+        assert_eq!(
+            slot.backend, "openai-local",
+            "the configured backend is kept"
+        );
         assert_eq!(slot.id, "google/gemma-3-27b-it", "the id rides verbatim");
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3710,7 +3710,7 @@ mod tests {
     /// The live cast roster is stamped onto each consultation tool's `cast` param as
     /// a JSON-Schema `enum`, so an agent reads the menu off the schema it fills
     /// arguments from — the fix for casts being discoverable only in handshake prose
-    /// a host may truncate. The keyless local `openai` cast is always usable, so it
+    /// a host may truncate. The keyless local `openai-local` cast is always usable, so it
     /// anchors the assertion regardless of which API keys the test env carries.
     #[test]
     fn consultation_tools_advertise_the_live_cast_enum() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1379,12 +1379,12 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Start a `consult` in the background and get back a `job-N` handle \
-            to collect later — the async sibling of `consult` (same investigation, same \
-            args). Reach for it to run several consults at once (a cross-model study: \
+        description = "Submit a `consult` and get a `job-N` handle back immediately — kaibo \
+            runs it in the background. The async sibling of `consult` (same investigation, \
+            same args). Reach for it to run several consults at once (a cross-model study: \
             submit one per cast, collect them all) or when a deep consult would otherwise \
-            block you: submit, go do other work, then `get` the answer (`cancel` stops it, \
-            `list` shows what's in flight, `wait` parks for results). The job lives for \
+            block you: submit, go do other work, then `wait` parks for results / `get` the \
+            answer (`cancel` stops it, `list` shows what's in flight). The job lives for \
             this server session only — collect it before you reconnect. For an answer in \
             this turn, use `consult`. See `kaibo://tools` for the async workflow."
     )]

--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -231,9 +231,13 @@ async fn image_attachment_to_blind_synth_is_refused() {
     slots.insert(ModelRole::Synth, slot);
     config.casts.insert(
         "blindcast".to_string(),
+        // `batch = true`: this exercises `batch_submit`, which now refuses a non-batch
+        // cast before the vision gate. Anthropic is batch-capable, so the cast is valid;
+        // the vision pin is what we're actually testing here.
         Cast {
             name: "blindcast".to_string(),
             slots,
+            batch: true,
         },
     );
     let handler = KaiboHandler::new(config).expect("handler builds");

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -32,15 +32,16 @@ fn builtin_reproduces_the_historical_defaults() {
     // The per-request LLM deadline default: 15 min (see Defaults::default).
     assert_eq!(c.defaults.request_timeout, Duration::from_secs(900));
 
-    // Four built-in backends + four same-named single-backend casts, carrying
-    // the model ids that used to live on the profiles.
+    // Four built-in backends + four single-backend casts, carrying the model ids
+    // that used to live on the profiles. Named after their kind, except the OpenAI
+    // built-in, which is `openai-local` (it defaults to a local endpoint).
     for kind in [
         ProviderKind::Anthropic,
         ProviderKind::DeepSeek,
         ProviderKind::Gemini,
         ProviderKind::Openai,
     ] {
-        let name = kind.canonical_name();
+        let name = kind.builtin_name();
         let backend = c.resolve_backend(name).unwrap();
         assert_eq!(backend.kind, kind);
         assert_eq!(backend.request_timeout, Duration::from_secs(900));
@@ -51,7 +52,7 @@ fn builtin_reproduces_the_historical_defaults() {
         let s = cast.require_slot(ModelRole::Synth).unwrap();
         assert_eq!(e.id, explorer, "{kind:?} explorer");
         assert_eq!(s.id, synth, "{kind:?} synth");
-        // Built-in casts are single-backend, named after their kind.
+        // Built-in casts are single-backend, named by `builtin_name`.
         assert_eq!(e.backend, name);
         assert_eq!(s.backend, name);
 
@@ -111,8 +112,8 @@ fn builtin_aliases_resolve_at_both_levels() {
     for a in ["local", "lemonade", "gemma", "gemma4"] {
         assert_eq!(
             c.resolve_cast(a).unwrap().name,
-            "openai",
-            "{a:?} should alias the openai cast"
+            "openai-local",
+            "{a:?} should alias the openai-local cast"
         );
     }
     // Backend level.
@@ -121,8 +122,8 @@ fn builtin_aliases_resolve_at_both_levels() {
     for a in ["local", "lemonade", "gemma", "gemma4"] {
         assert_eq!(
             c.resolve_backend(a).unwrap().name,
-            "openai",
-            "{a:?} should alias the openai backend"
+            "openai-local",
+            "{a:?} should alias the openai-local backend"
         );
     }
 }
@@ -224,14 +225,14 @@ fn a_chimera_cast_spans_backends_with_both_slot_forms() {
 #[test]
 fn slot_refs_split_on_the_first_slash_only() {
     // HuggingFace-style ids keep their inner slash: only the FIRST `/` splits.
-    let (backend, id) = parse_slot_ref("openai/Qwen/Qwen3-32B").unwrap();
-    assert_eq!(backend, "openai");
+    let (backend, id) = parse_slot_ref("openai-local/Qwen/Qwen3-32B").unwrap();
+    assert_eq!(backend, "openai-local");
     assert_eq!(id, "Qwen/Qwen3-32B");
     // And the same through the TOML string form.
     let c = Config::from_toml_str(
         r#"
         [casts.hf]
-        synth = "openai/Qwen/Qwen3-32B"
+        synth = "openai-local/Qwen/Qwen3-32B"
         "#,
     )
     .unwrap();
@@ -315,7 +316,7 @@ fn a_vision_pin_on_a_slot_wins_over_the_classifier() {
     let c = Config::from_toml_str(
         r#"
         [casts.x]
-        explorer = { backend = "openai", id = "llava-13b", vision = true }
+        explorer = { backend = "openai-local", id = "llava-13b", vision = true }
         synth = { backend = "anthropic", id = "claude-sonnet-4-6", vision = false }
         "#,
     )
@@ -363,7 +364,7 @@ fn two_openai_backends_resolve_to_distinct_endpoints() {
     assert_eq!(llama.resolved_base_url(), "http://localhost:8080/v1");
     // The built-ins are still present alongside.
     assert!(c.resolve_backend("anthropic").is_ok());
-    assert!(c.resolve_cast("openai").is_ok());
+    assert!(c.resolve_cast("openai-local").is_ok());
 }
 
 #[test]
@@ -371,7 +372,7 @@ fn a_builtin_openai_backend_without_base_url_uses_the_env_default() {
     // No explicit base_url → the resolved URL is whatever OPENAI_BASE_URL/default
     // yields (env-robust check).
     let c = Config::builtin();
-    let b = c.resolve_backend("openai").unwrap();
+    let b = c.resolve_backend("openai-local").unwrap();
     assert_eq!(b.resolved_base_url(), openai_base_url());
 }
 
@@ -509,7 +510,7 @@ fn an_unknown_backend_in_a_slot_names_the_known_backends() {
     let msg = format!("{err:#}");
     assert!(msg.contains("unknown backend \"nope\""), "got: {msg}");
     assert!(msg.contains("known backends"), "got: {msg}");
-    for known in ["anthropic", "deepseek", "gemini", "openai"] {
+    for known in ["anthropic", "deepseek", "gemini", "openai-local"] {
         assert!(msg.contains(known), "should name {known}, got: {msg}");
     }
 }
@@ -662,7 +663,7 @@ fn a_new_openai_backend_without_base_url_is_rejected_loudly() {
     // A user-declared openai-kind backend with a forgotten base_url would
     // silently dial the global default endpoint (OPENAI_BASE_URL or the local
     // llama.cpp server) — a wrong-server 404 mid-call. Only the built-in
-    // `openai` backend keeps that fallback; a new stanza must say where it points.
+    // `openai-local` backend keeps that fallback; a new stanza must say where it points.
     let err = Config::from_toml_str(
         r#"
         [backends.sd]
@@ -677,10 +678,10 @@ fn a_new_openai_backend_without_base_url_is_rejected_loudly() {
         "names the missing key, got: {msg}"
     );
     assert!(msg.contains("sd"), "names the backend, got: {msg}");
-    // The built-in `openai` backend keeps the env/default fallback: overriding
+    // The built-in `openai-local` backend keeps the env/default fallback: overriding
     // it without base_url stays valid, and a config-less load is unchanged.
-    let c = Config::from_toml_str("[backends.openai]\nkey_optional = false\n").unwrap();
-    assert!(c.resolve_backend("openai").unwrap().base_url.is_none());
+    let c = Config::from_toml_str("[backends.openai-local]\nkey_optional = false\n").unwrap();
+    assert!(c.resolve_backend("openai-local").unwrap().base_url.is_none());
 }
 
 #[test]
@@ -731,7 +732,7 @@ fn an_inverted_thinking_budget_is_rejected_at_the_resolved_slot() {
     Config::from_toml_str(
         r#"
         [casts.x]
-        synth = { backend = "openai", id = "m", max_tokens = 1000, thinking_budget = 2000 }
+        synth = { backend = "openai-local", id = "m", max_tokens = 1000, thinking_budget = 2000 }
         "#,
     )
     .expect("openai-kind slots have no budget/headroom coupling");
@@ -790,7 +791,7 @@ fn out_of_range_sampling_is_a_loud_error() {
     let err = Config::from_toml_str(
         r#"
         [casts.x]
-        synth = { backend = "openai", id = "m", temperature = 3.0 }
+        synth = { backend = "openai-local", id = "m", temperature = 3.0 }
         "#,
     )
     .unwrap_err();
@@ -1281,8 +1282,8 @@ fn the_shipped_example_config_parses() {
 fn a_bare_slot_carries_no_pins_or_tunables() {
     // `ModelSlot::bare` is the shape a per-call model override produces: the new
     // id classifies fresh, so no pin or tunable from the old slot may ride along.
-    let slot = ModelSlot::bare("openai", "some-model");
-    assert_eq!(slot.qualified(), "openai/some-model");
+    let slot = ModelSlot::bare("openai-local", "some-model");
+    assert_eq!(slot.qualified(), "openai-local/some-model");
     assert_eq!(slot.vision, None);
     assert_eq!(slot.max_tokens, None);
     assert_eq!(slot.thinking_budget, None);
@@ -1551,7 +1552,7 @@ fn a_slot_carries_a_per_model_preamble() {
     let c = Config::from_toml_str(
         r#"
         [casts.team]
-        explorer = { backend = "openai", id = "Gemma-4-E4B-it", preamble = "You are a careful reader." }
+        explorer = { backend = "openai-local", id = "Gemma-4-E4B-it", preamble = "You are a careful reader." }
         synth = "anthropic/claude-sonnet-4-6"
         "#,
     )

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -580,7 +580,7 @@ fn builtin_openai_cast_is_cheap_gemma_explorer_strong_gemma_synth() {
 
     // And the built-in `openai` cast resolves to exactly those, on the openai backend.
     let cfg = Config::builtin();
-    let cast = cfg.resolve_cast("openai").expect("built-in openai cast");
+    let cast = cfg.resolve_cast("openai-local").expect("built-in openai cast");
     let e = cast
         .require_slot(ModelRole::Explorer)
         .expect("explorer slot");
@@ -1285,8 +1285,8 @@ async fn recomposed_consult_runs_against_local_gemma() {
         "How does kaibo stop the explorer from deleting real files? Name the mechanism and the file.",
         None,
         root,
-        &builtin_arm("openai", ModelRole::Explorer),
-        &builtin_arm("openai", ModelRole::Synth),
+        &builtin_arm("openai-local", ModelRole::Explorer),
+        &builtin_arm("openai-local", ModelRole::Synth),
         &cfg,
         None,
     )
@@ -1315,7 +1315,7 @@ async fn recomposed_consult_runs_against_local_gemma() {
 #[tokio::test]
 #[ignore = "hits the local OpenAI-compatible (Gemma) server (oneshot); run with --ignored while it's up"]
 async fn oneshot_answers_from_pasted_context() {
-    let arm = builtin_arm("openai", ModelRole::Synth);
+    let arm = builtin_arm("openai-local", ModelRole::Synth);
 
     let answer = oneshot(
         "Context: src/sandbox.rs builds a read-only kernel; the LocalFs read-only \

--- a/tests/llm_timeout.rs
+++ b/tests/llm_timeout.rs
@@ -43,14 +43,14 @@ async fn oneshot_aborts_when_the_provider_never_responds() {
     // deadline so the test is quick but the mechanism is the production one.
     let cfg = Config::builtin();
     let mut backend = cfg
-        .resolve_backend("openai")
+        .resolve_backend("openai-local")
         .expect("built-in openai backend")
         .clone();
     backend.base_url = Some(base_url);
     backend.key_optional = true;
     backend.request_timeout = Duration::from_secs(2);
 
-    let cast = cfg.resolve_cast("openai").expect("built-in openai cast");
+    let cast = cfg.resolve_cast("openai-local").expect("built-in openai cast");
     let slot = cast
         .require_slot(ModelRole::Synth)
         .expect("openai cast has a synth slot");


### PR DESCRIPTION
Two related cast-semantics changes, folded into one PR at Amy's request.

## Why

A `gemini-batch` cast run through `consult_submit` did the wrong thing: it ran the offline-tuned Pro synth through the **interactive** tool loop — slow and expensive — while getting **none** of the provider batch API. The root cause: "batch" was never a property of a cast, only a naming convention, and `gemini-batch`'s own comment invited consult use ("usable for consult too").

## What changed

### Batch casts are a declared, enforced lane

- A cast declares its lane positively with **`batch = true`**.
- **Mixing is verboten both ways** (Amy's call — an accidental Opus/Pro batch is just as costly in the other direction, especially once Fable returns):
  - `consult` / `consult_submit` / `oneshot` / `generate_image` refuse a batch cast.
  - `batch_submit` refuses a non-batch cast.
  - Both gates fire right after the cast resolves, **before any network**, naming the right tool.
- The per-tool `cast` **enums split to match**: interactive tools advertise non-batch casts; `batch_submit` advertises only batch casts — advertised menu and runtime gate agree.
- Batch built-ins carry **synth only** (batch is a toolless oneshot): `gemini-batch` loses its now-dead explorer, and a new **`anthropic-batch`** ships (synth Opus, the Anthropic analogue of Gemini Pro).
- A `batch = true` cast whose synth backend has **no batch API** is a loud config-load error, not a 400 at submit time.

### `openai` built-in renamed to `openai-local`

The built-in `openai` connection defaults to a *local* keyless server, so the bare name misrepresented it.

- Now **`openai-local`**, via a new `ProviderKind::builtin_name()` that diverges only for Openai.
- The wire-protocol id stays `openai` — `canonical_name()`, the `kind = "openai"` field, and `FromStr` are unchanged.
- `openai` is **deliberately not an alias**, so a user can name their own `[backends.openai]` (the hosted API) without a collision. Aliases stay `local` / `lemonade` / `gemma` / `gemma4`.

### `consult_submit` description fix + a text-for-models doctrine

Tagging along because it's the same surface (the async tool descriptions) and the same review.

- A Claude Code client called `consult_submit` three times, then wrapped the calls in the host's own `run_in_background` — because the description led with "Start a `consult` in the background … to collect later". The missing signal was that **the call returns at once and kaibo already does the backgrounding**. New opener: "Submit a `consult` and get a `job-N` handle back immediately — kaibo runs it in the background." "immediately" reclaims the dead "to collect later", so the block stays ~flat; also surfaces `wait` ahead of `get`. `batch_submit` is left untouched — its "Fire-and-forget" + durable cross-restart handle already carry it.
- AGENTS.md gains a **Writing for models** section: re-read whole blocks holistically, ratchet toward compression (改善). Two audiences optimized differently — client-facing tool descriptions are *resident* per-session cost (they load whether or not the tool is ever called, so density is existential), agent-facing preambles run on large-context models where verbosity is licensed where it shapes behavior.

## Testing

- Offline suite green: **279 lib + every integration suite**.
- The gate's teeth are proven by a failing-first test (neutering it lets a real batch submit through).
- Both gate directions were **dogfood-verified live** on the rebuilt binary: `oneshot` + `anthropic-batch` and `batch_submit` + `deepseek` both refuse with the right pointer; the lane-split enums show on the live tool schemas.

## Review notes

Per repo discipline this wants a **cross-family** review of the diff (a different lineage than wrote it). The sensitive parts are the gate wiring in `server.rs` and the name-vs-kind separation in the `openai-local` rename (`kind = "openai"`, the rig source path `providers/openai/…`, and `api.openai.com` all correctly stay `openai`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
