### PR TITLE
docs: plan the release pipeline (OSS / GitHub-native, living doc)

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,35 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-07-05 — the build bootstrap: never-fired workflow → verified first release, in a day
+
+The release plan (PR #25, `docs/releases.md`) had sat unmerged since 2026-06-25 with its
+central artifact — `release.yml` — never once executed. Amy's call: review the plan, update
+it, then *realize* it as quick small PRs, Sonnet subagents on the toil, short bootstrapping
+prose. The day's shape validated two of the plan's own bets and overturned two predictions:
+
+- **"Fire it first" beat speculative hardening.** The baseline `workflow_dispatch` went
+  all-five-legs green on the first run ever — the pre-flight cross-family review's
+  high-confidence prediction (macOS `sha256sum` missing) was wrong (runners ship coreutils),
+  so the dial-in list became warnings-driven, not failure-driven. Measure, then fix.
+- **The one prediction that fired, fired on *us*.** The `ref_name`-slash footgun (flagged
+  latent, slated for later) broke slice (a)'s own validation dispatch from `ci/…` — the
+  validation path *is* a slash-bearing branch. Moved into the slice that hit it.
+- **Every slice validated live before review** (dispatch from the branch), and cross-family
+  review earned its keep twice: DeepSeek's 7z-entry-order finding became a stated
+  single-file boundary comment, and its taiki-e/dtolnay pin semantics all checked out
+  against independently-verified digests.
+- **The rc smoke tag closed the loop.** `v0.2.0-rc.1` exists to prove the never-run publish
+  leg *before* signing lands, so the real v0.2.0 ships born signed (plan PR 3). Proven the
+  way a user would: release download → checksum → fully static → `kaibo 0.2.0-rc.1`.
+- **CI arrived the same day** (#64) because the release bones were already right — same
+  pins, same voice, plus the TLS invariant finally getting automated teeth (a `cargo tree`
+  tripwire asserting on error text; exit codes proved unreliable for absent packages).
+
+Ships: #60 pins+permissions, #61 arm leg+smoke, #62 reproducible archives, #63 rc bump,
+#64 first CI, tag `v0.2.0-rc.1`. PRs 3–5 of the plan (signing/provenance/SBOM, ghcr image,
+channels) remain, sequenced in `docs/releases.md`.
+
 ## 2026-07-04 — `job_wait` parks-and-coalesces instead of returning on the first line
 
 Running the kaish 0.11.0 pre-release review as one background consult, Amy parked with

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -232,10 +232,14 @@ GitHub-native tooling: `cosign` **keyless** signing + **SLSA provenance**
 back-half **only if** package channels (brew/scoop/winget/nfpm) multiply. **GoReleaser Pro
 and any release-as-a-service are off the table** (the latter doesn't viably exist — see the
 doc's axo note). No Windows ABI change — MSVC stays, so the CLAUDE.md invariant is
-untouched. ghcr distroless image is **demoted/optional** (stdio server = `docker run -i`
-friction). **Parked behind the pre-1.0 work** — no `v*` tags until release-ready. Sequenced
-PRs (1 plan doc → 2 harden matrix → 3 signing/provenance/SBOM → 4 optional ghcr image →
-5 channels, gated on demand) in the doc; delete this entry when the pipeline ships.
+untouched. The **ghcr image is a first-class, early distribution path** (multiarch, non-root
+default, devcontainer-friendly; an OS-enforced containment layer under kaibo's own read-only
+sandbox) — with a companion **`/reconfigure`** host-agent prompt to tame the docker/podman/
+devcontainer `mcp add` config friction (kaibo advises via `kaibo://config`, the host agent
+edits — kaibo can't write configs or run docker). **Parked behind the pre-1.0 work** — no
+`v*` tags until release-ready. Sequenced PRs (1 plan doc → 2 harden matrix → 3 signing/
+provenance/SBOM → 4 ghcr image + container UX → 5 channels, gated on demand) in the doc;
+delete this entry when the pipeline ships.
 
 ### `KaishWorker::read_file` is unbounded — stat-then-read growth race
 `sandbox.rs` `Job::Read` slurps the whole file through the VFS with no size cap.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -219,6 +219,19 @@ in-process and reliable); the classification covers the user-facing symptom toda
 
 ## P3 — Infra, perf, polish
 
+### Release pipeline — GoReleaser, ghcr, signing (plan in `docs/releases.md`)
+The full plan and its decisions live in **`docs/releases.md`** (living doc); this is the
+tracker pointer. Direction settled 2026-06-25 (w/ Amy): **adopt GoReleaser** (the Rust
+builder = the same `cargo-zigbuild` engine `release.yml` already uses), **ghcr.io
+distroless** multi-arch images, **Sigstore keyless signing + SLSA provenance**. The
+existing `.github/workflows/release.yml` (6-target matrix, never fired) gets replaced by
+a thin SHA-pinned `goreleaser-action` workflow. **Parked behind the pre-1.0 work** — we
+don't cut `v*` tags until kaibo is release-ready; the PRs land incrementally before then.
+One invariant change rides PR 2: Windows moves `-msvc` → `-gnu` (zigbuild can't target
+MSVC), which the CLAUDE.md **Build & release** section must reword. Sequenced PRs (1
+plan doc → 2 GoReleaser core → 3 ghcr image → 4 signing → 5 brew → 6 scoop/winget) in
+the doc; delete this entry when the pipeline ships.
+
 ### `KaishWorker::read_file` is unbounded — stat-then-read growth race
 `sandbox.rs` `Job::Read` slurps the whole file through the VFS with no size cap.
 Both attachment resolvers check `metadata().len()` against their cap/budget *before*

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -236,10 +236,11 @@ untouched. The **ghcr image is a first-class, early distribution path** (multiar
 default, devcontainer-friendly; an OS-enforced containment layer under kaibo's own read-only
 sandbox) — with a companion **`/reconfigure`** host-agent prompt to tame the docker/podman/
 devcontainer `mcp add` config friction (kaibo advises via `kaibo://config`, the host agent
-edits — kaibo can't write configs or run docker). **Parked behind the pre-1.0 work** — no
-`v*` tags until release-ready. Sequenced PRs (1 plan doc → 2 harden matrix → 3 signing/
-provenance/SBOM → 4 ghcr image + container UX → 5 channels, gated on demand) in the doc;
-delete this entry when the pipeline ships.
+edits — kaibo can't write configs or run docker). **Going wide is gated on install ease**
+(engineering PRs and even tags land first — `v0.2.0-rc.1` already proved the tag→release
+leg). Sequenced PRs (1 plan doc, 2 harden matrix — both realized 2026-07-05 → **next: 3
+signing/provenance/SBOM** → 4 ghcr image + container UX → 5 channels, gated on demand) in
+the doc; delete this entry when the pipeline ships.
 
 ### `KaishWorker::read_file` is unbounded — stat-then-read growth race
 `sandbox.rs` `Job::Read` slurps the whole file through the VFS with no size cap.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -219,18 +219,23 @@ in-process and reliable); the classification covers the user-facing symptom toda
 
 ## P3 — Infra, perf, polish
 
-### Release pipeline — GoReleaser, ghcr, signing (plan in `docs/releases.md`)
+### Release pipeline — harden native matrix + GitHub-native signing (plan in `docs/releases.md`)
 The full plan and its decisions live in **`docs/releases.md`** (living doc); this is the
-tracker pointer. Direction settled 2026-06-25 (w/ Amy): **adopt GoReleaser** (the Rust
-builder = the same `cargo-zigbuild` engine `release.yml` already uses), **ghcr.io
-distroless** multi-arch images, **Sigstore keyless signing + SLSA provenance**. The
-existing `.github/workflows/release.yml` (6-target matrix, never fired) gets replaced by
-a thin SHA-pinned `goreleaser-action` workflow. **Parked behind the pre-1.0 work** — we
-don't cut `v*` tags until kaibo is release-ready; the PRs land incrementally before then.
-One invariant change rides PR 2: Windows moves `-msvc` → `-gnu` (zigbuild can't target
-MSVC), which the CLAUDE.md **Build & release** section must reword. Sequenced PRs (1
-plan doc → 2 GoReleaser core → 3 ghcr image → 4 signing → 5 brew → 6 scoop/winget) in
-the doc; delete this entry when the pipeline ships.
+tracker pointer. Direction settled 2026-06-25 (w/ Amy): **stay OSS / GitHub-native** —
+keep the existing native `release.yml` matrix (native macOS, native Windows MSVC, Linux
+musl via zigbuild) on GitHub-hosted runners, harden it (SHA-pin actions, `--version`
+smoke per target, reproducible archives), then add the transparency payoff with free
+GitHub-native tooling: `cosign` **keyless** signing + **SLSA provenance**
+(`actions/attest-build-provenance`) + an **SBOM** (`syft`). **No GoReleaser as the spine**
+(its cross-compile value doesn't apply — macOS can't cross from Linux given
+`security-framework`, so we build native anyway); GoReleaser-OSS is an *optional later*
+back-half **only if** package channels (brew/scoop/winget/nfpm) multiply. **GoReleaser Pro
+and any release-as-a-service are off the table** (the latter doesn't viably exist — see the
+doc's axo note). No Windows ABI change — MSVC stays, so the CLAUDE.md invariant is
+untouched. ghcr distroless image is **demoted/optional** (stdio server = `docker run -i`
+friction). **Parked behind the pre-1.0 work** — no `v*` tags until release-ready. Sequenced
+PRs (1 plan doc → 2 harden matrix → 3 signing/provenance/SBOM → 4 optional ghcr image →
+5 channels, gated on demand) in the doc; delete this entry when the pipeline ships.
 
 ### `KaishWorker::read_file` is unbounded — stat-then-read growth race
 `sandbox.rs` `Job::Read` slurps the whole file through the VFS with no size cap.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -45,10 +45,20 @@ the free GitHub-native signing/attestation layer. Specifically:
    Pro is off the table** — at $165/yr it would buy us orchestration of a build it isn't
    doing (we're native-matrix) plus notarization we can wire ourselves. If GoReleaser
    ever enters, it's the free OSS version, as a back-half channel publisher.
-4. **The ghcr container image is demoted to optional.** kaibo is a stdio MCP server that
-   operators launch as a *subprocess*; a container adds `docker run -i` + read-only-mount
-   friction that two independent reviewers called actively hostile for this shape. If we
-   ship it, the friction gets documented loudly and it's gated on real demand.
+4. **Ship the ghcr image as a first-class, early distribution path — not optional**
+   (decided with Amy, 2026-06-25). The reviewers' "stdio + container is hostile" objection
+   was scoped to a *host* agent hand-building `docker run -i` mounts; the **devcontainer**
+   case flips it — inside a devcontainer everything is already containerized and mounts are
+   declared in `devcontainer.json`, so a kaibo container is *idiomatic*. It also doubles as
+   an **OS-enforced containment layer beneath kaibo's own read-only sandbox** (belt and
+   suspenders): it doesn't replace the app-level boundary, it backstops it — limiting
+   blast radius if the sandbox code has a bug, and giving the operator a place to shape
+   kaibo's outbound-to-provider egress (controlled egress, *not* full isolation, or the
+   provider calls die). Non-negotiables: **multiarch** (amd64+arm64, from the per-arch
+   musl binaries we already build), **non-root by default** (`distroless:nonroot`), and
+   **documented user/volume mapping**. The real friction is *not* `-i` — it's UID/volume
+   mapping (podman `--userns=keep-id` vs docker `-u $(id -u):$(id -g)` against a read-only
+   project mount), which the configurator pass resolves (see "Container UX" below).
 
 ## Why we revised (the investigation)
 
@@ -164,14 +174,40 @@ The transparency payoff; all free, no middleman.
   --certificate-oidc-issuer …` and `gh attestation verify` invocations. Verification an
   operator can't run is theater.
 
-### PR 4 — ghcr distroless image *(optional / demoted — gated on demand)*
-Only if there's a real consumer; kaibo is stdio, so weigh it honestly.
-- Multi-arch `amd64`+`arm64` image `FROM gcr.io/distroless/static`, copying the static musl
-  binary; `COPY --chown=nonroot` / `USER nonroot`. Push to `ghcr.io/tobert/kaibo` (+`latest`).
-- Workflow gains ghcr login + `packages: write`; `cosign` signs the image too.
-- **Document the stdio friction loudly:** `docker run -i` is mandatory (silent EOF-exit
-  otherwise), and the operator must volume-mount any codebase the agent reads (read-only).
-  Smoke-test an outbound HTTPS call (TLS certs present in distroless).
+### PR 4 — ghcr distroless image (multiarch, non-root) — a first-class distribution path
+Lands *after* signing so the image is **born signed** — we don't ship an unsigned primary
+artifact.
+- **Multiarch `amd64`+`arm64`** manifest `FROM gcr.io/distroless/static:nonroot`, copying
+  the static musl binaries already built per-arch; `USER nonroot`. Push to
+  `ghcr.io/tobert/kaibo` (+`latest`); `cosign` signs the image with the PR 3 machinery.
+- Workflow gains ghcr login + `packages: write`.
+- **User/volume mapping is the core UX to document** (not `-i`): a read-only project mount +
+  UID mapping (docker `-u $(id -u):$(id -g)`, podman `--userns=keep-id`), and the
+  **devcontainer recipe** — the sweet spot, where mounts are already declared and kaibo
+  slots in as an MCP server. There is no truly zero-mount form (kaibo's job is reading your
+  code), so the documented baseline mounts cwd read-only; the configurator tailors the rest.
+- **Graceful no-stdin error**, not a silent EOF-exit 0 — the entrypoint detects a missing
+  stdin and prints a clear message (`distroless` has no shell to debug into). Smoke-test an
+  outbound HTTPS call (TLS certs present in distroless).
+
+### Container UX: the configurator / `reconfigure` pass (related host-agent workstream)
+The Docker downside is real — a verbose `docker run -i -u … -v …` line is painful to get
+right in `claude mcp add`, and iterating means a frustrating remove/re-add loop. Fix it in
+two phases: a known-good **baseline** `mcp add` (cwd mounted read-only) connects you, then a
+companion **`/reconfigure`** rewrites the *stored* MCP config **in place** for the user's
+real setup — podman vs docker, UID mapping, extra roots/worktrees, network policy,
+devcontainer nesting — which kills the re-add loop (you edit `~/.claude.json`, you don't
+re-run `mcp add`).
+
+**Where it lives matters for the invariants:** kaibo is read-only and runs no external
+commands, so it **cannot** write `~/.claude.json` or run docker itself. So `reconfigure` is
+a **host-agent skill / a kaibo-provided MCP *prompt***: kaibo *advises* (it already knows
+the roots/mounts it needs and exposes them via `kaibo://config`, so it can hand the agent
+the exact `-v` flags), and the host agent *acts* (edits the config with its own tools). That
+split keeps kaibo's stdio/read-only invariants intact. A tiny generated `kaibo-docker`
+wrapper script is an alternative the configurator could emit (point `mcp add` at the wrapper,
+iterate the wrapper, not the stored command). This is a distribution-UX workstream that
+rides alongside PR 4, not release-pipeline YAML.
 
 ### PR 5 — channels (Homebrew first), gated on demand
 - **Pre-req (external):** create the `tobert/homebrew-kaibo` tap repo + a token with access.
@@ -205,8 +241,13 @@ reference for the signing/attestation layer other projects lack:
 
 ## Open decisions
 
-- **Docker (PR 4): keep / demote / drop.** Leaning *demote-or-drop* — two reviewers judged a
-  container a poor fit for a subprocess-launched stdio server. Final call before PR 4.
+- **Docker — RESOLVED (2026-06-25, with Amy): keep & promote** to a first-class, early
+  distribution path (multiarch, non-root default, devcontainer-friendly). See decision 4 and
+  PR 4.
+- **Configurator / `reconfigure` ownership & scope** — a kaibo MCP prompt, a Claude Code
+  skill, or both? How much does it auto-detect (podman/devcontainer/UID) vs. ask? It edits a
+  sensitive file (`~/.claude.json`) with the *host agent's* tools (kaibo can't), so consent/
+  safety shape it. Design when PR 4's container UX is real.
 - **How many channels?** Few (a brew tap) → hand-roll, no GoReleaser. Many (brew+scoop+winget+nfpm)
   → bring in GoReleaser-OSS as the back-half. Decide when demand is real, not now.
 - **macOS signing timeline** — notarization needs the $99/yr Apple account; decide when a

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,214 @@
+# Releasing kaibo — pipeline plan & living record
+
+解剖（かいぼう）ships as a single static-ish binary per platform. This document is the
+*living* plan for how we build and publish those binaries — the sequence of PRs that
+gets us from "a workflow that has never fired" to "signed, attested, multi-channel
+releases an agent operator can trust." Update it as PRs land; it is the durable map the
+conversation can't reconstruct.
+
+> **Gating note.** This whole pipeline is **parked behind the pre-1.0 work** — kaibo is
+> not ready for a public release yet, and we will not cut `v*` tags in anger until that
+> lands. The value of writing the plan now is to *settle the decisions* so we don't
+> re-litigate them later, and to let the PRs land incrementally (each is independently
+> reviewable and mergeable) as the runway clears. Nothing here forces a release.
+
+---
+
+## Where we are now
+
+`.github/workflows/release.yml` already exists: a hand-rolled 6-target matrix (musl
+static via `cargo-zigbuild`, native macOS/Windows), `tar.gz`/`zip` packaging, sha256
+sidecars, and a `softprops/action-gh-release` publish on a `v*` tag. **It has never
+fired.** It is a good baseline — the static-musl + ring/no-aws-lc groundwork is real —
+but it does no Docker, no signing, no package channels, and it pins its actions by
+floating tag.
+
+## The decisions (2026-06-25, with Amy)
+
+1. **Adopt GoReleaser.** Replace the hand-rolled matrix with a `.goreleaser.yml` driven
+   by `goreleaser-action`. Amy has run GoReleaser on `otel-cli` (Go) for years, so the
+   `.goreleaser` shape, ghcr `dockers`/`docker_manifests`, and `brews` tap pattern are
+   familiar — kaibo reuses those patterns rather than inventing them. One config
+   collapses build + archive + checksum + changelog + release, and unlocks
+   Homebrew/Scoop/Winget, Docker, and signing as additive blocks.
+2. **Container images on `ghcr.io`, distroless base.** Same OIDC/`GITHUB_TOKEN` trust
+   path as the repo, no Docker Hub account or pull-rate tax. Base
+   `gcr.io/distroless/static` (CA certs / tzdata / nonroot user available if the stdio
+   process ever needs them), multi-arch `amd64`+`arm64` via `docker_manifests` — mirrors
+   the `otel-cli` ghcr layout.
+3. **Sigstore keyless signing + SLSA provenance.** `cosign` keyless (OIDC, *no
+   long-lived key to manage or leak*) over the archives, checksums, and image, plus
+   GitHub build-provenance attestation. This is new ground — `otel-cli` has no `signs:`
+   block — and it is the concrete payoff of staying on public CI (see "Why public CI").
+
+## Why GoReleaser, and the one thing Go never made us face
+
+GoReleaser's **Rust builder** (`builder: rust`, since v2.5) defaults to `cargo-zigbuild`
+— the *same* toolchain the current workflow already uses for musl. So the build engine
+doesn't change; GoReleaser just orchestrates it and everything downstream.
+
+The gotcha: **`cargo-zigbuild` can target `windows-gnu` but not `windows-msvc`** (zig
+links its bundled MinGW-w64, not MSVC). `otel-cli` cross-compiles MSVC-free Windows
+trivially *because it's Go*; Rust+zig cannot. GoReleaser's OSS path builds every target
+on **one Linux runner** (multi-runner "split & merge" is a **Pro** feature), so the
+coherent OSS choice is to cross-compile all targets from Linux:
+
+| Target | How | Notes |
+| --- | --- | --- |
+| `x86_64-unknown-linux-musl` | zigbuild | fully static (`not a dynamic executable`) |
+| `aarch64-unknown-linux-musl` | zigbuild | fully static |
+| `x86_64-apple-darwin` | zigbuild cross | builds unsigned; notarization deferred |
+| `aarch64-apple-darwin` | zigbuild cross | builds unsigned; notarization deferred |
+| `x86_64-pc-windows-gnu` | zigbuild cross | **was `-msvc`** — see invariant change below |
+
+**This cross-compile-from-one-runner is only feasible because of the TLS invariant**
+(rustls + ring, no aws-lc-sys / no OpenSSL): a C-free tree is what lets zig link
+darwin/windows-gnu without an MSVC install or a fragile aws-lc cross-build. The
+invariant we already hold is what makes the cheap path possible.
+
+### Invariant change this forces (do not skip)
+
+The CLAUDE.md **Build & release** section currently says *"Windows statically links the
+CRT via `+crt-static`"* (MSVC). Moving to `cargo-zigbuild` makes that **`x86_64-pc-
+windows-gnu`, statically linked against zig's bundled MinGW-w64.** The PR that lands the
+GoReleaser build (PR 2 below) must reword that bullet and the `.cargo/config.toml`
+note. For a CLI/MCP binary the gnu ABI is a non-issue; we trade the MSVC ABI for a
+single-runner OSS build. *(Open question — see below — is whether keeping MSVC + native
+runners is worth GoReleaser Pro. Default answer: no.)*
+
+## The deferred paid toll (no tool removes these)
+
+- **macOS notarization** — needs a Mac + an Apple Developer account ($99/yr). Until
+  then macOS binaries are *unsigned*: a Homebrew-tap install is fine (not quarantined),
+  but a direct download trips Gatekeeper (`xattr -d com.apple.quarantine`). Document
+  honestly; revisit when a public release justifies the cost.
+- **Windows Authenticode** — needs a code-signing cert ($). Until then the `.exe` is
+  unsigned (SmartScreen friction). Same posture: document, defer.
+
+Both are *automatable* by GoReleaser when we choose to pay; they're a cost decision, not
+a tooling gap.
+
+## Why public CI (and not local builds)
+
+Amy's instinct was that *no* public CI keeps kaibo off the radar of botnets hunting CI
+to attack, and that local builds might feel more honest. The analysis landed the other
+way, and it's worth recording so we don't reopen it:
+
+- The mass-attack vectors hunt for workflows that run on **fork PRs** (free-runner
+  crypto-mining) or that leak **long-lived secrets**. A **tag-only + `workflow_dispatch`**
+  release workflow with **no PAT** dodges both by shape.
+- The real residual risk is a **compromised third-party action** (cf. the
+  `tj-actions/changed-files` incident). Mitigation is cheap: **pin every `uses:` to a
+  commit SHA**, which every PR below does.
+- **Local builds fight the transparency goal.** A public CI log is a third-party-
+  witnessed, reproducible record; a laptop is an opaque box whose provenance is "Amy
+  says so." The modern answer to "why trust this binary" is **keyless provenance
+  attestation**, which is only cheaply attainable from public CI with OIDC — local
+  builds *structurally cannot* produce it. So public CI, hardened, maximizes
+  transparency **and** minimizes realistic attack surface; going dark trades the goal
+  for obscurity.
+- If hardware control is ever the itch, a **self-hosted runner** scratches it without
+  losing the public workflow — but for a tag-only release the GitHub-hosted runners
+  cost nothing and carry less surface. Not planned.
+
+---
+
+## The PR sequence
+
+Each PR lands on its own branch in a **git worktree** (Amy's workflow for this series),
+goes up as a PR, gets a **cross-family review** (a different model lineage than wrote
+it), and updates `CHANGELOG.md` where user-facing. They're ordered lowest-coupling
+first; signing comes after the artifacts exist; channels (which need external repos)
+come last.
+
+> **Pre-flight (not a PR):** fire the *existing* `release.yml` once via
+> `workflow_dispatch` to confirm the current matrix still produces good binaries — a
+> known-good baseline before GoReleaser's complexity. If it's already untrusted, skip
+> straight to PR 2 and validate there with `goreleaser release --snapshot --clean`.
+
+### PR 1 — this document
+The living plan itself (`docs/releases.md`). Settles the decisions above. No pipeline
+change. *(You are reading the artifact.)*
+
+### PR 2 — GoReleaser core: build + archive + checksum + release
+The foundation everything hangs off.
+- Add `.goreleaser.yml` (`version: 2`, `builder: rust`, the 5 targets above), `archives`
+  (`tar.gz`; `zip` override for windows), `checksum`, `changelog`.
+- Replace the hand-rolled matrix in `release.yml` with a thin `goreleaser-action`
+  workflow — **SHA-pinned** actions, keep `tags: ["v*"]` + `workflow_dispatch`, minimal
+  `permissions`. Install rust + zig + `cargo-zigbuild` in the job (GoReleaser does *not*
+  install them; it does run `rustup target add`).
+- **Reword the CLAUDE.md Windows invariant** (`-msvc` → `-gnu`) and the `.cargo/config.toml`
+  note.
+- **Validation gate:** `goreleaser release --snapshot --clean` builds all 5 targets
+  locally; confirm the musl binary is `not a dynamic executable` (`ldd`), the macOS
+  cross-link succeeds (ring-only/no-aws-lc is what lets it), and the windows-gnu `.exe`
+  is produced. `cargo tree -i aws-lc-rs` stays empty.
+- Cross-family review (build/release surface — a real look, not a glance).
+
+### PR 3 — ghcr distroless multi-arch image
+- `dockers:` (amd64 + arm64) + `docker_manifests:` → `ghcr.io/tobert/kaibo:<tag>` and
+  `:latest`, mirroring the `otel-cli` layout. `release/Dockerfile` `FROM
+  gcr.io/distroless/static` copying the static musl binary.
+- Workflow gains ghcr login + `packages: write`.
+- Document the **stdio caveat** in the image usage (`docker run -i ...`): the image is
+  for a pinned, pullable env, not a long-running service (kaibo never binds a socket).
+
+### PR 4 — Sigstore keyless signing + SLSA provenance
+The transparency payoff; new ground vs. otel-cli.
+- `signs:` (cosign keyless, `cosign-installer`) over checksums + artifacts; `docker_signs:`
+  for the image.
+- GitHub build-provenance attestation (`actions/attest-build-provenance`); add
+  `id-token: write` + `attestations: write`.
+- Document verification (`cosign verify-blob` / `gh attestation verify`) in the README so
+  an operator can actually check it — signing nobody verifies is theater.
+
+### PR 5 — Homebrew tap
+- `brews:` → `tobert/homebrew-kaibo` tap (mirror otel-cli: `url_template`, `repository`,
+  `skip_upload: "auto"` so prerelease tags don't publish). Requires creating the tap repo
+  and a token with access.
+- *(Optional, fold-or-defer:)* `nfpms:` (deb/rpm/apk) as otel-cli does — kaibo is niche,
+  so gate on whether anyone wants distro packages.
+
+### PR 6 — Windows channels: Scoop + Winget
+Additive, lowest priority (smallest audience). Winget also needs an external PR to
+`microsoft/winget-pkgs`. Land only if Windows demand is real.
+
+### Deferred decisions (own PRs when the cost is justified)
+- **macOS notarization** — Apple Developer account + a Mac runner (or GoReleaser Pro
+  split to a native macOS runner). Cost decision.
+- **Windows Authenticode** — code-signing cert. Cost decision.
+
+---
+
+## Future: reuse this pipeline elsewhere
+
+If this pipeline works out, Amy wants to bring the modern bits to other projects. The
+broadly *reusable* parts are the **signing + provenance attestation, distroless base,
+and ghcr hardening** patterns — kaibo becomes the reference for the signing/attestation
+layer those projects don't have yet. The **build** layer does *not* generalize, and the
+reason is exactly the `windows-gnu` constraint kaibo accepts:
+
+- **otel-cli (Go).** Go cross-compiles native Windows MSVC-free, so it stays on the
+  Pro-free native-cross path and keeps its existing nfpms/brew/docker blocks. It just
+  gains the signing/attestation layer.
+- **winit / GUI projects (Rust).** These are the case kaibo's cheap path *can't* be
+  copied onto. winit drags in the Windows desktop/graphics stack (`windows-rs`, wgpu,
+  DirectX), which is **MSVC-centric** — `windows-gnu` is nominally a target but the
+  ecosystem assumes msvc, so `cargo-zigbuild`'s gnu-only Windows build won't serve them.
+  That is precisely where **GoReleaser Pro split-and-merge** (or a dedicated native
+  `windows-msvc` runner job) earns its cost. Don't copy kaibo's one-runner gnu build
+  onto a winit app and expect it to link.
+
+## Open decisions
+
+- **Windows ABI — RESOLVED for kaibo (2026-06-25, with Amy): `windows-gnu`.** One OSS
+  runner, no Pro, no MSVC. Fine for a CLI/MCP binary, and Pro's cost would only buy the
+  MSVC ABI + native notarization we're deferring anyway. *This resolution is
+  kaibo-specific* — winit/GUI Rust projects need MSVC (see "reuse this pipeline
+  elsewhere"), so the decision does not carry to them.
+- **Drop a platform?** kaibo's audience is agent-operator dev machines — Linux + macOS
+  are the weight; Windows is nonzero but small. We keep all five for now; if windows-gnu
+  cross-compile proves fragile, dropping Windows (or moving it to nfpms/brew only) is on
+  the table.
+- **nfpms in PR 5 or skip?** Gate on real demand for distro packages.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,6 @@
 # Releasing kaibo — pipeline plan & living record
 
-解剖（かいぼう）ships as a single static-ish binary per platform. This document is the
+kaibo ships as a single static-ish binary per platform. This document is the
 *living* plan for how we build and publish those binaries — the sequence of PRs that
 gets us from "a workflow that has never fired" to "signed, attested releases an agent
 operator can trust." Update it as PRs land; it is the durable map the conversation

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,9 +2,9 @@
 
 解剖（かいぼう）ships as a single static-ish binary per platform. This document is the
 *living* plan for how we build and publish those binaries — the sequence of PRs that
-gets us from "a workflow that has never fired" to "signed, attested, multi-channel
-releases an agent operator can trust." Update it as PRs land; it is the durable map the
-conversation can't reconstruct.
+gets us from "a workflow that has never fired" to "signed, attested releases an agent
+operator can trust." Update it as PRs land; it is the durable map the conversation
+can't reconstruct.
 
 > **Gating note.** This whole pipeline is **parked behind the pre-1.0 work** — kaibo is
 > not ready for a public release yet, and we will not cut `v*` tags in anger until that
@@ -16,199 +16,198 @@ conversation can't reconstruct.
 
 ## Where we are now
 
-`.github/workflows/release.yml` already exists: a hand-rolled 6-target matrix (musl
-static via `cargo-zigbuild`, native macOS/Windows), `tar.gz`/`zip` packaging, sha256
-sidecars, and a `softprops/action-gh-release` publish on a `v*` tag. **It has never
-fired.** It is a good baseline — the static-musl + ring/no-aws-lc groundwork is real —
-but it does no Docker, no signing, no package channels, and it pins its actions by
+`.github/workflows/release.yml` already exists: a hand-rolled 6-target matrix that
+builds **natively per platform** — Linux `x86_64`/`aarch64` musl (fully static via
+`cargo-zigbuild`), macOS `x86_64`/`aarch64` (native `cargo build` on `macos-latest`),
+Windows `x86_64` MSVC (native, `+crt-static`) — then packages `tar.gz`/`zip`, writes
+sha256 sidecars, and publishes on a `v*` tag. **It has never fired.** It is a good
+baseline (the static-musl + ring/no-aws-lc groundwork is real), but it does no signing,
+no provenance, no container image, no package channels, and it pins its actions by
 floating tag.
 
-## The decisions (2026-06-25, with Amy)
+## The decisions (settled 2026-06-25, with Amy)
 
-1. **Adopt GoReleaser.** Replace the hand-rolled matrix with a `.goreleaser.yml` driven
-   by `goreleaser-action`. Amy has run GoReleaser on `otel-cli` (Go) for years, so the
-   `.goreleaser` shape, ghcr `dockers`/`docker_manifests`, and `brews` tap pattern are
-   familiar — kaibo reuses those patterns rather than inventing them. One config
-   collapses build + archive + checksum + changelog + release, and unlocks
-   Homebrew/Scoop/Winget, Docker, and signing as additive blocks.
-2. **Container images on `ghcr.io`, distroless base.** Same OIDC/`GITHUB_TOKEN` trust
-   path as the repo, no Docker Hub account or pull-rate tax. Base
-   `gcr.io/distroless/static` (CA certs / tzdata / nonroot user available if the stdio
-   process ever needs them), multi-arch `amd64`+`arm64` via `docker_manifests` — mirrors
-   the `otel-cli` ghcr layout.
-3. **Sigstore keyless signing + SLSA provenance.** `cosign` keyless (OIDC, *no
-   long-lived key to manage or leak*) over the archives, checksums, and image, plus
-   GitHub build-provenance attestation. This is new ground — `otel-cli` has no `signs:`
-   block — and it is the concrete payoff of staying on public CI (see "Why public CI").
+The short version: **stay OSS and GitHub-native; do not adopt a release framework for
+capability we already have.** The spine is the *existing native matrix*, hardened, plus
+the free GitHub-native signing/attestation layer. Specifically:
 
-## Why GoReleaser, and the one thing Go never made us face
+1. **Keep the native matrix on GitHub-hosted runners.** Each platform builds on its own
+   runner (native macOS, native Windows MSVC, Linux musl via zigbuild). Because we build
+   natively, there is **no cross-compile** — so no Apple-SDK hack, and **Windows stays
+   MSVC** (no ABI change, no invariant to reword). GitHub-hosted runners are fine; no
+   self-hosted runner needed.
+2. **Transparency payoff via GitHub-native tooling, no middleman:** `cosign` **keyless**
+   signing (OIDC, no long-lived key to leak), **SLSA build provenance** via
+   `actions/attest-build-provenance` (free, GitHub-native), and an **SBOM** via `syft`.
+   None of this needs a release framework or a paid service.
+3. **GoReleaser is optional, OSS-only, and later.** Reach for it *only if* package-manager
+   channel fan-out (Homebrew + Scoop + Winget + nfpm) grows into real toil. **GoReleaser
+   Pro is off the table** — at $165/yr it would buy us orchestration of a build it isn't
+   doing (we're native-matrix) plus notarization we can wire ourselves. If GoReleaser
+   ever enters, it's the free OSS version, as a back-half channel publisher.
+4. **The ghcr container image is demoted to optional.** kaibo is a stdio MCP server that
+   operators launch as a *subprocess*; a container adds `docker run -i` + read-only-mount
+   friction that two independent reviewers called actively hostile for this shape. If we
+   ship it, the friction gets documented loudly and it's gated on real demand.
 
-GoReleaser's **Rust builder** (`builder: rust`, since v2.5) defaults to `cargo-zigbuild`
-— the *same* toolchain the current workflow already uses for musl. So the build engine
-doesn't change; GoReleaser just orchestrates it and everything downstream.
+## Why we revised (the investigation)
 
-The gotcha: **`cargo-zigbuild` can target `windows-gnu` but not `windows-msvc`** (zig
-links its bundled MinGW-w64, not MSVC). `otel-cli` cross-compiles MSVC-free Windows
-trivially *because it's Go*; Rust+zig cannot. GoReleaser's OSS path builds every target
-on **one Linux runner** (multi-runner "split & merge" is a **Pro** feature), so the
-coherent OSS choice is to cross-compile all targets from Linux:
+Earlier the same day we had chosen "adopt GoReleaser, single Linux runner." Two findings
+flipped it; recording them so the reversal isn't mysterious later:
 
-| Target | How | Notes |
-| --- | --- | --- |
-| `x86_64-unknown-linux-musl` | zigbuild | fully static (`not a dynamic executable`) |
-| `aarch64-unknown-linux-musl` | zigbuild | fully static |
-| `x86_64-apple-darwin` | zigbuild cross | builds unsigned; notarization deferred |
-| `aarch64-apple-darwin` | zigbuild cross | builds unsigned; notarization deferred |
-| `x86_64-pc-windows-gnu` | zigbuild cross | **was `-msvc`** — see invariant change below |
+- **The macOS cross-compile that justified GoReleaser doesn't work for us.** GoReleaser's
+  headline value is its cross-compile matrix (zigbuild every target from one runner). But
+  `cargo-zigbuild` can't link an Apple-`darwin` target from Linux without the proprietary
+  Apple SDK (zig can't bundle it — Apple's EULA), and kaibo specifically pulls
+  `rustls-platform-verifier` → `security-framework`/`core-foundation`, which FFI into
+  Apple frameworks. So macOS *must* build on a real Mac — which is exactly where
+  GoReleaser stops building anything and becomes pure orchestration of archive/checksum/
+  release steps we already have in ~10 lines of bash. We'd carry a framework for the one
+  feature we can't use.
+- **There is no service to outsource this to, and the reason is structural.** The most
+  serious venture swing at "release engineering as a service" — **axo (axodotdev)**, Ashley
+  Williams, VC-backed, 2022 — built exactly this (cargo-dist + hosted release pages +
+  updater + analytics) and wound down; `axo.dev` is now a parked domain and the tool
+  (`dist`) survives only community-maintained. The market keeps re-converging on
+  OSS-tool-on-your-CI (GoReleaser, JReleaser, dist). *Why* the SaaS starves: the **build**
+  needs your runners/toolchain, the **signing** needs *your* identity (a service holding
+  it is the supply-chain single-point-of-trust the security-conscious refuse — Sigstore's
+  keyless design exists precisely to avoid a key-holding middleman), and the **publish**
+  step is thin git PRs. What's left to bill for is hosted pages + analytics — nice, not
+  need. So **free OSS + GitHub-native is the industry equilibrium, and it happens to align
+  exactly with kaibo's transparency/no-middleman values.**
+- **A cross-family review hardened the specifics** (Gemini batch + DeepSeek consult, run
+  *through kaibo's own tools* — dogfooding the review). Their validated findings are folded
+  into the PRs below.
 
-**This cross-compile-from-one-runner is only feasible because of the TLS invariant**
-(rustls + ring, no aws-lc-sys / no OpenSSL): a C-free tree is what lets zig link
-darwin/windows-gnu without an MSVC install or a fragile aws-lc cross-build. The
-invariant we already hold is what makes the cheap path possible.
+## Why public CI, hardened (not local builds)
 
-### Invariant change this forces (do not skip)
+Amy's instinct was that *no* public CI keeps kaibo off the radar of botnets hunting CI to
+attack, and that local builds might feel more honest. The analysis landed the other way;
+recording it so we don't reopen it:
 
-The CLAUDE.md **Build & release** section currently says *"Windows statically links the
-CRT via `+crt-static`"* (MSVC). Moving to `cargo-zigbuild` makes that **`x86_64-pc-
-windows-gnu`, statically linked against zig's bundled MinGW-w64.** The PR that lands the
-GoReleaser build (PR 2 below) must reword that bullet and the `.cargo/config.toml`
-note. For a CLI/MCP binary the gnu ABI is a non-issue; we trade the MSVC ABI for a
-single-runner OSS build. *(Open question — see below — is whether keeping MSVC + native
-runners is worth GoReleaser Pro. Default answer: no.)*
-
-## The deferred paid toll (no tool removes these)
-
-- **macOS notarization** — needs a Mac + an Apple Developer account ($99/yr). Until
-  then macOS binaries are *unsigned*: a Homebrew-tap install is fine (not quarantined),
-  but a direct download trips Gatekeeper (`xattr -d com.apple.quarantine`). Document
-  honestly; revisit when a public release justifies the cost.
-- **Windows Authenticode** — needs a code-signing cert ($). Until then the `.exe` is
-  unsigned (SmartScreen friction). Same posture: document, defer.
-
-Both are *automatable* by GoReleaser when we choose to pay; they're a cost decision, not
-a tooling gap.
-
-## Why public CI (and not local builds)
-
-Amy's instinct was that *no* public CI keeps kaibo off the radar of botnets hunting CI
-to attack, and that local builds might feel more honest. The analysis landed the other
-way, and it's worth recording so we don't reopen it:
-
-- The mass-attack vectors hunt for workflows that run on **fork PRs** (free-runner
-  crypto-mining) or that leak **long-lived secrets**. A **tag-only + `workflow_dispatch`**
-  release workflow with **no PAT** dodges both by shape.
+- Mass-attack vectors hunt for workflows that run on **fork PRs** (free-runner mining) or
+  leak **long-lived secrets**. A **tag-only + `workflow_dispatch`** release workflow with
+  **no PAT** dodges both by shape.
 - The real residual risk is a **compromised third-party action** (cf. the
   `tj-actions/changed-files` incident). Mitigation is cheap: **pin every `uses:` to a
-  commit SHA**, which every PR below does.
-- **Local builds fight the transparency goal.** A public CI log is a third-party-
-  witnessed, reproducible record; a laptop is an opaque box whose provenance is "Amy
-  says so." The modern answer to "why trust this binary" is **keyless provenance
-  attestation**, which is only cheaply attainable from public CI with OIDC — local
-  builds *structurally cannot* produce it. So public CI, hardened, maximizes
-  transparency **and** minimizes realistic attack surface; going dark trades the goal
-  for obscurity.
-- If hardware control is ever the itch, a **self-hosted runner** scratches it without
-  losing the public workflow — but for a tag-only release the GitHub-hosted runners
-  cost nothing and carry less surface. Not planned.
+  commit SHA** (PR 2).
+- **Local builds fight the transparency goal.** A public CI log is a third-party-witnessed,
+  reproducible record; a laptop is an opaque box whose provenance is "Amy says so." The
+  modern answer to "why trust this binary" is **keyless provenance attestation**, only
+  cheaply attainable from public CI with OIDC — local builds *structurally cannot* produce
+  it. So public CI, hardened, maximizes transparency **and** minimizes realistic attack
+  surface.
+
+## Cross-family review findings (folded into the PRs)
+
+Validated and actionable, with their home PR:
+
+- **"C-free" is imprecise** (both reviewers). `ring` *does* compile C/asm (via `cc` /
+  `zig cc`); the tree is free of *cmake/autotools/OpenSSL/aws-lc system-C*, not free of C.
+  Tighten the wording in `release.yml` comments and the CLAUDE.md **Build & release** /
+  **TLS** lines when PR 2/3 touches them. (No behavior change — the invariant holds; `cargo
+  tree -i aws-lc-rs` stays empty.)
+- **cosign keyless `verify-blob` fails without identity flags** (Gemini). A bare verify
+  *cannot* work for keyless — PR 3 docs must show the exact
+  `--certificate-identity "...release.yml@refs/tags/vX.Y.Z"` +
+  `--certificate-oidc-issuer "https://token.actions.githubusercontent.com"`. Signing nobody
+  can verify is theater.
+- **Add an SBOM** (Gemini). `syft` → SPDX/CycloneDX alongside the signatures (PR 3). For a
+  security-minded operator, "what's in it" is arguably more useful than "where it was built."
+- **Reproducible archives** (Gemini). Set `mod_timestamp`/`SOURCE_DATE_EPOCH` from the commit
+  date so the `tar.gz` is byte-stable (PR 2).
+- **Linking ≠ running** (DeepSeek). The validation gate must *run* each built binary
+  (`kaibo --version`) per target, not just `ldd`/`file` — a binary can link and still crash
+  at startup. The native matrix already exercises each platform on its own runner, which is
+  the right place to add the smoke run (PR 2).
+- **Distroless TLS cert smoke test** (DeepSeek). `rustls-native-certs`/`openssl-probe` should
+  find `/etc/ssl/certs/ca-certificates.crt` in `distroless/static` (it bundles CAs), with
+  `webpki-root-certs` as the bundled fallback — but smoke-test an outbound HTTPS call in the
+  image (PR 4).
+- **Homebrew tap is a blocking external prereq** (DeepSeek). `tobert/homebrew-kaibo` must
+  exist before PR 5 — a pre-PR-5 checklist item, not buried in prose.
+- **Container `-i` is a silent failure mode** (both). Without stdin attached, the MCP server
+  gets immediate EOF and exits 0 — the hardest failure to debug, and `distroless/static` has
+  no shell to `docker exec` into. Document prominently (PR 4).
 
 ---
 
 ## The PR sequence
 
 Each PR lands on its own branch in a **git worktree** (Amy's workflow for this series),
-goes up as a PR, gets a **cross-family review** (a different model lineage than wrote
-it), and updates `CHANGELOG.md` where user-facing. They're ordered lowest-coupling
-first; signing comes after the artifacts exist; channels (which need external repos)
-come last.
-
-> **Pre-flight (not a PR):** fire the *existing* `release.yml` once via
-> `workflow_dispatch` to confirm the current matrix still produces good binaries — a
-> known-good baseline before GoReleaser's complexity. If it's already untrusted, skip
-> straight to PR 2 and validate there with `goreleaser release --snapshot --clean`.
+goes up as a PR, gets a **cross-family review**, and updates `CHANGELOG.md` where
+user-facing. Ordered lowest-coupling first; signing after artifacts exist; channels last.
 
 ### PR 1 — this document
-The living plan itself (`docs/releases.md`). Settles the decisions above. No pipeline
-change. *(You are reading the artifact.)*
+The living plan itself (`docs/releases.md`) + a `docs/issues.md` pointer. Settles the
+decisions above. No pipeline change. *(You are reading the artifact.)*
 
-### PR 2 — GoReleaser core: build + archive + checksum + release
-The foundation everything hangs off.
-- Add `.goreleaser.yml` (`version: 2`, `builder: rust`, the 5 targets above), `archives`
-  (`tar.gz`; `zip` override for windows), `checksum`, `changelog`.
-- Replace the hand-rolled matrix in `release.yml` with a thin `goreleaser-action`
-  workflow — **SHA-pinned** actions, keep `tags: ["v*"]` + `workflow_dispatch`, minimal
-  `permissions`. Install rust + zig + `cargo-zigbuild` in the job (GoReleaser does *not*
-  install them; it does run `rustup target add`).
-- **Reword the CLAUDE.md Windows invariant** (`-msvc` → `-gnu`) and the `.cargo/config.toml`
-  note.
-- **Validation gate:** `goreleaser release --snapshot --clean` builds all 5 targets
-  locally; confirm the musl binary is `not a dynamic executable` (`ldd`), the macOS
-  cross-link succeeds (ring-only/no-aws-lc is what lets it), and the windows-gnu `.exe`
-  is produced. `cargo tree -i aws-lc-rs` stays empty.
-- Cross-family review (build/release surface — a real look, not a glance).
+### PR 2 — harden & extend the existing native matrix
+No framework, no ABI change — sharpen what's already there.
+- **SHA-pin every `uses:`** to a commit digest (the `tj-actions` lesson); confirm minimal
+  `permissions` and keep `tags: ["v*"]` + `workflow_dispatch`.
+- **Add a `--version` smoke run** per target on its native runner (linking ≠ running), and
+  **`mod_timestamp`** from the commit date for reproducible archives.
+- Tighten the **"C-free" wording** in the workflow comments (and CLAUDE.md if touched).
+- **Validation gate:** the matrix already builds all six natively; confirm the musl binary
+  is `not a dynamic executable` (`ldd`) and `cargo tree -i aws-lc-rs` is empty.
+- Cross-family review (release surface — a real look).
 
-### PR 3 — ghcr distroless multi-arch image
-- `dockers:` (amd64 + arm64) + `docker_manifests:` → `ghcr.io/tobert/kaibo:<tag>` and
-  `:latest`, mirroring the `otel-cli` layout. `release/Dockerfile` `FROM
-  gcr.io/distroless/static` copying the static musl binary.
-- Workflow gains ghcr login + `packages: write`.
-- Document the **stdio caveat** in the image usage (`docker run -i ...`): the image is
-  for a pinned, pullable env, not a long-running service (kaibo never binds a socket).
+### PR 3 — keyless signing + SLSA provenance + SBOM (GitHub-native)
+The transparency payoff; all free, no middleman.
+- `cosign` **keyless** signing (`cosign-installer`) over the archives + checksums.
+- **SLSA build provenance** via `actions/attest-build-provenance`; add `id-token: write`
+  + `attestations: write`.
+- **SBOM** via `syft` (SPDX/CycloneDX), attached to the release.
+- **Document verification** in the README — the exact `cosign verify-blob --certificate-identity …
+  --certificate-oidc-issuer …` and `gh attestation verify` invocations. Verification an
+  operator can't run is theater.
 
-### PR 4 — Sigstore keyless signing + SLSA provenance
-The transparency payoff; new ground vs. otel-cli.
-- `signs:` (cosign keyless, `cosign-installer`) over checksums + artifacts; `docker_signs:`
-  for the image.
-- GitHub build-provenance attestation (`actions/attest-build-provenance`); add
-  `id-token: write` + `attestations: write`.
-- Document verification (`cosign verify-blob` / `gh attestation verify`) in the README so
-  an operator can actually check it — signing nobody verifies is theater.
+### PR 4 — ghcr distroless image *(optional / demoted — gated on demand)*
+Only if there's a real consumer; kaibo is stdio, so weigh it honestly.
+- Multi-arch `amd64`+`arm64` image `FROM gcr.io/distroless/static`, copying the static musl
+  binary; `COPY --chown=nonroot` / `USER nonroot`. Push to `ghcr.io/tobert/kaibo` (+`latest`).
+- Workflow gains ghcr login + `packages: write`; `cosign` signs the image too.
+- **Document the stdio friction loudly:** `docker run -i` is mandatory (silent EOF-exit
+  otherwise), and the operator must volume-mount any codebase the agent reads (read-only).
+  Smoke-test an outbound HTTPS call (TLS certs present in distroless).
 
-### PR 5 — Homebrew tap
-- `brews:` → `tobert/homebrew-kaibo` tap (mirror otel-cli: `url_template`, `repository`,
-  `skip_upload: "auto"` so prerelease tags don't publish). Requires creating the tap repo
-  and a token with access.
-- *(Optional, fold-or-defer:)* `nfpms:` (deb/rpm/apk) as otel-cli does — kaibo is niche,
-  so gate on whether anyone wants distro packages.
-
-### PR 6 — Windows channels: Scoop + Winget
-Additive, lowest priority (smallest audience). Winget also needs an external PR to
-`microsoft/winget-pkgs`. Land only if Windows demand is real.
+### PR 5 — channels (Homebrew first), gated on demand
+- **Pre-req (external):** create the `tobert/homebrew-kaibo` tap repo + a token with access.
+- A Homebrew formula push (a small action, or a hand-rolled step). **This is the one place
+  GoReleaser-OSS earns its keep** — if/when we want brew **and** Scoop **and** Winget **and**
+  nfpm, its declarative, correct-by-construction channel blocks beat hand-rolling each. Reach
+  for it *here, OSS-only*, not as the spine. Until channels multiply, hand-roll the one tap.
 
 ### Deferred decisions (own PRs when the cost is justified)
-- **macOS notarization** — Apple Developer account + a Mac runner (or GoReleaser Pro
-  split to a native macOS runner). Cost decision.
-- **Windows Authenticode** — code-signing cert. Cost decision.
+- **macOS notarization** — Apple Developer account ($99/yr) for the cert; we already build on
+  a Mac runner, so the notarization step is scriptable (or a GoReleaser-OSS `notarize` block
+  if it's in by then). Until then macOS binaries are unsigned: a Homebrew-tap install is fine,
+  a direct download trips Gatekeeper (`xattr -d com.apple.quarantine`).
+- **Windows Authenticode** — a code-signing cert ($). Until then the `.exe` is unsigned
+  (SmartScreen friction). MSVC-native (our path) is *less* AV-hostile than a MinGW/gnu build
+  would have been, but unsigned is still unsigned.
 
 ---
 
 ## Future: reuse this pipeline elsewhere
 
-If this pipeline works out, Amy wants to bring the modern bits to other projects. The
-broadly *reusable* parts are the **signing + provenance attestation, distroless base,
-and ghcr hardening** patterns — kaibo becomes the reference for the signing/attestation
-layer those projects don't have yet. The **build** layer does *not* generalize, and the
-reason is exactly the `windows-gnu` constraint kaibo accepts:
-
-- **otel-cli (Go).** Go cross-compiles native Windows MSVC-free, so it stays on the
-  Pro-free native-cross path and keeps its existing nfpms/brew/docker blocks. It just
-  gains the signing/attestation layer.
-- **winit / GUI projects (Rust).** These are the case kaibo's cheap path *can't* be
-  copied onto. winit drags in the Windows desktop/graphics stack (`windows-rs`, wgpu,
-  DirectX), which is **MSVC-centric** — `windows-gnu` is nominally a target but the
-  ecosystem assumes msvc, so `cargo-zigbuild`'s gnu-only Windows build won't serve them.
-  That is precisely where **GoReleaser Pro split-and-merge** (or a dedicated native
-  `windows-msvc` runner job) earns its cost. Don't copy kaibo's one-runner gnu build
-  onto a winit app and expect it to link.
+The broadly *reusable* part is the **GitHub-native signing + SLSA provenance + SBOM layer**
+— it's language-agnostic and bolts onto any tag-triggered workflow. kaibo becomes the
+reference for the signing/attestation layer other projects lack:
+- **otel-cli (Go)** already runs GoReleaser-OSS; it just gains the `cosign`/attestation/SBOM
+  layer.
+- **winit / GUI projects (Rust)** — a native-matrix spine generalizes to them fine (native
+  Windows runners build MSVC, which the Windows graphics stack — `windows-rs`/wgpu/DirectX —
+  needs). The only thing that *wouldn't* have generalized was the abandoned single-runner
+  zigbuild-cross path (gnu-only Windows); since we're native-matrix, that concern is moot.
 
 ## Open decisions
 
-- **Windows ABI — RESOLVED for kaibo (2026-06-25, with Amy): `windows-gnu`.** One OSS
-  runner, no Pro, no MSVC. Fine for a CLI/MCP binary, and Pro's cost would only buy the
-  MSVC ABI + native notarization we're deferring anyway. *This resolution is
-  kaibo-specific* — winit/GUI Rust projects need MSVC (see "reuse this pipeline
-  elsewhere"), so the decision does not carry to them.
-- **Drop a platform?** kaibo's audience is agent-operator dev machines — Linux + macOS
-  are the weight; Windows is nonzero but small. We keep all five for now; if windows-gnu
-  cross-compile proves fragile, dropping Windows (or moving it to nfpms/brew only) is on
-  the table.
-- **nfpms in PR 5 or skip?** Gate on real demand for distro packages.
+- **Docker (PR 4): keep / demote / drop.** Leaning *demote-or-drop* — two reviewers judged a
+  container a poor fit for a subprocess-launched stdio server. Final call before PR 4.
+- **How many channels?** Few (a brew tap) → hand-roll, no GoReleaser. Many (brew+scoop+winget+nfpm)
+  → bring in GoReleaser-OSS as the back-half. Decide when demand is real, not now.
+- **macOS signing timeline** — notarization needs the $99/yr Apple account; decide when a
+  public release makes Gatekeeper friction worth paying down.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,11 +6,15 @@ gets us from "a workflow that has never fired" to "signed, attested releases an 
 operator can trust." Update it as PRs land; it is the durable map the conversation
 can't reconstruct.
 
-> **Gating note.** This whole pipeline is **parked behind the pre-1.0 work** — kaibo is
-> not ready for a public release yet, and we will not cut `v*` tags in anger until that
-> lands. The value of writing the plan now is to *settle the decisions* so we don't
-> re-litigate them later, and to let the PRs land incrementally (each is independently
-> reviewable and mergeable) as the runway clears. Nothing here forces a release.
+> **Gating note.** This whole pipeline is **parked behind the pre-1.0 work**. The hard
+> gate on **widening the audience** (announcing, promoting) is that kaibo must be **super
+> easy to install and use** first — for a tool whose users are *other people's agents*,
+> install friction is fatal. So the container + `/reconfigure` UX below isn't side-prep,
+> it's *on the critical path to going wide*. The engineering PRs (and even a `v*` tag) can
+> land before then; the go-wide moment waits on the ease bar. The value of writing the plan
+> now is to *settle the decisions* so we don't re-litigate them, and to let the PRs land
+> incrementally (each independently reviewable) as the runway clears. Nothing here forces a
+> release.
 
 ---
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,6 +40,20 @@ did **not** bite (macOS runners ship coreutils' `sha256sum`; bare `pip` exists) 
 prefer the portable forms (`shasum -a 256` isn't needed, but `python3 -m pip` is free)
 when touching those lines.
 
+**PR 2 realized — 2026-07-05, same day** (dial-in slices #60/#61/#62, each validated by
+a branch dispatch + cross-family reviewed): SHA-pinned actions (digests independently
+verified), least-privilege per-job permissions, branch-safe artifact names (the
+`ref_name` slash footgun fired on the first branch dispatch and was fixed in-slice),
+aarch64 leg on `ubuntu-24.04-arm` with per-leg `--version` smoke + musl `ldd` static
+assert, reproducible archives (`SOURCE_DATE_EPOCH`, gtar `--sort`/`--mtime` | `gzip -n`,
+pinned zip mtimes — teeth-tested byte-identical locally), prebuilt zigbuild. Also landed
+alongside: the repo's **first CI workflow** (#64 — offline suite, clippy `-D warnings`,
+a `cargo tree` TLS-invariant tripwire) and **`v0.2.0-rc.1`, the first-ever release**
+(#63 + tag): the publish job ran for the first time, produced a correctly-**prerelease**
+GitHub release with all 10 assets, and the end-to-end user path verified — download,
+checksum OK, fully static, binary reports `kaibo 0.2.0-rc.1`. The rc exists to prove the
+tag→release leg *before* PR 3, so the real v0.2.0 is born signed. **Next: PR 3.**
+
 This doc is the *pipeline* side only. The operator-side checklist for actually cutting
 a release (CHANGELOG retitle, kaish-kernel pin check, `docs/sandbox-probes.md` re-run,
 `cargo tree -i aws-lc-rs` empty, musl `not a dynamic executable`) lives in CLAUDE.md

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -20,14 +20,30 @@ can't reconstruct.
 
 ## Where we are now
 
-`.github/workflows/release.yml` already exists: a hand-rolled 6-target matrix that
+`.github/workflows/release.yml` already exists: a hand-rolled 5-target matrix that
 builds **natively per platform** — Linux `x86_64`/`aarch64` musl (fully static via
 `cargo-zigbuild`), macOS `x86_64`/`aarch64` (native `cargo build` on `macos-latest`),
 Windows `x86_64` MSVC (native, `+crt-static`) — then packages `tar.gz`/`zip`, writes
-sha256 sidecars, and publishes on a `v*` tag. **It has never fired.** It is a good
+sha256 sidecars, and publishes on a `v*` tag. It is a good
 baseline (the static-musl + ring/no-aws-lc groundwork is real), but it does no signing,
 no provenance, no container image, no package channels, and it pins its actions by
 floating tag.
+
+**Baseline run — 2026-07-05, the first fire ever** (`workflow_dispatch` from `main`,
+run 28745954560): **all five legs green first try**, ~8.5 min wall, artifacts + sha256
+sidecars for every target, publish job correctly skipped (tag-gated). The x86_64-musl
+artifact verified locally: checksum OK, `statically linked` / `not a dynamic
+executable`, `kaibo --version` runs. Observed for the dial-in PRs: Node 20 deprecation
+warnings on `checkout@v4`/`upload-artifact@v4` (bump majors while SHA-pinning) and a
+macos-latest → macOS 26 migration notice. The pre-flight review's portability worries
+did **not** bite (macOS runners ship coreutils' `sha256sum`; bare `pip` exists) — still
+prefer the portable forms (`shasum -a 256` isn't needed, but `python3 -m pip` is free)
+when touching those lines.
+
+This doc is the *pipeline* side only. The operator-side checklist for actually cutting
+a release (CHANGELOG retitle, kaish-kernel pin check, `docs/sandbox-probes.md` re-run,
+`cargo tree -i aws-lc-rs` empty, musl `not a dynamic executable`) lives in CLAUDE.md
+**Cutting a release** — the two reference each other so neither drifts.
 
 ## The decisions (settled 2026-06-25, with Amy)
 
@@ -159,12 +175,29 @@ decisions above. No pipeline change. *(You are reading the artifact.)*
 
 ### PR 2 — harden & extend the existing native matrix
 No framework, no ABI change — sharpen what's already there.
-- **SHA-pin every `uses:`** to a commit digest (the `tj-actions` lesson); confirm minimal
-  `permissions` and keep `tags: ["v*"]` + `workflow_dispatch`.
-- **Add a `--version` smoke run** per target on its native runner (linking ≠ running), and
-  **`mod_timestamp`** from the commit date for reproducible archives.
+- **Step 0 — DONE 2026-07-05: fired the workflow via `workflow_dispatch`.** All five
+  legs green on the first run; results + observed follow-ups in "Where we are now".
+  Since nothing broke, the rest of this PR lands as small dial-in slices: (a) SHA-pins +
+  per-job permissions, (b) arm leg + smoke runs, (c) packaging polish (reproducible
+  archives, `ref_name` slash sanitize, upload-glob cleanup, prebuilt zigbuild).
+- **SHA-pin every `uses:`** to a commit digest (the `tj-actions` lesson); minimal
+  `permissions` **per job** (build: `contents: read`; only the publish job keeps
+  `contents: write`) and keep `tags: ["v*"]` + `workflow_dispatch`.
+- **Move the `aarch64-unknown-linux-musl` leg to `ubuntu-24.04-arm`** (GitHub's arm64
+  runners, free for public repos since early 2025 — postdates this plan's first draft).
+  Still zigbuild→musl for the fully-static link; the point is the binary now smoke-runs
+  on real arm64 hardware, closing the one target the smoke gate couldn't cover.
+- **Add a `--version` smoke run** per target on its native runner (linking ≠ running;
+  `kaibo --version` exists — clap `version`, verified 2026-07-05), and
+  **`SOURCE_DATE_EPOCH`/`--mtime`** from the commit date for reproducible archives.
+  Note: `macos-latest` is arm64 (macos-14+), so the `x86_64-apple-darwin` smoke runs
+  under **Rosetta 2** — expected and fine; comment it in the workflow so nobody
+  "fixes" the leg later.
+- **Install `cargo-zigbuild` prebuilt** (a SHA-pinned installer action, e.g.
+  `taiki-e/install-action`) instead of `cargo install --locked` compiling it from
+  source on every run.
 - Tighten the **"C-free" wording** in the workflow comments (and CLAUDE.md if touched).
-- **Validation gate:** the matrix already builds all six natively; confirm the musl binary
+- **Validation gate:** the matrix already builds all five natively; confirm the musl binary
   is `not a dynamic executable` (`ldd`) and `cargo tree -i aws-lc-rs` is empty.
 - Cross-family review (release surface — a real look).
 


### PR DESCRIPTION
## What

Adds `docs/releases.md` — a **living plan** for how kaibo will build and publish release binaries — plus a P3 pointer in `docs/issues.md`. No pipeline change yet; this is PR 1 of a sequenced series, and it exists to **settle the decisions** before any YAML lands.

> Public release is **parked behind the pre-1.0 work** — we don't cut `v*` tags until kaibo is release-ready. The PRs land incrementally before then.

## Decisions (with Amy)

**Stay OSS and GitHub-native; don't adopt a release framework for capability we already have.**

- **Keep the existing native matrix** (native macOS, native Windows MSVC, Linux musl via zigbuild) on GitHub-hosted runners. No cross-compile → no Apple-SDK hack, and **Windows stays MSVC** (no invariant change).
- **Transparency payoff via free GitHub-native tooling:** `cosign` **keyless** signing + **SLSA provenance** (`actions/attest-build-provenance`) + **SBOM** (`syft`). No middleman.
- **GoReleaser is optional, OSS-only, later** — a back-half channel publisher *only if* brew/scoop/winget/nfpm multiply. **Pro is off the table**, and release-as-a-service doesn't viably exist (see the doc's axo note).
- **ghcr distroless image is a first-class, early distribution path** (revised with Amy after the first draft demoted it). The "stdio + container is hostile" worry was scoped to a *host agent* hand-building `docker run -i` mounts; the **devcontainer** case flips it — mounts are declared in `devcontainer.json` and kaibo slots in idiomatically — and the image doubles as an **OS-enforced containment layer beneath kaibo's own read-only sandbox** (belt and suspenders). Non-negotiables: **multiarch** (amd64+arm64), **non-root** (`distroless:nonroot`), and **documented UID/volume mapping** (the real friction, not `-i`).

## Why this is a pivot

An earlier draft chose "adopt GoReleaser, single Linux runner." A **cross-family review** (Gemini batch + DeepSeek consult, dogfooded through kaibo's own tools) flipped it: GoReleaser's value is its cross-compile matrix, but macOS **can't** cross-compile from Linux for our dep tree (`security-framework` via `rustls-platform-verifier` + Apple's un-bundleable SDK), so we build native anyway — where GoReleaser stops building and becomes pure orchestration of steps we already have. And there's no SaaS to outsource to, by structure (the build needs your runners, signing needs your identity). The full reasoning + the folded review fixes are in the doc.

## The sequence (in the doc)

1. **this PR** — plan doc
2. harden & extend the native matrix (SHA-pin actions, `--version` smoke per target, reproducible archives)
3. keyless signing + SLSA provenance + SBOM (GitHub-native)
4. ghcr distroless image (multiarch, non-root) — **a first-class distribution path**, lands after signing so the image is born signed
5. channels (Homebrew first), gated on demand

Deferred paid toll (own decisions later): macOS notarization, Windows Authenticode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
