### PR TITLE
docs: stay read-only — retire per-builtin timeouts, defer general RW mounts

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,9 +14,15 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
-## 2026-06-26 — Retired the per-builtin-timeout work (a seam for a customer we won't build)
+## 2026-06-26 — Stayed read-only: retired per-builtin timeouts *and* deferred general RW mounts
 
-Amy questioned the premise of the P1 "Per-builtin timeouts" entry directly: *if we never
+Two linked decisions in one session, one posture: **kaibo stays read-only as the product;
+any future write is a specific capability tool writing its own artifact, never a general
+mechanism and never `consult`.** Both retire/defer machinery built for a more general
+write surface we've decided we don't want.
+
+**Retired the per-builtin-timeout work (a seam for a customer we won't build).** Amy
+questioned the premise of the P1 "Per-builtin timeouts" entry directly: *if we never
 make model calls from inside kaish, do we still need to mess with timeouts?* We don't —
 so the entry is gone, not deferred-with-a-note.
 
@@ -43,9 +49,31 @@ kaish 0.8.2+), so it's a pickup, not a research task. The `KAISH_EXEC_TIMEOUT` d
 in `sandbox.rs` already states the 30s-bounds-a-runaway-script rationale correctly and
 needed no change.
 
-Process note: this rode its own small docs-only branch/PR even though it's pure deletion —
-the visible trail is the point (`docs/issues.md` is open-work-only; the *why* of a
-not-doing lands here).
+**Deferred the general RW mounts; reversed "consult gets RW."** The day-earlier RW-mounts
+design (2026-06-25) gave kaibo a *general* writable-mount surface (`rw_paths`) wired
+*uniformly* into every kernel — explicitly including `consult` — as the substrate for
+future RW tasks. Amy's call: *"defer this a while and stay read-only by having only
+specific tool accesses write to the underlying fs."* That flips the key sub-bullet. The
+general mount is parked; when a capability needs to deliver an artifact larger than the
+inline cap, it gets a *narrow, tool-specific* out-dir and returns a `ResourceLink` —
+decided per tool when first needed, not a broad `rw_paths` surface. Knock-on: the
+danger-surfacing design is moot (no broad mount to grade), and the consult-can-write
+prompt-injection exposure evaporates (consult stays read-only). The carefully-reasoned
+general-RW sub-bullets stay in `issues.md` under a "superseded, kept for reference" banner
+— if we ever revisit a general mount the canonicalize-before-route safety work is still
+the right shape; we're declining the *cost/exposure*, not faulting the design.
+
+Why both, why now: the two share a root. The per-builtin timeout only mattered for model
+calls *inside kaish*; the general RW mount's headline justification was being the substrate
+for those same in-kernel tasks (image-gen → image2image → …). Pull on "capabilities are
+handler-side MCP tools, kaibo's kernels stay read-only" and both fall out together. The
+read-only invariant doesn't relocate after all — it holds.
+
+Process note: rode one small docs-only branch even though it's deletion/deferral — the
+visible trail is the point (`docs/issues.md` is open-work-only; the *why* of a not-doing
+lands here). Heads-up for a future reader: PR #26 ("Lighten the RW-mount danger policy")
+merged 2026-06-25 tuned the danger-surfacing for a feature now deferred — that tuning is
+dormant, not live behavior.
 
 ## 2026-06-24 — Async consult (`consult_submit`), unified collect verbs, and a 24h `list` trim
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,39 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-26 — Retired the per-builtin-timeout work (a seam for a customer we won't build)
+
+Amy questioned the premise of the P1 "Per-builtin timeouts" entry directly: *if we never
+make model calls from inside kaish, do we still need to mess with timeouts?* We don't —
+so the entry is gone, not deferred-with-a-note.
+
+The whole entry existed for **one** scenario: a kaish builtin making a minutes-long model
+call *under the script clock*, which the 30s `KAISH_EXEC_TIMEOUT` watchdog would kill
+mid-flight. That's the only way a legitimately-slow operation lands under that clock. The
+30s budget governs *scripts* (runaway `grep`/`find`/loops) and for that it's correct.
+
+`generate_image` already proves the alternative is the real shape: a capability is a
+**handler-side MCP tool**, its provider call bounded by the backend `request_timeout`
+(rig's HTTP timeout), never touching the script watchdog. TTS/image2image-as-MCP-tools
+are identical. So the dependency chain is per-builtin timeout ⟵ in-kernel model builtins
+⟵ shell *composition* of model ops — and composition was always the deferred "later
+concern," with `generate_image` deliberately chosen as a direct tool because it was
+simpler. With composition looking like an idea that doesn't play out, the `ctx.patient`
+seam has no consumer. Building it now would be a mechanism for a customer we've decided
+not to build.
+
+What we kept: the *revival condition*, recorded in the media-spine entry. If a capability
+ever genuinely needs shell composition (a generated artifact fed to another model op
+within one `run_kaish` script), the slow op is back under the script clock and the problem
+returns — but the upstream seam already exists (`ctx.patient(budget) -> PatientGuard`,
+kaish 0.8.2+), so it's a pickup, not a research task. The `KAISH_EXEC_TIMEOUT` doc-comment
+in `sandbox.rs` already states the 30s-bounds-a-runaway-script rationale correctly and
+needed no change.
+
+Process note: this rode its own small docs-only branch/PR even though it's pure deletion —
+the visible trail is the point (`docs/issues.md` is open-work-only; the *why* of a
+not-doing lands here).
+
 ## 2026-06-24 — Async consult (`consult_submit`), unified collect verbs, and a 24h `list` trim
 
 The seed was a self-observation: Claude (the caller) was spawning throwaway sub-agents

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -51,13 +51,27 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
 - **Media moves by VFS path; base64 only at the edges** (provider wire, MCP
   content). Scratch `MemoryFs` is the working bus — bounded now that kaish landed
   `ByteBudget` (kaish-vfs, 2026-06-10; kaibo pickup tracked in the P2 entry below).
-  **RW mounts — design settled 2026-06-25 (w/ Amy), supersedes the inline-only
-  `--out-dir` plan.** Instead of a special-case artifact dir, kaibo gains a *general*
-  set of writable mounts: `rw_paths` (CLI `--rw-path` / `KAIBO_RW_PATHS` /
-  `[server] rw_paths`, default none) — the read-only `allow_paths` shape with the
-  mount flag flipped, reusing the same `$VAR` expansion + canonicalize + contain
-  machinery (`config.rs` `expand_env_vars`/`resolve_var`, `server.rs` containment).
-  Decisions that fell out of the conversation:
+  **RW mounts — DEFERRED 2026-06-26 (w/ Amy).** *"We're going to defer this a while
+  and stay read-only by having only specific tool accesses write to the underlying
+  fs."* The direction flips: rather than a **general** writable-mount surface wired into
+  every kernel, kaibo **stays read-only as the product** and any future write is a
+  *specific capability tool* writing its own artifact to the fs (the `generate_image`
+  shape — handler-side, narrow, its own path), never a broad mount and never `consult`.
+  This **reverses the "uniform RW into every kernel, consult *does* get RW" sub-bullet
+  below** — that was the cost we're declining. It also moots the danger-surfacing design
+  (no broad mount to grade) and the consult-can-write prompt-injection exposure (consult
+  stays read-only). The general-RW sub-bullets below are kept only as the *if we ever
+  revisit a general mount* record; the live plan is artifact-out via a specific tool.
+  Pairs with the per-builtin-timeout retirement (devlog 2026-06-26) — same posture:
+  capabilities are handler-side tools, kaibo's kernels stay read-only.
+
+  *(Superseded general-RW design, settled 2026-06-25, kept for reference.)* Instead of a
+  special-case artifact dir, kaibo gains a *general* set of writable mounts: `rw_paths`
+  (CLI `--rw-path` / `KAIBO_RW_PATHS` / `[server] rw_paths`, default none) — the
+  read-only `allow_paths` shape with the mount flag flipped, reusing the same `$VAR`
+  expansion + canonicalize + contain machinery (`config.rs`
+  `expand_env_vars`/`resolve_var`, `server.rs` containment). Decisions that fell out of
+  the conversation:
   - **The invariant relocates, it doesn't weaken.** Not "kaibo is read-only" but
     *kaibo never writes to the project under analysis; writes are confined to RW
     mounts the user explicitly named (default none)*. The project mount stays ro
@@ -103,7 +117,8 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
     project, but it's a real new instruction-following exposure to document honestly
     when this lands.
 - **Delivery over MCP:** small images inline as `Content::image` (rmcp 0.16,
-  `model/content.rs:165`); large objects flush to a RW mount and return as
+  `model/content.rs:165`); large objects flush to a tool-specific out-dir (a narrow
+  per-capability path, not the deferred general RW mount) and return as
   `RawContent::ResourceLink` (`model/content.rs:140`) instead of base64 blobs.
 - **Capabilities are data on the `ModelShape` seam** — SHIPPED
   2026-06-11: `ModelCaps` + the vision classifier (`consult.rs`), per-slot
@@ -124,20 +139,18 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
 **Sequencing:** (0) the backends/casts split — SHIPPED 2026-06-11. (1) vision-in —
 SHIPPED 2026-06-11, path-only. (2) **image-out — SHIPPED 2026-06-13** as the
 `generate_image` capability tool (live-verified; see the top Last pass), inline
-`Content::image` only. **Next: (3)** the general **RW mounts** above (the design that
-supersedes the inline-only `--out-dir`): `rw_paths` wired uniformly into every kernel,
-then `ResourceLink` delivery for artifacts over the inline cap (flush to a RW mount),
-then *maybe someday* the kaish-builtin/VFS surface for *composition* (image2image,
-feeding a generated artifact to another tool in a `run_kaish` script). Composition is
-the **only** thing that would run a minutes-long model call *under the script clock*
-and thus revive the per-builtin-timeout problem; as long as capabilities stay
-handler-side MCP tools (the `generate_image` shape, bounded by the backend
-`request_timeout`), it never arises — so that work was retired, not built (devlog
-2026-06-26). If composition ever lands, the upstream seam already exists
-(`ctx.patient(budget) -> PatientGuard`, kaish 0.8.2+). Artifact delivery to a RW mount
-needs none of this. Failing-first tests when RW lands: write outside a named RW mount refused, project ro even with RW set,
-canonicalize-before-route write-escape (symlink/`..` out of an RW subtree refused),
-ENOSPC surfaces loud. Additive after that.
+`Content::image` only. **Next:** stays narrow — the general **RW mounts** are DEFERRED
+(see the banner above): kaibo stays read-only, and any future write is a *specific
+capability tool* writing its own artifact (the `generate_image` shape), not a broad
+mount and not `consult`. So a larger-than-inline artifact would flush to a
+tool-specific path and return as `ResourceLink` — a narrow per-tool out-dir, decided
+when the first over-inline-cap capability needs it, **not** the general `rw_paths`
+surface. The kaish-builtin/VFS *composition* path (image2image piped in a `run_kaish`
+script) is the **only** thing that would run a minutes-long model call *under the script
+clock* and revive the per-builtin-timeout problem; as long as capabilities stay
+handler-side MCP tools, it never arises — so that work was retired, not built (devlog
+2026-06-26). If composition is ever revisited, the upstream timeout seam already exists
+(`ctx.patient(budget) -> PatientGuard`, kaish 0.8.2+).
 
 **Open design points (for the production builtins):** session history records
 `[image: path, mime]` markers, not blobs; the input size cap is a `view_image` const

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -127,11 +127,15 @@ SHIPPED 2026-06-11, path-only. (2) **image-out — SHIPPED 2026-06-13** as the
 `Content::image` only. **Next: (3)** the general **RW mounts** above (the design that
 supersedes the inline-only `--out-dir`): `rw_paths` wired uniformly into every kernel,
 then `ResourceLink` delivery for artifacts over the inline cap (flush to a RW mount),
-then the kaish-builtin/VFS surface for *composition* (image2image, feeding a generated
-artifact to another tool in a `run_kaish` script). The composition builtins need the
-per-builtin timeout (its own P1 entry) before a minutes-long model call; artifact
-delivery to a RW mount doesn't, so it can land first. Failing-first tests when RW
-lands: write outside a named RW mount refused, project ro even with RW set,
+then *maybe someday* the kaish-builtin/VFS surface for *composition* (image2image,
+feeding a generated artifact to another tool in a `run_kaish` script). Composition is
+the **only** thing that would run a minutes-long model call *under the script clock*
+and thus revive the per-builtin-timeout problem; as long as capabilities stay
+handler-side MCP tools (the `generate_image` shape, bounded by the backend
+`request_timeout`), it never arises — so that work was retired, not built (devlog
+2026-06-26). If composition ever lands, the upstream seam already exists
+(`ctx.patient(budget) -> PatientGuard`, kaish 0.8.2+). Artifact delivery to a RW mount
+needs none of this. Failing-first tests when RW lands: write outside a named RW mount refused, project ro even with RW set,
 canonicalize-before-route write-escape (symlink/`..` out of an RW subtree refused),
 ENOSPC surfaces loud. Additive after that.
 
@@ -146,7 +150,8 @@ image-processing crate.
 **TTS/STT — PARKED pending rig provider coverage (decided 2026-06-13).** No sound
 devices in scope: file-in/file-out only (TTS writes an audio file, STT reads one and
 returns text — `stt` is the natural fit for a kaish builtin emitting text, no new
-delivery channel; TTS is the artifact path needing out-dir + per-builtin timeout).
+delivery channel; TTS is the artifact path needing out-dir, an MCP tool like
+`generate_image` so the provider call is handler-side, not under the script clock).
 The blocker is rig, not kaibo's design. rig 0.38 *has* the traits
 (`AudioGenerationModel` = TTS, `TranscriptionModel` = STT) but coverage is uneven:
 - **TTS** — openai-kind only (also xai/azure/openrouter); **no Gemini, no Anthropic,
@@ -164,38 +169,10 @@ non-rig wire path to maintain, against the one-primitive grain). Kept as ready s
 `config.example.toml` was scrubbed of the `tts` slot — the embedded template must not
 advertise a capability kaibo lacks; `docs/config.md`/`docs/casts.md` document the
 reserved roles honestly. **When this un-parks** (rig adds Gemini/Anthropic TTS, or
-openai-only TTS is judged enough): wire the `tts` builtin (needs the per-builtin
-timeout + out-dir below), add the `stt` role + builtin, restore the example slots.
-
-### Per-builtin timeouts: the 30s script timeout cannot serve model-backed builtins
-The kernel exec timeout is one global knob: `KAISH_EXEC_TIMEOUT` (30s,
-`sandbox.rs:103`) threaded via `with_request_timeout` (`sandbox.rs:184`),
-overridable only wholesale (`[sandbox].exec_timeout_secs` /
-`KAIBO_EXEC_TIMEOUT_SECS`, `config.rs`). 30s is *way* too small for complex
-pro-model calls — image gen and pro-tier completions routinely run minutes — so
-every production builtin (image2image, tts; P1 media-spine entry above) would be
-killed mid-flight with exit 124. But the fix is not raising the global: that one
-knob is doing two jobs — killing runaway scripts (30s is right) and bounding
-provider patience (30s is wrong) — and stretching it to minutes hands a
-`while true` loop the same minutes.
-
-Fix shape: split the jobs. Model-backed builtins get their own timeout budget
-(per-builtin or per-tool-class, config-overridable, generous default — minutes,
-not seconds), aligned with the per-backend `request_timeout` already governing
-rig's HTTP calls so the kernel never undercuts a legitimate in-flight provider
-call; plain script execution keeps the tight 30s. Mechanism question answered
-2026-06-11: enforcement is a kernel-side watchdog, strictly per-execute — a
-timer task sleeps the whole duration and fires the cancel token (kaish
-`kernel.rs:1511,1618-1625`); `ExecuteOptions.timeout` resizes per-script but
-nothing can suspend it mid-script, so this *does* need a kaish-kernel seam.
-The upstream seam **shipped** (kaish 0.8.2/0.8.3): `ctx.patient(budget) ->
-PatientGuard` on `ToolCtx` (kaish `watchdog.rs`, a `timeout` builtin), a movable
-deadline whose cancel surface stays live while suspended. So the blocker is
-cleared — but kaibo has no in-kernel model-backed builtin to wire it onto yet
-(production capabilities ship as MCP tools, not kaish builtins). kaibo's half
-lands *before or with* the first production builtin;
-failing-first test: a builtin that sleeps past 30s but under its own budget
-completes, while a pure-script spin still dies at 30s.
+openai-only TTS is judged enough): wire `tts` as a handler-side MCP capability (the
+`generate_image` shape — out-dir for the artifact, provider call bounded by the backend
+`request_timeout`, no script-clock involvement), add the `stt` role + builtin, restore
+the example slots.
 
 ---
 


### PR DESCRIPTION
Two linked tracker decisions from this session, one posture: **kaibo stays read-only as the product; any future write is a specific capability tool writing its own artifact, never a general mechanism and never `consult`.**

## Retire per-builtin timeouts
The P1 "Per-builtin timeouts" entry existed for exactly one scenario: a kaish builtin making a minutes-long model call *under the 30s script clock*. Capabilities ship as handler-side MCP tools (the `generate_image` shape, bounded by the backend `request_timeout`) and never touch the script watchdog, so the `ctx.patient` seam has no consumer. Removed the entry (it's decided-against, not shipped); recorded the revival condition (only shell *composition* of model ops brings it back, and the upstream seam already exists for that day).

## Defer general RW mounts
> "We're going to defer this a while and stay read-only by having only specific tool accesses write to the underlying fs."

Reverses the 2026-06-25 "general `rw_paths` wired uniformly into every kernel, `consult` *does* get RW" design. Marked DEFERRED with a banner; kept the general-RW sub-bullets under "superseded, kept for reference" (the canonicalize-before-route safety work is still the right shape if ever revisited). Retargeted delivery of over-inline-cap artifacts at a narrow tool-specific out-dir. Knock-on: danger-surfacing is moot and the consult-can-write prompt-injection exposure evaporates.

Both fall out of the same root — both were substrate for in-kernel model tasks. Pull on "capabilities are handler-side tools, kernels stay read-only" and they go together. The read-only invariant doesn't relocate after all; it holds.

Docs-only (`docs/issues.md` + `docs/devlog.md`); no code or CHANGELOG change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)