### PR TITLE
generate_image: write artifact to out-dir, return the path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,20 @@ project and cannot run external commands.
   disk), and (3) external commands disabled. The `Blocked` wrapper survives only for
   the config-driven `[sandbox].disable_builtins`, which can make the box *stricter* —
   see the module doc-comment. Any change here keeps `tests/sandbox.rs` green and adds
-  a test that can fail. Read-*scope* is also
-  bounded: every call's path must canonicalize (symlinks, `..` resolved) into the
-  allowed set (`--root` / `--allow-path`, launch cwd when unset), enforced in
-  `server.rs::resolve_root` with tests in `tests/containment.rs`.
+  a test that can fail. The one *write* path is a **capability tool writing its own
+  artifact**, handler-side via `std::fs`, only to the kaibo-owned **out-dir**
+  (`config.out_dir`, default `$XDG_CACHE_HOME/kaibo`) — never through kaish, so all four
+  levers above are untouched: kaish still cannot write anywhere. (`generate_image` is
+  the only such tool today.) Read-*scope* is also bounded: every call's path must
+  canonicalize (symlinks, `..` resolved) into the allowed set (`--root` /
+  `--allow-path`, launch cwd when unset) **plus the out-dir**, which is mounted
+  *read-only* into kaish so a consult can read a generated artifact back — a deliberate,
+  narrow widening to kaibo's own cache (a consult *can* ship those own-generated
+  artifacts to a model; that's expected, not a leak). Enforced in
+  `server.rs::resolve_root` and the out-dir mount in
+  `sandbox.rs::build_readonly_kernel_and_vfs`, with tests in `tests/containment.rs` and
+  the `out_dir_*` battery in `tests/sandbox.rs` (artifact readable, out-dir read-only to
+  kaish, siblings of the out-dir *not* exposed).
 - **stdio only.** kaibo can read a filesystem, so it must never bind a socket.
 - **kaish is `!Send`.** The kernel runs on a dedicated thread behind `KaishWorker`;
   rig tools require `Send` futures. Don't hold the kernel across an `.await`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,10 +67,12 @@ project and cannot run external commands.
   levers above are untouched: kaish still cannot write anywhere. (`generate_image` is
   the only such tool today.) Read-*scope* is also bounded: every call's path must
   canonicalize (symlinks, `..` resolved) into the allowed set (`--root` /
-  `--allow-path`, launch cwd when unset) **plus the out-dir**, which is mounted
-  *read-only* into kaish so a consult can read a generated artifact back — a deliberate,
-  narrow widening to kaibo's own cache (a consult *can* ship those own-generated
-  artifacts to a model; that's expected, not a leak). Enforced in
+  `--allow-path`, launch cwd when unset) **plus the out-dir** when `out_dir_readable`
+  (default on): the out-dir is mounted *read-only* into kaish **and** joined to the
+  allowed-set, so a consult can read a generated artifact back and an out-dir path can be
+  `attach`ed/targeted — a deliberate, narrow widening to kaibo's own cache (a consult
+  *can* ship those own-generated artifacts to a model; that's expected, not a leak).
+  `out_dir_readable = false` removes both; `out_dir = "/"` is refused at load. Enforced in
   `server.rs::resolve_root` and the out-dir mount in
   `sandbox.rs::build_readonly_kernel_and_vfs`, with tests in `tests/containment.rs` and
   the `out_dir_*` battery in `tests/sandbox.rs` (artifact readable, out-dir read-only to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,10 @@ project and cannot run external commands.
   allowed-set, so a consult can read a generated artifact back and an out-dir path can be
   `attach`ed/targeted — a deliberate, narrow widening to kaibo's own cache (a consult
   *can* ship those own-generated artifacts to a model; that's expected, not a leak).
-  `out_dir_readable = false` removes both; `out_dir = "/"` is refused at load. Enforced in
+  `out_dir_readable = false` removes both; `out_dir = "/"` is refused at load; and when the
+  out-dir falls back to a **world-shared system temp** (no XDG cache, no `$HOME`) read-back
+  *defaults off* — kaibo writes artifacts there but won't auto-mount a shared temp (a
+  planted symlink could redirect the read mount). Enforced in
   `server.rs::resolve_root` and the out-dir mount in
   `sandbox.rs::build_readonly_kernel_and_vfs`, with tests in `tests/containment.rs` and
   the `out_dir_*` battery in `tests/sandbox.rs` (artifact readable, out-dir read-only to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,21 @@ the git log. Each later release appends a new section at the top.
 - **`run_kaish`** — drive the read-only kaish shell yourself, no model in the loop:
   exit code + stdout + stderr.
 - **`generate_image`** — kaibo's first *capability* (an artifact handed back to the
-  caller, not reasoning run into kaibo's own models): prompt → image, returned inline
-  as MCP image content. OpenAI-compatible image backends only (hosted
-  `gpt-image` / DALL·E, or a local Stable-Diffusion server). Its `cast` parameter
-  advertises the casts that actually carry a usable image slot as a schema enum, so a
-  host agent picks one off the schema — as discoverable as the consultation tools.
+  caller, not reasoning run into kaibo's own models): prompt → image, **written to a
+  file**, with the path returned (open it to view). No inline blob, so a multi-MiB
+  picture costs your context nothing until you read it. Files land in kaibo's artifact
+  out-dir (`server.out_dir` / `KAIBO_OUT_DIR` / `--out-dir`, default
+  `$XDG_CACHE_HOME/kaibo`); that dir is also mounted read-only into kaish, so a later
+  `consult`/`run_kaish` can read a generated artifact back. OpenAI-compatible image
+  backends only (hosted `gpt-image` / DALL·E, or a local Stable-Diffusion server). Its
+  `cast` parameter advertises the casts that actually carry a usable image slot as a
+  schema enum, so a host agent picks one off the schema — as discoverable as the
+  consultation tools.
+- **Artifact out-dir** — capability tools write their outputs to a kaibo-owned
+  directory (`server.out_dir` / `KAIBO_OUT_DIR` / `--out-dir`, default
+  `$XDG_CACHE_HOME/kaibo`, else `~/.cache/kaibo`). kaibo writes there directly (never
+  through kaish — the read-only sandbox is unchanged) and mounts it read-only into kaish
+  so consultations can read a generated artifact back. Visible at `kaibo://config`.
 - **Batch (`batch_submit`)** — the *offline, async sibling* of `oneshot`: submit a list
   of tool-less prompts, get a handle, then collect it with the shared `get`/`cancel`/
   `list` verbs (see below) — read every answer when the provider's batch lane finishes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,13 @@ the git log. Each later release appends a new section at the top.
 - **Artifact out-dir** — capability tools write their outputs to a kaibo-owned
   directory (`server.out_dir` / `KAIBO_OUT_DIR` / `--out-dir`, default
   `$XDG_CACHE_HOME/kaibo`, else `~/.cache/kaibo`). kaibo writes there directly (never
-  through kaish — the read-only sandbox is unchanged) and mounts it read-only into kaish
-  so consultations can read a generated artifact back. Visible at `kaibo://config`.
+  through kaish — the read-only sandbox is unchanged) and, when readable, mounts it
+  read-only into kaish *and* adds it to the containment allowed-set: a consultation can
+  read a generated artifact back, and an out-dir path can be `attach`ed to a follow-up
+  `consult`/`oneshot`/`batch` or targeted as a call `path`. Set `out_dir_readable = false`
+  (`--no-out-dir-read` / `KAIBO_NO_OUT_DIR_READABLE`) to keep the out-dir out of kaibo's
+  read surface entirely — artifacts are still written and their paths returned, but kaibo
+  never reads them back. `out_dir = "/"` is refused. Visible at `kaibo://config`.
 - **Batch (`batch_submit`)** — the *offline, async sibling* of `oneshot`: submit a list
   of tool-less prompts, get a handle, then collect it with the shared `get`/`cancel`/
   `list` verbs (see below) — read every answer when the provider's batch lane finishes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,12 @@ the git log. Each later release appends a new section at the top.
   `consult`/`oneshot`/`batch` or targeted as a call `path`. Set `out_dir_readable = false`
   (`--no-out-dir-read` / `KAIBO_NO_OUT_DIR_READABLE`) to keep the out-dir out of kaibo's
   read surface entirely — artifacts are still written and their paths returned, but kaibo
-  never reads them back. `out_dir = "/"` is refused. Visible at `kaibo://config`.
+  never reads them back. `out_dir = "/"` is refused. In a stripped environment with no
+  `$XDG_CACHE_HOME` and no `$HOME` (a container), the out-dir falls back to a world-shared
+  system temp and read-back **defaults off** for safety — kaibo won't auto-mount a shared
+  temp into kaish (a planted symlink could redirect the read mount); `generate_image` still
+  works and returns the path, and you can opt back in by naming a kaibo-owned `out_dir`.
+  Visible at `kaibo://config`.
 - **Batch (`batch_submit`)** — the *offline, async sibling* of `oneshot`: submit a list
   of tool-less prompts, get a handle, then collect it with the shared `get`/`cancel`/
   `list` verbs (see below) — read every answer when the provider's batch lane finishes,

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -59,6 +59,19 @@
 # (also: --no-follow-worktrees, KAIBO_NO_FOLLOW_WORKTREES).
 # follow_worktrees = true
 
+# Where capability tools (generate_image) write their artifacts. A kaibo-owned dir,
+# default $XDG_CACHE_HOME/kaibo (else ~/.cache/kaibo). kaibo writes there directly
+# (never through kaish) and returns the file path. Also: --out-dir, KAIBO_OUT_DIR
+# (these expand ~ / $VAR). `/` is refused (it would read-mount the whole host).
+# out_dir = "~/.cache/kaibo"
+
+# Whether the out-dir is part of kaibo's *read* surface (default true): mounted
+# read-only into kaish so a consult can read an artifact back, and joined to the
+# allowed-set so an out-dir path can be `attach`ed or targeted as a call `path`. Set
+# false for the tightest boundary — kaibo still writes artifacts and returns the path
+# but never reads them back (also: --no-out-dir-read, KAIBO_NO_OUT_DIR_READABLE).
+# out_dir_readable = true
+
 # Default cast (by name or alias) when a call omits `cast`. The old `provider`
 # key is a load error (unknown field) — see docs/casts.md for the rename map.
 cast = "anthropic"

--- a/docs/config.md
+++ b/docs/config.md
@@ -741,6 +741,16 @@ kaish mount, not in the allowed-set. kaibo still writes artifacts and returns th
 (the calling agent opens them with its own tools), but kaibo itself never reads them back.
 The tightest boundary, for anyone who'd rather artifacts not re-enter kaibo's read scope.
 
+**No XDG cache, no `$HOME` (containers).** When neither `$XDG_CACHE_HOME` nor `$HOME` is
+set, the default out-dir falls back to a subdir of the system temp dir — a *world-shared*
+location. kaibo will still write artifacts there, but **read-back defaults off** in that
+case: it won't auto-mount a shared temp into kaish, because a symlink planted in a
+world-writable temp could redirect the read mount onto an attacker-chosen tree (which a
+consult could then ship to a model). `generate_image` keeps working and returns the path;
+to enable read-back, set `out_dir` to a kaibo-owned directory you name (an explicit
+`out_dir` is trusted, so read-back defaults on for it). An explicit `out_dir_readable`
+always wins, either way.
+
 ## kaibo://config
 
 An MCP resource at the URI `kaibo://config` (`application/toml`) exposes the server's

--- a/docs/config.md
+++ b/docs/config.md
@@ -288,6 +288,7 @@ role the cast doesn't carry). The naming rule for everything else is mechanical:
 | config file location | — | `KAIBO_CONFIG` | `--config <path>` |
 | default root | `server.root` | `KAIBO_ROOT` | `--root` |
 | additional allowed trees | `server.allow_paths` *(list)* | `KAIBO_ALLOW_PATHS` *(colon-separated)* | `--allow-path DIR` *(repeatable)* |
+| artifact out-dir | `server.out_dir` | `KAIBO_OUT_DIR` | `--out-dir DIR` |
 | default cast | `server.cast` | `KAIBO_CAST` | `--cast` |
 | disable a tool | `server.tools.<t> = false` | `KAIBO_NO_<T>` | `--no-<t>` |
 | log filter | `server.log` | `RUST_LOG` *(wins)* / `KAIBO_LOG` | — |
@@ -703,6 +704,34 @@ The worktrees currently followed are listed at `kaibo://config` under `[runtime]
 (see below), recomputed on each read so a mid-session worktree shows up without a
 reconnect.
 
+## Artifact out-dir: `server.out_dir`
+
+Capability tools (today, `generate_image`) write their output to a **kaibo-owned
+out-dir** and hand back the path — no inline blob, so a large artifact costs the
+caller's context nothing until it opens the file. Default `$XDG_CACHE_HOME/kaibo`
+(else `~/.cache/kaibo`, else `<temp>/kaibo`); set it explicitly with any of:
+
+```toml
+[server]
+out_dir = "~/kaibo-artifacts"   # expands ~ / $VAR like root/allow_paths
+```
+
+```sh
+KAIBO_OUT_DIR=/data/kaibo-art kaibo     # env
+kaibo --out-dir /data/kaibo-art         # CLI (wins over env/file)
+```
+
+Two properties make this safe with the read-only invariant. **kaibo writes the out-dir
+directly** (`std::fs`), never through kaish — the read-only sandbox levers are
+untouched, and kaish still cannot write anywhere. **The out-dir is mounted *read-only*
+into kaish**, so a later `consult`/`run_kaish` can read a generated artifact back. That
+read-back is a deliberate, narrow widening of read-scope to kaibo's own cache — which is
+why the default is a kaibo-owned subdir, not bare `/tmp`: mounting a shared temp would
+expose every other process's files to a consult (and a consult can ship what it reads to
+a model). Point `out_dir` at a kaibo-owned directory if you override it. It's durable (a
+cache, not auto-cleared) — artifacts accumulate; clear it yourself if it grows. The
+resolved path shows at `kaibo://config` as `out_dir`.
+
 ## kaibo://config
 
 An MCP resource at the URI `kaibo://config` (`application/toml`) exposes the server's
@@ -711,6 +740,7 @@ operator) the full picture:
 
 - `allowed_paths` — the canonicalized trees a per-call path must be at-or-under
 - `default_root` — the `--root` value, if set
+- `out_dir` — where capability tools write artifacts (also mounted read-only into kaish)
 - `default_cast` — which cast is used when a call omits `cast`
 - `runtime` — state *computed at read time*, kept distinct from the configured
   knobs above so a reader can tell "what kaibo discovered" from "what the operator

--- a/docs/config.md
+++ b/docs/config.md
@@ -289,6 +289,7 @@ role the cast doesn't carry). The naming rule for everything else is mechanical:
 | default root | `server.root` | `KAIBO_ROOT` | `--root` |
 | additional allowed trees | `server.allow_paths` *(list)* | `KAIBO_ALLOW_PATHS` *(colon-separated)* | `--allow-path DIR` *(repeatable)* |
 | artifact out-dir | `server.out_dir` | `KAIBO_OUT_DIR` | `--out-dir DIR` |
+| out-dir readable | `server.out_dir_readable` | `KAIBO_NO_OUT_DIR_READABLE` | `--no-out-dir-read` |
 | default cast | `server.cast` | `KAIBO_CAST` | `--cast` |
 | disable a tool | `server.tools.<t> = false` | `KAIBO_NO_<T>` | `--no-<t>` |
 | log filter | `server.log` | `RUST_LOG` *(wins)* / `KAIBO_LOG` | — |
@@ -724,13 +725,21 @@ kaibo --out-dir /data/kaibo-art         # CLI (wins over env/file)
 Two properties make this safe with the read-only invariant. **kaibo writes the out-dir
 directly** (`std::fs`), never through kaish — the read-only sandbox levers are
 untouched, and kaish still cannot write anywhere. **The out-dir is mounted *read-only*
-into kaish**, so a later `consult`/`run_kaish` can read a generated artifact back. That
-read-back is a deliberate, narrow widening of read-scope to kaibo's own cache — which is
-why the default is a kaibo-owned subdir, not bare `/tmp`: mounting a shared temp would
-expose every other process's files to a consult (and a consult can ship what it reads to
-a model). Point `out_dir` at a kaibo-owned directory if you override it. It's durable (a
-cache, not auto-cleared) — artifacts accumulate; clear it yourself if it grows. The
-resolved path shows at `kaibo://config` as `out_dir`.
+into kaish** (and joined to the containment allowed-set), so a later `consult`/`run_kaish`
+can read a generated artifact back — and an out-dir path can be `attach`ed to a follow-up
+consult/oneshot/batch or targeted as a call `path`. That read-back is a deliberate, narrow
+widening of read-scope to kaibo's own cache — which is why the default is a kaibo-owned
+subdir, not bare `/tmp`: mounting a shared temp would expose every other process's files
+to a consult (and a consult can ship what it reads to a model). `out_dir = "/"` is refused
+outright for the same reason. Point `out_dir` at a kaibo-owned directory if you override
+it. It's durable (a cache, not auto-cleared) — artifacts accumulate; clear it yourself if
+it grows. The resolved path shows at `kaibo://config` as `out_dir`.
+
+**Turning read-back off.** `out_dir_readable = false` (or `--no-out-dir-read` /
+`KAIBO_NO_OUT_DIR_READABLE`) keeps the out-dir out of kaibo's read surface entirely — no
+kaish mount, not in the allowed-set. kaibo still writes artifacts and returns their paths
+(the calling agent opens them with its own tools), but kaibo itself never reads them back.
+The tightest boundary, for anyone who'd rather artifacts not re-enter kaibo's read scope.
 
 ## kaibo://config
 
@@ -741,6 +750,7 @@ operator) the full picture:
 - `allowed_paths` — the canonicalized trees a per-call path must be at-or-under
 - `default_root` — the `--root` value, if set
 - `out_dir` — where capability tools write artifacts (also mounted read-only into kaish)
+- `out_dir_readable` — whether the out-dir is in the read surface (mount + allowed-set)
 - `default_cast` — which cast is used when a call omits `cast`
 - `runtime` — state *computed at read time*, kept distinct from the configured
   knobs above so a reader can tell "what kaibo discovered" from "what the operator

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,56 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-26 — Artifact out-dir: `generate_image` writes a file, hands back the path
+
+The narrow *specific-tool* write the RW-mount deferral pointed at, now built.
+`generate_image` no longer streams a base64 blob inline; it writes the image to a
+kaibo-owned **out-dir** and returns the absolute path. The caller's context pays nothing
+for a multi-MiB picture until it chooses to open the file — and a generated image is an
+artifact worth keeping, so a durable home beats an inline blob that evaporates.
+
+**The shape, and what we rejected getting there (conversation w/ Amy).**
+- **Path, not `ResourceLink`.** We weighed returning an MCP `ResourceLink` (+ the
+  bytes served lazily as a binary resource on `resources/read`). Dropped it: a
+  spec-compliant client resolves a `ResourceLink` by reading it back *from the server*,
+  so kaibo would grow a `file://` `resources/read` channel that bypasses project
+  containment — a genuinely new read surface needing its own hard-look review — for no
+  win over a plain path the calling agent opens with its own tools. "Just files,
+  wherever `--out-dir` points" (Amy) is the whole feature.
+- **Handler-side write, never kaish.** The artifact is written with `std::fs` in the
+  tool handler (`generate_image::write_artifact`). kaish is untouched — all four
+  read-only levers in `sandbox.rs` still hold, kaish can't write anywhere. The
+  "read-only is the product" invariant didn't move; it gained one sentence naming the
+  capability-tool write path.
+- **Out-dir is read-back-mounted.** The dir is mounted **read-only** into every kaish
+  kernel (`build_readonly_kernel_and_vfs`, the existing `VfsRouter` multi-mount — *not*
+  the deferred general-RW machinery) so a later `consult`/`run_kaish` can read a
+  generated artifact back. This is forward substrate for image2image; nothing needs it
+  yet (the agent opens the path itself).
+- **Default `$XDG_CACHE_HOME/kaibo`, and *why* it's kaibo-owned, not `/tmp`.** Amy first
+  said `/tmp`; we landed on the XDG cache because the read-back mount widens read-*scope*
+  to whatever the out-dir is — and a consult can ship what kaish reads to a remote model.
+  Mounting bare `/tmp` would expose every other process's temp files to a consult.
+  A kaibo-owned subdir keeps the read-scope to *our own* generated artifacts. The
+  containment test pins exactly this: the out-dir is readable, a sibling is **not**.
+  Durable (a cache, not auto-cleared) by choice — "change it later if users ask" (Amy);
+  no cleanup built.
+
+**The inline cap is gone.** `GENERATE_IMAGE_MAX_BYTES` existed only to bound base64 in
+the caller's context; with path delivery there's nothing to bound, so a large image is
+just a large file. The over-cap error path (and its test) retired with it.
+
+**Teeth.** `tests/sandbox.rs` `out_dir_*` battery: artifact readable back, out-dir
+**read-only** to kaish (mount it `LocalFs::new` and the write-denial assert fails), and
+a sibling of the out-dir **not** exposed. `tests/config.rs` pins the `out_dir`
+precedence (default < file < env < CLI) and the sandbox mirror. `tests/generate_image`
+covers the write (bytes verbatim, ext from MIME, unique names, lazy dir creation) and
+path-only delivery. `docs/sandbox-probes.md` gained Battery E for the live audit.
+
+The read-scope boundary moving — even narrowly to a kaibo-owned cache — is the part of
+this that deserved the careful look; it's why this PR wants a cross-family review on the
+mount + the out-dir read path specifically.
+
 ## 2026-06-26 — Stayed read-only: retired per-builtin timeouts *and* deferred general RW mounts
 
 Two linked decisions in one session, one posture: **kaibo stays read-only as the product;

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -64,6 +64,24 @@ The read-scope boundary moving — even narrowly to a kaibo-owned cache — is t
 this that deserved the careful look; it's why this PR wants a cross-family review on the
 mount + the out-dir read path specifically.
 
+**Follow-up from the reviews — out-dir is fully *readable*, with an off switch (Amy).**
+The Gemini review flagged that an artifact couldn't be re-`attach`ed to a follow-up
+consult/oneshot (the out-dir wasn't in the containment `allowed_set`, and consult-attach
+required a subpath of the project root). Amy's call: make the out-dir readable rather than
+leave the wart — *"add out-dir to allowed_set for read and have a way to disable that … I
+don't think this would be surprising."* So one knob, `out_dir_readable` (default true,
+`--no-out-dir-read` / `KAIBO_NO_OUT_DIR_READABLE` / `[server] out_dir_readable`), now gates
+**both** sides of out-dir readability together — the kaish read-back mount *and* the
+allowed-set membership — so "readable" stays one concept. When on: the out-dir joins
+`allowed_set` (so oneshot/batch `attach` and per-call `path` accept it), and
+`resolve_consult_attachments` accepts an out-dir file as an *absolute* path (the consult
+shell mounts root + out-dir, the only two trees it can read; an in-root file stays
+root-relative, an out-dir file is absolute, anything else refused). When off: no mount, not
+in the allowed-set — kaibo writes artifacts and returns paths but never reads them back.
+Surfaced in `config.example.toml`, `kaibo://config`, and `docs/config.md` so it's
+adjustable and visible, per Amy. The boundary still only ever widens to the kaibo-owned
+out-dir (the consult-attach test pins that a *sibling* of the out-dir is still refused).
+
 ## 2026-06-26 — Stayed read-only: retired per-builtin timeouts *and* deferred general RW mounts
 
 Two linked decisions in one session, one posture: **kaibo stays read-only as the product;

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -82,6 +82,26 @@ Surfaced in `config.example.toml`, `kaibo://config`, and `docs/config.md` so it'
 adjustable and visible, per Amy. The boundary still only ever widens to the kaibo-owned
 out-dir (the consult-attach test pins that a *sibling* of the out-dir is still refused).
 
+**Safe default for the no-XDG/no-HOME case — a real exfil hole closed (Gemini + Amy).**
+A scenario-driven Gemini Pro batch (attachments via kaibo, asked to *play through* the
+code paths) confirmed Amy's instinct that the `temp_dir()/kaibo` fallback was a genuine
+hole, not just untidy: in a stripped container with no `$XDG_CACHE_HOME`/`$HOME`, kaibo
+landed in a *world-shared* temp and auto-mounted it read-only into kaish. An attacker who
+pre-plants `<tmp>/kaibo` as a symlink to `/etc` or `/home/<someone>` would have kaibo
+canonicalize it, mount the **target** read-only, add it to `allowed_set`, and a consult
+could exfiltrate it — the `out_dir = "/"` guard doesn't catch a symlink to a non-`/` tree.
+Fix (Amy's "no XDG ⇒ no automatic permission", Gemini's refined option b): classify the
+default out-dir (`DefaultOutDir::Cache` vs `SharedTemp` in `config.rs`), and when it's the
+shared-temp fallback default **read-back off** — kaibo still *writes* the artifact and
+returns the path (no frustrating hard failure in a container; the agent opens it with its
+own tools), but won't auto-mount a world-shared temp. An explicit `out_dir` is trusted
+(read-back on); an explicit `out_dir_readable` always wins. A startup warning in `main.rs`
+and primed `configure`-prompt prose (step 5, `server.rs`) tell the agent how to restore
+read-back by naming a kaibo-owned dir. The remaining write-side symlink (artifact dropped
+at a symlink's target) is a low-severity nuisance — unique names prevent overwrite —
+tracked in `docs/issues.md`, not the critical read path. Tested via injected-env
+classification (`default_out_dir_from`, all three branches incl. the empty-`$VAR` guard).
+
 ## 2026-06-26 — Stayed read-only: retired per-builtin timeouts *and* deferred general RW mounts
 
 Two linked decisions in one session, one posture: **kaibo stays read-only as the product;

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -195,23 +195,6 @@ the example slots.
 
 ## P2 — Focused fixes & hardening
 
-### Re-`attach` a generated artifact to a follow-up consult/oneshot/batch
-Surfaced by the Gemini cross-family review of the out-dir PR (2026-06-26). A consult
-*inside* its loop can already read a generated artifact (kaish `view_image` over the
-read-only out-dir mount), but the **calling agent can't pass the out-dir path into a
-later tool's `attach`** arg: `out_dir` isn't in the handler's `allowed_set`, so
-`oneshot`/`batch_submit`'s `containing_tree` rejects it, and `consult`'s
-`resolve_consult_attachments` requires a subpath of the project `root`. So "generate an
-image, then ask a vision cast about it via `attach`" fails with an out-of-bounds error
-(workaround: put the image under the project, or the consult model reads it via kaish).
-Not a correctness bug and no doc claims otherwise (the AGENTS.md "consult can ship its
-own artifacts" line is about the read-back *mount*, which works) — but a real coherence
-wart: the dir kaish may read should plausibly be attachable. Fix is security-sensitive
-(it widens the containment `allowed_set` / attach acceptance to a non-project tree), so
-it wants its own deliberate pass: append `config.out_dir` to `allowed_set` at startup
-and teach `resolve_consult_attachments` to pass an out-dir-prefixed path through as
-absolute. Decide with Amy whether re-attach is wanted before widening the boundary.
-
 ### Flaky: `omitted_path_zero_config_infers_cwd_as_default_root` (cwd race)
 `tests/containment.rs:222` reads the process-wide `std::env::current_dir()` and asserts
 the handler infers it as the default root. It fails intermittently (~1 in 5 full

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -118,10 +118,13 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
     it — bounded to the named RW mount, can't escape or execute, can't touch the
     project, but it's a real new instruction-following exposure to document honestly
     when this lands.
-- **Delivery over MCP:** small images inline as `Content::image` (rmcp 0.16,
-  `model/content.rs:165`); large objects flush to a tool-specific out-dir (a narrow
-  per-capability path, not the deferred general RW mount) and return as
-  `RawContent::ResourceLink` (`model/content.rs:140`) instead of base64 blobs.
+- **Delivery over MCP — DECIDED 2026-06-26 (w/ Amy):** a capability writes its
+  artifact to a kaibo-owned **out-dir** and returns the **absolute path as text** —
+  no inline base64 blob, no `ResourceLink`/resource-read channel. The resource path
+  was weighed and dropped: it'd add a `file://` `resources/read` surface that
+  bypasses project containment (its own hard-look review) for no win over a plain
+  path the calling agent opens with its own tools. The earlier "small inline,
+  large→`ResourceLink`" split retires with it.
 - **Capabilities are data on the `ModelShape` seam** — SHIPPED
   2026-06-11: `ModelCaps` + the vision classifier (`consult.rs`), per-slot
   `vision` pin in the role table, resolved caps at `kaibo://config`. The vision
@@ -140,19 +143,18 @@ is the workflow layer. Rationale recorded here so it survives the conversation.
 
 **Sequencing:** (0) the backends/casts split — SHIPPED 2026-06-11. (1) vision-in —
 SHIPPED 2026-06-11, path-only. (2) **image-out — SHIPPED 2026-06-13** as the
-`generate_image` capability tool (live-verified; see the top Last pass), inline
-`Content::image` only. **Next:** stays narrow — the general **RW mounts** are DEFERRED
-(see the banner above): kaibo stays read-only, and any future write is a *specific
-capability tool* writing its own artifact (the `generate_image` shape), not a broad
-mount and not `consult`. So a larger-than-inline artifact would flush to a
-tool-specific path and return as `ResourceLink` — a narrow per-tool out-dir, decided
-when the first over-inline-cap capability needs it, **not** the general `rw_paths`
-surface. The kaish-builtin/VFS *composition* path (image2image piped in a `run_kaish`
-script) is the **only** thing that would run a minutes-long model call *under the script
-clock* and revive the per-builtin-timeout problem; as long as capabilities stay
-handler-side MCP tools, it never arises — so that work was retired, not built (devlog
-2026-06-26). If composition is ever revisited, the upstream timeout seam already exists
-(`ctx.patient(budget) -> PatientGuard`, kaish 0.8.2+).
+`generate_image` capability tool, **artifact out-dir SHIPPED 2026-06-26**: it now
+writes the image to the kaibo-owned out-dir (`server.out_dir`, default
+`$XDG_CACHE_HOME/kaibo`) and hands back the path — the narrow *specific-tool* write the
+RW-mount deferral pointed at, never the broad `rw_paths` surface and not `consult`. The
+out-dir is mounted read-only into kaish for read-back (see the devlog 2026-06-26 entry
+for the design + the read-scope tradeoff). **Next:** the kaish-builtin/VFS *composition*
+path (image2image piped in a `run_kaish` script) is the **only** thing that would run a
+minutes-long model call *under the script clock* and revive the per-builtin-timeout
+problem; as long as capabilities stay handler-side MCP tools, it never arises — so that
+work was retired, not built (devlog 2026-06-26). If composition is ever revisited, the
+upstream timeout seam already exists (`ctx.patient(budget) -> PatientGuard`, kaish
+0.8.2+).
 
 **Open design points (for the production builtins):** session history records
 `[image: path, mime]` markers, not blobs; the input size cap is a `view_image` const

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -195,6 +195,23 @@ the example slots.
 
 ## P2 — Focused fixes & hardening
 
+### Re-`attach` a generated artifact to a follow-up consult/oneshot/batch
+Surfaced by the Gemini cross-family review of the out-dir PR (2026-06-26). A consult
+*inside* its loop can already read a generated artifact (kaish `view_image` over the
+read-only out-dir mount), but the **calling agent can't pass the out-dir path into a
+later tool's `attach`** arg: `out_dir` isn't in the handler's `allowed_set`, so
+`oneshot`/`batch_submit`'s `containing_tree` rejects it, and `consult`'s
+`resolve_consult_attachments` requires a subpath of the project `root`. So "generate an
+image, then ask a vision cast about it via `attach`" fails with an out-of-bounds error
+(workaround: put the image under the project, or the consult model reads it via kaish).
+Not a correctness bug and no doc claims otherwise (the AGENTS.md "consult can ship its
+own artifacts" line is about the read-back *mount*, which works) — but a real coherence
+wart: the dir kaish may read should plausibly be attachable. Fix is security-sensitive
+(it widens the containment `allowed_set` / attach acceptance to a non-project tree), so
+it wants its own deliberate pass: append `config.out_dir` to `allowed_set` at startup
+and teach `resolve_consult_attachments` to pass an out-dir-prefixed path through as
+absolute. Decide with Amy whether re-attach is wanted before widening the boundary.
+
 ### Flaky: `omitted_path_zero_config_infers_cwd_as_default_root` (cwd race)
 `tests/containment.rs:222` reads the process-wide `std::env::current_dir()` and asserts
 the handler infers it as the default root. It fails intermittently (~1 in 5 full

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -195,6 +195,17 @@ the example slots.
 
 ## P2 — Focused fixes & hardening
 
+### `write_artifact` follows a symlinked out-dir (low-severity arbitrary file drop)
+Surfaced by the Gemini review of the out-dir PR (2026-06-26). `generate_image::write_artifact`
+canonicalizes the out-dir before writing, so if the out-dir path is a symlink the artifact
+lands at the *resolved* target. In a world-shared temp an attacker could pre-plant
+`<tmp>/kaibo` → some dir and have kaibo drop a PNG there. It's a **write** nuisance, not the
+critical read-exfil (that's closed: read-back defaults off for the shared-temp fallback, see
+devlog 2026-06-26), and `unique_artifact_name` prevents overwriting an existing file — so the
+worst case is an unexpected file appearing in an attacker-chosen dir, not corruption or a
+leak. Hardening if it ever matters: refuse a symlinked out-dir component, or `O_NOFOLLOW` the
+final create. Low priority; the read side was the real hole.
+
 ### Flaky: `omitted_path_zero_config_infers_cwd_as_default_root` (cwd race)
 `tests/containment.rs:222` reads the process-wide `std::env::current_dir()` and asserts
 the handler infers it as the default root. It fails intermittently (~1 in 5 full

--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -158,6 +158,29 @@ path arg itself, and a file (vs. directory) is refused at the parameter boundary
 
 ---
 
+## 4b. Battery E — the artifact out-dir is read-only and narrow
+
+The artifact out-dir (`kaibo://config` → `out_dir`, default `$XDG_CACHE_HOME/kaibo`) is
+mounted **read-only** into kaish so a consult can read a generated artifact back. Probe
+that it stays read-only and doesn't expose its neighbors. First generate an artifact (a
+`generate_image` call, or just note an existing `$OUT/kaibo-image-*.png`), then via
+`run_kaish` with `$OUT` = the resolved out_dir:
+
+```sh
+cat $OUT/<some-artifact>                 ; echo "read-back=$?"     # 0 — readable
+echo x > $OUT/kaish-wrote-this           ; echo "write=$?"        # non-zero — read-only
+cat $OUT/../<sibling>/secret             ; echo "sibling=$?"      # not found — narrow
+```
+
+**Pass:** the read-back succeeds (exit 0), the write is refused with `permission denied:
+filesystem read-only` and creates no real file, and a path that climbs out of the
+out-dir routes into the empty `/` MemoryFs and 404s — the mount exposes the out-dir
+alone, never its parent or siblings. This is why the default out-dir is a kaibo-owned
+subdir, not bare `/tmp`. Pinned continuously by the `out_dir_*` battery in
+`tests/sandbox.rs`.
+
+---
+
 ## 5. The always-on guard: the test suites
 
 The live probes are a periodic spot-check; the *continuous* guard is the test tree.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1088,11 +1088,17 @@ impl Config {
             .map(|s| expand_path(s))
             .collect::<anyhow::Result<Vec<_>>>()?;
         let follow_worktrees = server.follow_worktrees.unwrap_or(true);
-        // The artifact out-dir: expanded like root/allow_paths, else the kaibo-owned
-        // XDG-cache default. Always resolves (a capability write needs a home).
-        let out_dir = match server.out_dir.as_deref() {
-            Some(s) => expand_path(s)?,
-            None => default_out_dir(),
+        // The artifact out-dir: expanded like root/allow_paths, else the default. An
+        // explicitly-named out_dir is the operator's call (trusted); the auto default is
+        // flagged when it fell back to a *world-shared* system temp (no XDG/HOME), so the
+        // read-back default below can withhold the mount there.
+        let (out_dir, default_shared_temp) = match server.out_dir.as_deref() {
+            Some(s) => (expand_path(s)?, false),
+            None => {
+                let d = default_out_dir_from(|k| std::env::var_os(k));
+                let shared = d.is_shared_temp();
+                (d.into_path(), shared)
+            }
         };
         // Refuse `/` outright: the out-dir is mounted *read-only into kaish*, so `/` would
         // hand a consult read of the entire host filesystem (and a consult can ship what
@@ -1106,9 +1112,13 @@ impl Config {
                  consult. Point it at a kaibo-owned directory (default $XDG_CACHE_HOME/kaibo)."
             );
         }
-        // Whether the out-dir is part of the read surface (mount + allowed-set), default
-        // on. Gates both surfaces, so they can't drift apart.
-        let out_dir_readable = server.out_dir_readable.unwrap_or(true);
+        // Whether the out-dir is part of the read surface (mount + allowed-set). Gates
+        // both surfaces together. Defaults ON for a kaibo-owned dir, but OFF when the
+        // out-dir is the *unsafe shared-temp fallback* (no XDG/HOME): kaibo still writes
+        // artifacts there, but won't auto-mount a world-shared temp into kaish — a planted
+        // symlink could redirect the read mount and a consult could exfiltrate. An
+        // explicit `out_dir_readable` always wins (the operator's deliberate choice).
+        let out_dir_readable = server.out_dir_readable.unwrap_or(!default_shared_temp);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default())?;
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;
@@ -2145,23 +2155,56 @@ pub fn default_config_path() -> Option<PathBuf> {
     })
 }
 
-/// The default artifact out-dir: `$XDG_CACHE_HOME/kaibo`, else `~/.cache/kaibo`, else
-/// `temp_dir()/kaibo` when neither var is set. Unlike [`default_config_path`] this
-/// *always* resolves — a capability that writes an artifact must have a home even with
-/// `$HOME` unset, so the system temp dir is the last-resort floor rather than `None`.
-/// It's a kaibo-*owned* subdir on purpose: the dir is mounted read-only into kaish so a
-/// later consult/run_kaish can read a generated artifact back, and scoping it to a
-/// kaibo subdir (not bare `/tmp`) keeps that read-scope to our own artifacts, never a
-/// shared temp full of other processes' files. Durable (a cache, not auto-cleared) by
-/// design — artifacts persist; cleanup is a future concern, revisited only if it bites.
+/// The default artifact out-dir, classified by how much kaibo can trust it — the
+/// distinction the read-back default keys off (see [`default_out_dir_from`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefaultOutDir {
+    /// A kaibo-owned cache under `$XDG_CACHE_HOME` or `~/.cache` — a narrow, isolated dir
+    /// kaibo trusts enough to auto-mount read-only for read-back.
+    Cache(PathBuf),
+    /// A subdir of the shared system temp dir — the last resort when neither
+    /// `$XDG_CACHE_HOME` nor `$HOME` is set (a stripped container, a systemd unit). A
+    /// *world-shared* location: kaibo writes artifacts here but must **not** auto-grant
+    /// read-back (the kaish mount + allowed-set), because a pre-planted symlink in a
+    /// world-writable temp could redirect the read mount onto an attacker-chosen tree and
+    /// a consult could exfiltrate it. Read-back here is opt-in via an explicit `out_dir`.
+    SharedTemp(PathBuf),
+}
+
+impl DefaultOutDir {
+    /// The resolved path, regardless of trust class.
+    pub fn into_path(self) -> PathBuf {
+        match self {
+            Self::Cache(p) | Self::SharedTemp(p) => p,
+        }
+    }
+    /// True for the untrusted shared-temp fallback (no XDG/HOME).
+    pub fn is_shared_temp(&self) -> bool {
+        matches!(self, Self::SharedTemp(_))
+    }
+}
+
+/// Classify the default out-dir from an injected env getter — `$XDG_CACHE_HOME/kaibo`,
+/// else `~/.cache/kaibo`, else the shared-temp fallback `<temp>/kaibo`. The testable core
+/// of [`default_out_dir`]. *Always* resolves (unlike [`default_config_path`]) — a
+/// capability that writes an artifact must have a home even with `$HOME` unset — but the
+/// shared-temp last resort is tagged [`DefaultOutDir::SharedTemp`] so the caller can
+/// withhold read-back there (a kaibo-owned cache is safe to auto-mount; a world-shared
+/// temp is not). Durable (a cache, not auto-cleared) by design — artifacts persist.
+fn default_out_dir_from(get: impl Fn(&str) -> Option<std::ffi::OsString>) -> DefaultOutDir {
+    if let Some(xdg) = get("XDG_CACHE_HOME").filter(|s| !s.is_empty()) {
+        return DefaultOutDir::Cache(PathBuf::from(xdg).join("kaibo"));
+    }
+    if let Some(home) = get("HOME").filter(|s| !s.is_empty()) {
+        return DefaultOutDir::Cache(PathBuf::from(home).join(".cache").join("kaibo"));
+    }
+    DefaultOutDir::SharedTemp(std::env::temp_dir().join("kaibo"))
+}
+
+/// The default artifact out-dir path (see [`default_out_dir_from`] for the trust
+/// classification the read-back default keys off).
 pub fn default_out_dir() -> PathBuf {
-    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME").filter(|s| !s.is_empty()) {
-        return PathBuf::from(xdg).join("kaibo");
-    }
-    if let Some(home) = std::env::var_os("HOME").filter(|s| !s.is_empty()) {
-        return PathBuf::from(home).join(".cache").join("kaibo");
-    }
-    std::env::temp_dir().join("kaibo")
+    default_out_dir_from(|k| std::env::var_os(k)).into_path()
 }
 
 /// Expand a leading `~` or `~/...` to `$HOME`. Leaves every other path untouched —
@@ -2331,6 +2374,49 @@ fn expand_env_vars(s: &str) -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- default_out_dir classification ---------------------------------------
+
+    /// The default out-dir is a trusted kaibo-owned cache when `$XDG_CACHE_HOME` or
+    /// `$HOME` is set, but the *untrusted shared-temp fallback* when neither is — the
+    /// distinction the read-back default keys off (no XDG/HOME ⇒ read-back defaults off,
+    /// so kaibo never auto-mounts a world-shared temp into kaish). Env is injected so the
+    /// no-HOME container case is deterministic without touching the real environment.
+    #[test]
+    fn default_out_dir_classifies_cache_vs_shared_temp() {
+        let xdg = default_out_dir_from(|k| (k == "XDG_CACHE_HOME").then(|| "/x/cache".into()));
+        assert_eq!(xdg, DefaultOutDir::Cache(PathBuf::from("/x/cache/kaibo")));
+        assert!(!xdg.is_shared_temp());
+
+        let home = default_out_dir_from(|k| (k == "HOME").then(|| "/home/me".into()));
+        assert_eq!(
+            home,
+            DefaultOutDir::Cache(PathBuf::from("/home/me/.cache/kaibo"))
+        );
+
+        // XDG wins over HOME when both are set.
+        let both = default_out_dir_from(|k| match k {
+            "XDG_CACHE_HOME" => Some("/x/cache".into()),
+            "HOME" => Some("/home/me".into()),
+            _ => None,
+        });
+        assert_eq!(both, DefaultOutDir::Cache(PathBuf::from("/x/cache/kaibo")));
+
+        // Neither set (a stripped container): the untrusted shared-temp fallback.
+        let none = default_out_dir_from(|_| None);
+        assert!(
+            none.is_shared_temp(),
+            "no XDG/HOME must classify as shared temp"
+        );
+        assert_eq!(none.into_path(), std::env::temp_dir().join("kaibo"));
+
+        // An empty value is treated as unset (no silent empty path segment).
+        let empty = default_out_dir_from(|k| (k == "XDG_CACHE_HOME").then(|| "".into()));
+        assert!(
+            empty.is_shared_temp(),
+            "an empty $XDG_CACHE_HOME is not a usable dir"
+        );
+    }
 
     // --- expand_tilde ---------------------------------------------------------
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -544,6 +544,15 @@ pub struct Config {
     /// untouched. It *is* mounted read-only into kaish (see [`SandboxConfig::out_dir`])
     /// so a later consult can read a generated artifact back.
     pub out_dir: PathBuf,
+    /// Whether the out-dir is part of kaibo's *read* surface: mounted read-only into
+    /// kaish (so a consult can read an artifact back) **and** joined to the containment
+    /// allowed-set (so an out-dir path can be `attach`ed or targeted as a call `path`).
+    /// Default `true` — kaibo wrote the artifact, so reading it back is the unsurprising
+    /// default. Set `false` (`[server] out_dir_readable = false`,
+    /// `KAIBO_NO_OUT_DIR_READABLE`, `--no-out-dir-read`) for the tightest boundary: kaibo
+    /// still writes the artifact and returns its path, but never reads it back itself.
+    /// Gates both surfaces together so "readable" stays one concept.
+    pub out_dir_readable: bool,
     /// Default cast name when a call omits `cast`.
     pub default_cast: String,
     /// `EnvFilter` directive used when `RUST_LOG` is unset.
@@ -1090,13 +1099,16 @@ impl Config {
         // it reads to a model). Never a real artifact dir — a loud load error, not a
         // silent host-wide exposure. ($HOME is the softer case — warned at startup in
         // `main`, not refused, since a deliberately-broad home cache is the user's call.)
-        if out_dir == PathBuf::from("/") {
+        if out_dir.as_path() == std::path::Path::new("/") {
             bail!(
                 "[server] out_dir resolves to `/` — refusing: the out-dir is mounted \
                  read-only into kaish, so `/` would expose the whole host filesystem to a \
                  consult. Point it at a kaibo-owned directory (default $XDG_CACHE_HOME/kaibo)."
             );
         }
+        // Whether the out-dir is part of the read surface (mount + allowed-set), default
+        // on. Gates both surfaces, so they can't drift apart.
+        let out_dir_readable = server.out_dir_readable.unwrap_or(true);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default())?;
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;
@@ -1106,9 +1118,10 @@ impl Config {
         // safety), but resolves onto the same struct the kernel builder consumes.
         sandbox.ignore = merge_kaish(raw.kaish.unwrap_or_default())?;
         // Mirror the artifact out-dir onto the sandbox so the kernel builder mounts it
-        // read-only (the read-back seam — see `build_readonly_kernel_and_vfs`). The
-        // handler writes it via `std::fs`; this mount only lets kaish *read* it back.
-        sandbox.out_dir = Some(out_dir.clone());
+        // read-only (the read-back seam — see `build_readonly_kernel_and_vfs`), but only
+        // when it's readable. The handler writes it via `std::fs` regardless; this mount
+        // only lets kaish *read* it back, so it's gated by `out_dir_readable`.
+        sandbox.out_dir = out_dir_readable.then(|| out_dir.clone());
         // A zero scratch budget rejects *every* write to the `/` MemoryFs — mktemp,
         // every redirect — which breaks normal explorer operation, so it's never a
         // real intent (there's no "unbounded" escape hatch by design: an unbounded
@@ -1127,6 +1140,7 @@ impl Config {
             allow_paths,
             follow_worktrees,
             out_dir,
+            out_dir_readable,
             default_cast,
             log,
             tools,
@@ -1170,16 +1184,22 @@ impl Config {
         project_context_files: Vec<String>,
         user_context_files: Vec<PathBuf>,
         out_dir: Option<PathBuf>,
+        disable_out_dir_read: bool,
     ) {
         if let Some(root) = root {
             self.root = Some(root);
         }
-        // CLI out-dir wins. Mirror it onto the sandbox too, so the read-back mount
-        // tracks the final resolved dir (the merge set both; keep them in lockstep).
+        // CLI out-dir / readability win. Like `--no-<tool>`, the CLI can only turn the
+        // read surface OFF, never force it on over a `[server] out_dir_readable = false`.
         if let Some(out_dir) = out_dir {
-            self.sandbox.out_dir = Some(out_dir.clone());
             self.out_dir = out_dir;
         }
+        if disable_out_dir_read {
+            self.out_dir_readable = false;
+        }
+        // Re-derive the sandbox read-back mount mirror from the final out-dir + readability
+        // (the merge set it; a CLI override of either must keep them in lockstep).
+        self.sandbox.out_dir = self.out_dir_readable.then(|| self.out_dir.clone());
         // Mirrors the `--no-<tool>` discipline: the CLI can only turn the follow OFF,
         // never force it on over a `[server] follow_worktrees = false` in the file.
         if disable_follow_worktrees {
@@ -1532,6 +1552,9 @@ struct RawServer {
     /// Where capability tools write artifacts. Default `$XDG_CACHE_HOME/kaibo` (see
     /// [`default_out_dir`]). Env: `KAIBO_OUT_DIR`. CLI: `--out-dir`. Expands `$VAR`/`~`.
     out_dir: Option<String>,
+    /// Whether the out-dir joins kaibo's read surface (mount + allowed-set). Default
+    /// true. Env: `KAIBO_NO_OUT_DIR_READABLE`. CLI: `--no-out-dir-read`.
+    out_dir_readable: Option<bool>,
     /// The default cast (was `provider` before the backends/casts split; the old
     /// key is now an unknown-field load error via `deny_unknown_fields`).
     cast: Option<String>,
@@ -1958,6 +1981,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if let Some(v) = get("KAIBO_OUT_DIR") {
         server.out_dir = Some(v);
+    }
+    if env_flag(get, "KAIBO_NO_OUT_DIR_READABLE") {
+        server.out_dir_readable = Some(false);
     }
     if let Some(v) = get("KAIBO_CAST") {
         server.cast = Some(v);

--- a/src/config.rs
+++ b/src/config.rs
@@ -537,21 +537,32 @@ pub struct Config {
     /// `--no-follow-worktrees`, `KAIBO_NO_FOLLOW_WORKTREES`, or
     /// `[server] follow_worktrees = false`) to keep the boundary strictly static.
     pub follow_worktrees: bool,
-    /// Where capability tools write their artifacts (`generate_image` today). A
-    /// kaibo-owned dir, default `$XDG_CACHE_HOME/kaibo` (see [`default_out_dir`]),
-    /// settable via `--out-dir` / `KAIBO_OUT_DIR` / `[server] out_dir`. Written
-    /// *handler-side* (`std::fs`), never through kaish — the read-only sandbox is
-    /// untouched. It *is* mounted read-only into kaish (see [`SandboxConfig::out_dir`])
-    /// so a later consult can read a generated artifact back.
+    /// **The artifact out-dir — canonical reference for the whole feature.** Where
+    /// capability tools (`generate_image` today) write their output; default
+    /// `$XDG_CACHE_HOME/kaibo` (see [`DefaultOutDir`]), set via `--out-dir` /
+    /// `KAIBO_OUT_DIR` / `[server] out_dir`. The pieces elsewhere link here rather than
+    /// restate this:
+    ///
+    /// - **Write is handler-side `std::fs`, never through kaish** ([`crate::generate_image::write_artifact`]).
+    ///   So the four read-only sandbox levers are untouched — kaish still can't write
+    ///   anywhere; the out-dir is the *one* place kaibo writes, and only a capability tool
+    ///   does it.
+    /// - **Read-back is gated by [`out_dir_readable`](Self::out_dir_readable)** (default
+    ///   on). When on, the out-dir is mounted *read-only* into kaish
+    ///   ([`SandboxConfig::out_dir`], via `build_readonly_kernel_and_vfs`) **and** joined
+    ///   to the containment allowed-set (in [`crate::server`]), so a consult
+    ///   can read an artifact back and an out-dir path can be `attach`ed or targeted as a
+    ///   call `path`. This is the read-*scope* widening — bounded to the kaibo-owned dir,
+    ///   and a real exfil surface (a consult can ship what it reads to a model), which is
+    ///   why the dir is kaibo-owned and narrow, why `out_dir = "/"` is refused and `$HOME`
+    ///   warned, and why the untrusted shared-temp fallback defaults read-back *off* (see
+    ///   [`DefaultOutDir`]).
     pub out_dir: PathBuf,
-    /// Whether the out-dir is part of kaibo's *read* surface: mounted read-only into
-    /// kaish (so a consult can read an artifact back) **and** joined to the containment
-    /// allowed-set (so an out-dir path can be `attach`ed or targeted as a call `path`).
-    /// Default `true` — kaibo wrote the artifact, so reading it back is the unsurprising
-    /// default. Set `false` (`[server] out_dir_readable = false`,
-    /// `KAIBO_NO_OUT_DIR_READABLE`, `--no-out-dir-read`) for the tightest boundary: kaibo
-    /// still writes the artifact and returns its path, but never reads it back itself.
-    /// Gates both surfaces together so "readable" stays one concept.
+    /// Gates the out-dir's whole *read* surface (mount + allowed-set) as one concept — see
+    /// [`out_dir`](Self::out_dir) for what that surface is and why. Default `true`
+    /// (`false` via `[server] out_dir_readable = false` / `KAIBO_NO_OUT_DIR_READABLE` /
+    /// `--no-out-dir-read`): kaibo still writes artifacts and returns their paths, but
+    /// never reads them back.
     pub out_dir_readable: bool,
     /// Default cast name when a call omits `cast`.
     pub default_cast: String,
@@ -1100,11 +1111,9 @@ impl Config {
                 (d.into_path(), shared)
             }
         };
-        // Refuse `/` outright: the out-dir is mounted *read-only into kaish*, so `/` would
-        // hand a consult read of the entire host filesystem (and a consult can ship what
-        // it reads to a model). Never a real artifact dir — a loud load error, not a
-        // silent host-wide exposure. ($HOME is the softer case — warned at startup in
-        // `main`, not refused, since a deliberately-broad home cache is the user's call.)
+        // Refuse `/` outright: it would read-mount the whole host filesystem into kaish
+        // (the read-scope concern on `Config::out_dir`). Never a real artifact dir — a loud
+        // load error. ($HOME is the softer case, warned at startup in `main`, not refused.)
         if out_dir.as_path() == std::path::Path::new("/") {
             bail!(
                 "[server] out_dir resolves to `/` — refusing: the out-dir is mounted \
@@ -1112,12 +1121,9 @@ impl Config {
                  consult. Point it at a kaibo-owned directory (default $XDG_CACHE_HOME/kaibo)."
             );
         }
-        // Whether the out-dir is part of the read surface (mount + allowed-set). Gates
-        // both surfaces together. Defaults ON for a kaibo-owned dir, but OFF when the
-        // out-dir is the *unsafe shared-temp fallback* (no XDG/HOME): kaibo still writes
-        // artifacts there, but won't auto-mount a world-shared temp into kaish — a planted
-        // symlink could redirect the read mount and a consult could exfiltrate. An
-        // explicit `out_dir_readable` always wins (the operator's deliberate choice).
+        // Read-back default: ON for a kaibo-owned dir, OFF for the untrusted shared-temp
+        // fallback (see [`DefaultOutDir::SharedTemp`] for why). An explicit
+        // `out_dir_readable` always wins.
         let out_dir_readable = server.out_dir_readable.unwrap_or(!default_shared_temp);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default())?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -537,6 +537,13 @@ pub struct Config {
     /// `--no-follow-worktrees`, `KAIBO_NO_FOLLOW_WORKTREES`, or
     /// `[server] follow_worktrees = false`) to keep the boundary strictly static.
     pub follow_worktrees: bool,
+    /// Where capability tools write their artifacts (`generate_image` today). A
+    /// kaibo-owned dir, default `$XDG_CACHE_HOME/kaibo` (see [`default_out_dir`]),
+    /// settable via `--out-dir` / `KAIBO_OUT_DIR` / `[server] out_dir`. Written
+    /// *handler-side* (`std::fs`), never through kaish — the read-only sandbox is
+    /// untouched. It *is* mounted read-only into kaish (see [`SandboxConfig::out_dir`])
+    /// so a later consult can read a generated artifact back.
+    pub out_dir: PathBuf,
     /// Default cast name when a call omits `cast`.
     pub default_cast: String,
     /// `EnvFilter` directive used when `RUST_LOG` is unset.
@@ -1072,6 +1079,12 @@ impl Config {
             .map(|s| expand_path(s))
             .collect::<anyhow::Result<Vec<_>>>()?;
         let follow_worktrees = server.follow_worktrees.unwrap_or(true);
+        // The artifact out-dir: expanded like root/allow_paths, else the kaibo-owned
+        // XDG-cache default. Always resolves (a capability write needs a home).
+        let out_dir = match server.out_dir.as_deref() {
+            Some(s) => expand_path(s)?,
+            None => default_out_dir(),
+        };
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default())?;
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;
@@ -1080,6 +1093,10 @@ impl Config {
         // The ignore policy lives in its own `[kaish.ignore]` stanza (behavior, not
         // safety), but resolves onto the same struct the kernel builder consumes.
         sandbox.ignore = merge_kaish(raw.kaish.unwrap_or_default())?;
+        // Mirror the artifact out-dir onto the sandbox so the kernel builder mounts it
+        // read-only (the read-back seam — see `build_readonly_kernel_and_vfs`). The
+        // handler writes it via `std::fs`; this mount only lets kaish *read* it back.
+        sandbox.out_dir = Some(out_dir.clone());
         // A zero scratch budget rejects *every* write to the `/` MemoryFs — mktemp,
         // every redirect — which breaks normal explorer operation, so it's never a
         // real intent (there's no "unbounded" escape hatch by design: an unbounded
@@ -1097,6 +1114,7 @@ impl Config {
             root,
             allow_paths,
             follow_worktrees,
+            out_dir,
             default_cast,
             log,
             tools,
@@ -1139,9 +1157,16 @@ impl Config {
         disable_follow_worktrees: bool,
         project_context_files: Vec<String>,
         user_context_files: Vec<PathBuf>,
+        out_dir: Option<PathBuf>,
     ) {
         if let Some(root) = root {
             self.root = Some(root);
+        }
+        // CLI out-dir wins. Mirror it onto the sandbox too, so the read-back mount
+        // tracks the final resolved dir (the merge set both; keep them in lockstep).
+        if let Some(out_dir) = out_dir {
+            self.sandbox.out_dir = Some(out_dir.clone());
+            self.out_dir = out_dir;
         }
         // Mirrors the `--no-<tool>` discipline: the CLI can only turn the follow OFF,
         // never force it on over a `[server] follow_worktrees = false` in the file.
@@ -1492,6 +1517,9 @@ struct RawServer {
     /// Follow git worktrees of an already-allowed repo. Default `true`. Env:
     /// `KAIBO_NO_FOLLOW_WORKTREES`. CLI: `--no-follow-worktrees`.
     follow_worktrees: Option<bool>,
+    /// Where capability tools write artifacts. Default `$XDG_CACHE_HOME/kaibo` (see
+    /// [`default_out_dir`]). Env: `KAIBO_OUT_DIR`. CLI: `--out-dir`. Expands `$VAR`/`~`.
+    out_dir: Option<String>,
     /// The default cast (was `provider` before the backends/casts split; the old
     /// key is now an unknown-field load error via `deny_unknown_fields`).
     cast: Option<String>,
@@ -1833,6 +1861,9 @@ fn merge_sandbox(raw: RawSandbox) -> SandboxConfig {
         disable_builtins: raw.disable_builtins.unwrap_or(d.disable_builtins),
         // Resolved separately from `[kaish.ignore]` and stitched in by `merge`.
         ignore: d.ignore,
+        // The artifact out-dir comes from `[server] out_dir` (not `[sandbox]`) and is
+        // mirrored on by `merge`; None here means "no read-back mount" until then.
+        out_dir: d.out_dir,
     }
 }
 
@@ -1912,6 +1943,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if env_flag(get, "KAIBO_NO_FOLLOW_WORKTREES") {
         server.follow_worktrees = Some(false);
+    }
+    if let Some(v) = get("KAIBO_OUT_DIR") {
+        server.out_dir = Some(v);
     }
     if let Some(v) = get("KAIBO_CAST") {
         server.cast = Some(v);
@@ -2071,6 +2105,25 @@ pub fn default_config_path() -> Option<PathBuf> {
             .join("kaibo")
             .join("config.toml")
     })
+}
+
+/// The default artifact out-dir: `$XDG_CACHE_HOME/kaibo`, else `~/.cache/kaibo`, else
+/// `temp_dir()/kaibo` when neither var is set. Unlike [`default_config_path`] this
+/// *always* resolves — a capability that writes an artifact must have a home even with
+/// `$HOME` unset, so the system temp dir is the last-resort floor rather than `None`.
+/// It's a kaibo-*owned* subdir on purpose: the dir is mounted read-only into kaish so a
+/// later consult/run_kaish can read a generated artifact back, and scoping it to a
+/// kaibo subdir (not bare `/tmp`) keeps that read-scope to our own artifacts, never a
+/// shared temp full of other processes' files. Durable (a cache, not auto-cleared) by
+/// design — artifacts persist; cleanup is a future concern, revisited only if it bites.
+pub fn default_out_dir() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME").filter(|s| !s.is_empty()) {
+        return PathBuf::from(xdg).join("kaibo");
+    }
+    if let Some(home) = std::env::var_os("HOME").filter(|s| !s.is_empty()) {
+        return PathBuf::from(home).join(".cache").join("kaibo");
+    }
+    std::env::temp_dir().join("kaibo")
 }
 
 /// Expand a leading `~` or `~/...` to `$HOME`. Leaves every other path untouched —

--- a/src/config.rs
+++ b/src/config.rs
@@ -1085,6 +1085,18 @@ impl Config {
             Some(s) => expand_path(s)?,
             None => default_out_dir(),
         };
+        // Refuse `/` outright: the out-dir is mounted *read-only into kaish*, so `/` would
+        // hand a consult read of the entire host filesystem (and a consult can ship what
+        // it reads to a model). Never a real artifact dir — a loud load error, not a
+        // silent host-wide exposure. ($HOME is the softer case — warned at startup in
+        // `main`, not refused, since a deliberately-broad home cache is the user's call.)
+        if out_dir == PathBuf::from("/") {
+            bail!(
+                "[server] out_dir resolves to `/` — refusing: the out-dir is mounted \
+                 read-only into kaish, so `/` would expose the whole host filesystem to a \
+                 consult. Point it at a kaibo-owned directory (default $XDG_CACHE_HOME/kaibo)."
+            );
+        }
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default())?;
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -825,7 +825,9 @@ impl Arm {
 /// content, not extension — matching how `view_image` re-sniffs authoritatively at read.
 #[derive(Debug, Clone)]
 pub struct ConsultAttachment {
-    /// Root-relative path the model passes to `cat -n` or `view_image`.
+    /// The path the model passes to `cat -n` or `view_image`: root-relative for a file
+    /// under the project root, or *absolute* for one under the read-only artifact out-dir
+    /// (the other tree the consult shell mounts) — the server picks the form per file.
     pub path: String,
     /// True when the file sniffed as a known image type — route it to `view_image`, not
     /// the shell. A consult that carries an image attachment must run a vision-capable

--- a/src/generate_image.rs
+++ b/src/generate_image.rs
@@ -1,19 +1,29 @@
-//! `generate_image` — the MCP capability tool: prompt → image, returned inline.
+//! `generate_image` — the MCP capability tool: prompt → image, written to the
+//! artifact out-dir, path handed back.
 //!
 //! This is a *capability*, not consultation: no `run_phase` model loop, no kaish
 //! shell. The handler resolves the cast's `image` slot into an [`ImageGen`]
-//! ([`crate::image_gen`]), generates the bytes, sniffs their MIME, and hands them
-//! back as an MCP [`Content::image`] alongside a short text caption. The provider
-//! logic lives behind the [`ImageGen`] seam so this whole path is exercised offline
-//! by a scripted backend; the live wire is proven by an `#[ignore]`d probe.
+//! ([`crate::image_gen`]), generates the bytes, sniffs their MIME, writes the artifact
+//! to the kaibo-owned out-dir ([`crate::config::Config::out_dir`]), and hands back the
+//! **absolute path** as a short text caption. The provider logic lives behind the
+//! [`ImageGen`] seam so this whole path is exercised offline by a scripted backend; the
+//! live wire is proven by an `#[ignore]`d probe.
 //!
-//! **Scratch/inline only, by design (this slice).** The bytes ride back inline,
-//! base64 on the MCP edge, capped at [`GENERATE_IMAGE_MAX_BYTES`]. An image past the
-//! cap is an honest, loud error — large-artifact delivery (`--out-dir` +
-//! `ResourceLink`) and the kaish-builtin/VFS composition surface (for image2image
-//! pipelines) are tracked follow-ons in `docs/issues.md`, not silent truncation here.
+//! **Path delivery, not inline.** The image is written to disk and only its path
+//! crosses the MCP edge — no base64 blob in the tool result, so a multi-MiB picture
+//! costs the calling agent nothing until it chooses to open the file. The write is
+//! handler-side (`std::fs`), never through kaish, so the read-only sandbox is
+//! untouched; the out-dir is separately mounted *read-only* into kaish so a later
+//! consult can read the artifact back. There is no inline size cap — the old
+//! `GENERATE_IMAGE_MAX_BYTES` guard existed only to bound base64 in context and is gone
+//! with inline delivery. The decision (path over `ResourceLink`) is recorded in
+//! `docs/issues.md`.
 
-use anyhow::{anyhow, Result};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
 use rmcp::model::Content;
 use rmcp::schemars::{self, JsonSchema};
 use serde::Deserialize;
@@ -24,17 +34,6 @@ use crate::view_image::sniff_mime;
 /// Default square size when the caller doesn't ask for one. Generous enough to be
 /// useful; a turbo SD model or a hosted gpt-image both accept it.
 pub const DEFAULT_SIZE: (u32, u32) = (1024, 1024);
-
-/// Inline-delivery cap for a *generated* image — its own knob, deliberately looser
-/// than [`view_image`](crate::view_image)'s `DEFAULT_MAX_IMAGE_BYTES`. The two pull
-/// in opposite directions: `view_image` reads workspace files (screenshots/diagrams,
-/// rarely large) and wants a tight cap so a stray read can't flood model context; a
-/// generated 1024² PNG routinely lands several MiB, and the cap is enforced *after*
-/// the (paid) call, so it must be generous enough that a rejection is genuinely
-/// exceptional, not routine. 20 MiB clears typical SD/gpt-image output with room to
-/// spare; past it is a loud error until large-artifact delivery (`--out-dir` /
-/// `ResourceLink`) lands.
-pub const GENERATE_IMAGE_MAX_BYTES: usize = 20 * 1024 * 1024;
 
 /// Arguments to `generate_image`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -82,9 +81,9 @@ pub enum GenerateError {
     /// The image backend / provider call failed (network, auth, rate-limit, an empty
     /// response). Not the caller's fault — maps to an MCP internal error.
     Backend(anyhow::Error),
-    /// The bytes came back but can't be delivered as asked — an unrecognized format,
-    /// or over the inline cap. The caller can change the request — maps to an MCP
-    /// invalid-params error.
+    /// The bytes came back but can't be delivered as asked — an unrecognized format
+    /// (not a real image). The caller can change the request (pick another model) —
+    /// maps to an MCP invalid-params error.
     Unusable(String),
 }
 
@@ -124,13 +123,14 @@ pub fn parse_size(spec: Option<&str>) -> Result<(u32, u32)> {
     Ok((parse(w, "width")?, parse(h, "height")?))
 }
 
-/// Generate one image: call the backend, sniff the MIME, enforce the inline cap.
+/// Generate one image: call the backend, sniff the MIME.
 ///
 /// Errors loudly, and *categorized* (see [`GenerateError`]): a failed/empty
-/// generation is [`GenerateError::Backend`]; bytes in an unrecognized format or over
-/// the inline cap are [`GenerateError::Unusable`] (the caller can fix those). None of
-/// these is a silent fallback — a blob we can't recognize is suspicious, not
-/// something to mislabel, and an over-cap image is refused, never quietly dropped.
+/// generation is [`GenerateError::Backend`]; bytes in an unrecognized format are
+/// [`GenerateError::Unusable`] (the caller can pick another model). Neither is a silent
+/// fallback — a blob we can't recognize is suspicious, not something to mislabel. There
+/// is no size cap: the artifact is written to disk, not inlined, so a large image is
+/// fine ([`write_artifact`] is the next step).
 pub async fn generate(
     image_gen: &dyn ImageGen,
     prompt: &str,
@@ -147,33 +147,72 @@ pub async fn generate(
             bytes.len()
         ))
     })?;
-    if bytes.len() > GENERATE_IMAGE_MAX_BYTES {
-        return Err(GenerateError::Unusable(format!(
-            "generated image is {} bytes, over the {} byte inline cap; large-artifact \
-             delivery (--out-dir / ResourceLink) is not yet wired — lower the size or use a \
-             model that emits smaller images",
-            bytes.len(),
-            GENERATE_IMAGE_MAX_BYTES
-        )));
-    }
     Ok(GeneratedImage { bytes, mime })
 }
 
-/// Assemble the MCP content for a generated image: the image part (base64 on the
-/// wire) plus a short text caption so a client rendering only text still sees what
-/// happened.
-pub fn to_content(image: &GeneratedImage, prompt: &str, size: (u32, u32)) -> Vec<Content> {
-    use base64::Engine;
-    let data = base64::engine::general_purpose::STANDARD.encode(&image.bytes);
+/// The file extension for a sniffed image MIME. Total over the four formats
+/// [`sniff_mime`] recognizes — an artifact only reaches here after a successful sniff,
+/// so the fallback (`bin`) is unreachable in practice but keeps the function total.
+fn mime_ext(mime: &str) -> &'static str {
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        _ => "bin",
+    }
+}
+
+/// A unique artifact filename: `kaibo-image-<unix_nanos>-<pid>-<counter>.<ext>`. The
+/// nanosecond clock plus the process id plus a monotonic in-process counter make a
+/// collision astronomically unlikely without pulling in an RNG dependency — two writes
+/// in the same process get distinct counters, and two processes differ on pid.
+fn unique_artifact_name(ext: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("kaibo-image-{nanos}-{}-{n}.{ext}", std::process::id())
+}
+
+/// Write a generated image to `out_dir`, returning its absolute path.
+///
+/// Handler-side `std::fs` — this is the *only* write path for an artifact, and it never
+/// touches kaish, so the read-only sandbox is unaffected. Creates `out_dir` on demand
+/// (the lazy creation the read-back mount waits on) and errors loudly on any failure
+/// (a full disk or unwritable cache dir is the operator's environment, not the caller's
+/// request — the handler maps it to an internal error). Never delivers a half-written
+/// artifact as success: a failed write is an `Err`, not a quietly dropped image.
+pub fn write_artifact(out_dir: &Path, image: &GeneratedImage) -> Result<PathBuf> {
+    std::fs::create_dir_all(out_dir)
+        .with_context(|| format!("creating artifact out-dir {}", out_dir.display()))?;
+    let path = out_dir.join(unique_artifact_name(mime_ext(image.mime)));
+    std::fs::write(&path, &image.bytes)
+        .with_context(|| format!("writing artifact to {}", path.display()))?;
+    Ok(path)
+}
+
+/// The MCP content for a written artifact: a single text caption naming the size, MIME,
+/// byte count, and the **absolute path** the calling agent opens to view it. No image
+/// part — delivery is by path, not inline base64 (see the module doc).
+pub fn to_content(
+    path: &Path,
+    image: &GeneratedImage,
+    prompt: &str,
+    size: (u32, u32),
+) -> Vec<Content> {
     let caption = format!(
-        "Generated a {}×{} {} ({:.1} KiB) for: {}",
+        "Generated a {}×{} {} ({:.1} KiB) for: {}\nSaved to {} — open it to view.",
         size.0,
         size.1,
         image.mime,
         image.bytes.len() as f64 / 1024.0,
-        prompt
+        prompt,
+        path.display(),
     );
-    vec![Content::image(data, image.mime), Content::text(caption)]
+    vec![Content::text(caption)]
 }
 
 #[cfg(test)]
@@ -211,13 +250,71 @@ mod tests {
             vec![("a red circle".to_string(), (640, 480))],
             "the prompt and size must reach the backend verbatim"
         );
+    }
 
-        let content = to_content(&img, "a red circle", (640, 480));
-        // First part is the image; the caption rides as text.
-        let is_image = matches!(content.first().map(|c| c.raw.as_image()), Some(Some(_)));
+    #[test]
+    fn write_artifact_writes_bytes_with_the_right_ext_and_unique_names() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let img = GeneratedImage {
+            bytes: fake_png(32),
+            mime: "image/png",
+        };
+        let p1 = write_artifact(dir.path(), &img).expect("write succeeds");
+        let p2 = write_artifact(dir.path(), &img).expect("second write succeeds");
+        // Bytes land verbatim on disk — no truncation, no re-encode.
+        assert_eq!(
+            std::fs::read(&p1).unwrap(),
+            img.bytes,
+            "file holds the exact bytes"
+        );
+        // Extension comes from the sniffed MIME.
+        assert_eq!(p1.extension().and_then(|e| e.to_str()), Some("png"));
+        // Two writes never collide — the artifact channel must not clobber.
+        assert_ne!(p1, p2, "each artifact gets a distinct path");
+        assert!(p1.starts_with(dir.path()), "artifact lands inside out_dir");
+    }
+
+    #[test]
+    fn write_artifact_creates_a_missing_out_dir() {
+        // The read-back mount waits on lazy creation — write_artifact must make the dir.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nested = dir.path().join("does/not/exist/yet");
+        let img = GeneratedImage {
+            bytes: fake_png(8),
+            mime: "image/png",
+        };
+        let p = write_artifact(&nested, &img).expect("write creates the dir tree");
         assert!(
-            is_image,
-            "the first content part must be the image: {content:?}"
+            p.exists(),
+            "artifact written under a freshly-created out_dir"
+        );
+    }
+
+    #[test]
+    fn to_content_delivers_the_path_not_an_inline_image() {
+        let img = GeneratedImage {
+            bytes: fake_png(16),
+            mime: "image/png",
+        };
+        let path = Path::new("/cache/kaibo/kaibo-image-1-2-3.png");
+        let content = to_content(path, &img, "a red circle", (640, 480));
+        // Exactly one part, and it is text (no base64 image part rides along).
+        assert_eq!(
+            content.len(),
+            1,
+            "path delivery is a single text part: {content:?}"
+        );
+        let is_image = matches!(content.first().map(|c| c.raw.as_image()), Some(Some(_)));
+        assert!(!is_image, "no inline image part — delivery is by path");
+        let text = content[0]
+            .raw
+            .as_text()
+            .expect("the part is text")
+            .text
+            .clone();
+        assert!(
+            text.contains("/cache/kaibo/kaibo-image-1-2-3.png"),
+            "the caption names the artifact path: {text}"
         );
     }
 
@@ -231,19 +328,6 @@ mod tests {
         assert!(
             matches!(err, GenerateError::Unusable(ref m) if m.contains("unrecognized format")),
             "expected a caller-fixable Unusable naming the format problem: {err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn generate_rejects_oversized_as_unusable() {
-        // A valid png header followed by enough filler to exceed the inline cap.
-        let backend = ScriptedImageGen::returning(fake_png(GENERATE_IMAGE_MAX_BYTES + 1));
-        let err = generate(&backend, "x", DEFAULT_SIZE)
-            .await
-            .expect_err("an over-cap image must error, never be silently dropped");
-        assert!(
-            matches!(err, GenerateError::Unusable(ref m) if m.contains("inline cap")),
-            "expected a caller-fixable Unusable naming the cap: {err:?}"
         );
     }
 

--- a/src/generate_image.rs
+++ b/src/generate_image.rs
@@ -180,15 +180,24 @@ fn unique_artifact_name(ext: &str) -> String {
 /// Write a generated image to `out_dir`, returning its absolute path.
 ///
 /// Handler-side `std::fs` — this is the *only* write path for an artifact, and it never
-/// touches kaish, so the read-only sandbox is unaffected. Creates `out_dir` on demand
-/// (the lazy creation the read-back mount waits on) and errors loudly on any failure
-/// (a full disk or unwritable cache dir is the operator's environment, not the caller's
-/// request — the handler maps it to an internal error). Never delivers a half-written
-/// artifact as success: a failed write is an `Err`, not a quietly dropped image.
+/// touches kaish, so the read-only sandbox is unaffected. Creates `out_dir` if absent
+/// (normally pre-created at startup; this is the defensive fallback) and errors loudly
+/// on any failure (a full disk or unwritable cache dir is the operator's environment,
+/// not the caller's request — the handler maps it to an internal error). Never delivers
+/// a half-written artifact as success: a failed write is an `Err`, not a quietly dropped
+/// image. Returns the *canonical* absolute path (see the in-fn note).
 pub fn write_artifact(out_dir: &Path, image: &GeneratedImage) -> Result<PathBuf> {
     std::fs::create_dir_all(out_dir)
         .with_context(|| format!("creating artifact out-dir {}", out_dir.display()))?;
-    let path = out_dir.join(unique_artifact_name(mime_ext(image.mime)));
+    // Canonicalize the dir (it exists now) so the path we return matches the read-only
+    // out-dir mount kaish sees: that mount is keyed on the *canonical* out-dir, so a
+    // symlinked out_dir (e.g. `~/.cache/kaibo` under a symlinked `$HOME`) would otherwise
+    // hand the model a path that doesn't resolve through the VFS on read-back. It also
+    // gives the calling agent the real resolved absolute path.
+    let dir = out_dir
+        .canonicalize()
+        .with_context(|| format!("resolving artifact out-dir {}", out_dir.display()))?;
+    let path = dir.join(unique_artifact_name(mime_ext(image.mime)));
     std::fs::write(&path, &image.bytes)
         .with_context(|| format!("writing artifact to {}", path.display()))?;
     Ok(path)
@@ -271,7 +280,11 @@ mod tests {
         assert_eq!(p1.extension().and_then(|e| e.to_str()), Some("png"));
         // Two writes never collide — the artifact channel must not clobber.
         assert_ne!(p1, p2, "each artifact gets a distinct path");
-        assert!(p1.starts_with(dir.path()), "artifact lands inside out_dir");
+        // The returned path is canonical (matches the read-back mount), so compare
+        // against the canonicalized dir — on macOS a tempdir under /var resolves to
+        // /private/var, which a raw `dir.path()` prefix check would miss.
+        let dir_canon = dir.path().canonicalize().unwrap();
+        assert!(p1.starts_with(&dir_canon), "artifact lands inside out_dir");
     }
 
     #[test]

--- a/src/generate_image.rs
+++ b/src/generate_image.rs
@@ -9,15 +9,11 @@
 //! [`ImageGen`] seam so this whole path is exercised offline by a scripted backend; the
 //! live wire is proven by an `#[ignore]`d probe.
 //!
-//! **Path delivery, not inline.** The image is written to disk and only its path
-//! crosses the MCP edge — no base64 blob in the tool result, so a multi-MiB picture
-//! costs the calling agent nothing until it chooses to open the file. The write is
-//! handler-side (`std::fs`), never through kaish, so the read-only sandbox is
-//! untouched; the out-dir is separately mounted *read-only* into kaish so a later
-//! consult can read the artifact back. There is no inline size cap — the old
-//! `GENERATE_IMAGE_MAX_BYTES` guard existed only to bound base64 in context and is gone
-//! with inline delivery. The decision (path over `ResourceLink`) is recorded in
-//! `docs/issues.md`.
+//! **Path delivery, not inline.** Only the path crosses the MCP edge — no base64 blob in
+//! the tool result, so a multi-MiB picture costs the calling agent nothing until it opens
+//! the file. (No inline size cap: the old `GENERATE_IMAGE_MAX_BYTES` only bounded base64
+//! in context. The path-over-`ResourceLink` decision is in `docs/issues.md`.) The out-dir
+//! write/read-back model and its safety live on [`crate::config::Config::out_dir`].
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -179,13 +175,12 @@ fn unique_artifact_name(ext: &str) -> String {
 
 /// Write a generated image to `out_dir`, returning its absolute path.
 ///
-/// Handler-side `std::fs` — this is the *only* write path for an artifact, and it never
-/// touches kaish, so the read-only sandbox is unaffected. Creates `out_dir` if absent
-/// (normally pre-created at startup; this is the defensive fallback) and errors loudly
-/// on any failure (a full disk or unwritable cache dir is the operator's environment,
-/// not the caller's request — the handler maps it to an internal error). Never delivers
-/// a half-written artifact as success: a failed write is an `Err`, not a quietly dropped
-/// image. Returns the *canonical* absolute path (see the in-fn note).
+/// The one write path for an artifact: handler-side `std::fs`, never kaish (see
+/// [`crate::config::Config::out_dir`]). Creates `out_dir` if absent, returns the
+/// *canonical* absolute path so it matches the read-back mount (see the in-fn note), and
+/// errors loudly on any failure (a full disk / unwritable dir → the handler maps it to an
+/// internal error). Never reports a half-written artifact as success — a failed write is
+/// an `Err`.
 pub fn write_artifact(out_dir: &Path, image: &GeneratedImage) -> Result<PathBuf> {
     std::fs::create_dir_all(out_dir)
         .with_context(|| format!("creating artifact out-dir {}", out_dir.display()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,14 @@ struct Args {
     #[arg(long)]
     no_follow_worktrees: bool,
 
+    /// Where capability tools (generate_image) write their artifacts. A kaibo-owned
+    /// dir, default $XDG_CACHE_HOME/kaibo (else ~/.cache/kaibo). Written handler-side,
+    /// never through kaish; also mounted read-only into kaish so a later consult can
+    /// read a generated artifact back. Also settable via KAIBO_OUT_DIR or
+    /// [server] out_dir (those expand a leading `~`/`$VAR`; on the CLI your shell does).
+    #[arg(long = "out-dir", value_name = "DIR")]
+    out_dir: Option<PathBuf>,
+
     /// Default cast when a call omits it (a built-in name or a cast defined in
     /// config.toml). Built-ins: anthropic | deepseek | gemini | openai-local
     /// (plus aliases: claude, google, local, …) and the batch casts gemini-batch
@@ -142,6 +150,7 @@ async fn main() -> Result<()> {
         args.no_follow_worktrees,
         args.project_context_file.clone(),
         args.user_context_file.clone(),
+        args.out_dir.clone(),
     );
 
     // Logs MUST go to stderr; stdout carries the MCP protocol. RUST_LOG wins, else
@@ -210,6 +219,7 @@ async fn main() -> Result<()> {
         cast = %config.default_cast,
         root = ?config.root.as_ref().map(|p| p.display().to_string()),
         allow_paths = ?config.allow_paths.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        out_dir = %config.out_dir.display(),
         backends = ?config.backends.keys().collect::<Vec<_>>(),
         casts = ?config.casts.keys().collect::<Vec<_>>(),
         gating = ?config.tools,

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,19 @@ async fn main() -> Result<()> {
     // and surfaces the hard error loudly at call time — but a warning lets the operator
     // catch an unwritable cache dir early.
     if config.tools.generate_image {
+        // A broad out-dir is read-only-mounted into kaish, so a consult could read (and
+        // ship to a model) anything under it. `/` is refused at load; warn on `$HOME`,
+        // where the adjacent-secret files (`~/.ssh`, provider key files) live — the user
+        // may have meant a narrow subdir. A warning, not a refusal: a deliberate broad
+        // home cache is their call.
+        if std::env::var_os("HOME").is_some_and(|h| config.out_dir == PathBuf::from(h)) {
+            tracing::warn!(
+                out_dir = %config.out_dir.display(),
+                "out_dir is your home directory — it's mounted read-only into kaish, so a \
+                 consult can read (and send to a model) anything under it, including \
+                 adjacent secrets. Prefer a narrow kaibo-owned dir (default $XDG_CACHE_HOME/kaibo)."
+            );
+        }
         if let Err(e) = std::fs::create_dir_all(&config.out_dir) {
             tracing::warn!(
                 out_dir = %config.out_dir.display(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,6 +247,21 @@ async fn main() -> Result<()> {
                  adjacent secrets. Prefer a narrow kaibo-owned dir (default $XDG_CACHE_HOME/kaibo)."
             );
         }
+        // No XDG cache and no HOME → the out-dir fell back to a world-shared system temp,
+        // and config defaulted read-back OFF there (a planted symlink in a shared temp
+        // could redirect the read mount). Tell the operator how to restore read-back: name
+        // a kaibo-owned out_dir. (Detected by the forced-off readable on a temp-rooted dir;
+        // an explicit out_dir under temp with readable left on won't trip this.)
+        if !config.out_dir_readable && config.out_dir.starts_with(std::env::temp_dir()) {
+            tracing::warn!(
+                out_dir = %config.out_dir.display(),
+                "no XDG cache or HOME found — artifacts go to a shared system temp dir and \
+                 read-back into kaish is disabled (a shared temp isn't safe to auto-mount). \
+                 generate_image still works and returns the path; to enable consult read-back \
+                 / out-dir attach, set KAIBO_OUT_DIR (or [server] out_dir) to a kaibo-owned \
+                 directory."
+            );
+        }
         if let Err(e) = std::fs::create_dir_all(&config.out_dir) {
             tracing::warn!(
                 out_dir = %config.out_dir.display(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,13 @@ struct Args {
     #[arg(long = "out-dir", value_name = "DIR")]
     out_dir: Option<PathBuf>,
 
+    /// Don't make the artifact out-dir readable: skip mounting it into kaish and keep it
+    /// out of the containment allowed-set. kaibo still writes artifacts there and returns
+    /// the path, but won't read them back (no consult read-back, no out-dir `attach`).
+    /// Also settable via KAIBO_NO_OUT_DIR_READABLE or [server] out_dir_readable = false.
+    #[arg(long = "no-out-dir-read")]
+    no_out_dir_read: bool,
+
     /// Default cast when a call omits it (a built-in name or a cast defined in
     /// config.toml). Built-ins: anthropic | deepseek | gemini | openai-local
     /// (plus aliases: claude, google, local, …) and the batch casts gemini-batch
@@ -151,6 +158,7 @@ async fn main() -> Result<()> {
         args.project_context_file.clone(),
         args.user_context_file.clone(),
         args.out_dir.clone(),
+        args.no_out_dir_read,
     );
 
     // Logs MUST go to stderr; stdout carries the MCP protocol. RUST_LOG wins, else
@@ -229,7 +237,9 @@ async fn main() -> Result<()> {
         // where the adjacent-secret files (`~/.ssh`, provider key files) live — the user
         // may have meant a narrow subdir. A warning, not a refusal: a deliberate broad
         // home cache is their call.
-        if std::env::var_os("HOME").is_some_and(|h| config.out_dir == PathBuf::from(h)) {
+        if std::env::var_os("HOME")
+            .is_some_and(|h| config.out_dir.as_path() == std::path::Path::new(&h))
+        {
             tracing::warn!(
                 out_dir = %config.out_dir.display(),
                 "out_dir is your home directory — it's mounted read-only into kaish, so a \

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,25 @@ async fn main() -> Result<()> {
     // build — a typo must crash here, not silently leave the builtin enabled.
     config.validate_against_builtins(&kaibo::sandbox::builtin_names()?)?;
 
+    // Pre-create the artifact out-dir so the read-only read-back mount is present for
+    // every kaish kernel from the first call. The mount is decided at kernel-build time
+    // and skipped when the dir doesn't exist yet; a `consult` session built *before* the
+    // first `generate_image` keeps a long-lived `run_kaish` worker, so without this its
+    // model couldn't `cat` an artifact created mid-session. Only when a capability can
+    // actually write there. Not fatal — `write_artifact` does its own `create_dir_all`
+    // and surfaces the hard error loudly at call time — but a warning lets the operator
+    // catch an unwritable cache dir early.
+    if config.tools.generate_image {
+        if let Err(e) = std::fs::create_dir_all(&config.out_dir) {
+            tracing::warn!(
+                out_dir = %config.out_dir.display(),
+                error = %e,
+                "could not pre-create the artifact out-dir; generate_image will retry at \
+                 call time and fail loudly there if it still can't write"
+            );
+        }
+    }
+
     tracing::info!(
         cast = %config.default_cast,
         root = ?config.root.as_ref().map(|p| p.display().to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,20 +223,16 @@ async fn main() -> Result<()> {
     // build — a typo must crash here, not silently leave the builtin enabled.
     config.validate_against_builtins(&kaibo::sandbox::builtin_names()?)?;
 
-    // Pre-create the artifact out-dir so the read-only read-back mount is present for
-    // every kaish kernel from the first call. The mount is decided at kernel-build time
-    // and skipped when the dir doesn't exist yet; a `consult` session built *before* the
-    // first `generate_image` keeps a long-lived `run_kaish` worker, so without this its
-    // model couldn't `cat` an artifact created mid-session. Only when a capability can
-    // actually write there. Not fatal — `write_artifact` does its own `create_dir_all`
-    // and surfaces the hard error loudly at call time — but a warning lets the operator
-    // catch an unwritable cache dir early.
+    // Artifact out-dir startup handling — only when a capability can write there. The
+    // read surface + its safety are documented on `Config::out_dir`; here we (1) warn on
+    // the two risky shapes that aren't hard-refused, then (2) pre-create the dir so the
+    // read-back mount is present from the first call (it's decided at kernel-build time and
+    // skipped if the dir is absent, which would otherwise miss a long-lived consult session
+    // started before the first generate_image). Creation failure isn't fatal —
+    // `write_artifact` retries and fails loudly at call time.
     if config.tools.generate_image {
-        // A broad out-dir is read-only-mounted into kaish, so a consult could read (and
-        // ship to a model) anything under it. `/` is refused at load; warn on `$HOME`,
-        // where the adjacent-secret files (`~/.ssh`, provider key files) live — the user
-        // may have meant a narrow subdir. A warning, not a refusal: a deliberate broad
-        // home cache is their call.
+        // `$HOME` as the out-dir read-mounts adjacent secrets (`~/.ssh`, key files) into
+        // kaish — warn, but don't refuse (a deliberate broad home cache is the user's call).
         if std::env::var_os("HOME")
             .is_some_and(|h| config.out_dir.as_path() == std::path::Path::new(&h))
         {
@@ -247,11 +243,9 @@ async fn main() -> Result<()> {
                  adjacent secrets. Prefer a narrow kaibo-owned dir (default $XDG_CACHE_HOME/kaibo)."
             );
         }
-        // No XDG cache and no HOME → the out-dir fell back to a world-shared system temp,
-        // and config defaulted read-back OFF there (a planted symlink in a shared temp
-        // could redirect the read mount). Tell the operator how to restore read-back: name
-        // a kaibo-owned out_dir. (Detected by the forced-off readable on a temp-rooted dir;
-        // an explicit out_dir under temp with readable left on won't trip this.)
+        // The shared-temp fallback (no XDG/HOME) defaulted read-back off (see
+        // `DefaultOutDir::SharedTemp`); tell the operator how to restore it. Detected by the
+        // forced-off readable on a temp-rooted dir.
         if !config.out_dir_readable && config.out_dir.starts_with(std::env::temp_dir()) {
             tracing::warn!(
                 out_dir = %config.out_dir.display(),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -154,6 +154,15 @@ pub struct SandboxConfig {
     /// `[kaish.ignore]`. Defaults to [`IgnoreConfig::agent`] (`.gitignore` + built-in
     /// defaults, enforced scope) so omitting the stanza preserves today's behavior.
     pub ignore: IgnoreConfig,
+    /// The capability artifact out-dir ([`crate::config::Config::out_dir`]), mounted
+    /// **read-only** into the kernel so a consult/run_kaish can read a generated
+    /// artifact back. This widens read-*scope* to the kaibo-owned cache only — it is
+    /// **not** a write path (the handler writes via `std::fs`; kaish never does), so the
+    /// read-only invariant is untouched. `None` (the default) mounts nothing; the mount
+    /// is also skipped until the dir exists (created lazily on the first artifact write)
+    /// and when it already falls under the project mount. See
+    /// [`build_readonly_kernel_and_vfs`].
+    pub out_dir: Option<PathBuf>,
 }
 
 impl Default for SandboxConfig {
@@ -164,6 +173,7 @@ impl Default for SandboxConfig {
             scratch_limit_bytes: DEFAULT_SCRATCH_LIMIT_BYTES,
             disable_builtins: Vec::new(),
             ignore: IgnoreConfig::agent(),
+            out_dir: None,
         }
     }
 }
@@ -233,6 +243,27 @@ fn build_readonly_kernel_and_vfs(
     vfs.mount("/", MemoryFs::with_budget(scratch_budget));
     // The project itself: real files, read-only.
     vfs.mount(&mount_point, LocalFs::read_only(&root));
+
+    // The capability artifact out-dir, mounted **read-only** so a consult/run_kaish can
+    // read a generated artifact back (the `generate_image` output, etc.). It's the same
+    // `LocalFs::read_only` the project rides, so this only adds read-*scope* to the
+    // kaibo-owned cache — never a write path (the handler writes via `std::fs`; kaish
+    // can't). Skipped when (a) unset, (b) the dir doesn't exist yet (created lazily on
+    // the first write — nothing to read until then), or (c) it already falls under the
+    // project mount (the project's read-only `LocalFs` already serves it; a second mount
+    // would just shadow it identically). Canonicalize first so the mount point matches
+    // how kaish resolves an absolute path (symlinks/`..` resolved), and so the
+    // under-root check can't be fooled by a symlink — the same canonicalize-then-decide
+    // discipline as `resolve_root`.
+    if let Some(out_dir) = sandbox.out_dir.as_ref() {
+        if let Ok(canon) = out_dir.canonicalize() {
+            let root_canon = root.canonicalize().unwrap_or_else(|_| root.clone());
+            if canon != root_canon && !canon.starts_with(&root_canon) {
+                let out_mount = canon.to_string_lossy().to_string();
+                vfs.mount(&out_mount, LocalFs::read_only(&canon));
+            }
+        }
+    }
 
     // Keep a handle to the project router before it disappears into the backend, so
     // the worker can read bytes through these mounts (the kernel's own `vfs()` won't

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -159,8 +159,9 @@ pub struct SandboxConfig {
     /// artifact back. This widens read-*scope* to the kaibo-owned cache only — it is
     /// **not** a write path (the handler writes via `std::fs`; kaish never does), so the
     /// read-only invariant is untouched. `None` (the default) mounts nothing; the mount
-    /// is also skipped until the dir exists (created lazily on the first artifact write)
-    /// and when it already falls under the project mount. See
+    /// is also skipped when the dir doesn't exist (normally pre-created at startup in
+    /// `main`, so this is the defensive fallback for a gated-off or uncreatable dir) and
+    /// when it already falls under the project mount. See
     /// [`build_readonly_kernel_and_vfs`].
     pub out_dir: Option<PathBuf>,
 }
@@ -248,10 +249,11 @@ fn build_readonly_kernel_and_vfs(
     // read a generated artifact back (the `generate_image` output, etc.). It's the same
     // `LocalFs::read_only` the project rides, so this only adds read-*scope* to the
     // kaibo-owned cache — never a write path (the handler writes via `std::fs`; kaish
-    // can't). Skipped when (a) unset, (b) the dir doesn't exist yet (created lazily on
-    // the first write — nothing to read until then), or (c) it already falls under the
-    // project mount (the project's read-only `LocalFs` already serves it; a second mount
-    // would just shadow it identically). Canonicalize first so the mount point matches
+    // can't). Skipped when (a) unset, (b) the dir doesn't exist (normally pre-created at
+    // startup in `main` when generate_image is enabled, so this guards the gated-off /
+    // uncreatable case — nothing to read until an artifact lands anyway), or (c) it
+    // already falls under the project mount (the project's read-only `LocalFs` already
+    // serves it; a second mount would just shadow it identically). Canonicalize first so the mount point matches
     // how kaish resolves an absolute path (symlinks/`..` resolved), and so the
     // under-root check can't be fooled by a symlink — the same canonicalize-then-decide
     // discipline as `resolve_root`.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -154,15 +154,11 @@ pub struct SandboxConfig {
     /// `[kaish.ignore]`. Defaults to [`IgnoreConfig::agent`] (`.gitignore` + built-in
     /// defaults, enforced scope) so omitting the stanza preserves today's behavior.
     pub ignore: IgnoreConfig,
-    /// The capability artifact out-dir ([`crate::config::Config::out_dir`]), mounted
-    /// **read-only** into the kernel so a consult/run_kaish can read a generated
-    /// artifact back. This widens read-*scope* to the kaibo-owned cache only — it is
-    /// **not** a write path (the handler writes via `std::fs`; kaish never does), so the
-    /// read-only invariant is untouched. `None` (the default) mounts nothing; the mount
-    /// is also skipped when the dir doesn't exist (normally pre-created at startup in
-    /// `main`, so this is the defensive fallback for a gated-off or uncreatable dir) and
-    /// when it already falls under the project mount. See
-    /// [`build_readonly_kernel_and_vfs`].
+    /// The readable artifact out-dir to mount **read-only** into the kernel for read-back
+    /// — `Some` iff `out_dir_readable` (see [`crate::config::Config::out_dir`] for the
+    /// policy and why this is a read mount, not a write path). `None` mounts nothing.
+    /// [`build_readonly_kernel_and_vfs`] also skips it when the dir doesn't exist yet or
+    /// already falls under the project mount.
     pub out_dir: Option<PathBuf>,
 }
 
@@ -245,18 +241,13 @@ fn build_readonly_kernel_and_vfs(
     // The project itself: real files, read-only.
     vfs.mount(&mount_point, LocalFs::read_only(&root));
 
-    // The capability artifact out-dir, mounted **read-only** so a consult/run_kaish can
-    // read a generated artifact back (the `generate_image` output, etc.). It's the same
-    // `LocalFs::read_only` the project rides, so this only adds read-*scope* to the
-    // kaibo-owned cache — never a write path (the handler writes via `std::fs`; kaish
-    // can't). Skipped when (a) unset, (b) the dir doesn't exist (normally pre-created at
-    // startup in `main` when generate_image is enabled, so this guards the gated-off /
-    // uncreatable case — nothing to read until an artifact lands anyway), or (c) it
-    // already falls under the project mount (the project's read-only `LocalFs` already
-    // serves it; a second mount would just shadow it identically). Canonicalize first so the mount point matches
-    // how kaish resolves an absolute path (symlinks/`..` resolved), and so the
-    // under-root check can't be fooled by a symlink — the same canonicalize-then-decide
-    // discipline as `resolve_root`.
+    // The readable artifact out-dir, mounted read-only for read-back (see
+    // [`crate::config::Config::out_dir`]). Same `LocalFs::read_only` as the project, so no
+    // write path is opened. Skipped when unset, when the dir doesn't exist yet (nothing to
+    // read until an artifact lands), or when it already falls under the project mount.
+    // Canonicalize first so the mount point matches how kaish resolves an absolute path
+    // and the under-root check can't be fooled by a symlink — the canonicalize-then-decide
+    // discipline `resolve_root` uses.
     if let Some(out_dir) = sandbox.out_dir.as_ref() {
         if let Ok(canon) = out_dir.canonicalize() {
             let root_canon = root.canonicalize().unwrap_or_else(|_| root.clone());

--- a/src/server.rs
+++ b/src/server.rs
@@ -517,6 +517,22 @@ impl KaiboHandler {
             }
         };
 
+        // The artifact out-dir joins the read allowed-set when readable, so an out-dir
+        // path can be `attach`ed (oneshot/batch) or targeted as a call `path` — keeping
+        // the attach/containment surface in step with the read-only kaish mount. Added
+        // *after* the default-root resolution above so it never becomes the inferred
+        // default root. Canonicalized (normally pre-created at startup); skipped silently
+        // when it doesn't exist yet (nothing to read until an artifact lands) or already
+        // falls under an allowed tree. Unlike `--root`/`--allow-path` a missing out-dir is
+        // not a loud error — it's auto-defaulted and lazily created, so absence is normal.
+        if config.out_dir_readable {
+            if let Ok(canon) = std::fs::canonicalize(&config.out_dir) {
+                if canon.is_dir() && !allowed.iter().any(|tree| canon.starts_with(tree)) {
+                    allowed.push(canon);
+                }
+            }
+        }
+
         // Stamp the live cast roster onto the consultation tools' `cast` param as a
         // JSON-Schema `enum`, so an agent choosing a team reads the menu off the tool
         // schema it already fills arguments from — not only the handshake prose, which
@@ -753,8 +769,23 @@ impl KaiboHandler {
     /// itself — a text file with `cat -n`, an image with `view_image` — and what
     /// [`consult_user_prompt`](crate::consult::consult_user_prompt) names in the driver
     /// prompt, deferring the byte-level IO to the model's own reads.
+    /// The canonical artifact out-dir *as kaish mounts it* — `Some` only when the out-dir
+    /// is readable (`config.sandbox.out_dir`, set iff `out_dir_readable`) and exists on
+    /// disk. This is the one tree besides the project root a consult's shell can read, so
+    /// it's what [`resolve_consult_attachments`](Self::resolve_consult_attachments) checks
+    /// an out-of-root attachment against. `None` when the out-dir isn't readable or hasn't
+    /// been created yet (no artifact to attach).
+    fn out_dir_mount(&self) -> Option<PathBuf> {
+        self.config
+            .sandbox
+            .out_dir
+            .as_ref()
+            .and_then(|p| std::fs::canonicalize(p).ok())
+    }
+
     fn resolve_consult_attachments(
         root: &std::path::Path,
+        out_dir_mount: Option<&std::path::Path>,
         attach: &[String],
     ) -> Result<Vec<crate::consult::ConsultAttachment>, McpError> {
         let mut out = Vec::with_capacity(attach.len());
@@ -784,22 +815,37 @@ impl KaiboHandler {
                     None,
                 ));
             }
-            // Must be under the consult's root — the tree its read-only shell is mounted
-            // at, so anything outside it the model simply can't `cat`. (oneshot/batch
-            // attach inline from anywhere in the allowed set; consult reads in situ.)
-            let rel = canon.strip_prefix(root).map_err(|_| {
-                McpError::invalid_params(
-                    format!(
-                        "attached file {} resolves outside the project root {} — consult \
-                         reads attachments through its shell, so they must live under the \
-                         project. Paste it into `context`, or use `oneshot`/`batch` attach \
-                         (which inline a file from anywhere in the allowed set).",
-                        raw.display(),
+            // The consult model reads attachments through its shell, which mounts exactly
+            // two real trees: the project root and (when readable) the artifact out-dir.
+            // A path under root is passed root-relative (the model `cat`s it from cwd); a
+            // path under the out-dir is passed absolute (the out-dir mounts at its own
+            // absolute path, so the model opens it directly). Anything else the shell
+            // can't reach — refuse, naming both reachable trees.
+            let display_path = if let Ok(rel) = canon.strip_prefix(root) {
+                rel.display().to_string()
+            } else if out_dir_mount.is_some_and(|o| canon.starts_with(o)) {
+                canon.display().to_string()
+            } else {
+                let where_ = match out_dir_mount {
+                    Some(o) => format!(
+                        "the project root {} or the artifact out-dir {}",
                         root.display(),
+                        o.display()
+                    ),
+                    None => format!("the project root {}", root.display()),
+                };
+                return Err(McpError::invalid_params(
+                    format!(
+                        "attached file {} resolves outside {} — consult reads attachments \
+                         through its shell, which only mounts those. Paste it into `context`, \
+                         or use `oneshot`/`batch` attach (which inline a file from anywhere in \
+                         the allowed set).",
+                        raw.display(),
+                        where_,
                     ),
                     None,
-                )
-            })?;
+                ));
+            };
             // Sniff the file's type so the driver prompt routes it to the right tool: a
             // text file the model reads with `cat -n`, an image it views with `view_image`
             // (which `cat` would refuse as binary). Classify by content, not extension — a
@@ -826,7 +872,7 @@ impl KaiboHandler {
                 crate::view_image::sniff_mime(&buf[..n]).is_some()
             };
             out.push(crate::consult::ConsultAttachment {
-                path: rel.display().to_string(),
+                path: display_path,
                 is_image,
             });
         }
@@ -1310,7 +1356,11 @@ impl KaiboHandler {
         // Resolve + classify attachments, then gate: an image needs a vision-capable synth
         // (consult views it with `view_image`, which only a vision synth carries). Refuse
         // here, before the loop, the same honest up-front refusal oneshot/batch give.
-        let attachments = Self::resolve_consult_attachments(&root, &input.attach)?;
+        let attachments = Self::resolve_consult_attachments(
+            &root,
+            self.out_dir_mount().as_deref(),
+            &input.attach,
+        )?;
         Self::gate_consult_image_attachments(
             &attachments,
             synth.caps.vision,
@@ -1419,7 +1469,11 @@ impl KaiboHandler {
         let defaults = &self.config.defaults;
         // Resolve + classify + gate before spawning: a bad attach (or an image to a blind
         // synth) is a clean synchronous refusal, not a job that fails on poll.
-        let attachments = Self::resolve_consult_attachments(&root, &input.attach)?;
+        let attachments = Self::resolve_consult_attachments(
+            &root,
+            self.out_dir_mount().as_deref(),
+            &input.attach,
+        )?;
         Self::gate_consult_image_attachments(
             &attachments,
             synth.caps.vision,
@@ -2677,6 +2731,10 @@ fn render_config_resource(
         /// also mounted read-only into kaish so a consult can read an artifact back — so
         /// it's part of the read-scope, surfaced here for transparency.
         out_dir: String,
+        /// Whether the out-dir is readable: mounted into kaish and in the allowed-set
+        /// (so an out-dir path can be attached/targeted). `false` → kaibo writes there
+        /// but never reads it back. (When true, `out_dir` also appears in `allowed_paths`.)
+        out_dir_readable: bool,
         /// Runtime-derived state — computed at read time, not configured. Distinct
         /// from the static knobs above so a reader can tell "what kaibo discovered"
         /// from "what the operator set".
@@ -2987,6 +3045,7 @@ fn render_config_resource(
         default_root_inferred,
         default_cast: config.default_cast.clone(),
         out_dir: config.out_dir.display().to_string(),
+        out_dir_readable: config.out_dir_readable,
         runtime: RuntimeDoc {
             follow_worktrees: config.follow_worktrees,
             followed_worktrees: followed_worktrees
@@ -3522,9 +3581,12 @@ mod tests {
         std::fs::write(root_canon.join("src/jobs.rs"), b"// in tree").unwrap();
 
         // A relative path resolves to its root-relative form (what the model `cat`s).
-        let rel =
-            KaiboHandler::resolve_consult_attachments(&root_canon, &["src/jobs.rs".to_string()])
-                .expect("an in-tree file resolves");
+        let rel = KaiboHandler::resolve_consult_attachments(
+            &root_canon,
+            None,
+            &["src/jobs.rs".to_string()],
+        )
+        .expect("an in-tree file resolves");
         assert_eq!(rel.len(), 1);
         assert_eq!(rel[0].path, "src/jobs.rs");
 
@@ -3536,6 +3598,7 @@ mod tests {
         std::fs::write(&outside_file, b"diff").unwrap();
         let err = KaiboHandler::resolve_consult_attachments(
             &root_canon,
+            None,
             &[outside_file.display().to_string()],
         )
         .expect_err("an out-of-root file must be refused");
@@ -3544,6 +3607,52 @@ mod tests {
             "the refusal names the boundary: {}",
             err.message
         );
+    }
+
+    /// A file under the readable artifact out-dir is accepted as an absolute path — the
+    /// re-attach path for a generated artifact. The out-dir mounts read-only into the
+    /// consult shell at its own absolute path, so unlike an in-root file (passed
+    /// root-relative) it's passed absolute. A sibling of the out-dir is still refused.
+    #[test]
+    fn consult_attach_accepts_out_dir_file_as_absolute() {
+        let root = tempfile::tempdir().unwrap();
+        let root_canon = std::fs::canonicalize(root.path()).unwrap();
+        let out = tempfile::Builder::new()
+            .prefix("kaibo-out")
+            .tempdir()
+            .unwrap();
+        let out_canon = std::fs::canonicalize(out.path()).unwrap();
+        let artifact = out_canon.join("kaibo-image-1-2-3.png");
+        std::fs::write(
+            &artifact,
+            [0x89u8, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+        )
+        .unwrap();
+
+        let got = KaiboHandler::resolve_consult_attachments(
+            &root_canon,
+            Some(out_canon.as_path()),
+            &[artifact.display().to_string()],
+        )
+        .expect("an out-dir artifact resolves");
+        assert_eq!(got.len(), 1);
+        assert_eq!(
+            got[0].path,
+            artifact.display().to_string(),
+            "an out-dir attachment is passed absolute (the mount lives at its own path)"
+        );
+        assert!(got[0].is_image, "the PNG signature classifies as an image");
+
+        // A sibling of the out-dir is not mounted — still refused even with a mount set.
+        let sibling = tempfile::tempdir().unwrap();
+        let stray = std::fs::canonicalize(sibling.path()).unwrap().join("x.png");
+        std::fs::write(&stray, b"x").unwrap();
+        KaiboHandler::resolve_consult_attachments(
+            &root_canon,
+            Some(out_canon.as_path()),
+            &[stray.display().to_string()],
+        )
+        .expect_err("a file outside both root and the out-dir must be refused");
     }
 
     /// consult `attach` sniffs each file's *content* (not its extension) so the driver
@@ -3563,6 +3672,7 @@ mod tests {
 
         let out = KaiboHandler::resolve_consult_attachments(
             &root_canon,
+            None,
             &["shot.txt".to_string(), "notes.png".to_string()],
         )
         .expect("both resolve");

--- a/src/server.rs
+++ b/src/server.rs
@@ -531,14 +531,12 @@ impl KaiboHandler {
             }
         };
 
-        // The artifact out-dir joins the read allowed-set when readable, so an out-dir
-        // path can be `attach`ed (oneshot/batch) or targeted as a call `path` — keeping
-        // the attach/containment surface in step with the read-only kaish mount. Added
-        // *after* the default-root resolution above so it never becomes the inferred
-        // default root. Canonicalized (normally pre-created at startup); skipped silently
-        // when it doesn't exist yet (nothing to read until an artifact lands) or already
-        // falls under an allowed tree. Unlike `--root`/`--allow-path` a missing out-dir is
-        // not a loud error — it's auto-defaulted and lazily created, so absence is normal.
+        // When readable, the out-dir joins the allowed-set so an out-dir path can be
+        // `attach`ed or targeted as a call `path` — the containment half of the read
+        // surface on [`crate::config::Config::out_dir`], kept in step with the kaish mount.
+        // Added *after* default-root resolution so it never becomes the inferred root.
+        // Skipped silently when it doesn't exist yet or already falls under an allowed tree
+        // — unlike `--root`/`--allow-path`, a missing auto-defaulted out-dir isn't an error.
         if config.out_dir_readable {
             if let Ok(canon) = std::fs::canonicalize(&config.out_dir) {
                 if canon.is_dir() && !allowed.iter().any(|tree| canon.starts_with(tree)) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -408,6 +408,20 @@ fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, tools: &[&str], casts
     }
 }
 
+/// The artifact out-dir's state for `consult` attachment resolution — the consult shell
+/// mounts exactly the project root + (when readable) the out-dir, so an out-of-root
+/// attachment is reachable only when it falls under a *readable* out-dir.
+enum OutDirAttach {
+    /// No out-dir on disk yet (nothing to attach).
+    None,
+    /// Mounted read-only into the consult shell at this canonical path — out-dir files
+    /// attach as absolute paths.
+    Readable(PathBuf),
+    /// Exists, but `out_dir_readable` is off: an out-dir attachment is refused with a
+    /// tailored hint, since neither the consult shell nor oneshot/batch can reach it.
+    Unreadable(PathBuf),
+}
+
 #[tool_router]
 impl KaiboHandler {
     /// Build the handler from a resolved [`Config`]. Snapshots the kernel's builtin
@@ -760,32 +774,33 @@ impl KaiboHandler {
         )
     }
 
-    /// Validate caller-named `consult` attachments and return them as **root-relative
-    /// paths the model reads itself** — no bytes are read here, unlike
-    /// [`resolve_attachments`](Self::resolve_attachments), which inlines for the tool-less
-    /// tools. Each path must canonicalize to a regular file *under the consult's `root`*,
-    /// because the consult reads it through a kaish worker rooted there; an out-of-root
-    /// path is refused with guidance. The returned relative paths are what the model opens
-    /// itself — a text file with `cat -n`, an image with `view_image` — and what
-    /// [`consult_user_prompt`](crate::consult::consult_user_prompt) names in the driver
-    /// prompt, deferring the byte-level IO to the model's own reads.
-    /// The canonical artifact out-dir *as kaish mounts it* — `Some` only when the out-dir
-    /// is readable (`config.sandbox.out_dir`, set iff `out_dir_readable`) and exists on
-    /// disk. This is the one tree besides the project root a consult's shell can read, so
-    /// it's what [`resolve_consult_attachments`](Self::resolve_consult_attachments) checks
-    /// an out-of-root attachment against. `None` when the out-dir isn't readable or hasn't
-    /// been created yet (no artifact to attach).
-    fn out_dir_mount(&self) -> Option<PathBuf> {
-        self.config
-            .sandbox
-            .out_dir
-            .as_ref()
-            .and_then(|p| std::fs::canonicalize(p).ok())
+    /// The artifact out-dir's state for `consult` attachment resolution, derived from the
+    /// real on-disk dir (see [`OutDirAttach`]). `Readable` carries the canonical path the
+    /// consult shell mounts; `Unreadable` means the dir exists but `out_dir_readable` is
+    /// off; `None` means no out-dir exists yet. Used by
+    /// [`resolve_consult_attachments`](Self::resolve_consult_attachments).
+    fn out_dir_attach_state(&self) -> OutDirAttach {
+        match std::fs::canonicalize(&self.config.out_dir) {
+            Ok(canon) if self.config.out_dir_readable => OutDirAttach::Readable(canon),
+            Ok(canon) => OutDirAttach::Unreadable(canon),
+            Err(_) => OutDirAttach::None,
+        }
     }
 
+    /// Validate caller-named `consult` attachments and return the path the model opens
+    /// itself — no bytes are read here, unlike
+    /// [`resolve_attachments`](Self::resolve_attachments), which inlines for the tool-less
+    /// tools. Each path must canonicalize to a regular file the consult shell can reach:
+    /// *under the consult's `root`* (returned root-relative, `cat`'d from cwd) or *under a
+    /// readable out-dir* (returned absolute — the out-dir mounts at its own path). An
+    /// out-dir file with read-back off, or any other out-of-reach path, is refused with
+    /// guidance. The returned paths are what the model opens — a text file with `cat -n`,
+    /// an image with `view_image` — and what
+    /// [`consult_user_prompt`](crate::consult::consult_user_prompt) names in the driver
+    /// prompt, deferring the byte-level IO to the model's own reads.
     fn resolve_consult_attachments(
         root: &std::path::Path,
-        out_dir_mount: Option<&std::path::Path>,
+        out_dir: &OutDirAttach,
         attach: &[String],
     ) -> Result<Vec<crate::consult::ConsultAttachment>, McpError> {
         let mut out = Vec::with_capacity(attach.len());
@@ -816,23 +831,37 @@ impl KaiboHandler {
                 ));
             }
             // The consult model reads attachments through its shell, which mounts exactly
-            // two real trees: the project root and (when readable) the artifact out-dir.
-            // A path under root is passed root-relative (the model `cat`s it from cwd); a
-            // path under the out-dir is passed absolute (the out-dir mounts at its own
-            // absolute path, so the model opens it directly). Anything else the shell
-            // can't reach — refuse, naming both reachable trees.
+            // two real trees: the project root and (when readable) the artifact out-dir. A
+            // path under root is passed root-relative (the model `cat`s it from cwd); a
+            // path under a *readable* out-dir is passed absolute (the out-dir mounts at its
+            // own absolute path). An out-dir file with read-back OFF gets a tailored
+            // refusal — oneshot/batch can't reach it either, so don't suggest them.
+            // Anything else out of reach gets the generic refusal naming the reachable
+            // trees.
             let display_path = if let Ok(rel) = canon.strip_prefix(root) {
                 rel.display().to_string()
-            } else if out_dir_mount.is_some_and(|o| canon.starts_with(o)) {
+            } else if matches!(out_dir, OutDirAttach::Readable(o) if canon.starts_with(o)) {
                 canon.display().to_string()
+            } else if matches!(out_dir, OutDirAttach::Unreadable(o) if canon.starts_with(o)) {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "attached file {} is in the artifact out-dir, but read-back is off \
+                         (out_dir_readable = false), so kaibo can't read it back — neither \
+                         consult nor oneshot/batch can reach it. Enable read-back \
+                         (out_dir_readable = true, or drop --no-out-dir-read), or open the \
+                         file with your own tools.",
+                        raw.display(),
+                    ),
+                    None,
+                ));
             } else {
-                let where_ = match out_dir_mount {
-                    Some(o) => format!(
+                let where_ = match out_dir {
+                    OutDirAttach::Readable(o) => format!(
                         "the project root {} or the artifact out-dir {}",
                         root.display(),
                         o.display()
                     ),
-                    None => format!("the project root {}", root.display()),
+                    _ => format!("the project root {}", root.display()),
                 };
                 return Err(McpError::invalid_params(
                     format!(
@@ -1356,11 +1385,8 @@ impl KaiboHandler {
         // Resolve + classify attachments, then gate: an image needs a vision-capable synth
         // (consult views it with `view_image`, which only a vision synth carries). Refuse
         // here, before the loop, the same honest up-front refusal oneshot/batch give.
-        let attachments = Self::resolve_consult_attachments(
-            &root,
-            self.out_dir_mount().as_deref(),
-            &input.attach,
-        )?;
+        let attachments =
+            Self::resolve_consult_attachments(&root, &self.out_dir_attach_state(), &input.attach)?;
         Self::gate_consult_image_attachments(
             &attachments,
             synth.caps.vision,
@@ -1469,11 +1495,8 @@ impl KaiboHandler {
         let defaults = &self.config.defaults;
         // Resolve + classify + gate before spawning: a bad attach (or an image to a blind
         // synth) is a clean synchronous refusal, not a job that fails on poll.
-        let attachments = Self::resolve_consult_attachments(
-            &root,
-            self.out_dir_mount().as_deref(),
-            &input.attach,
-        )?;
+        let attachments =
+            Self::resolve_consult_attachments(&root, &self.out_dir_attach_state(), &input.attach)?;
         Self::gate_consult_image_attachments(
             &attachments,
             synth.caps.vision,
@@ -3589,7 +3612,7 @@ mod tests {
         // A relative path resolves to its root-relative form (what the model `cat`s).
         let rel = KaiboHandler::resolve_consult_attachments(
             &root_canon,
-            None,
+            &OutDirAttach::None,
             &["src/jobs.rs".to_string()],
         )
         .expect("an in-tree file resolves");
@@ -3604,7 +3627,7 @@ mod tests {
         std::fs::write(&outside_file, b"diff").unwrap();
         let err = KaiboHandler::resolve_consult_attachments(
             &root_canon,
-            None,
+            &OutDirAttach::None,
             &[outside_file.display().to_string()],
         )
         .expect_err("an out-of-root file must be refused");
@@ -3637,7 +3660,7 @@ mod tests {
 
         let got = KaiboHandler::resolve_consult_attachments(
             &root_canon,
-            Some(out_canon.as_path()),
+            &OutDirAttach::Readable(out_canon.clone()),
             &[artifact.display().to_string()],
         )
         .expect("an out-dir artifact resolves");
@@ -3655,10 +3678,50 @@ mod tests {
         std::fs::write(&stray, b"x").unwrap();
         KaiboHandler::resolve_consult_attachments(
             &root_canon,
-            Some(out_canon.as_path()),
+            &OutDirAttach::Readable(out_canon.clone()),
             &[stray.display().to_string()],
         )
         .expect_err("a file outside both root and the out-dir must be refused");
+    }
+
+    /// An out-dir file attached with read-back OFF gets a *tailored* refusal that names
+    /// the `out_dir_readable` toggle and does NOT misdirect to oneshot/batch (which can't
+    /// reach it either, since the out-dir isn't in the allowed-set when read-back is off).
+    #[test]
+    fn consult_attach_out_dir_file_with_read_back_off_refuses_with_tailored_hint() {
+        let root = tempfile::tempdir().unwrap();
+        let root_canon = std::fs::canonicalize(root.path()).unwrap();
+        let out = tempfile::Builder::new()
+            .prefix("kaibo-out")
+            .tempdir()
+            .unwrap();
+        let out_canon = std::fs::canonicalize(out.path()).unwrap();
+        let artifact = out_canon.join("kaibo-image-9.png");
+        std::fs::write(
+            &artifact,
+            [0x89u8, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+        )
+        .unwrap();
+
+        let err = KaiboHandler::resolve_consult_attachments(
+            &root_canon,
+            &OutDirAttach::Unreadable(out_canon.clone()),
+            &[artifact.display().to_string()],
+        )
+        .expect_err("an out-dir file with read-back off must be refused");
+        // Names the real fix (the read-back toggle)...
+        assert!(
+            err.message.contains("out_dir_readable") && err.message.contains("read-back"),
+            "the refusal must name the read-back toggle: {}",
+            err.message
+        );
+        // ...and does NOT dangle the generic "use oneshot/batch" workaround (the old
+        // message's false promise — those can't reach an out-dir file with read-back off).
+        assert!(
+            !err.message.contains("anywhere in the allowed set"),
+            "must not misdirect to oneshot/batch as a workaround: {}",
+            err.message
+        );
     }
 
     /// consult `attach` sniffs each file's *content* (not its extension) so the driver
@@ -3678,7 +3741,7 @@ mod tests {
 
         let out = KaiboHandler::resolve_consult_attachments(
             &root_canon,
-            None,
+            &OutDirAttach::None,
             &["shot.txt".to_string(), "notes.png".to_string()],
         )
         .expect("both resolve");

--- a/src/server.rs
+++ b/src/server.rs
@@ -1600,15 +1600,16 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Generate an image from a text prompt and return it inline. A \
-            capability tool: no codebase investigation, no shell — the cast's `image` model \
-            draws what you describe and hands back the picture plus a short caption. Runs \
-            the cast's `image` slot — an OpenAI-compatible backend (hosted gpt-image/DALL·E, \
-            or a local Stable-Diffusion server); `image_backend` can retarget to one even on \
-            a cast that carries no image slot, and `kaibo://config` shows which casts qualify \
-            as-is. Takes `size` (\"WxH\", default 1024x1024) plus the usual `cast` / \
-            `image_model` / `image_backend` selectors (see `kaibo://tools`). A picture too \
-            large to inline is a clear error, not a silent drop."
+        description = "Generate an image from a text prompt; it's written to a file and \
+            the path is returned (open it to view — no inline blob, so a large picture \
+            costs you nothing until you read it). A capability tool: no codebase \
+            investigation, no shell — the cast's `image` model draws what you describe. \
+            Runs the cast's `image` slot — an OpenAI-compatible backend (hosted \
+            gpt-image/DALL·E, or a local Stable-Diffusion server); `image_backend` can \
+            retarget to one even on a cast that carries no image slot, and `kaibo://config` \
+            shows which casts qualify as-is. Takes `size` (\"WxH\", default 1024x1024) plus \
+            the usual `cast` / `image_model` / `image_backend` selectors (see \
+            `kaibo://tools`). Files land in kaibo's artifact dir (`kaibo://config`)."
     )]
     pub async fn generate_image(
         &self,
@@ -1651,7 +1652,16 @@ impl KaiboHandler {
             }
         };
 
+        // Write the artifact to the kaibo-owned out-dir and hand back its path — no
+        // inline blob. The write is handler-side `std::fs` (never kaish), so the
+        // read-only sandbox is untouched. A write failure is the operator's environment
+        // (a full disk, an unwritable cache dir), not the caller's request, so it maps
+        // to an internal error — and we never report success on a half-written artifact.
+        let path = crate::generate_image::write_artifact(&self.config.out_dir, &image)
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+
         Ok(CallToolResult::success(crate::generate_image::to_content(
+            &path,
             &image,
             &input.prompt,
             size,
@@ -2663,6 +2673,10 @@ fn render_config_resource(
         default_root_inferred: bool,
         /// Default cast name (what a call omitting `cast` gets).
         default_cast: String,
+        /// Where capability tools (generate_image) write artifacts. A kaibo-owned dir,
+        /// also mounted read-only into kaish so a consult can read an artifact back — so
+        /// it's part of the read-scope, surfaced here for transparency.
+        out_dir: String,
         /// Runtime-derived state — computed at read time, not configured. Distinct
         /// from the static knobs above so a reader can tell "what kaibo discovered"
         /// from "what the operator set".
@@ -2939,6 +2953,9 @@ fn render_config_resource(
         scratch_limit_bytes,
         disable_builtins,
         ignore,
+        // Surfaced at the top level from `config.out_dir` (the authoritative copy);
+        // this sandbox field is the read-back-mount mirror, so skip it here.
+        out_dir: _,
     } = &config.sandbox;
     let crate::config::Defaults {
         explorer_max_turns,
@@ -2969,6 +2986,7 @@ fn render_config_resource(
         default_root: default_root.map(|p| p.display().to_string()),
         default_root_inferred,
         default_cast: config.default_cast.clone(),
+        out_dir: config.out_dir.display().to_string(),
         runtime: RuntimeDoc {
             follow_worktrees: config.follow_worktrees,
             followed_worktrees: followed_worktrees

--- a/src/server.rs
+++ b/src/server.rs
@@ -2443,15 +2443,21 @@ default.
 (`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
 the secret stays outside it. Tell me which env vars to set or files to write, and let \
 me put the keys in myself.
-5. (Optional) Read scope. By default kaibo reads only the project tree it's pointed at \
-(plus linked git worktrees), and it only ever *reads* — never writes. If a workflow \
-hands kaibo artifacts to read from a scratch space — a diff, a generated file, a log \
-dropped in a temp dir — name that space in `[server] allow_paths` so it's in bounds. \
-Prefer the host-portable form `allow_paths = [\"$TMPDIR\"]` or \
-`[\"$XDG_RUNTIME_DIR/scratch\"]` over a hardcoded `/tmp` — `$VAR` / `${VAR}` and a \
-leading `~` expand in these paths, resolving per machine. Ask me whether I want a scratch \
-space readable before adding one: it widens what the team can see (read-only, but still a \
-real boundary), so it's a deliberate opt-in, not a default.
+5. (Optional) Read scope & artifact storage. By default kaibo reads only the project \
+tree (plus linked git worktrees) and only ever *reads* — never writes. Two things widen \
+what the team can see, both deliberate opt-ins worth asking me about first: (a) a scratch \
+space kaibo should read from — a diff, a log, a generated file — name it in \
+`[server] allow_paths`; (b) the artifact out-dir, where capability tools (`generate_image`) \
+write and which kaibo mounts read-only so a later consult can read an artifact back. The \
+out-dir defaults to a kaibo-owned cache (`$XDG_CACHE_HOME/kaibo`). **If I'm in a stripped \
+environment with no `$XDG_CACHE_HOME` and no `$HOME` — a container, a CI runner — kaibo \
+falls back to a shared system temp and turns read-back OFF for safety: `generate_image` \
+still works and returns the file path, but a consult can't read it back (a world-shared \
+temp isn't safe to auto-mount).** To restore read-back there, set `[server] out_dir` to a \
+safe, kaibo-owned directory I name. Prefer the host-portable `out_dir = \"$XDG_RUNTIME_DIR/kaibo\"` \
+(or a path under my home) over a hardcoded `/tmp`; `$VAR` / `${VAR}` and a leading `~` \
+expand here, resolving per machine. `out_dir = \"/\"` is refused, and `$HOME` is warned — \
+these read-mount into kaish, a real boundary.
 6. When the file is written, remind me to reconnect the kaibo MCP server so it re-reads \
 the config and keys — both load once at startup.";
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use kaibo::config::{
-    default_models, parse_slot_ref, Backend, Config, ModelRole, ModelSlot, ToolDisables,
+    default_models, default_out_dir, parse_slot_ref, Backend, Config, ModelRole, ModelSlot,
+    ToolDisables,
 };
 use kaibo::consult::ThinkingStyleOverride;
 use kaibo::credentials::{openai_base_url, ProviderKind, PLACEHOLDER_OPENAI_KEY};
@@ -874,6 +875,7 @@ fn cli_cast_wins_over_env_and_file() {
         false,  // --no-follow-worktrees not passed
         vec![], // no --project-context-file flags
         vec![], // no --user-context-file flags
+        None,   // no --out-dir
     );
     assert_eq!(c.default_cast, "deepseek", "--cast beats env and file");
     assert_eq!(c.root.as_deref(), Some(std::path::Path::new("/tmp/proj")));
@@ -901,6 +903,7 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
         false,
         vec![],
         vec![],
+        None,
     );
     // The env/file-layer value must survive.
     assert!(
@@ -1631,5 +1634,56 @@ fn a_zero_orientation_ceiling_is_a_loud_error() {
     assert!(
         format!("{err:#}").contains("full_list_max_files"),
         "names the knob: {err:#}"
+    );
+}
+
+/// The artifact out-dir layers like the rest of config — default < file < env < CLI —
+/// and the resolved value is mirrored onto the sandbox so the read-back mount tracks it.
+#[test]
+fn out_dir_layers_default_file_env_and_cli() {
+    use std::path::Path;
+
+    // Unset → the kaibo-owned XDG-cache default (same process, same env, so equal).
+    let c = Config::from_toml_str("").unwrap();
+    assert_eq!(
+        c.out_dir,
+        default_out_dir(),
+        "an unset out_dir falls back to the default, not empty"
+    );
+    assert_eq!(
+        c.sandbox.out_dir.as_deref(),
+        Some(c.out_dir.as_path()),
+        "the sandbox mirrors out_dir for the read-back mount"
+    );
+
+    // File: [server] out_dir wins over the default.
+    let c = Config::from_toml_str("[server]\nout_dir = \"/var/kaibo-art\"\n").unwrap();
+    assert_eq!(c.out_dir, Path::new("/var/kaibo-art"));
+
+    // Env: KAIBO_OUT_DIR beats the file.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[server]\nout_dir = \"/file/kaibo-art\"\n").unwrap();
+    let env: HashMap<&str, &str> = [("KAIBO_OUT_DIR", "/env/kaibo-art")].into_iter().collect();
+    let c = Config::load_with(None, Some(path), |k| env.get(k).map(|s| s.to_string())).unwrap();
+    assert_eq!(c.out_dir, Path::new("/env/kaibo-art"), "env beats file");
+
+    // CLI: --out-dir beats everything and updates the sandbox mirror too.
+    let mut c = Config::builtin();
+    c.apply_cli(
+        None,
+        None,
+        ToolDisables::default(),
+        vec![],
+        false,
+        vec![],
+        vec![],
+        Some("/cli/kaibo-art".into()),
+    );
+    assert_eq!(c.out_dir, Path::new("/cli/kaibo-art"));
+    assert_eq!(
+        c.sandbox.out_dir.as_deref(),
+        Some(Path::new("/cli/kaibo-art")),
+        "CLI override updates the sandbox mirror so the mount tracks the final dir"
     );
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -876,6 +876,7 @@ fn cli_cast_wins_over_env_and_file() {
         vec![], // no --project-context-file flags
         vec![], // no --user-context-file flags
         None,   // no --out-dir
+        false,  // out-dir stays readable
     );
     assert_eq!(c.default_cast, "deepseek", "--cast beats env and file");
     assert_eq!(c.root.as_deref(), Some(std::path::Path::new("/tmp/proj")));
@@ -904,6 +905,7 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
         vec![],
         vec![],
         None,
+        false,
     );
     // The env/file-layer value must survive.
     assert!(
@@ -1679,12 +1681,60 @@ fn out_dir_layers_default_file_env_and_cli() {
         vec![],
         vec![],
         Some("/cli/kaibo-art".into()),
+        false,
     );
     assert_eq!(c.out_dir, Path::new("/cli/kaibo-art"));
     assert_eq!(
         c.sandbox.out_dir.as_deref(),
         Some(Path::new("/cli/kaibo-art")),
         "CLI override updates the sandbox mirror so the mount tracks the final dir"
+    );
+}
+
+/// `out_dir_readable` (default true) gates the read-back mount mirror: off means the
+/// out-dir is not mounted into kaish, layering default < file < env < CLI like the rest.
+#[test]
+fn out_dir_readable_gates_the_mount_mirror() {
+    // Default on: the sandbox mirror is set so the kernel builder mounts it.
+    let c = Config::from_toml_str("").unwrap();
+    assert!(c.out_dir_readable);
+    assert_eq!(c.sandbox.out_dir.as_deref(), Some(c.out_dir.as_path()));
+
+    // File off: no mount mirror.
+    let c = Config::from_toml_str("[server]\nout_dir_readable = false\n").unwrap();
+    assert!(!c.out_dir_readable);
+    assert!(
+        c.sandbox.out_dir.is_none(),
+        "an unreadable out-dir is not mounted"
+    );
+
+    // Env off (KAIBO_NO_OUT_DIR_READABLE).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "").unwrap();
+    let env: HashMap<&str, &str> = [("KAIBO_NO_OUT_DIR_READABLE", "1")].into_iter().collect();
+    let c = Config::load_with(None, Some(path), |k| env.get(k).map(|s| s.to_string())).unwrap();
+    assert!(!c.out_dir_readable, "env disables readability");
+    assert!(c.sandbox.out_dir.is_none());
+
+    // CLI --no-out-dir-read disables it and clears the mirror.
+    let mut c = Config::builtin();
+    assert!(c.sandbox.out_dir.is_some(), "builtin default is readable");
+    c.apply_cli(
+        None,
+        None,
+        ToolDisables::default(),
+        vec![],
+        false,
+        vec![],
+        vec![],
+        None,
+        true,
+    );
+    assert!(!c.out_dir_readable);
+    assert!(
+        c.sandbox.out_dir.is_none(),
+        "CLI --no-out-dir-read clears the mount mirror"
     );
 }
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1687,3 +1687,17 @@ fn out_dir_layers_default_file_env_and_cli() {
         "CLI override updates the sandbox mirror so the mount tracks the final dir"
     );
 }
+
+/// `out_dir = "/"` is refused at load: the out-dir is mounted read-only into kaish, so
+/// `/` would expose the whole host filesystem to a consult. A loud error, not a silent
+/// host-wide read scope.
+#[test]
+fn out_dir_root_is_refused() {
+    let err = Config::from_toml_str("[server]\nout_dir = \"/\"\n")
+        .expect_err("out_dir = / must be a loud load error, not a host-wide read mount");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("out_dir") && msg.contains("/"),
+        "the refusal should name out_dir and `/`: {msg}"
+    );
+}

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -504,13 +504,68 @@ fn allow_paths_from_env_overrides_file() {
 fn allow_paths_cli_replaces_env_and_file() {
     let mut c = kaibo::config::Config::builtin();
     c.allow_paths = vec![std::path::PathBuf::from("/tmp/env-only")];
-    c.apply_cli(None, None, kaibo::config::ToolDisables::default(), vec![
-        std::path::PathBuf::from("/tmp/cli-a"),
-        std::path::PathBuf::from("/tmp/cli-b"),
-    ], false, vec![], vec![], None);
+    c.apply_cli(
+        None,
+        None,
+        kaibo::config::ToolDisables::default(),
+        vec![
+            std::path::PathBuf::from("/tmp/cli-a"),
+            std::path::PathBuf::from("/tmp/cli-b"),
+        ],
+        false,
+        vec![],
+        vec![],
+        None,
+        false,
+    );
     assert_eq!(c.allow_paths.len(), 2);
-    assert!(c.allow_paths.iter().any(|p| p == std::path::Path::new("/tmp/cli-a")));
-    assert!(c.allow_paths.iter().any(|p| p == std::path::Path::new("/tmp/cli-b")));
+    assert!(c
+        .allow_paths
+        .iter()
+        .any(|p| p == std::path::Path::new("/tmp/cli-a")));
+    assert!(c
+        .allow_paths
+        .iter()
+        .any(|p| p == std::path::Path::new("/tmp/cli-b")));
+}
+
+/// A readable artifact out-dir joins the containment allowed-set, so an out-dir path can
+/// be `attach`ed (oneshot/batch) or targeted as a call `path` — matching the read-only
+/// kaish mount. Disabling readability keeps it out. The out-dir must already exist (it's
+/// pre-created at startup in `main`); here the tempdir stands in.
+#[test]
+fn readable_out_dir_joins_allowed_set() {
+    let root = tempdir().unwrap();
+    let out = tempfile::Builder::new()
+        .prefix("kaibo-out")
+        .tempdir()
+        .unwrap();
+    let out_canon = std::fs::canonicalize(out.path()).unwrap();
+
+    let mut config = Config::builtin();
+    config.root = Some(root.path().to_path_buf());
+    config.out_dir = out_canon.clone();
+    config.out_dir_readable = true;
+    config.sandbox.out_dir = Some(out_canon.clone());
+    let handler = KaiboHandler::new(config).expect("handler builds");
+    assert!(
+        handler.allowed_set().iter().any(|p| p == &out_canon),
+        "a readable out-dir must be in the allowed set: {:?}",
+        handler.allowed_set()
+    );
+
+    // Disabled: the out-dir stays out of the allowed set.
+    let mut config = Config::builtin();
+    config.root = Some(root.path().to_path_buf());
+    config.out_dir = out_canon.clone();
+    config.out_dir_readable = false;
+    config.sandbox.out_dir = None;
+    let handler = KaiboHandler::new(config).expect("handler builds");
+    assert!(
+        !handler.allowed_set().iter().any(|p| p == &out_canon),
+        "an unreadable out-dir must stay out of the allowed set: {:?}",
+        handler.allowed_set()
+    );
 }
 
 // --- worktree follow ----------------------------------------------------------

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -507,7 +507,7 @@ fn allow_paths_cli_replaces_env_and_file() {
     c.apply_cli(None, None, kaibo::config::ToolDisables::default(), vec![
         std::path::PathBuf::from("/tmp/cli-a"),
         std::path::PathBuf::from("/tmp/cli-b"),
-    ], false, vec![], vec![]);
+    ], false, vec![], vec![], None);
     assert_eq!(c.allow_paths.len(), 2);
     assert!(c.allow_paths.iter().any(|p| p == std::path::Path::new("/tmp/cli-a")));
     assert!(c.allow_paths.iter().any(|p| p == std::path::Path::new("/tmp/cli-b")));

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -392,3 +392,124 @@ fn builtin_schemas_enumerate_the_read_toolbox() {
         );
     }
 }
+
+// --- artifact out-dir read-back mount ----------------------------------------
+//
+// A capability writes its artifact to the out-dir (handler-side `std::fs`); the
+// out-dir is mounted *read-only* into the kernel so a later consult/run_kaish can read
+// it back. These pin the three properties that matter: the read-back works, it is
+// read-*only* (kaish still can't write the out-dir), and it widens read-*scope* to the
+// out-dir alone — never its siblings. Non-dotted tempdir prefixes so the absolute paths
+// don't trip kaish's dot-filename tokenization.
+
+/// Build a `SandboxConfig` whose only non-default field is the artifact out-dir.
+fn sandbox_with_out_dir(out_dir: &std::path::Path) -> SandboxConfig {
+    SandboxConfig {
+        out_dir: Some(out_dir.to_path_buf()),
+        ..SandboxConfig::default()
+    }
+}
+
+/// A generated artifact in the out-dir is readable back through kaish — the whole point
+/// of the read-only mount (a consult can inspect what `generate_image` produced).
+#[tokio::test(flavor = "current_thread")]
+async fn out_dir_artifacts_are_readable() {
+    let proj = tempfile::Builder::new()
+        .prefix("kaibo-proj")
+        .tempdir()
+        .unwrap();
+    let out = tempfile::Builder::new()
+        .prefix("kaibo-out")
+        .tempdir()
+        .unwrap();
+    let artifact = out.path().join("kaibo-image-1-2-3.png");
+    fs::write(&artifact, b"PNGBYTESHERE").unwrap();
+
+    let kernel =
+        build_readonly_kernel_with(proj.path(), &sandbox_with_out_dir(out.path())).unwrap();
+    let r = run(&kernel, &format!("cat {}", artifact.display()))
+        .await
+        .unwrap();
+
+    assert!(
+        r.ok(),
+        "reading an out-dir artifact must succeed, got {r:?}"
+    );
+    assert!(
+        r.text_out().contains("PNGBYTESHERE"),
+        "the artifact bytes must come back, got {:?}",
+        r.text_out()
+    );
+}
+
+/// The out-dir mount is **read-only**: kaish cannot write into it. The handler owns the
+/// only write path (`std::fs`); this proves the read-back mount didn't open a kaish
+/// write surface. Teeth: mount it with `LocalFs::new` instead of `read_only` and the
+/// write lands — the read-only mount is the only thing refusing it.
+#[tokio::test(flavor = "current_thread")]
+async fn out_dir_is_read_only_to_kaish() {
+    let proj = tempfile::Builder::new()
+        .prefix("kaibo-proj")
+        .tempdir()
+        .unwrap();
+    let out = tempfile::Builder::new()
+        .prefix("kaibo-out")
+        .tempdir()
+        .unwrap();
+
+    let kernel =
+        build_readonly_kernel_with(proj.path(), &sandbox_with_out_dir(out.path())).unwrap();
+    let target = out.path().join("kaish-wrote-this.txt");
+    let r = run(&kernel, &format!("echo pwned > {}", target.display()))
+        .await
+        .unwrap();
+
+    assert!(
+        !r.ok(),
+        "a write into the read-only out-dir must be refused, got {r:?}"
+    );
+    assert!(
+        r.err.contains("read-only"),
+        "the refusal should cite the read-only mount, got {r:?}"
+    );
+    assert!(
+        !target.exists(),
+        "kaish must not create a real file in the out-dir"
+    );
+}
+
+/// The read-back mount widens read-*scope* to the out-dir **only** — never its parent
+/// or siblings. A secret in a sibling directory (outside both the project and the
+/// out-dir) must stay unreadable: it routes to the `/` MemoryFs scratch and the bytes
+/// never surface. This is why the out-dir default is a kaibo-owned subdir, not bare
+/// `/tmp` — mounting the narrow dir can't expose a neighbor.
+#[tokio::test(flavor = "current_thread")]
+async fn out_dir_mount_does_not_expose_siblings() {
+    let proj = tempfile::Builder::new()
+        .prefix("kaibo-proj")
+        .tempdir()
+        .unwrap();
+    let out = tempfile::Builder::new()
+        .prefix("kaibo-out")
+        .tempdir()
+        .unwrap();
+    // A sibling of the out-dir, outside every mount. Its secret must stay invisible.
+    let sibling = tempfile::Builder::new()
+        .prefix("kaibo-sib")
+        .tempdir()
+        .unwrap();
+    let secret = sibling.path().join("secret.txt");
+    fs::write(&secret, b"SECRETLEAKMARKER").unwrap();
+
+    let kernel =
+        build_readonly_kernel_with(proj.path(), &sandbox_with_out_dir(out.path())).unwrap();
+    let r = run(&kernel, &format!("cat {}", secret.display()))
+        .await
+        .unwrap();
+
+    assert!(
+        !r.text_out().contains("SECRETLEAKMARKER"),
+        "a sibling of the out-dir must not be readable, got {:?}",
+        r.text_out()
+    );
+}


### PR DESCRIPTION
`generate_image` no longer streams a base64 blob inline — it writes the image to a kaibo-owned **out-dir** and hands back the absolute path. A multi-MiB picture costs the caller's context nothing until it opens the file, and the artifact gets a durable home. This is the narrow *specific-tool* write the [RW-mount deferral](../blob/main/docs/issues.md) pointed at — not the broad `rw_paths` surface, and not `consult`.

## Decisions (from the conversation with Amy)

- **Path, not `ResourceLink`.** A `ResourceLink` would make a spec-compliant client read the bytes back *from the server*, growing a `file://` `resources/read` channel that bypasses project containment — a new read surface — for no win over a plain path the agent opens itself. Dropped.
- **Handler-side write, never kaish.** `write_artifact` uses `std::fs` in the tool handler; all four read-only sandbox levers in `sandbox.rs` hold untouched — kaish still cannot write anywhere. The invariant gained a sentence, it did not move.
- **Read-back mount.** The out-dir is mounted **read-only** into every kaish kernel (the existing `VfsRouter` multi-mount, *not* the deferred general-RW machinery) so a later `consult`/`run_kaish` can read a generated artifact back. Forward substrate for image2image; nothing needs it yet.
- **Default `$XDG_CACHE_HOME/kaibo`, kaibo-owned on purpose.** The read-back mount widens read-*scope* to whatever the out-dir is, and a consult can ship what kaish reads to a remote model. Mounting bare `/tmp` would expose other processes' files; a kaibo-owned subdir keeps the scope to our own artifacts. Durable by choice (cleanup revisited only if users ask).
- **Inline cap removed.** `GENERATE_IMAGE_MAX_BYTES` only bounded base64 in context; path delivery has nothing to bound.

## Review focus

The one part that warrants a hard look is the **read-scope boundary moving** — even narrowly, to a kaibo-owned cache. The new read-only out-dir mount (`sandbox.rs::build_readonly_kernel_and_vfs`) and its containment behavior are where to look. Pinned by the `out_dir_*` battery in `tests/sandbox.rs` (artifact readable, out-dir read-only to kaish, **siblings not exposed**), `out_dir` precedence in `tests/config.rs`, and Battery E in `docs/sandbox-probes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)