### PR TITLE
De-flake cwd-inference test; record the kaish-vfs list TOCTOU it exposed

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,36 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-29 — A "flaky test" was a real inherited robustness bug
+
+`omitted_path_zero_config_infers_cwd_as_default_root` failed ~1 in 5 full `cargo test`
+runs and the tracker had filed it twice (P2 + P4) as a "cwd race" — the hypothesis being
+that two cwd-reading containment tests race on the process-global `current_dir()`. That
+hypothesis was wrong, so I reproduced it (~10% under load) and instrumented the failure
+instead of trusting the note. The diagnostics killed the cwd theory outright: on a failing
+run `proc_cwd`, its canonical form, and `handler.default_root()` were *all* the correct
+crate root. The real symptom was `ls: .: not found: No such file or directory (os error
+2)` — a **real** ENOENT from a real syscall, not a logic error.
+
+Tracing it down through `KaishWorker` → `LocalBackend` → the `kaish-vfs` `LocalFs` mount
+landed on the contributing factor: `LocalFs::list` (`kaish-vfs/src/local.rs`, 0.9.0)
+`read_dir`s a directory, then calls `symlink_metadata` on *each* entry and `?`-propagates
+any error — so if a single sibling is unlinked between the enumeration and its per-entry
+stat, the **entire** listing fails. The test enumerated the *live* crate root while a
+parallel `cargo test` churned `target/`; one vanished artifact sank the whole `ls`. Only
+this test asserted `ls` *content* (others check exit status), so only it surfaced the
+flake.
+
+Contributing-factors, not root-cause: (a) the test enumerated a live, churning directory
+to prove cwd inference; (b) `kaish-vfs` `list` hard-fails on a vanished entry instead of
+skipping it the way `ls(1)` does. Fixed (a) in scope — the test now reads one known file
+(`cat -n Cargo.toml`, no directory walk) and asserts `name = "kaibo"`, still proving the
+omitted path resolved to *this* crate; 120/120 clean after. Recorded (b) as an upstream
+`kaish-vfs` item in `issues.md`: it's a genuine product gap (a `consult` listing a live
+repo with a running build / `node_modules` churn can spuriously fail), and since Amy
+co-develops kaish it's a direct contribution, not a route-around. Collapsed the duplicate
+tracker entries into that one upstream note.
+
 ## 2026-06-28 — Dropping image generation: kaibo perceives and reasons, it doesn't render
 
 A design conversation with Amy reversed the `generate_image` direction. The clean

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -59,14 +59,21 @@ planned.
 
 ## P2 — Focused fixes & hardening
 
-### Flaky: `omitted_path_zero_config_infers_cwd_as_default_root` (cwd race)
-`tests/containment.rs:222` reads the process-wide `std::env::current_dir()` and asserts
-the handler infers it as the default root. It fails intermittently (~1 in 5 full
-`cargo test` runs) and passes in isolation and on re-run — a parallel-execution race on
-the shared process cwd, not a logic bug (untouched by the async-consult work). Fix is to
-make the test not depend on the ambient cwd — drive it through an explicit root/config
-fixture, or serialize the cwd-reading tests. Low priority; it's a test-quality issue, the
-boundary itself is sound.
+### Upstream kaish-vfs: `LocalFs::list` hard-fails when an entry vanishes mid-walk
+`kaish-vfs` `LocalFs::list` (`src/local.rs`, 0.9.0) enumerates a directory with
+`read_dir`, then calls `symlink_metadata` on *each* entry and propagates any error with
+`?` — so if a single sibling is unlinked between the enumeration and its per-entry stat,
+the **whole** listing fails with `os error 2` (surfaced as `ls: .: not found`). This is a
+real product gap kaibo inherits: a `consult` that lists a *live* repo (a running build
+churning `target/`, `node_modules`, editor temp files) can spuriously fail an `ls`/`grep`/
+`find`. It's also what made `omitted_path_zero_config_infers_cwd_as_default_root` flaky
+(~1 in 5 full `cargo test` runs) — the test enumerated the crate root while a parallel
+`cargo test` churned `target/`. The kaibo-side symptom is **fixed**: that test now reads a
+single known file (`cat -n Cargo.toml`) instead of enumerating, so it does no directory
+walk (`tests/containment.rs`). The real fix is upstream — `list` should skip (or tolerate)
+an entry that disappears between `read_dir` and `symlink_metadata`, the way `ls(1)` does,
+rather than aborting the listing. Amy co-develops kaish, so this is a direct contribution,
+not a route-around; track it for the next `kaish-vfs` bump.
 
 
 ### Async consult (`consult_submit` + shared `get`/`cancel`/`list`) — follow-ups
@@ -423,14 +430,3 @@ Both reuse the same off-by-default `[telemetry]` gate and endpoint; the open
 question is whether the content/cost of a logs signal is worth it given traces
 already carry the prompts/completions. The session's `otlp-mcp` collector is the
 sink for a probe.
-
-
-### Flaky: `containment::omitted_path_zero_config_infers_cwd_as_default_root`
-Failed once under a full `cargo test`, passed in isolation and on the next full run.
-The test reads process-global `current_dir()`; containment.rs has two cwd-reading
-tests and the harness runs a binary's tests on parallel threads, so a cwd-sensitive
-assert can race. Not tied to any one feature (the batch-cast work that surfaced it
-touches no root logic). Fix candidates: serialize the cwd-reading tests (a shared
-mutex / `serial_test`), or have the test assert against an explicit root rather than
-the ambient cwd. Cross-reference [[tracing-callsite-interest-poisoning]] — same
-"global state shared across a binary's tests" failure class.

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -223,9 +223,15 @@ async fn omitted_path_zero_config_infers_cwd_as_default_root() {
     let config = Config::builtin(); // no root, no allow_paths -> cwd inferred
     let handler = KaiboHandler::new(config).expect("handler builds");
 
+    // Read a *single, known* file at the crate root rather than enumerating the
+    // directory: this proves the omitted path resolved to the inferred cwd without
+    // a full `ls`, whose per-entry stat hard-fails if any *sibling* vanishes mid-list
+    // (a `target/` build artifact under a parallel `cargo test`, say) — an upstream
+    // kaish-vfs `list` TOCTOU that made the old `ls` form flaky. `cat` of one path
+    // does no directory walk, so it's immune to that churn.
     let out = handler
         .run_kaish(Parameters(RunKaishInput {
-            script: "ls".to_string(),
+            script: "cat -n Cargo.toml".to_string(),
             path: None,
         }))
         .await
@@ -236,10 +242,11 @@ async fn omitted_path_zero_config_infers_cwd_as_default_root() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    // `ls` at the crate root (the test process cwd) lists real files.
+    // The crate's own `Cargo.toml` names the package — a stable marker that the
+    // inferred root is *this* crate, not an empty mount.
     assert!(
-        out.contains("Cargo.toml"),
-        "inferred-cwd call should list the crate root, got: {out}"
+        out.contains("name = \"kaibo\""),
+        "inferred-cwd call should read the crate's Cargo.toml, got: {out}"
     );
 
     // The handler must expose the inferred default root, and mark it inferred.


### PR DESCRIPTION
## What & why

`omitted_path_zero_config_infers_cwd_as_default_root` flaked ~1 in 5 full `cargo test` runs and the tracker had filed it **twice** (P2 + P4) as a "cwd race." Rather than trust that hypothesis, I reproduced it (~10% under parallel load) and instrumented the failure.

The cwd-race theory was wrong. On a failing run the process cwd, its canonical form, and `handler.default_root()` were **all** the correct crate root — the real symptom was `ls: .: not found: No such file or directory (os error 2)`, a genuine ENOENT from a real syscall.

Tracing through `KaishWorker` → `LocalBackend` → the `kaish-vfs` mount found the contributing factor: `LocalFs::list` (`kaish-vfs/src/local.rs`, 0.9.0) `read_dir`s a directory, then calls `symlink_metadata` on **each** entry and `?`-propagates any error. So if one sibling is unlinked between enumeration and its per-entry stat, the **whole** listing fails. The test enumerated the *live* crate root while a parallel `cargo test` churned `target/`; one vanished artifact sank the `ls`. Only this test asserted `ls` *content*, so only it surfaced the flake.

## Changes

- **`tests/containment.rs`** — prove cwd inference by reading one known file (`cat -n Cargo.toml`, no directory walk → immune to sibling churn) and asserting `name = "kaibo"`. The handler-API assertions (`default_root` + `inferred` flag) are unchanged. **120/120 clean** after (was ~10% failing).
- **`docs/issues.md`** — collapse the two duplicate "flaky" entries into one **upstream kaish-vfs** item recording the `list` TOCTOU. It's a real product gap kaibo inherits (a `consult` listing a live repo with a running build / `node_modules` churn can spuriously fail `ls`/`grep`/`find`); the upstream fix is for `list` to skip a vanished entry the way `ls(1)` does. Amy co-develops kaish, so it's a direct contribution, not a route-around.
- **`docs/devlog.md`** — the contributing-factors narrative.

## Test

`cargo test --test containment` green; ran the suite 120× in a loop with zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)