### PR TITLE
Async-job polish: job_capacity knob + get/list show the latest consult beat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ the git log. Each later release appends a new section at the top.
   as `consult`. Built for running several consults at once — a cross-model study submits
   one per `cast` and collects them all — or for not blocking on a long answer: submit, go
   do other work, collect later. Jobs are in-memory and live only for the server session
-  (no restart survival), evicted by capacity like sessions. Replaces the pattern of
+  (no restart survival), evicted by capacity (LRU) — its own `[defaults] job_capacity` /
+  `KAIBO_JOB_CAPACITY` knob (default 64), separate from `session_capacity` because a held
+  job result is heavier than a session's Q&A pair. Replaces the pattern of
   spawning a throwaway sub-agent just to hold a blocking `consult` open. On completion a
   job emits a soft notification on the MCP logging channel (a clue for a client watching
   the log stream) — advisory only, since no MCP primitive wakes the calling agent;
@@ -105,7 +107,9 @@ the git log. Each later release appends a new section at the top.
 - **`get` / `cancel` / `list`** — one shared surface to collect, stop, and survey
   *both* kinds of async work, told apart by the handle: a batch handle is
   `backend/provider-id`, a consult job is `job-N`. `get <handle>` returns a progress/
-  status line while the work runs and the full result when it lands; `cancel <handle>`
+  status line while the work runs — for a consult job it echoes the latest investigation
+  beat (e.g. *currently: exploring …*) with a step count, the same one-liner `wait`
+  streams, so a poller sees forward motion — and the full result when it lands; `cancel <handle>`
   stops it; `list` shows everything in flight — your in-memory consult jobs plus the
   batches each backend still holds — each with a ready-to-use handle. One mental model
   for everything you submit. The verbs stay available as long as either `consult` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,8 @@ the git log. Each later release appends a new section at the top.
   as `consult`. Built for running several consults at once — a cross-model study submits
   one per `cast` and collects them all — or for not blocking on a long answer: submit, go
   do other work, collect later. Jobs are in-memory and live only for the server session
-  (no restart survival), evicted by capacity (LRU) — its own `[defaults] job_capacity` /
-  `KAIBO_JOB_CAPACITY` knob (default 64), separate from `session_capacity` because a held
-  job result is heavier than a session's Q&A pair. Replaces the pattern of
+  (no restart survival), evicted by capacity (LRU) via its own `[defaults] job_capacity` /
+  `KAIBO_JOB_CAPACITY` knob (default 64). Replaces the pattern of
   spawning a throwaway sub-agent just to hold a blocking `consult` open. On completion a
   job emits a soft notification on the MCP logging channel (a clue for a client watching
   the log stream) — advisory only, since no MCP primitive wakes the calling agent;

--- a/docs/config.md
+++ b/docs/config.md
@@ -195,6 +195,10 @@ The `[defaults]` knobs themselves:
   only (plus per-call): they bound the *loop*, not the model.
 - **`session_capacity`** (128, must be > 0): max multi-turn consult sessions held
   in memory (LRU, capacity-evicted, no TTL).
+- **`job_capacity`** (64, must be > 0): max async-`consult` jobs (`consult_submit`)
+  held in memory — running plus finished-but-uncollected (LRU, capacity-evicted, no
+  TTL; evicting a still-running job aborts it). Its own knob, smaller than
+  `session_capacity` because a held job result is heavier than a session's Q&A pair.
 
 ### Built-in registry (the defaults)
 
@@ -300,6 +304,7 @@ role the cast doesn't carry). The naming rule for everything else is mechanical:
 | thinking style | `defaults.thinking_style` *(per-slot override)* | `KAIBO_THINKING_STYLE` | — |
 | LLM request timeout (s) | `defaults.request_timeout_secs` *(per-backend override)* | `KAIBO_REQUEST_TIMEOUT_SECS` | — |
 | session cache size | `defaults.session_capacity` *(must be > 0)* | `KAIBO_SESSION_CAPACITY` | — |
+| async job cache size | `defaults.job_capacity` *(must be > 0; default 64)* | `KAIBO_JOB_CAPACITY` | — |
 | exec timeout (s) | `sandbox.exec_timeout_secs` | `KAIBO_EXEC_TIMEOUT_SECS` | — |
 | output cap (bytes) | `sandbox.output_limit_bytes` | `KAIBO_OUTPUT_LIMIT_BYTES` | — |
 | scratch cap (bytes) | `sandbox.scratch_limit_bytes` *(must be > 0; default 64 MB)* | `KAIBO_SCRATCH_LIMIT_BYTES` | — |

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -44,6 +44,39 @@ repo with a running build / `node_modules` churn can spuriously fail), and since
 co-develops kaish it's a direct contribution, not a route-around. Collapsed the duplicate
 tracker entries into that one upstream note.
 
+## 2026-06-29 — Async-job polish: a `job_capacity` knob and `get` that shows the work
+
+Two `docs/issues.md` follow-ups from the async-consult surface, landed together because
+both live on `JobStore`/`consult_submit`.
+
+**`job_capacity` is its own knob.** Jobs had been borrowing `defaults.session_capacity`
+for their LRU cap — fine for a trial, but a held job result (a full answer + optional
+explorer report) is heavier than a session's lean Q&A pair, so the honest cap is smaller.
+Now `[defaults] job_capacity` / `KAIBO_JOB_CAPACITY`, default **64** (vs sessions' 128),
+plumbed the same way as `session_capacity` (struct + default + raw + merge + env + a
+zero-is-rejected guard) and surfaced in `kaibo://config`. Independent tests pin the
+default, the file/env override, and the loud zero-rejection.
+
+**`get` now shows the work.** The issue note said `consult_submit` ran on a `NullSink` so
+`get` could only report "running, Ns" — but that premise had already gone stale: the async
+path moved to `TracingSink`, and a `wait` tool + notification ring shipped, so the live
+sweep/turn narrative *was* reachable, just through `wait`, not `get`. Confirmed that with
+Amy and took the residual: a caller who polls with `get` (the natural verb) still saw no
+motion. Fix is a small `ProgressLog` **decorator** in `progress.rs` — it records the latest
+beat's one-liner + a beat count while teeing every event on to the inner `TracingSink`, so
+the `wait`/`mcp_log` stream is untouched and the job *also* remembers its last beat. The
+job holds the same `Arc<ProgressLog>` the running consult emits through; `get`/`list` echo
+`currently: exploring … (step N)` on a still-running job (the step count advances even when
+two polls catch the same kind of beat), and a finished snapshot drops it — a Done job
+carries its answer, not a stale "currently" line. The decorator shape means no second
+emit path and the existing `wait` view is byte-for-byte unchanged.
+
+The model-driven progress events were already in `PhaseEvent`; this just adds a second,
+pull-side consumer beside the push-side `TracingSink`. Tests: `ProgressLog` starts empty /
+remembers the latest / tees to its inner sink (a counting sink proves forwarding), and a
+`JobStore` test drives a beat through the shared log and asserts the running snapshot
+echoes it while a finished one doesn't.
+
 ## 2026-06-28 — Dropping image generation: kaibo perceives and reasons, it doesn't render
 
 A design conversation with Amy reversed the `generate_image` direction. The clean

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -79,6 +79,19 @@ not a route-around; track it for the next `kaish-vfs` bump.
 ### Async consult (`consult_submit` + shared `get`/`cancel`/`list`) — follow-ups
 The async-consult surface shipped (`src/jobs.rs` `JobStore`, `consult_submit` in
 `server.rs`, the unified handle-dispatched `get`/`cancel`/`list`). Open polish:
+- **Eviction silently aborts a still-running job — surface it on a burst.** The
+  `JobStore` LRU aborts the least-recently-used job when a new submit pushes past
+  `job_capacity` (`jobs.rs`, `Job::drop` → `abort`), intentionally (an unreachable job
+  shouldn't burn tokens). But the abort is silent on the *submit* side: a caller that
+  fires a burst of > `job_capacity` (default 64) `consult_submit`s in a tight cross-model
+  loop has its oldest in-flight consults killed mid-investigation, and only finds out when
+  `get` returns `Unknown`. Pre-existing (eviction always aborted running jobs); the 128→64
+  default made it more reachable. Surfaced by the gemini-batch cross-family review
+  (2026-06-29). Fix options: a `Warn` `tracing` event when eviction aborts a *running*
+  (not terminal) job so a `wait`-draining caller sees it, and/or document the cap as a
+  concurrency ceiling in the tool description. Backpressure (refuse a submit at capacity
+  instead of evicting) is a *different* contract — don't add it without deciding. Low
+  priority: 64 concurrent live consults hits provider rate limits first.
 - **Completion notification is log-only (by necessity).** A finished job emits an `info`
   `tracing` event onto the MCP `notifications/message` bridge (`mcp_log`). Confirmed live:
   Claude Code does *not* surface that into the agent's loop (it's a client log/debug

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -79,15 +79,6 @@ not a route-around; track it for the next `kaish-vfs` bump.
 ### Async consult (`consult_submit` + shared `get`/`cancel`/`list`) — follow-ups
 The async-consult surface shipped (`src/jobs.rs` `JobStore`, `consult_submit` in
 `server.rs`, the unified handle-dispatched `get`/`cancel`/`list`). Open polish:
-- **Dedicated `job_capacity` knob.** Jobs currently reuse `defaults.session_capacity`
-  for their LRU cap (`server.rs`, `JobStore::new` call). Fine for a trial — both are
-  diskless client-keyed registries — but a job result is heavier than a `QaTurn`, so a
-  separate `[defaults] job_capacity` (+ `KAIBO_JOB_CAPACITY`) is the honest knob. Mirror
-  `session_capacity`'s plumbing in `config.rs`.
-- **Progress into the job.** `consult_submit` runs on a `NullSink`, so `get` reports only
-  "running, Ns" — not sweep/turn beats. A buffering `ProgressSink` stored on the job
-  (drained by `get`) would restore the visibility a synchronous `consult` streams. Cheap,
-  high-value; the reason the subagent-wrapper pattern felt opaque.
 - **Completion notification is log-only (by necessity).** A finished job emits an `info`
   `tracing` event onto the MCP `notifications/message` bridge (`mcp_log`). Confirmed live:
   Claude Code does *not* surface that into the agent's loop (it's a client log/debug

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,12 @@ pub struct Defaults {
     /// is capacity-driven only (no TTL) — see [`crate::session`]. Server-wide (a
     /// session is a client thread, not a model trait).
     pub session_capacity: NonZeroUsize,
+    /// Max async-`consult` jobs (`consult_submit`) held in memory at once — running
+    /// plus finished-but-uncollected. Capacity-LRU like sessions, no TTL; evicting a
+    /// still-running job aborts it (see [`crate::jobs`]). Its own knob because a job
+    /// result (a full answer + optional explorer report) is heavier than a session's
+    /// lean Q&A pair, so the honest cap is smaller.
+    pub job_capacity: NonZeroUsize,
 }
 
 impl Default for Defaults {
@@ -119,6 +125,11 @@ impl Default for Defaults {
             // 128 lean Q&A threads is a few KB of strings — generous for a personal
             // server, and capacity (not time) is the only eviction pressure.
             session_capacity: NonZeroUsize::new(128).expect("128 is nonzero"),
+            // Fewer than sessions: a held job result (answer + maybe a report) is
+            // heavier, and a caller rarely has many async consults in flight at once.
+            // 64 is generous headroom before the LRU starts aborting the oldest
+            // still-running job to make room.
+            job_capacity: NonZeroUsize::new(64).expect("64 is nonzero"),
         }
     }
 }
@@ -1469,6 +1480,7 @@ struct RawDefaults {
     thinking_style: Option<String>,
     request_timeout_secs: Option<u64>,
     session_capacity: Option<usize>,
+    job_capacity: Option<usize>,
 }
 
 /// One `[backends.<name>]` stanza: connection knobs only — models live on casts.
@@ -1647,6 +1659,13 @@ fn merge_defaults(raw: RawDefaults) -> Result<Defaults> {
             .ok_or_else(|| anyhow!("[defaults] session_capacity must be > 0 (got 0)"))?,
         None => d.session_capacity,
     };
+    // Same zero-is-never-intent reasoning as session_capacity: a zero cap can't build
+    // an LruCache and would mean "hold no jobs", which defeats `consult_submit`.
+    let job_capacity = match raw.job_capacity {
+        Some(n) => NonZeroUsize::new(n)
+            .ok_or_else(|| anyhow!("[defaults] job_capacity must be > 0 (got 0)"))?,
+        None => d.job_capacity,
+    };
     Ok(Defaults {
         explorer_max_turns: raw.explorer_max_turns.unwrap_or(d.explorer_max_turns),
         synth_max_turns: raw.synth_max_turns.unwrap_or(d.synth_max_turns),
@@ -1666,6 +1685,7 @@ fn merge_defaults(raw: RawDefaults) -> Result<Defaults> {
             .map(Duration::from_secs)
             .unwrap_or(d.request_timeout),
         session_capacity,
+        job_capacity,
     })
 }
 
@@ -1911,6 +1931,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if let Some(v) = get("KAIBO_SESSION_CAPACITY") {
         defaults.session_capacity = Some(parse_env_int("KAIBO_SESSION_CAPACITY", &v)?);
+    }
+    if let Some(v) = get("KAIBO_JOB_CAPACITY") {
+        defaults.job_capacity = Some(parse_env_int("KAIBO_JOB_CAPACITY", &v)?);
     }
 
     // Context files: colon-separated like PATH (and like KAIBO_ALLOW_PATHS), so a

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -32,6 +32,8 @@ use std::time::{Duration, Instant};
 use lru::LruCache;
 use tokio::task::AbortHandle;
 
+use crate::progress::ProgressLog;
+
 /// A completed consultation, ready to render back to the calling agent. `answer`
 /// already carries its provenance footer; `report` is the explorer's aggregated
 /// report when the submit asked for it (`include_report`), else `None`.
@@ -62,6 +64,11 @@ pub struct JobSnapshot {
     pub state: JobState,
     pub label: String,
     pub age: Duration,
+    /// The most recent progress beat — `(one-liner, beat count)` — for a still-running
+    /// job, or `None` if it hasn't emitted yet (or already finished). `get`/`list` echo
+    /// it so a poller sees forward motion without reaching for `wait`. See
+    /// [`crate::progress::ProgressLog`].
+    pub last_progress: Option<(String, u64)>,
 }
 
 /// What `cancel` did, so the tool layer can word the reply honestly.
@@ -84,6 +91,10 @@ struct Job {
     abort: AbortHandle,
     label: String,
     started: Instant,
+    /// The job's progress recorder — the same [`ProgressLog`] the spawned consult emits
+    /// through, so `get`/`list` can echo the latest beat. Shared (`Arc`) with the running
+    /// task's sink; reading `latest()` here never blocks the task (a tiny `Mutex`).
+    progress: Arc<ProgressLog>,
 }
 
 impl Drop for Job {
@@ -149,10 +160,17 @@ impl JobStore {
     }
 
     /// Spawn `fut` as a job and return its id immediately. `label` is the human-facing
-    /// cast/model summary a poll line shows. The future's `Ok`/`Err` becomes the job's
-    /// terminal `Done`/`Failed` state; an abort (via [`cancel`](Self::cancel)) leaves it
-    /// `Canceled` because the task never runs its tail.
-    pub fn submit<F>(&self, label: impl Into<String>, fut: F) -> String
+    /// cast/model summary a poll line shows; `progress` is the recorder the running phase
+    /// emits through, kept so `get`/`list` can echo the latest beat (pass it the *same*
+    /// `Arc` the consult's `ConsultConfig.progress` holds). The future's `Ok`/`Err`
+    /// becomes the job's terminal `Done`/`Failed` state; an abort (via
+    /// [`cancel`](Self::cancel)) leaves it `Canceled` because the task never runs its tail.
+    pub fn submit<F>(
+        &self,
+        label: impl Into<String>,
+        progress: Arc<ProgressLog>,
+        fut: F,
+    ) -> String
     where
         F: Future<Output = Result<JobResult, String>> + Send + 'static,
     {
@@ -207,6 +225,7 @@ impl JobStore {
             abort: handle.abort_handle(),
             label: label.into(),
             started: Instant::now(),
+            progress,
         });
         self.lock().put(id.clone(), job);
         id
@@ -216,12 +235,24 @@ impl JobStore {
     /// existed, or evicted). Touching the job promotes it to most-recently-used.
     pub fn get(&self, id: &str) -> Option<JobSnapshot> {
         let job = self.lock().get(id).cloned()?;
+        Some(Self::snapshot(&job))
+    }
+
+    /// Render one job to a snapshot: clone its terminal-or-running state and, while it's
+    /// still running, the latest progress beat. A finished job carries its answer, not a
+    /// beat — the recorder's last line is moot once `state` is terminal, so we only attach
+    /// it for `Running`.
+    fn snapshot(job: &Job) -> JobSnapshot {
         let state = job.state.lock().expect("job state mutex poisoned").clone();
-        Some(JobSnapshot {
+        let last_progress = matches!(state, JobState::Running)
+            .then(|| job.progress.latest())
+            .flatten();
+        JobSnapshot {
             state,
             label: job.label.clone(),
             age: job.started.elapsed(),
-        })
+            last_progress,
+        }
     }
 
     /// Abort a running job and mark it `Canceled`. Idempotent on an already-canceled
@@ -249,17 +280,7 @@ impl JobStore {
     pub fn list(&self) -> Vec<(String, JobSnapshot)> {
         self.lock()
             .iter()
-            .map(|(id, job)| {
-                let state = job.state.lock().expect("job state mutex poisoned").clone();
-                (
-                    id.clone(),
-                    JobSnapshot {
-                        state,
-                        label: job.label.clone(),
-                        age: job.started.elapsed(),
-                    },
-                )
-            })
+            .map(|(id, job)| (id.clone(), Self::snapshot(job)))
             .collect()
     }
 
@@ -296,6 +317,12 @@ mod tests {
         }
     }
 
+    /// A record-only progress log for tests that don't exercise the beat echo — the
+    /// store needs one per `submit`, but most lifecycle tests only care about state.
+    fn pl() -> Arc<ProgressLog> {
+        Arc::new(ProgressLog::silent())
+    }
+
     /// Poll `get` until the job leaves `Running`, or panic after a generous bound — the
     /// spawned task needs a runtime tick to land its result, so tests can't read it
     /// synchronously right after `submit`. Returns the terminal state.
@@ -320,7 +347,7 @@ mod tests {
     #[tokio::test]
     async fn a_ready_future_lands_as_done() {
         let store = JobStore::new(cap(4));
-        let id = store.submit("cast `x`", async { Ok(done("the answer")) });
+        let id = store.submit("cast `x`", pl(), async { Ok(done("the answer")) });
         assert_eq!(
             await_terminal(&store, &id).await,
             JobState::Done(done("the answer"))
@@ -330,7 +357,7 @@ mod tests {
     #[tokio::test]
     async fn a_failing_future_lands_as_failed() {
         let store = JobStore::new(cap(4));
-        let id = store.submit("cast `x`", async { Err("provider exploded".to_string()) });
+        let id = store.submit("cast `x`", pl(), async { Err("provider exploded".to_string()) });
         assert_eq!(
             await_terminal(&store, &id).await,
             JobState::Failed("provider exploded".to_string())
@@ -343,7 +370,7 @@ mod tests {
         // Gate the future on a channel the test holds, so "Running" is observable
         // deterministically rather than by racing the scheduler.
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let id = store.submit("cast `x`", async move {
+        let id = store.submit("cast `x`", pl(), async move {
             let _ = rx.await;
             Ok(done("eventually"))
         });
@@ -362,11 +389,11 @@ mod tests {
     #[tokio::test]
     async fn submitting_past_capacity_evicts_the_least_recently_used() {
         let store = JobStore::new(cap(2));
-        let a = store.submit("a", async { Ok(done("a")) });
-        let b = store.submit("b", async { Ok(done("b")) });
+        let a = store.submit("a", pl(), async { Ok(done("a")) });
+        let b = store.submit("b", pl(), async { Ok(done("b")) });
         // Touch `a` so `b` becomes the least-recently-used.
         let _ = store.get(&a);
-        let c = store.submit("c", async { Ok(done("c")) });
+        let c = store.submit("c", pl(), async { Ok(done("c")) });
 
         assert!(
             store.get(&b).is_none(),
@@ -385,7 +412,7 @@ mod tests {
         let store = JobStore::new(cap(4));
         // A future that would run forever if not aborted — its tail must never land.
         let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let id = store.submit("cast `x`", async move {
+        let id = store.submit("cast `x`", pl(), async move {
             let _ = rx.await;
             Ok(done("should never be seen"))
         });
@@ -405,7 +432,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_on_a_finished_job_reports_already_finished() {
         let store = JobStore::new(cap(4));
-        let id = store.submit("cast `x`", async { Ok(done("fast")) });
+        let id = store.submit("cast `x`", pl(), async { Ok(done("fast")) });
         let _ = await_terminal(&store, &id).await;
         assert_eq!(store.cancel(&id), CancelOutcome::AlreadyFinished);
     }
@@ -419,13 +446,13 @@ mod tests {
         let ran_tail = Arc::new(AtomicBool::new(false));
         let flag = ran_tail.clone();
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let _evicted = store.submit("a", async move {
+        let _evicted = store.submit("a", pl(), async move {
             let _ = rx.await;
             flag.store(true, AOrd::SeqCst);
             Ok(done("a"))
         });
         // A second submit at cap 1 evicts the first → its `Job` drops → task aborts.
-        let _b = store.submit("b", async { Ok(done("b")) });
+        let _b = store.submit("b", pl(), async { Ok(done("b")) });
         // Release the gate; an aborted task must never run its tail.
         let _ = tx.send(());
         for _ in 0..200 {
@@ -443,7 +470,7 @@ mod tests {
         // the FinishGuard the state would sit at Running forever. The guard turns the
         // unwind into a terminal Failed, so `await_terminal` resolves instead of spinning.
         let store = JobStore::new(cap(4));
-        let id = store.submit("cast `x`", async { panic!("boom in the consult loop") });
+        let id = store.submit("cast `x`", pl(), async { panic!("boom in the consult loop") });
         assert!(
             matches!(await_terminal(&store, &id).await, JobState::Failed(_)),
             "a panicking task must land as Failed, not hang in Running forever"
@@ -451,10 +478,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_running_jobs_snapshot_echoes_the_latest_progress_beat() {
+        use crate::progress::{PhaseEvent, ProgressSink};
+        let store = JobStore::new(cap(4));
+        // Hold the progress log so the test can drive beats through it, the way the real
+        // consult loop emits into the `ConsultConfig.progress` clone the job shares.
+        let progress = Arc::new(ProgressLog::silent());
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let id = store.submit("cast `x`", progress.clone(), async move {
+            let _ = rx.await;
+            Ok(done("eventually"))
+        });
+
+        // Before any beat, a running job has nothing to echo.
+        assert_eq!(store.get(&id).unwrap().last_progress, None);
+
+        // A beat fires → the snapshot surfaces it (message + count) while still Running.
+        progress.emit(PhaseEvent::SweepStarted {
+            question: "where is the sandbox?".into(),
+        });
+        assert_eq!(
+            store.get(&id).unwrap().last_progress,
+            Some(("exploring: where is the sandbox?".to_string(), 1))
+        );
+
+        // Once it finishes, the beat is moot — a Done snapshot carries the answer, not a
+        // stale "currently …" line.
+        tx.send(()).unwrap();
+        assert_eq!(
+            await_terminal(&store, &id).await,
+            JobState::Done(done("eventually"))
+        );
+        assert_eq!(store.get(&id).unwrap().last_progress, None);
+    }
+
+    #[tokio::test]
     async fn list_returns_every_live_job_newest_first() {
         let store = JobStore::new(cap(4));
-        let a = store.submit("cast `a`", async { Ok(done("a")) });
-        let b = store.submit("cast `b`", async { Ok(done("b")) });
+        let a = store.submit("cast `a`", pl(), async { Ok(done("a")) });
+        let b = store.submit("cast `b`", pl(), async { Ok(done("b")) });
         let listed: Vec<String> = store.list().into_iter().map(|(id, _)| id).collect();
         // Most-recently-submitted first: b before a.
         assert_eq!(listed, vec![b, a]);
@@ -463,8 +525,8 @@ mod tests {
     #[tokio::test]
     async fn ids_are_unique_and_monotonic() {
         let store = JobStore::new(cap(8));
-        let a = store.submit("a", async { Ok(done("a")) });
-        let b = store.submit("b", async { Ok(done("b")) });
+        let a = store.submit("a", pl(), async { Ok(done("a")) });
+        let b = store.submit("b", pl(), async { Ok(done("b")) });
         assert_ne!(a, b);
         assert_eq!(a, "job-1");
         assert_eq!(b, "job-2");

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -112,17 +112,13 @@ impl ProgressSink for TracingSink {
     }
 }
 
-/// A [`ProgressSink`] that *remembers* the most recent beat while teeing each event on to
-/// an inner sink. Built for an async `consult` job: the job's progress streams to the
-/// caller through `wait` (the inner [`TracingSink`] → notification ring), but a caller who
-/// polls with `get` instead reads no stream — so the job also holds one of these and
-/// `get` echoes [`latest`](Self::latest), the same one-liner `wait` would show, inline in
-/// the "still running" line. A decorator, not a replacement: it records *and* forwards, so
-/// the `wait`/`mcp_log` view is unchanged.
-///
-/// The state is a tiny `Mutex` (last message + a beat count); `emit` is still sync and
-/// infallible — it computes the one-liner, stores it, and forwards — so it honors the
-/// "never block or fail on a progress hop" contract.
+/// A [`ProgressSink`] decorator that remembers the most recent beat while teeing each
+/// event to an inner sink. An async `consult` job streams its progress to the caller
+/// through `wait` (the inner [`TracingSink`] → notification ring); a caller polling with
+/// `get` reads no stream, so the job also holds one of these and `get` echoes
+/// [`latest`](Self::latest) inline. Records *and* forwards — the `wait`/`mcp_log` view is
+/// unchanged. State is a tiny `Mutex` (last message + beat count); `emit` stays sync and
+/// infallible per the [`ProgressSink`] contract.
 #[derive(Debug)]
 pub struct ProgressLog {
     inner: Arc<dyn ProgressSink>,
@@ -310,6 +306,26 @@ mod tests {
         assert_eq!(
             log.latest(),
             Some(("exploring: where is the sandbox?".to_string(), 2))
+        );
+    }
+
+    #[test]
+    fn progress_log_step_count_advances_on_a_repeated_event_kind() {
+        // The step count is the "forward motion" signal `get` shows, so it must advance on
+        // *every* beat — including two of the same kind in a row (two `KaishRun`s), where
+        // the message alone wouldn't tell a poller anything moved.
+        let log = ProgressLog::silent();
+        log.emit(PhaseEvent::KaishRun {
+            script: "cat -n a.rs".into(),
+        });
+        assert_eq!(log.latest(), Some(("running kaish: cat -n a.rs".to_string(), 1)));
+        log.emit(PhaseEvent::KaishRun {
+            script: "grep -rn foo .".into(),
+        });
+        assert_eq!(
+            log.latest(),
+            Some(("running kaish: grep -rn foo .".to_string(), 2)),
+            "a second beat of the same kind still advances the step count"
         );
     }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -14,6 +14,8 @@
 //! and never names a transport type. The translation to MCP lives at the edge.
 
 use std::fmt;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 /// A semantic step in a running phase. The sink decides how (or whether) to surface
 /// it; the loop just announces what it's doing. Ordered roughly by when they fire,
@@ -107,6 +109,69 @@ impl ProgressSink for TracingSink {
         } else {
             tracing::info!(target: "kaibo::consult", "{msg}");
         }
+    }
+}
+
+/// A [`ProgressSink`] that *remembers* the most recent beat while teeing each event on to
+/// an inner sink. Built for an async `consult` job: the job's progress streams to the
+/// caller through `wait` (the inner [`TracingSink`] → notification ring), but a caller who
+/// polls with `get` instead reads no stream — so the job also holds one of these and
+/// `get` echoes [`latest`](Self::latest), the same one-liner `wait` would show, inline in
+/// the "still running" line. A decorator, not a replacement: it records *and* forwards, so
+/// the `wait`/`mcp_log` view is unchanged.
+///
+/// The state is a tiny `Mutex` (last message + a beat count); `emit` is still sync and
+/// infallible — it computes the one-liner, stores it, and forwards — so it honors the
+/// "never block or fail on a progress hop" contract.
+#[derive(Debug)]
+pub struct ProgressLog {
+    inner: Arc<dyn ProgressSink>,
+    state: Mutex<ProgressState>,
+}
+
+#[derive(Debug, Default)]
+struct ProgressState {
+    /// The most recent event's glanceable one-liner, or `None` before the first beat.
+    latest: Option<String>,
+    /// How many beats have fired — lets `get` show forward motion ("step 7") even when
+    /// two polls land on the same kind of beat.
+    steps: u64,
+}
+
+impl ProgressLog {
+    /// Wrap `inner`, recording each event before forwarding it. Pass [`NullSink`] for a
+    /// record-only log with nowhere to tee (what a test or a no-`wait` client uses).
+    pub fn new(inner: Arc<dyn ProgressSink>) -> Self {
+        Self {
+            inner,
+            state: Mutex::new(ProgressState::default()),
+        }
+    }
+
+    /// A record-only log: nothing downstream, just the latest beat for `get` to echo.
+    pub fn silent() -> Self {
+        Self::new(Arc::new(NullSink))
+    }
+
+    /// The most recent beat's one-liner and the running beat count, or `None` if the
+    /// phase hasn't emitted yet. `get` renders this as the "currently …" tail on a
+    /// still-running job.
+    pub fn latest(&self) -> Option<(String, u64)> {
+        let s = self.state.lock().expect("progress log mutex poisoned");
+        s.latest.clone().map(|msg| (msg, s.steps))
+    }
+}
+
+impl ProgressSink for ProgressLog {
+    fn emit(&self, event: PhaseEvent) {
+        // One-liner first (it borrows `event`), then forward the owned event downstream.
+        let msg = event.message();
+        {
+            let mut s = self.state.lock().expect("progress log mutex poisoned");
+            s.latest = Some(msg);
+            s.steps += 1;
+        }
+        self.inner.emit(event);
     }
 }
 
@@ -227,6 +292,45 @@ mod tests {
         sink.emit(PhaseEvent::SweepFinished);
         sink.emit(PhaseEvent::TurnCapReached);
         sink.emit(PhaseEvent::PhaseFinished { phase: "consult" });
+    }
+
+    #[test]
+    fn progress_log_starts_empty_then_remembers_the_latest_beat() {
+        let log = ProgressLog::silent();
+        // Before any beat, there's nothing to echo.
+        assert_eq!(log.latest(), None);
+
+        log.emit(PhaseEvent::PhaseStarted { phase: "consult" });
+        assert_eq!(log.latest(), Some(("starting consult".to_string(), 1)));
+
+        // A second beat replaces the message and advances the count.
+        log.emit(PhaseEvent::SweepStarted {
+            question: "where is the sandbox?".into(),
+        });
+        assert_eq!(
+            log.latest(),
+            Some(("exploring: where is the sandbox?".to_string(), 2))
+        );
+    }
+
+    #[test]
+    fn progress_log_tees_every_event_to_its_inner_sink() {
+        // A counting sink proves the decorator forwards, so the `wait`/mcp_log stream is
+        // untouched when a job also records for `get`.
+        #[derive(Debug, Default)]
+        struct Counter(std::sync::atomic::AtomicUsize);
+        impl ProgressSink for Counter {
+            fn emit(&self, _event: PhaseEvent) {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let counter = Arc::new(Counter::default());
+        let log = ProgressLog::new(counter.clone());
+        log.emit(PhaseEvent::SweepFinished);
+        log.emit(PhaseEvent::PhaseFinished { phase: "consult" });
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::SeqCst), 2);
+        // And it still recorded the last one for `get`.
+        assert_eq!(log.latest(), Some(("consult complete".to_string(), 2)));
     }
 
     /// `Arc<dyn ProgressSink>` must be `Debug` (it rides inside `ConsultConfig`,

--- a/src/server.rs
+++ b/src/server.rs
@@ -3626,6 +3626,56 @@ mod tests {
         assert!(empty.contains("Nothing new in 30s"), "clean empty: {empty}");
     }
 
+    #[test]
+    fn running_beat_renders_a_phrase_only_when_a_beat_exists() {
+        assert_eq!(running_beat(&None), "");
+        assert_eq!(
+            running_beat(&Some(("exploring: the sandbox".to_string(), 3))),
+            ", currently: exploring: the sandbox (step 3)"
+        );
+    }
+
+    #[test]
+    fn render_job_echoes_the_latest_beat_on_a_running_job() {
+        let text = |r: CallToolResult| {
+            r.content
+                .into_iter()
+                .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        // A running job with a beat shows it inline; one without stays a bare status line.
+        let with_beat = render_job(
+            "job-1",
+            JobSnapshot {
+                state: JobState::Running,
+                label: "cast `x`".into(),
+                age: std::time::Duration::from_secs(12),
+                last_progress: Some(("exploring: where?".to_string(), 2)),
+            },
+        );
+        let out = text(with_beat);
+        assert!(out.contains("still running"), "status line: {out}");
+        assert!(
+            out.contains("currently: exploring: where? (step 2)"),
+            "echoes the latest beat: {out}"
+        );
+
+        let no_beat = render_job(
+            "job-2",
+            JobSnapshot {
+                state: JobState::Running,
+                label: "cast `x`".into(),
+                age: std::time::Duration::from_secs(1),
+                last_progress: None,
+            },
+        );
+        assert!(
+            !text(no_beat).contains("currently:"),
+            "no beat yet → no 'currently' phrase"
+        );
+    }
+
     fn batch_item(created_at: Option<&str>) -> crate::batch::BatchListItem {
         crate::batch::BatchListItem {
             provider_id: "id".into(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,7 +38,7 @@ use crate::kaish_syntax::{
     kaibo_instructions_with_scope, kaibo_sandbox_doc, render_builtin_help, render_topic, topics,
 };
 use crate::mcp_log;
-use crate::progress::{NullSink, PhaseEvent, ProgressSink, TracingSink};
+use crate::progress::{NullSink, PhaseEvent, ProgressLog, ProgressSink, TracingSink};
 use crate::sandbox::{KaishWorker, builtin_schemas};
 use crate::session::SessionStore;
 
@@ -589,10 +589,10 @@ impl KaiboHandler {
         );
 
         let sessions = SessionStore::new(config.defaults.session_capacity);
-        // Async-consult jobs reuse the session capacity for now — both are diskless,
-        // client-keyed, capacity-LRU registries. (docs/issues.md tracks giving jobs
-        // their own `job_capacity` knob.)
-        let jobs = JobStore::new(config.defaults.session_capacity);
+        // Async-consult jobs get their own cap: a held job result (answer + optional
+        // report) is heavier than a session's lean Q&A pair, so `job_capacity` is a
+        // separate, smaller knob (`[defaults] job_capacity` / `KAIBO_JOB_CAPACITY`).
+        let jobs = JobStore::new(config.defaults.job_capacity);
         Ok(Self {
             config: Arc::new(config),
             tool_router,
@@ -1455,17 +1455,21 @@ impl KaiboHandler {
             &synth.model,
             &cast.name,
         )?;
+        // An async job has no live MCP peer to push progress notifications to, so route
+        // its liveness onto the `tracing` stream: the `mcp_log` bridge mirrors it to a
+        // watching client (the live view sync `consult` had) and the notification buffer
+        // tees it for `wait`. The `ProgressLog` decorator wraps that `TracingSink` so the
+        // job *also* remembers the latest beat — `get`/`list` echo it inline, a second
+        // channel for a poller who isn't using `wait`. The job below keeps a clone of this
+        // exact handle, so what it reads is what the running phase emitted.
+        let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
         let cfg = ConsultConfig {
             explorer_max_turns: input
                 .explorer_max_turns
                 .unwrap_or(defaults.explorer_max_turns),
             synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
             sandbox: self.config.sandbox.clone(),
-            // An async job has no live MCP peer to push progress notifications to, so
-            // route its liveness onto the `tracing` stream: the `mcp_log` bridge mirrors
-            // it to a watching client (the live view sync `consult` had) and the
-            // notification buffer tees it for `wait`. See [`TracingSink`].
-            progress: Arc::new(TracingSink),
+            progress: progress_log.clone(),
             house_rules: self.house_rules(&root)?,
             prompts: self.resolved_prompts(&cast),
             orientation: self.orientation(&root).await?,
@@ -1486,7 +1490,7 @@ impl KaiboHandler {
         let label =
             format!("cast `{cast_name}` (explorer `{explorer_model}`, synth `{synth_model}`)");
 
-        let job_id = self.jobs.submit(label, async move {
+        let job_id = self.jobs.submit(label, progress_log, async move {
             let session = session_id.as_ref().map(|id| (&sessions, id.as_str()));
             match consult(
                 &question,
@@ -2720,6 +2724,7 @@ fn render_config_resource(
         thinking_style: String,
         request_timeout_secs: u64,
         session_capacity: usize,
+        job_capacity: usize,
     }
 
     /// Telemetry as resolved. SECRET-SAFETY: `header_names` lists the keys of any
@@ -2917,6 +2922,7 @@ fn render_config_resource(
         thinking_style,
         request_timeout,
         session_capacity,
+        job_capacity,
     } = &config.defaults;
     let crate::config::TelemetryConfig {
         enabled: telemetry_enabled,
@@ -2977,6 +2983,7 @@ fn render_config_resource(
             thinking_style: format!("{thinking_style:?}").to_lowercase(),
             request_timeout_secs: request_timeout.as_secs(),
             session_capacity: session_capacity.get(),
+            job_capacity: job_capacity.get(),
         },
         telemetry: TelemetryDoc {
             enabled: *telemetry_enabled,
@@ -3160,6 +3167,17 @@ fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> Stri
     format!("{tool} could not complete (cast `{cast}`): {detail}. {guidance}")
 }
 
+/// Render a still-running job's latest progress beat as an inline phrase, or `""` before
+/// the first beat lands. Echoes the same one-liner `wait` streams (e.g. "exploring: …"),
+/// so a caller polling with `get` sees forward motion — `step N` advances every beat even
+/// when two polls catch the same kind of event. See [`crate::progress::ProgressLog`].
+fn running_beat(last_progress: &Option<(String, u64)>) -> String {
+    match last_progress {
+        Some((msg, steps)) => format!(", currently: {msg} (step {steps})"),
+        None => String::new(),
+    }
+}
+
 /// Render an async consultation job for the unified `get`: a status line while it runs,
 /// the grounded answer (and optional report) when it's done, the stored failure text on
 /// error, or a canceled notice. Mirrors the synchronous `consult` result shape so an
@@ -3167,10 +3185,11 @@ fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> Stri
 fn render_job(id: &str, snap: JobSnapshot) -> CallToolResult {
     match snap.state {
         JobState::Running => CallToolResult::success(vec![Content::text(format!(
-            "Consultation `{id}` is still running — {} ({}s elapsed). No need to wait: go \
+            "Consultation `{id}` is still running — {} ({}s elapsed){}. No need to wait: go \
              do other work and `get` it again later.",
             snap.label,
             snap.age.as_secs(),
+            running_beat(&snap.last_progress),
         ))]),
         JobState::Done(result) => {
             let include_report = result.report.is_some();
@@ -3330,7 +3349,9 @@ fn render_jobs_section(jobs: &[(String, JobSnapshot)]) -> String {
     let mut s = String::from("Consult jobs (this session), newest first:");
     for (id, snap) in jobs {
         let state = match &snap.state {
-            JobState::Running => format!("running, {}s", snap.age.as_secs()),
+            JobState::Running => {
+                format!("running, {}s{}", snap.age.as_secs(), running_beat(&snap.last_progress))
+            }
             JobState::Done(_) => "done — `get` it for the answer".to_string(),
             JobState::Failed(_) => "failed — `get` it for the reason".to_string(),
             JobState::Canceled => "canceled".to_string(),
@@ -4061,13 +4082,13 @@ mod tests {
 
         let h = handler();
         // Two finished jobs; we only collect the first.
-        let collected = h.jobs.submit("test", async {
+        let collected = h.jobs.submit("test", Arc::new(ProgressLog::silent()), async {
             Ok(JobResult {
                 answer: "answer".into(),
                 report: None,
             })
         });
-        let other = h.jobs.submit("test", async {
+        let other = h.jobs.submit("test", Arc::new(ProgressLog::silent()), async {
             Ok(JobResult {
                 answer: "answer".into(),
                 report: None,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1116,6 +1116,33 @@ fn zero_session_capacity_is_rejected_loudly() {
     );
 }
 
+#[test]
+fn job_capacity_defaults_overrides_from_file_and_env() {
+    use std::num::NonZeroUsize;
+    // Absent → the built-in 64 (its own knob, smaller than sessions' 128).
+    let c = Config::from_toml_str("").unwrap();
+    assert_eq!(c.defaults.job_capacity, NonZeroUsize::new(64).unwrap());
+    // Set in [defaults] → honored, and independent of session_capacity.
+    let c = Config::from_toml_str("[defaults]\njob_capacity = 9\n").unwrap();
+    assert_eq!(c.defaults.job_capacity, NonZeroUsize::new(9).unwrap());
+    assert_eq!(c.defaults.session_capacity, NonZeroUsize::new(128).unwrap());
+    // Env wins over the file, like every other [defaults] knob.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[defaults]\njob_capacity = 9\n").unwrap();
+    let env: HashMap<&str, &str> = [("KAIBO_JOB_CAPACITY", "5")].into_iter().collect();
+    let c = Config::load_with(None, Some(path), |k| env.get(k).map(|s| s.to_string())).unwrap();
+    assert_eq!(c.defaults.job_capacity, NonZeroUsize::new(5).unwrap());
+}
+
+#[test]
+fn zero_job_capacity_is_rejected_loudly() {
+    // Same as sessions: a zero cap can't build an LruCache and would mean "hold no
+    // jobs", defeating `consult_submit`. Fail at load, not on the first submit.
+    let err = Config::from_toml_str("[defaults]\njob_capacity = 0\n").unwrap_err();
+    assert!(format!("{err:#}").contains("job_capacity"), "got: {err:#}");
+}
+
 // --- Key resolution (now a Backend concern) --------------------------------------
 
 fn local_backend(api_key_file: Option<String>, key_optional: bool) -> Backend {


### PR DESCRIPTION
Two `docs/issues.md` follow-ups from the async-consult surface, landed together because both live on `JobStore`/`consult_submit`.

## `job_capacity` — its own knob

Async jobs had been borrowing `defaults.session_capacity` for their LRU cap. But a held job result (a full answer + optional explorer report) is heavier than a session's lean Q&A pair, so the honest cap is smaller. New `[defaults] job_capacity` / `KAIBO_JOB_CAPACITY`, **default 64** (vs sessions' 128), plumbed exactly like `session_capacity` (struct + default + raw + merge + env + a loud zero-rejection) and surfaced in `kaibo://config`.

## `get`/`list` show the work

The issue note said `consult_submit` ran on a `NullSink` so `get` could only report *"running, Ns"*. That premise had gone stale — the async path already moved to `TracingSink`, and a `wait` tool + notification ring shipped, so the live sweep/turn narrative **was** reachable, just through `wait`, not `get`. Confirmed with Amy and took the residual: a caller who polls with `get` (the natural verb) still saw no motion.

Fix is a small **`ProgressLog` decorator** (`progress.rs`): it records the latest beat's one-liner + a beat count while teeing every event on to the inner `TracingSink`. So the `wait`/`mcp_log` stream is **byte-for-byte unchanged**, and the job *also* remembers its last beat. The job holds the same `Arc<ProgressLog>` the running consult emits through; `get`/`list` now echo `currently: exploring … (step N)` on a still-running job (the step count advances even when two polls catch the same kind of beat). A finished snapshot drops it — a Done job carries its answer, not a stale "currently" line.

## Tests

- `ProgressLog`: starts empty / remembers the latest / tees to its inner sink (a counting sink proves forwarding).
- `JobStore`: drives a beat through the shared log and asserts the running snapshot echoes it while a finished one doesn't.
- `job_capacity`: default, file + env override (independent of `session_capacity`), and loud zero-rejection.
- Full suite green; `kaibo://config` renderer updated for the new field.

Closes the two shipped bullets in the "Async consult — follow-ups" tracker entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)