### PR TITLE
Advertise the live cast roster in the resident tool descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,11 @@ the git log. Each later release appends a new section at the top.
   with a hosted synth. Built-in casts ship so
   kaibo runs with zero config; `config.toml` merges over them. Precedence:
   per-call > CLI > env > file > built-in, and a missing config file is not an error.
+  Your usable casts' names are advertised to the *calling* agent — both as the `cast`
+  param's enum and in the consult/oneshot/batch tool descriptions ("Casts ready now:
+  …", with the default flagged) — so a host told "have deepseek review this" routes off
+  the roster, and a meaningful name (`local-only`, `deep-dive`) reads as intent without
+  the caller opening your config.
 - **Guided setup.** A built-in `configure` MCP prompt walks your host agent through
   writing `config.toml`, alongside `kaibo://config` (resolved runtime state) and
   `kaibo://config/example` (annotated template) resources. Secrets are referenced by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,10 +125,10 @@ the git log. Each later release appends a new section at the top.
   kaibo runs with zero config; `config.toml` merges over them. Precedence:
   per-call > CLI > env > file > built-in, and a missing config file is not an error.
   Your usable casts' names are advertised to the *calling* agent — both as the `cast`
-  param's enum and in the consult/oneshot/batch tool descriptions ("Casts ready now:
-  …", with the default flagged) — so a host told "have deepseek review this" routes off
-  the roster, and a meaningful name (`local-only`, `deep-dive`) reads as intent without
-  the caller opening your config.
+  param's enum and in the tool descriptions ("Casts ready now: …", with the default
+  flagged) — so a host told "have deepseek review this" routes off the roster, and a
+  meaningful name (`local-only`, `deep-dive`) reads as intent without the caller opening
+  your config.
 - **Guided setup.** A built-in `configure` MCP prompt walks your host agent through
   writing `config.toml`, alongside `kaibo://config` (resolved runtime state) and
   `kaibo://config/example` (annotated template) resources. Secrets are referenced by

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ config has three concepts for configuring models:
 - **role** — a *job* a model does: `explorer` (fast sweeps) and `synth` (the voice that
   answers). A slot that reads images carries a `vision` pin (see [`docs/casts.md`](docs/casts.md)).
 - **cast** — a *composition*: a named team assigning models to roles. The `cast` call
-  argument selects the ensemble.
+  argument selects the ensemble. The name is advertised to the *calling* agent — on the
+  `cast` param and in the tool descriptions ("Casts ready now: …") — so a meaningful name
+  (`local-only`, `deep-dive`) lets it pick one by intent without reading your config.
 
 ```toml
 # ~/.config/kaibo/config.toml

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ config has three concepts for configuring models:
 - **role** — a *job* a model does: `explorer` (fast sweeps) and `synth` (the voice that
   answers). A slot that reads images carries a `vision` pin (see [`docs/casts.md`](docs/casts.md)).
 - **cast** — a *composition*: a named team assigning models to roles. The `cast` call
-  argument selects the ensemble. The name is advertised to the *calling* agent — on the
-  `cast` param and in the tool descriptions ("Casts ready now: …") — so a meaningful name
-  (`local-only`, `deep-dive`) lets it pick one by intent without reading your config.
+  argument selects the ensemble; the calling agent sees these names in its tool listing,
+  so a descriptive name (`local-only`, `deep-dive`) lets it pick a team by intent without
+  reading your config.
 
 ```toml
 # ~/.config/kaibo/config.toml

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -40,7 +40,11 @@ Three concepts, each owning exactly one idea:
   the only channel into model context is the rig request envelope. A slot carries
   a `vision` pin where it reads images.
 - **cast** — a named assignment of models to roles, freely spanning backends.
-  This is what the `cast` call param selects.
+  This is what the `cast` call param selects. The name reaches the calling agent —
+  a usable cast is advertised both as a `cast`-param enum value and in the
+  consult/oneshot tool descriptions ("Casts ready now: …") — so a name like
+  `local-only` or `deep-dive` lets it route "have deepseek review this" off that
+  roster without reading the config.
 
 **Selection rule:** calls pick casts; backends are reachable *only through* a
 cast's slots. That indirection is the whole cleanup — calls choose a

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -41,10 +41,9 @@ Three concepts, each owning exactly one idea:
   a `vision` pin where it reads images.
 - **cast** — a named assignment of models to roles, freely spanning backends.
   This is what the `cast` call param selects. The name reaches the calling agent —
-  a usable cast is advertised both as a `cast`-param enum value and in the
-  consult/oneshot tool descriptions ("Casts ready now: …") — so a name like
-  `local-only` or `deep-dive` lets it route "have deepseek review this" off that
-  roster without reading the config.
+  a usable cast is advertised both as a `cast`-param enum value and in the tool
+  descriptions ("Casts ready now: …") — so a name like `local-only` or `deep-dive`
+  lets it route "have deepseek review this" off that roster without reading the config.
 
 **Selection rule:** calls pick casts; backends are reachable *only through* a
 cast's slots. That indirection is the whole cleanup — calls choose a

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -5,8 +5,9 @@
 #
 # EVERYTHING here is optional. With no config file at all, kaibo runs exactly as it
 # does today: four built-in BACKENDS (connections: anthropic/deepseek/gemini/openai-local)
-# and four same-named single-backend CASTS (compositions: role → "backend/model-id")
-# ship in code; this file only OVERRIDES fields or ADDS backends and casts.
+# and six built-in CASTS (compositions: role → "backend/model-id") — four same-named
+# interactive ones plus two batch casts (anthropic-batch, gemini-batch) — ship in code;
+# this file only OVERRIDES fields or ADDS backends and casts.
 # `[profiles]` is gone — a config that still carries it is a load error pointing at
 # docs/casts.md.
 #
@@ -67,11 +68,12 @@ cast = "anthropic"
 log = "kaibo=info"
 
 # Tool gating — true advertises the tool, false drops it (the --no-<tool> flags).
-# A config with all three false is refused at startup, same as today.
+# All four default true; a config that turns all four off is refused at startup.
 [server.tools]
 consult        = true
 oneshot        = true
 run_kaish      = true
+batch          = true
 
 # ---------------------------------------------------------------------------
 # [defaults] — tunables every cast slot falls back to. The model-tracking knobs
@@ -219,11 +221,13 @@ key_optional = true                          # keyless local default → placeho
 #     built-in `openai-local` backend alone — a forgotten base_url is a load error, not
 #     a silent dial of the wrong server). ---
 
-# Hosted OpenAI, keyed.
+# Hosted OpenAI, keyed. Backends take their own `aliases`, just like casts — a new
+# alias must not collide with a built-in or another name.
 [backends.gpt]
 kind = "openai"
 base_url = "https://api.openai.com/v1"
 api_key_env = "OPENAI_API_KEY"
+aliases = ["oai"]                            # now `oai/gpt-5` resolves to this backend
 key_optional = false
 
 # A second local llama.cpp server on another port, keyless. A slow local model
@@ -238,9 +242,8 @@ request_timeout_secs = 1800
 # [casts.<name>] — COMPOSITIONS: role → model, freely spanning backends. This is
 # what the `cast` call param (and `server.cast` / KAIBO_CAST / --cast) selects.
 #
-# Cast names reach the calling model: each usable cast appears on the `cast` param
-# (a JSON-Schema enum) and in the tool descriptions ("Casts ready now: chimera,
-# local-only, … (default)"). Name for intent (`local-only`, `deep-dive`), not `cast2`.
+# The calling agent sees your cast names — name them for intent (`local-only`,
+# `deep-dive`) so it can route by name without reading this file.
 #
 # Roles: explorer, synth (the agent phases). There are no output/production roles —
 # kaibo reasons over code and renders nothing. A typo'd role is a loud load
@@ -296,7 +299,7 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 [casts.deep-dive]
 aliases  = ["deep"]                          # casts (and backends) take aliases
-explorer = "deepseek/deepseek-v4-flash"
+explorer = { backend = "deepseek", id = "deepseek-v4-flash", temperature = 0.0, thinking_budget = 4096, thinking_style = "auto" }
 synth    = { backend = "claude", id = "claude-opus-4-8", effort = "max", max_tokens = 32768 }
 
 # --- A per-model prompt: a local Gemma explorer wants different framing than a
@@ -312,6 +315,15 @@ synth    = "claude/claude-sonnet-4-6"        # no per-model prompt → [prompts]
 [casts.gpt]
 explorer = "gpt/gpt-5-mini"
 synth    = "gpt/gpt-5"
+
+# --- A custom batch cast: the offline `batch_submit` lane (max thinking). `batch = true`
+#     declares it; it needs a synth slot on a batch-capable backend (Anthropic or Gemini)
+#     and runs the synth alone (no explorer). The built-in anthropic-batch / gemini-batch
+#     casts are the same shape. ---
+
+[casts.pro-batch]
+batch    = true
+synth    = "gemini/gemini-pro-latest"        # synth must be batch-capable (Anthropic | Gemini)
 
 # ---------------------------------------------------------------------------
 # [context] — "house rules" files spliced into every consultation tool's preamble
@@ -340,12 +352,14 @@ synth    = "gpt/gpt-5"
 # Precedence per phase: slot `preamble` (per-model, above) > [prompts].<phase> >
 # built-in. The synth slot feeds both `consult` and `oneshot`, but each keeps
 # its own key, so they can diverge. Phases: `explorer` (the nested explore′ sweep),
-# `consult` (the driver), `oneshot` (the thin toolless answer).
+# `consult` (the driver), `oneshot` (the thin toolless answer), `batch` (the offline
+# max-thinking answer).
 # ---------------------------------------------------------------------------
 #
 # [prompts]
 # explorer = "You are a security auditor. Hunt injection sinks and unsafe deserialization."
 # oneshot  = "Answer concisely; you have no codebase access, so reason from what you're given."
+# batch    = "Answer concisely; you're offline at max thinking. Reason from what you're given."
 # consult  = """
 # You are a staff engineer reviewing this codebase.
 # Prefer architectural answers; name the file:line that carries each claim.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -238,11 +238,9 @@ request_timeout_secs = 1800
 # [casts.<name>] — COMPOSITIONS: role → model, freely spanning backends. This is
 # what the `cast` call param (and `server.cast` / KAIBO_CAST / --cast) selects.
 #
-# The name reaches the calling model: a usable cast is advertised on the `cast`
-# param (a schema enum) and in the consult/oneshot tool descriptions ("Casts ready
-# now: chimera, local-only, …", default flagged). So an agent told "have chimera
-# review this" picks it without reading the config — name for intent (`local-only`,
-# `deep-dive`), not `cast2`.
+# Cast names reach the calling model: each usable cast appears on the `cast` param
+# (a JSON-Schema enum) and in the tool descriptions ("Casts ready now: chimera,
+# local-only, … (default)"). Name for intent (`local-only`, `deep-dive`), not `cast2`.
 #
 # Roles: explorer, synth (the agent phases). There are no output/production roles —
 # kaibo reasons over code and renders nothing. A typo'd role is a loud load

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -238,6 +238,12 @@ request_timeout_secs = 1800
 # [casts.<name>] — COMPOSITIONS: role → model, freely spanning backends. This is
 # what the `cast` call param (and `server.cast` / KAIBO_CAST / --cast) selects.
 #
+# The name reaches the calling model: a usable cast is advertised on the `cast`
+# param (a schema enum) and in the consult/oneshot tool descriptions ("Casts ready
+# now: chimera, local-only, …", default flagged). So an agent told "have chimera
+# review this" picks it without reading the config — name for intent (`local-only`,
+# `deep-dive`), not `cast2`.
+#
 # Roles: explorer, synth (the agent phases). There are no output/production roles —
 # kaibo reasons over code and renders nothing. A typo'd role is a loud load
 # error. A cast may omit roles — the tool that needs a missing role fails at call time,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -383,6 +383,26 @@ endpoint still surfaces as a mid-call error. A startup check (key presence + an
 teams up front — "cast `chimera` is degraded: backend `sd` unreachable" beats a
 mid-consult error. An MCP resource enumerating models could ride along.
 
+### `config.example.toml` clarity — illustrative stanzas read as required; `gpt` dual-name
+Surfaced by the cross-model review of the cast-roster change (an Anthropic `consult`
+cross-checking the example against `config.rs`, plus a deepseek/gemini/anthropic
+parse-back, 2026-06-29). Both are doc-clarity, not correctness — the example parses and
+all three families read it right otherwise — so they were left out of the roster PR:
+- **The four built-in backend stanzas are shown uncommented.** The
+  `[backends.anthropic/deepseek/gemini/openai-local]` block sits live even though the
+  preceding comment says they're illustrative and you only list a backend to *change*
+  something. An operator scanning the file may copy all four as if required — the
+  getting-started block and `[telemetry]` are commented-out for exactly this reason.
+  Comment them out (or collapse to one representative stanza). Care needed: the example's
+  casts resolve against these backends, so a wrong cut breaks
+  `tests/config.rs::the_shipped_example_config_parses` (which is the guard that makes the
+  pass safe).
+- **`gpt` names both `[backends.gpt]` and `[casts.gpt]`.** The namespaces are separate so
+  this is legal, but the file reserves *alias* names "at both levels" without saying a
+  *primary* name may be shared across the backend/cast namespaces — a reader can't tell the
+  co-naming is intentional vs. a latent collision. One clarifying clause near the
+  `[casts.<name>]` header settles it.
+
 ---
 
 ## P4 — Eventually

--- a/src/server.rs
+++ b/src/server.rs
@@ -3876,6 +3876,85 @@ mod tests {
         );
     }
 
+    /// The roster split by lane lands in the prose too — the mirror of
+    /// `cast_enums_split_by_lane`: an interactive tool's description names the interactive
+    /// cast and never a batch cast, and `batch_submit`'s description names the batch cast
+    /// and never an interactive one, so the advertised prose can't tempt an agent toward a
+    /// cast that lane will refuse. Keyless local gemini backend so both lanes are usable
+    /// offline (without it the batch append hits the empty-guard and the split goes
+    /// untested).
+    #[test]
+    fn roster_splits_by_lane_in_descriptions() {
+        let h = handler_from_toml(
+            r#"
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.mybatch]
+            batch = true
+            synth = "gem/some-pro"
+
+            [casts.myinteractive]
+            explorer = "gem/some-lite"
+            synth = "gem/some-flash"
+            "#,
+        );
+        let desc_of = |tool: &str| -> String {
+            h.tool_router
+                .get(tool)
+                .expect("tool advertised")
+                .description
+                .clone()
+                .unwrap_or_default()
+                .into_owned()
+        };
+        for tool in ["consult", "consult_submit", "oneshot"] {
+            let d = desc_of(tool);
+            assert!(
+                d.contains("myinteractive"),
+                "{tool} description should name the interactive cast, got:\n{d}"
+            );
+            assert!(
+                !d.contains("mybatch"),
+                "{tool} description must not name a batch cast, got:\n{d}"
+            );
+        }
+        let batch = desc_of("batch_submit");
+        assert!(
+            batch.contains("mybatch"),
+            "batch_submit description should name the batch cast, got:\n{batch}"
+        );
+        assert!(
+            !batch.contains("myinteractive"),
+            "batch_submit description must not name an interactive cast, got:\n{batch}"
+        );
+    }
+
+    /// `append_cast_roster` shares `inject_cast_enum`'s empty guard: an empty roster (no
+    /// cast can reach a model) leaves the description byte-for-byte untouched, so a
+    /// keyless-everything server never appends a vacuous "Casts ready now: ." to its tools.
+    #[test]
+    fn empty_roster_leaves_descriptions_unchanged() {
+        let mut router = KaiboHandler::tool_router();
+        let desc = |r: &ToolRouter<KaiboHandler>| -> String {
+            r.get("consult")
+                .expect("tool present")
+                .description
+                .clone()
+                .unwrap_or_default()
+                .into_owned()
+        };
+        let before = desc(&router);
+        append_cast_roster(&mut router, &["consult", "oneshot"], &[], "deepseek");
+        let after = desc(&router);
+        assert_eq!(before, after, "an empty roster must not alter the description");
+        assert!(
+            !after.contains("Casts ready now"),
+            "an empty roster must not append the roster line:\n{after}"
+        );
+    }
+
     /// A per-model slot `preamble` wins over the global `[prompts].<phase>`, and the
     /// synth slot feeds *both* capable-model phases (the `consult` driver and the
     /// toolless `oneshot`) — the "its own, even if a copy" shape: same value today,

--- a/src/server.rs
+++ b/src/server.rs
@@ -404,6 +404,43 @@ fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, tools: &[&str], casts
     }
 }
 
+/// Append the live cast roster to each named tool's `description` — the resident
+/// prose a host always shows, where `inject_cast_enum`'s param `enum` and the
+/// handshake list (which a host may truncate) don't reliably land. This is what
+/// lets an agent that hears "have deepseek review" index straight to a kaibo tool:
+/// the team names sit in the description text its tool-picker reads. The default
+/// cast is flagged so a bare call's team is legible. `casts` is the per-lane roster
+/// (same split as the enum), so the advertised menu matches what the tool accepts;
+/// skipped when empty, the same "no valid value" guard as the enum.
+fn append_cast_roster(
+    router: &mut ToolRouter<KaiboHandler>,
+    tools: &[&str],
+    casts: &[String],
+    default_cast: &str,
+) {
+    if casts.is_empty() {
+        return;
+    }
+    let menu = casts
+        .iter()
+        .map(|c| {
+            if c == default_cast {
+                format!("{c} (default)")
+            } else {
+                c.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    for name in tools {
+        let Some(route) = router.map.get_mut(*name) else {
+            continue;
+        };
+        let base = route.attr.description.as_deref().unwrap_or_default();
+        route.attr.description = Some(format!("{base} Casts ready now: {menu}.").into());
+    }
+}
+
 #[tool_router]
 impl KaiboHandler {
     /// Build the handler from a resolved [`Config`]. Snapshots the kernel's builtin
@@ -535,6 +572,21 @@ impl KaiboHandler {
             &interactive_usable,
         );
         inject_cast_enum(&mut tool_router, &["batch_submit"], &batch_usable);
+        // ...and name that same roster in the resident prose, so an agent that hears
+        // "have deepseek review" indexes to a kaibo tool from the description it always
+        // reads, not only the param enum the tool-picker may skim past.
+        append_cast_roster(
+            &mut tool_router,
+            &["consult", "consult_submit", "oneshot"],
+            &interactive_usable,
+            &config.default_cast,
+        );
+        append_cast_roster(
+            &mut tool_router,
+            &["batch_submit"],
+            &batch_usable,
+            &config.default_cast,
+        );
 
         let sessions = SessionStore::new(config.defaults.session_capacity);
         // Async-consult jobs reuse the session capacity for now — both are diskless,
@@ -3644,6 +3696,46 @@ mod tests {
             assert!(
                 variants.iter().any(|v| v == "openai-local"),
                 "{tool}: cast enum should list the always-usable local cast, got {variants:?}"
+            );
+        }
+    }
+
+    /// The live roster also lands in the *prose* description — the text a host always
+    /// shows and an agent's tool-picker actually skims — with the default cast flagged.
+    /// This is what lets "have deepseek review" index to a kaibo tool. Driven through a
+    /// keyless local gemini backend and an explicit default so the assertion holds
+    /// regardless of which API keys the test env carries.
+    #[test]
+    fn consultation_tools_name_the_live_roster_in_their_description() {
+        let h = handler_from_toml(
+            r#"
+            [server]
+            cast = "myinteractive"
+
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.myinteractive]
+            explorer = "gem/some-lite"
+            synth = "gem/some-flash"
+            "#,
+        );
+        for tool in ["consult", "consult_submit", "oneshot"] {
+            let desc = h
+                .tool_router
+                .get(tool)
+                .expect("tool advertised")
+                .description
+                .clone()
+                .unwrap_or_default();
+            assert!(
+                desc.contains("Casts ready now:"),
+                "{tool}: description should carry the live roster, got:\n{desc}"
+            );
+            assert!(
+                desc.contains("myinteractive (default)"),
+                "{tool}: description should flag the default cast, got:\n{desc}"
             );
         }
     }


### PR DESCRIPTION
## Why

When a user says "have deepseek review this," their agent needs the name `deepseek` to sit somewhere its tool-picker actually reads — the resident tool **description** — to index from that phrasing to a kaibo tool. We already stamp the usable cast names onto the `cast` *parameter* as a JSON-Schema enum (`inject_cast_enum`), but a host's tool-picker leans on description prose and may skim past param schemas (the same reason the enum injection exists: the handshake list a host may truncate). So the names weren't reliably resident where it counts.

## What

`append_cast_roster` (sibling to `inject_cast_enum`, built at startup from the same usable set, same batch/interactive lane split, same empty-roster guard) appends `Casts ready now: deepseek (default), gemini, …` to the resident descriptions of `consult`/`consult_submit`/`oneshot` (interactive roster) and `batch_submit` (batch roster), default flagged.

Because the name now reaches the client, naming a cast for *intent* (`local-only`, `deep-dive`) is what lets a host route by name without reading the config — documented at each cast-definition site.

## Decisions

- **Density split for the docs.** The enum / "Casts ready now" *mechanics* are kept in the design doc (`docs/casts.md`) and `CHANGELOG`; the resident user-facing texts (`README`, `config.example.toml`) are purely descriptive — "the calling agent sees your cast names." Repeating implementation mechanics in resident text doesn't pay rent (per AGENTS.md "Writing for models").
- **Folded in an example-config fix.** A review pass cross-checking `config.example.toml` against `config.rs` caught a real bug — `[server.tools]` omitted `batch` and said "three" when the all-off refusal needs all *four* false — plus several features the example never demonstrated. Fixed the bug and added worked examples: a `batch = true` cast (`pro-batch`), `[prompts].batch`, backend `aliases`, and the slot tunables `temperature`/`thinking_budget`/`thinking_style`. All validated by the real loader via `the_shipped_example_config_parses`.
- **Two clarity leftovers recorded, not fixed** (`docs/issues.md`, P3): the illustrative backend stanzas read as required, and `gpt` names both a backend and a cast without the file noting the namespaces are separate.

## Review

Dogfooded a cross-family pass *through kaibo itself* — `consult` (deepseek) over the diff, a second `consult` (anthropic) cross-checking the example against the parser, a `batch` (gemini-pro) over source + docs, and a deepseek/gemini/anthropic parse-back of the example config. Findings and the changes they drove are posted as PR comments. The two test gaps the code reviewers flagged (batch lane, empty guard) are closed in `b83935a`.

## Tests

- `roster_splits_by_lane_in_descriptions` — mirrors `cast_enums_split_by_lane` for descriptions (interactive tools name the interactive cast and never a batch cast; `batch_submit` the reverse).
- `empty_roster_leaves_descriptions_unchanged` — the empty-guard, byte-for-byte.
- Full suite green (the lone intermittent failure is the known tracing-callsite flake, unrelated).
