### PR TITLE
chore(deps): bump kaish-kernel 0.9.0 → 0.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,9 +239,10 @@ even for a one-line doc fix.
   `v*` tag. Before tagging: confirm the `kaish-kernel` pin is current (next bullet),
   re-run `docs/sandbox-probes.md` and stamp its "Last run" line, and verify
   `cargo tree -i aws-lc-rs` is empty and the musl binary is `not a dynamic executable`.
-- **kaish pin.** Currently `kaish-kernel = "0.9.0"`. The bump from `0.8.4` carried one
-  API break: the `mcp()` config constructors (`IgnoreConfig`/`OutputLimitConfig`/
-  `KernelConfig`) were renamed to `agent()` — same presets, just the embedder-facing
-  name. Adapted the three call sites in `sandbox.rs`; offline suite green, boundary
-  tests still have teeth. Keep this current per the **Working here** kaish-bump
-  discipline before cutting.
+- **kaish pin.** Currently `kaish-kernel = "0.10.0"`. The bump from `0.9.0` was
+  API-compatible — no kaibo call sites changed, identical builtin/tool set; under the
+  hood kaish gained bignum arithmetic (`num-bigint`) and a new regex engine
+  (`regex-bites`). Offline suite green (462 tests), boundary tests still have teeth.
+  The prior `0.8.4 → 0.9.0` step had renamed the `mcp()` config constructors
+  (`IgnoreConfig`/`OutputLimitConfig`/`KernelConfig`) to `agent()` in `sandbox.rs`.
+  Keep this current per the **Working here** kaish-bump discipline before cutting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
@@ -423,6 +429,38 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -834,9 +872,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hifijson"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
+checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "http"
@@ -1121,6 +1159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,9 +1193,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
-version = "2.2.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77526a72eb79412c29fd141767a6549bbfcb1cb40e00556fe16532d5e878e098"
+checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -1160,31 +1204,80 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "1.1.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
+checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
 dependencies = [
+ "bstr",
+ "bytes",
  "foldhash 0.1.5",
  "hifijson",
  "indexmap",
  "jaq-core",
  "jaq-std",
+ "num-bigint",
+ "num-traits",
+ "ryu",
+ "self_cell",
 ]
 
 [[package]]
 name = "jaq-std"
-version = "2.1.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c264fe397c981705976c71f1bfe020382b9eda52ae950e57fe885e147bdd67d"
+checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
 dependencies = [
  "aho-corasick",
  "base64",
- "chrono",
+ "bstr",
  "jaq-core",
+ "jiff",
  "libm",
  "log",
- "regex-lite",
+ "regex-bites",
  "urlencoding",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -1279,29 +1372,30 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868f33bffc2574e15b1f0e95f35242781e4cb7bd9834307929a324440d4946f9"
+checksum = "e004c2b35ef382d73a3848cf99d91b3dd802b4297742f08ba17aa4ee98ff6d25"
 dependencies = [
  "async-trait",
  "ignore",
+ "infer",
  "thiserror",
 ]
 
 [[package]]
 name = "kaish-help"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86409a898ec7075582df301a92b779eafe187606ec84923750f07cb207fc04e2"
+checksum = "e909e59dd3ceeb52fca039e5bdaf3de3daabbc54a2222a6101bc216b33dece6a"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398391c4b14ae5ad38903786946aea3f60de9dcc766318addc262bcde06420b5"
+checksum = "7159e8c95950d54e5fa45a31abaedbfaaab61a01129326392e3719ac7ff60bb6"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1345,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccb53fcb5f0ebb6bfef939199d86689bfe5fd920e38b1e121925b540cb2a39f"
+checksum = "5224be7bfee3db6c3190375accbcf1a809d9b6dc866517156b4459568159bd9e"
 dependencies = [
  "async-trait",
  "clap",
@@ -1356,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab674433bd72c43972089d3454e8b291e3ba67bedb3cf03d52fddf3c63fa9eee"
+checksum = "9198f9f6098e84ba99656feb9fe02401eeaa3edee7fc8085408b31fa4d597ec3"
 dependencies = [
  "base64",
  "serde",
@@ -1369,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c8f771613845ac69b9401d1c510d833bc37c95100c089a5e4839dd83208926"
+checksum = "b4f35edc501e437e760765b4a50d4d3fb4e8a58dd4793112ff797695dfbd85ca"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -1555,6 +1649,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1766,6 +1879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1932,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1989,10 +2133,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
+name = "regex-bites"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "regex-syntax"
@@ -2163,7 +2307,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2250,6 +2394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,7 +2449,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2315,6 +2465,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -2369,6 +2525,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2546,7 +2703,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2777,7 +2934,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http",
@@ -3141,7 +3298,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3428,7 +3585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.12.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # `os-integration` (trash) OFF — so those builtins are never compiled in. kaibo's
 # read-only safety is thus structural (the dangerous surface doesn't exist),
 # backed by the runtime read-only mount; see src/sandbox.rs.
-kaish-kernel = { version = "0.9.0", default-features = false, features = ["localfs"] }
+kaish-kernel = { version = "0.10.0", default-features = false, features = ["localfs"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
 async-trait = "0.1"
 anyhow = "1"

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,18 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-06-29 — kaish-kernel 0.10.0
+
+Bumped the published dep `0.9.0 → 0.10.0`. API-compatible this time — no kaibo call
+sites changed and the builtin/tool set is identical. Under the hood kaish gained bignum
+arithmetic (`num-bigint`) and swapped in a new regex engine (`regex-bites`); both are
+shell-engine internals that surface to a user only through `run_kaish`/`consult`, so
+there's no kaibo behavior we authored to record in the changelog (and 0.2.0 is the first
+tracked release anyway — no baseline to diff against). Offline suite green (462), TLS
+tree still C-free (`aws-lc-rs`/`aws-lc-sys`/`openssl-sys` all absent), boundary tests
+still have teeth. Per the kaish-bump discipline: adapt to the new shape, don't pin
+around it — nothing to adapt here.
+
 ## 2026-06-29 — A "flaky test" was a real inherited robustness bug
 
 `omitted_path_zero_config_infers_cwd_as_default_root` failed ~1 in 5 full `cargo test`

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -16,7 +16,7 @@ Conventions:
   fixes & hardening · **P3** infra, perf, polish · **P4** eventually.
 
 History of shipped work moved to `docs/devlog.md` (2026-06-18). Newest entry there:
-kaish-kernel 0.9.0.
+kaish-kernel 0.10.0.
 
 ---
 


### PR DESCRIPTION
## What

Bumps the embedded `kaish-kernel` pin from `0.9.0` to the freshly published `0.10.0`.

## Why it's a low-risk bump

Unlike the `0.8.4 → 0.9.0` step (which renamed the `mcp()` config constructors to `agent()`), this one is **API-compatible**: no kaibo call sites changed and the builtin/tool set is byte-for-byte identical between the two registry sources. Under the hood kaish gained bignum arithmetic (`num-bigint`) and a new regex engine (`regex-bites`) — shell-engine internals that surface to a user only through `run_kaish`/`consult`.

## No changelog entry — on purpose

The new behavior is kaish's, not kaibo-authored, and `0.2.0` is still the first *tracked* release (the unreleased section captures the feature set going public, not a diff against a prior release — there's no baseline to diff against). Per the repo's "internal-only changes need no entry" rule, the record lives in the **AGENTS.md kaish-pin discipline note** and a dated **devlog** entry instead.

## Verification

- Offline suite green: **462 passed, 0 failed**.
- TLS invariant intact: `cargo tree -i` finds no `aws-lc-rs` / `aws-lc-sys` / `openssl-sys`.
- Sandbox/containment boundary tests still pass (still have teeth).

Review scaled to the change: a clean, API-compatible dependency pin bump is a glance, not a hard look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)