### PR TITLE
docs(config): recommend Gemini Pro batch-only

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -319,11 +319,13 @@ synth    = "gpt/gpt-5"
 # --- A custom batch cast: the offline `batch_submit` lane (max thinking). `batch = true`
 #     declares it; it needs a synth slot on a batch-capable backend (Anthropic or Gemini)
 #     and runs the synth alone (no explorer). The built-in anthropic-batch / gemini-batch
-#     casts are the same shape. ---
+#     casts are the same shape. Gemini Pro especially earns this lane: interactively it's
+#     refusal-prone on security framing and 503s under load, but batch sidesteps both — so
+#     reach for Pro batch-only (the built-in `gemini-batch` cast, or a custom one like this). ---
 
 [casts.pro-batch]
 batch    = true
-synth    = "gemini/gemini-pro-latest"        # synth must be batch-capable (Anthropic | Gemini)
+synth    = "gemini/gemini-pro-latest"        # batch-capable synth (Anthropic | Gemini); Pro is batch-only
 
 # ---------------------------------------------------------------------------
 # [context] — "house rules" files spliced into every consultation tool's preamble


### PR DESCRIPTION
## What

Both the shipped example config (`docs/config.example.toml`, embedded and served as `kaibo://config/example`) and Amy's personal box config now steer **Gemini Pro to the batch lane only**.

## Why

Pro reasons materially deeper than Flash, but interactively it's the *least* recommendable Gemini: refusal-prone on security framing and 503-prone under load (proven 2026-06-12). The offline `batch_submit` lane sidesteps both — async, no held turn, more reliable delivery. So:

- **Flash** stays the interactive answer (the one Gemini we recommend live).
- **Pro** is reached batch-only — the built-in `gemini-batch` cast (`synth = gemini-pro-latest`), or a custom `pro-batch`.

This commit only touches the repo's example config: the `pro-batch` block's comment now explains *why* the batch lane exists for Pro instead of merely showing the cast. (The personal `~/.config/kaibo/config.toml` got the matching treatment locally — not in this repo.)

No behavior change, no CHANGELOG entry — comment-only polish to the still-unreleased 0.2.0 example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)