### PR TITLE
feat(handshake): name each cast's synth model in the ## Casts roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,10 @@ the git log. Each later release appends a new section at the top.
   param's enum and in the tool descriptions ("Casts ready now: …", with the default
   flagged) — so a host told "have deepseek review this" routes off the roster, and a
   meaningful name (`local-only`, `deep-dive`) reads as intent without the caller opening
-  your config.
+  your config. The startup handshake's `## Casts` roster goes further: each line names
+  the cast's **answering (synth) model** and tags a batch-only cast `batch`, so a host
+  told "ask Gemini Pro" indexes `gemini-batch → gemini/gemini-pro-latest (batch)` — and
+  knows it's the `batch_submit` lane — without reading `kaibo://config`.
 - **Guided setup.** A built-in `configure` MCP prompt walks your host agent through
   writing `config.toml`, alongside `kaibo://config` (resolved runtime state) and
   `kaibo://config/example` (annotated template) resources. Secrets are referenced by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,15 @@ the git log. Each later release appends a new section at the top.
 - **Single self-contained binary** per platform; Linux builds are fully static
   (musl). TLS is rustls + ring — no OpenSSL, no aws-lc, no C toolchain.
 
+### Fixed
+
+- **The advertised cast roster marks the default even when it's set by an alias.**
+  Setting `server.cast` (or `--cast` / `KAIBO_CAST`) to a cast *alias* — say `claude`
+  for `anthropic` — used to drop the `(default)` tag from the handshake's `## Casts`
+  roster and the tools' "Casts ready now" line, because the tag compared the raw string
+  against the canonical names kaibo advertises. The default is now resolved before
+  comparison, so the right cast is flagged however you named it.
+
 ### Security
 
 - **Read-only is structural, not best-effort.** kaibo compiles in only kaish's

--- a/src/config.rs
+++ b/src/config.rs
@@ -641,6 +641,18 @@ impl Config {
         self.casts.get(name).is_some_and(|c| c.batch)
     }
 
+    /// Whether canonical cast `name` is the configured default — comparing against the
+    /// *resolved* default, so an alias default (`server.cast = "claude"`) still matches
+    /// its canonical cast (`anthropic`). The roster renderers (`casts_section`,
+    /// `append_cast_roster`) get canonical names from [`usable_casts`](Self::usable_casts),
+    /// so a bare `name == default_cast` string compare would silently drop the
+    /// `(default)` tag whenever the default was set by an alias. An unresolvable default
+    /// (can't happen post-load, validated there) reads as "nothing is default".
+    pub fn is_default_cast(&self, name: &str) -> bool {
+        self.resolve_cast(&self.default_cast)
+            .is_ok_and(|c| c.name == name)
+    }
+
     /// Resolve a backend by name or alias (the seam slot refs and per-call
     /// qualified overrides go through). An unknown name is a loud error naming
     /// the known backends.
@@ -2627,6 +2639,27 @@ mod tests {
         assert_eq!(
             cfg.cast_usability(cast, env),
             CastUsability::LocalUnverified
+        );
+    }
+
+    /// `is_default_cast` matches the canonical default *and* an alias default — the
+    /// roster's `(default)` tag depends on it, and an operator may set `server.cast` to
+    /// an alias. Compares against the resolved name, not the raw string.
+    #[test]
+    fn is_default_cast_matches_through_an_alias() {
+        let mut cfg = Config::builtin(); // `claude` is a built-in alias for `anthropic`
+        cfg.default_cast = "claude".to_string();
+        assert!(
+            cfg.is_default_cast("anthropic"),
+            "an alias default must match its canonical cast"
+        );
+        assert!(
+            !cfg.is_default_cast("claude"),
+            "the canonical name is what usable_casts yields and what we compare"
+        );
+        assert!(
+            !cfg.is_default_cast("deepseek"),
+            "a non-default cast must not be tagged default"
         );
     }
 

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -230,7 +230,7 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
         .iter()
         .map(|(name, state)| {
             let mut tags = Vec::new();
-            if name == &config.default_cast {
+            if config.is_default_cast(name) {
                 tags.push("default".to_string());
             }
             if matches!(state, CastUsability::LocalUnverified) {
@@ -641,6 +641,64 @@ mod tests {
         assert!(
             pro_line.contains("batch"),
             "the gemini-batch line must carry a batch tag:\n{pro_line}"
+        );
+    }
+
+    /// The `(default)` tag survives a default cast set by *alias*. `usable_casts`
+    /// yields canonical names (`anthropic`), but an operator may write
+    /// `server.cast = "claude"` (an alias) — a raw `name == default_cast` would compare
+    /// `"anthropic" == "claude"`, miss, and silently drop the tag. The roster must
+    /// resolve the default before comparing. (Reviewer-found: the alias/default
+    /// equality bug, latent in the bare-string compare.)
+    #[test]
+    fn casts_section_marks_the_default_even_when_set_by_alias() {
+        let mut config = Config::builtin();
+        config.default_cast = "claude".to_string(); // alias → canonical `anthropic`
+        let usable = vec![("anthropic".to_string(), CastUsability::Ready)];
+        let text = kaibo_instructions_with_scope(
+            &[],
+            &config,
+            &[PathBuf::from("/tmp")],
+            None,
+            false,
+            CastUsability::Ready,
+            &usable,
+        );
+        let line = text
+            .lines()
+            .find(|l| l.contains("anthropic"))
+            .expect("anthropic has a roster line");
+        assert!(
+            line.contains("(default)"),
+            "the canonical cast of an alias default must still be tagged default:\n{line}"
+        );
+    }
+
+    /// An explorer-only cast (no synth slot) renders its name with no `→ model` — the
+    /// handshake doesn't invent an answerer it can't name (the synth gap surfaces at
+    /// call time). Exercises the `None` arm DeepSeek flagged as uncovered.
+    #[test]
+    fn casts_section_renders_a_synthless_cast_as_name_only() {
+        let config = Config::builtin();
+        // A name absent from the registry resolves to no synth slot — the same render
+        // path a real explorer-only cast takes, without fabricating one in the config.
+        let usable = vec![("explorer-only".to_string(), CastUsability::Ready)];
+        let text = kaibo_instructions_with_scope(
+            &[],
+            &config,
+            &[PathBuf::from("/tmp")],
+            None,
+            false,
+            CastUsability::Ready,
+            &usable,
+        );
+        let line = text
+            .lines()
+            .find(|l| l.contains("explorer-only"))
+            .expect("explorer-only has a roster line");
+        assert!(
+            !line.contains('→'),
+            "a cast with no synth slot must not render an arrow/model:\n{line}"
         );
     }
 

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -23,7 +23,7 @@ use kaish_kernel::help::{
 };
 use kaish_kernel::tools::ToolSchema;
 
-use crate::config::{CastUsability, Config};
+use crate::config::{CastUsability, Config, ModelRole};
 
 /// The kaibo-specific half of the core: the read-only boundary, the exit-code
 /// contract, the no-cwd rule, and the line-number idioms that make citations
@@ -208,17 +208,21 @@ fn setup_section(config: &Config) -> String {
 }
 
 /// The `## Casts` block: the casts that can reach a model *right now* (from
-/// [`Config::usable_casts`]), the default marked and a local/unverified one tagged.
-/// This is the handshake answering "what can I pass as `cast`?" truthfully — it
-/// names config.toml casts the static per-tool `cast` enum can't, and lists only
-/// what will actually work (an unconfigured cast is filtered upstream). It closes by
-/// pointing at `kaibo://config` as canonical for the full configured state, since
-/// this list is deliberately partial (usable-only) and read once at startup.
+/// [`Config::usable_casts`]), each line naming the cast's answering (synth) model —
+/// the team's voice, so an agent told "ask Gemini Pro" indexes the right cast — with
+/// the default marked, a local/unverified one tagged, and a batch-only cast tagged
+/// `batch` (it's the `batch_submit` lane). This is the handshake answering "what can I
+/// pass as `cast`?" truthfully — it names config.toml casts the static per-tool `cast`
+/// enum can't, and lists only what will actually work (an unconfigured cast is filtered
+/// upstream). It closes by pointing at `kaibo://config` as canonical for the full
+/// configured state, since this list is deliberately partial (usable-only) and read
+/// once at startup. The synth model lives on the resolved `Config` already (it's what
+/// `kaibo://config` prints) — this surfaces it where the calling agent first reads.
 ///
 /// Empty `usable` (no cast can reach a model) renders nothing — the `Unconfigured`
 /// setup banner already owns that case and would otherwise say it twice. Returns a
 /// trailing `\n\n` so the caller can splice it in unconditionally.
-fn casts_section(default_cast: &str, usable: &[(String, CastUsability)]) -> String {
+fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String {
     if usable.is_empty() {
         return String::new();
     }
@@ -226,16 +230,35 @@ fn casts_section(default_cast: &str, usable: &[(String, CastUsability)]) -> Stri
         .iter()
         .map(|(name, state)| {
             let mut tags = Vec::new();
-            if name == default_cast {
-                tags.push("default");
+            if name == &config.default_cast {
+                tags.push("default".to_string());
             }
             if matches!(state, CastUsability::LocalUnverified) {
-                tags.push("local, unverified");
+                tags.push("local, unverified".to_string());
             }
-            if tags.is_empty() {
-                format!("- `{name}`")
+            // A batch cast runs synth alone on the `batch_submit` lane (no explorer),
+            // so tag it: the agent learns which tool the cast belongs to, not just its
+            // name. `cast_is_batch` is the same predicate the per-lane enum split uses.
+            if config.cast_is_batch(name) {
+                tags.push("batch".to_string());
+            }
+            let suffix = if tags.is_empty() {
+                String::new()
             } else {
-                format!("- `{name}` ({})", tags.join(", "))
+                format!(" ({})", tags.join(", "))
+            };
+            // Name the answering (synth) model — the team's voice, the thing an agent
+            // told "ask Gemini Pro" indexes on. The data is already resolved on the
+            // Config (it's what `kaibo://config` prints); a cast with no synth slot
+            // (explorer-only) just renders its name. Resolution is structural, not
+            // key-gated, so it holds for every usable cast.
+            let synth = config.resolve_cast(name).ok().and_then(|cast| {
+                cast.slot(ModelRole::Synth)
+                    .map(|slot| format!("{}/{}", slot.backend, slot.id))
+            });
+            match synth {
+                Some(model) => format!("- `{name}`{suffix} → {model}"),
+                None => format!("- `{name}`{suffix}"),
             }
         })
         .collect::<Vec<_>>()
@@ -283,7 +306,7 @@ pub fn kaibo_instructions_with_scope(
     // roster, then the kaish onboarding spine. A caller's first decision is "which
     // team", so it precedes the syntax detail — and survives a host that truncates.
     let lead = kaibo_lead();
-    let casts = casts_section(&config.default_cast, usable_casts);
+    let casts = casts_section(config, usable_casts);
     let reference = kaish_reference(schemas);
 
     // Scope section: always accurate, never ambiguous. Report the *effective* default
@@ -576,6 +599,48 @@ mod tests {
         assert!(
             text.contains("canonical") && text.contains("kaibo://config"),
             "Casts section must point at kaibo://config as canonical:\n{text}"
+        );
+    }
+
+    /// Each roster line names the cast's **answering (synth) model**, so an agent told
+    /// "ask Gemini Pro" can index `gemini-batch → …/gemini-pro-latest` straight from the
+    /// handshake without re-reading `kaibo://config`. A batch cast (synth-only, a
+    /// different tool/lane) is tagged `batch` so the agent picks the right one. The data
+    /// is already on the resolved `Config` — this just renders it.
+    #[test]
+    fn casts_section_names_each_synth_model_and_tags_batch() {
+        let config = Config::builtin(); // built-in casts: anthropic, gemini-batch, …
+        let usable = vec![
+            ("anthropic".to_string(), CastUsability::Ready),
+            ("gemini-batch".to_string(), CastUsability::Ready),
+        ];
+        let text = kaibo_instructions_with_scope(
+            &[],
+            &config,
+            &[PathBuf::from("/tmp")],
+            None,
+            false,
+            CastUsability::Ready,
+            &usable,
+        );
+        // The interactive cast names its synth (Claude Sonnet, the built-in anthropic synth).
+        assert!(
+            text.contains("anthropic/claude-sonnet-4-6"),
+            "roster must name the anthropic cast's synth model:\n{text}"
+        );
+        // The batch cast names Gemini Pro — the whole point: Pro is reachable only here.
+        assert!(
+            text.contains("gemini/gemini-pro-latest"),
+            "roster must name gemini-batch's synth (Gemini Pro):\n{text}"
+        );
+        // ...and the line is tagged `batch`, so the agent knows it's the batch_submit lane.
+        let pro_line = text
+            .lines()
+            .find(|l| l.contains("gemini-batch"))
+            .expect("gemini-batch has a roster line");
+        assert!(
+            pro_line.contains("batch"),
+            "the gemini-batch line must carry a batch tag:\n{pro_line}"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -416,7 +416,7 @@ fn append_cast_roster(
     router: &mut ToolRouter<KaiboHandler>,
     tools: &[&str],
     casts: &[String],
-    default_cast: &str,
+    config: &Config,
 ) {
     if casts.is_empty() {
         return;
@@ -424,7 +424,11 @@ fn append_cast_roster(
     let menu = casts
         .iter()
         .map(|c| {
-            if c == default_cast {
+            // Resolve before tagging: an alias default (`server.cast = "claude"`) must
+            // still flag its canonical cast — the same alias/default trap `casts_section`
+            // hit. `casts` holds canonical names, so `is_default_cast` compares like to
+            // like.
+            if config.is_default_cast(c) {
                 format!("{c} (default)")
             } else {
                 c.clone()
@@ -579,14 +583,9 @@ impl KaiboHandler {
             &mut tool_router,
             &["consult", "consult_submit", "oneshot"],
             &interactive_usable,
-            &config.default_cast,
+            &config,
         );
-        append_cast_roster(
-            &mut tool_router,
-            &["batch_submit"],
-            &batch_usable,
-            &config.default_cast,
-        );
+        append_cast_roster(&mut tool_router, &["batch_submit"], &batch_usable, &config);
 
         let sessions = SessionStore::new(config.defaults.session_capacity);
         // Async-consult jobs get their own cap: a held job result (answer + optional
@@ -4017,7 +4016,7 @@ mod tests {
                 .into_owned()
         };
         let before = desc(&router);
-        append_cast_roster(&mut router, &["consult", "oneshot"], &[], "deepseek");
+        append_cast_roster(&mut router, &["consult", "oneshot"], &[], &Config::builtin());
         let after = desc(&router);
         assert_eq!(before, after, "an empty roster must not alter the description");
         assert!(


### PR DESCRIPTION
## What

The startup handshake's `## Casts` roster now renders each line as `- \`name\` (tags) → backend/synth-id`, naming the cast's **answering (synth) model** and tagging a batch-only cast `batch`:

```
- `anthropic` (default) → anthropic/claude-sonnet-4-6
- `gemini` → gemini/gemini-3.5-flash
- `gemini-batch` (batch) → gemini/gemini-pro-latest
- `zorak` → gemma-26b/gemma4-26b
```

## Why

Follows the Gemini-Pro-batch-only config change (#34). With Pro reachable only via the `gemini-batch` cast, an agent told "ask Gemini Pro" still had no way to *find* it from the handshake — the roster listed bare cast names, so "pro" was invisible until the agent read `kaibo://config`. Now `gemini-batch → gemini/gemini-pro-latest (batch)` makes Pro self-evident **and** correctly routed to the `batch_submit` lane.

The data was already there: every `Cast` carries its `slots` map, `usable_casts` already iterates the full struct, and the synth id is exactly what `kaibo://config` prints. This is pure rendering — `casts_section` now takes `&Config` and resolves `slot(Synth)` + `cast_is_batch` per line.

## Scope — where it does *not* go

Deliberately confined to the **read-once handshake** block. The per-tool `description` roster (`append_cast_roster`) and the `cast` param `enum` stay **name-only**: those are *resident* cost — loaded into every caller's context every session whether or not a tool fires — and per AGENTS.md that's the existential-density surface. Model ids per cast on every description is exactly the accretion we avoid. The enum values must also stay bare cast names (they're the accepted call args).

## Test

Failing-first `casts_section_names_each_synth_model_and_tags_batch` (kaish_syntax.rs): asserts the rendered handshake names `anthropic/claude-sonnet-4-6`, names `gemini/gemini-pro-latest`, and tags the `gemini-batch` line `batch`. Watched it fail on bare-name rendering, then pass. Full suite green (280 lib + integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)