### PR TITLE
Model-facing surface pass: budget the handshake, job_* renames, standalone descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,11 +147,21 @@ Two audiences are optimized differently:
 
 - **Client-facing text** — the MCP server instructions and each tool's `description`
   in `server.rs`, read by the *calling* agent. Density is existential here because it's
-  *resident* cost: the descriptions load into the caller's context every session
-  whether or not the tool is ever called — an unused tool still bills the user. We ask
-  people to spend a few tokens on kaibo in every session they connect us; each one has
-  to earn its place and be additive to their experience. Terse, concrete, no clause
-  that doesn't pay rent.
+  *resident* cost: an unused tool still bills the user every session. Hard numbers
+  (measured 2026-07-01): Claude Code truncates the instructions **and each tool
+  description at 2048 characters** (per server, hardcoded, silent). Claude Desktop
+  never shows instructions to the model at all, so **every description stands alone** —
+  a model that read nothing else still picks the right tool. In deferral hosts (Claude
+  Code, Codex) tool schemas default to names-only *and* the instructions double as the
+  tool-search **retrieval index** — the opening lines decide whether our tools get
+  *found* (front-load the words a working agent would search for: "codebase", "review",
+  "second opinion", "read-only", "batch"); pin a front-door tool resident with
+  `_meta["anthropic/alwaysLoad"]` (we pin `consult`). So: the first 2048 characters are
+  the whole resident pitch. Decisions above the line (what kaibo is, the casts, scope,
+  that an async lane exists); execution detail lives in schemas and resources *named
+  from above the line*. The `instructions_*` budget tests in `kaish_syntax.rs` enforce
+  the ceiling — a new clause must displace an old one. Terse, concrete, no clause that
+  doesn't pay rent.
 - **Agent-facing text** — preambles, the kaish cheatsheet, the casts' answering
   instructions, read by the commercial models *we* drive, with windows in the hundreds
   of thousands to millions of tokens. Here verbosity is *licensed where it shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ the git log. Each later release appends a new section at the top.
 - **`run_kaish`** — drive the read-only kaish shell yourself, no model in the loop:
   exit code + stdout + stderr.
 - **Batch (`batch_submit`)** — the *offline, async sibling* of `oneshot`: submit a list
-  of tool-less prompts, get a handle, then collect it with the shared `get`/`cancel`/
-  `list` verbs (see below) — read every answer when the provider's batch lane finishes,
+  of tool-less prompts, get a handle, then collect it with the shared `job_get`/`job_cancel`/
+  `job_list` verbs (see below) — read every answer when the provider's batch lane finishes,
   no call held open per answer. Built for fanning many prompts (or one hard question you'll wait on) at a
   top-tier model: it maxes the knobs (forces high thinking effort + a generous token
   budget) regardless of how the cast was tuned for interactive use, and a per-call
@@ -75,8 +75,8 @@ the git log. Each later release appends a new section at the top.
   (one flag over every verb). Batch carries its
   own system preamble fit to the offline lane — one complete, self-contained response with
   no follow-up, told to spend on depth — overridable via `[prompts].batch` like the other
-  phases. While a batch runs, `get` reminds you to go do other work and check back
-  rather than wait on it. Lost a handle? `list` re-discovers the batches a backend
+  phases. While a batch runs, `job_get` reminds you to go do other work and check back
+  rather than wait on it. Lost a handle? `job_list` re-discovers the batches a backend
   still holds (newest first, each with its handle, status, and progress), so a batch is
   never orphaned — defaulting across every batch-capable backend, or scoped to one with
   `backend`. **`attach`** lets you name workspace files to inline as shared context for
@@ -86,8 +86,8 @@ the git log. Each later release appends a new section at the top.
   (with a vision-capable synth model). Paths obey the same workspace boundary as
   everything else (worktrees included); a file outside it, a directory, an oversized
   file, or a binary that isn't a known image is refused with a clear error.
-- **`wait`** — block briefly and productively for your async work instead of
-  blind-polling `get`. Fire off consults and batches, do your other work, then `wait`
+- **`job_wait`** — block briefly and productively for your async work instead of
+  blind-polling `job_get`. Fire off consults and batches, do your other work, then `job_wait`
   when you're ready to spend a minute on kaibo: it blocks up to `timeout_secs` (you
   choose — no clamp; interruptible) and returns as soon as something lands, or on a clean
   timeout. By default it hands back what kaibo flags as worth your attention (a job
@@ -95,24 +95,25 @@ the git log. Each later release appends a new section at the top.
   `level: "info"` to also pull the watchable narrative — each kaish command, sweep, and
   milestone the agents ran — into your context. Name batch handles in `handles` to fold a
   one-shot poll of them in too. Nothing wakes you (you choose when to block) and it isn't
-  the source of truth — `get`/`list` are; a clean empty return just means nothing new yet.
+  the source of truth — `job_get`/`job_list` are; a clean empty return just means nothing new yet.
   This pairs with launching work in parallel: submit several, do everything else, then
-  `wait` to merge the outputs.
+  `job_wait` to merge the outputs.
 - **Async consults are watchable again.** A `consult_submit` job now streams its liveness
   (each kaish command, sweep, and milestone) onto kaibo's logging channel — the live
   "watch it work" view a synchronous `consult` always had, restored for the async path.
   It rides kaibo's level convention (Info = the narrative; Warn = "the calling model
-  should see this"), so a watching client sees the show and `wait` pulls the salient bits.
-- **`get` / `cancel` / `list`** — one shared surface to collect, stop, and survey
-  *both* kinds of async work, told apart by the handle: a batch handle is
-  `backend/provider-id`, a consult job is `job-N`. `get <handle>` returns a progress/
+  should see this"), so a watching client sees the show and `job_wait` pulls the salient bits.
+- **`job_get` / `job_cancel` / `job_list`** — one shared surface to collect, stop, and survey
+  *both* kinds of async work (the `job_` prefix self-namespaces even in hosts that
+  flatten tool names into one list), told apart by the handle: a batch handle is
+  `backend/provider-id`, a consult job is `job-N`. `job_get <handle>` returns a progress/
   status line while the work runs — for a consult job it echoes the latest investigation
-  beat (e.g. *currently: exploring …*) with a step count, the same one-liner `wait`
-  streams, so a poller sees forward motion — and the full result when it lands; `cancel <handle>`
-  stops it; `list` shows everything in flight — your in-memory consult jobs plus the
+  beat (e.g. *currently: exploring …*) with a step count, the same one-liner `job_wait`
+  streams, so a poller sees forward motion — and the full result when it lands; `job_cancel <handle>`
+  stops it; `job_list` shows everything in flight — your in-memory consult jobs plus the
   batches each backend still holds — each with a ready-to-use handle. One mental model
   for everything you submit. The verbs stay available as long as either `consult` or
-  batch is enabled (gated off only when both are). `list` trims its batch section to the
+  batch is enabled (gated off only when both are). `job_list` trims its batch section to the
   **last 24 hours** by default — a provider keeps months of finished batches and dumping
   them all just burns tokens, while anything older is done and still collectible by its
   handle; it reports how many it hid and takes `all: true` for the full history (true
@@ -127,15 +128,23 @@ the git log. Each later release appends a new section at the top.
   with a hosted synth. Built-in casts ship so
   kaibo runs with zero config; `config.toml` merges over them. Precedence:
   per-call > CLI > env > file > built-in, and a missing config file is not an error.
-  Your usable casts' names are advertised to the *calling* agent — both as the `cast`
-  param's enum and in the tool descriptions ("Casts ready now: …", with the default
-  flagged) — so a host told "have deepseek review this" routes off the roster, and a
-  meaningful name (`local-only`, `deep-dive`) reads as intent without the caller opening
-  your config. The startup handshake's `## Casts` roster goes further: each line names
+  Your usable casts' names are advertised to the *calling* agent as the per-lane `cast`
+  param enum (the tool's schema, with the default flagged) — so a host told "have
+  deepseek review this" routes off the roster, and a meaningful name (`local-only`,
+  `deep-dive`) reads as intent without the caller opening your config. The startup
+  handshake's `## Casts` roster goes further: each line names
   the cast's **answering (synth) model** and tags a batch-only cast `batch`, so a host
   told "ask Gemini Pro" indexes `gemini-batch → gemini/gemini-pro-latest (batch)` — and
   knows it's the `batch_submit` lane — without reading `kaibo://config`.
-- **Guided setup.** A built-in `configure` MCP prompt walks your host agent through
+- **Handshake built to the host's real limits.** Claude Code truncates a server's MCP
+  `instructions` at 2048 characters (measured, per-server, hardcoded) — so the resident
+  handshake is budgeted to fit, with `## Scope` (the read-only/containment posture)
+  moved *above* that fold where a truncating host used to drop it. The kaish shell
+  reference leaves the resident text entirely — `run_kaish`'s own description and the
+  `kaibo://kaish/*` resources carry it — and each tool description now stands alone
+  (some hosts show the model no instructions at all) and opens with the words an agent
+  would search for. Under hosts that defer tool schemas to names-only, `consult` is
+  pinned resident (`_meta["anthropic/alwaysLoad"]`) so the front door is always legible.
   writing `config.toml`, alongside `kaibo://config` (resolved runtime state) and
   `kaibo://config/example` (annotated template) resources. Secrets are referenced by
   env-var name or key-file path, never inlined. `kaibo://config` flags any per-slot

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -43,12 +43,13 @@ job record should carry its batch handle after submit). Persistence stays out of
 `explore`/`deliberate` descriptions are already drafted in the plan doc; they ship with
 their tools. Delete this entry when arc 2 ships.
 
-Small arc-1 tidy-ups (not blockers): `kaibo_instructions_with_scope`'s `schemas` param
-is now vestigial (`_schemas`) — drop it and update call sites. And the composed
-`agent_onboarding` spine (`kaibo_instructions`/`kaish_reference`) is no longer resident
-and isn't served standalone; if a caller wants the single-doc kaish mental model, serve
-it at `kaibo://kaish/onboarding` (the `kaibo://kaish/*` topic resources already cover
-the reference piecemeal, so low priority).
+Note (arc-1 follow-on, low priority): the composed `agent_onboarding` mental-model view
+is no longer produced anywhere — arc 1 deleted `kaibo_instructions`/`kaish_reference`
+along with the resident kaish reference. The `kaibo://kaish/*` topic resources
+(`syntax`, `builtins`, `vfs`, `scatter`, `sandbox`) cover the reference piecemeal and
+`run_kaish`'s description carries the operating contract, so nothing is lost for a
+caller today; if a single-doc kaish onboarding is ever wanted, recompose
+`Recipe::agent_onboarding()` behind a `kaibo://kaish/onboarding` resource.
 
 ### Media spine — perception in, production removed
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -22,18 +22,33 @@ kaish-kernel 0.10.0.
 
 ## P1 — High-leverage features & robustness
 
-### Model-facing text pass + `deliberate` (Fable-batch consultation)
+### Model-facing text pass + `deliberate`/`explore` (Fable-batch consultation)
 
-Plan lives in **`docs/desc-and-schema-tuning.md`** (started 2026-07-01, w/ Amy). The
-caller's-seat audit found Claude Code truncates the handshake `instructions` at ~2.5 KB
-(the `## Scope` section never reaches the calling model) and defers tool schemas to
-names-only. The doc sequences: handshake restructure (scope above the kaish wall,
-byte-budget tests), lead rewrite (async lane is invisible today), renames of the generic
-async tools (`get`/`list`), schema hygiene (rustdoc cross-refs ship on the wire), and the
-big one — `deliberate`: an interactive Sonnet-class model builds a grounded dossier, then
-a frontier synth (Fable) deliberates on the batch lane at batch prices. Two Sonnet
-research passes pending (exact truncation caps; per-host instructions handling) — their
-numbers land in that doc. Delete this entry when the doc's sections have all shipped.
+Plan lives in **`docs/desc-and-schema-tuning.md`** (started 2026-07-01, w/ Amy).
+**Arc 1 (the holistic surface PR) shipped** — handshake restructure (scope above the
+kaish wall, kaish reference off the resident text, 2048-char budget + Scope-ordering
+tests), lead rewrite, `get`/`list`/`wait`/`cancel` → `job_*` renames, all descriptions
+rewritten to the doc's target drafts, `consult` pinned resident via
+`_meta["anthropic/alwaysLoad"]`, the "Casts ready now" prose tails dropped (the `cast`
+enum is the sole roster home), rustdoc cross-refs stripped from shipped schemas, and
+the AGENTS.md client-facing budget guidance.
+
+**Arc 2 — still open (`explore` + `deliberate`):** the config lane reshape first
+(per-slot lane `batch | direct`; today's batch casts become the degenerate case), then
+`explore` (a new `run_phase` composition over `report_preamble` — not a re-mount of the
+RunExplore sub-agent), then `deliberate` (dossier → offline synth, two lanes; the
+two-stage handle crosses the disjoint `job-N` / `backend/provider-id` namespaces — the
+job record should carry its batch handle after submit). Persistence stays out of scope
+(local `deliberate` jobs are session-scoped `job-N`, said loudly in the schema). The
+`explore`/`deliberate` descriptions are already drafted in the plan doc; they ship with
+their tools. Delete this entry when arc 2 ships.
+
+Small arc-1 tidy-ups (not blockers): `kaibo_instructions_with_scope`'s `schemas` param
+is now vestigial (`_schemas`) — drop it and update call sites. And the composed
+`agent_onboarding` spine (`kaibo_instructions`/`kaish_reference`) is no longer resident
+and isn't served standalone; if a caller wants the single-doc kaish mental model, serve
+it at `kaibo://kaish/onboarding` (the `kaibo://kaish/*` topic resources already cover
+the reference piecemeal, so low priority).
 
 ### Media spine — perception in, production removed
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -434,7 +434,7 @@ fn parse_results_jsonl(body: &str) -> Result<Vec<BatchAnswer>> {
 pub fn render_poll(poll: &BatchPoll, label: &str) -> String {
     match poll {
         BatchPoll::Pending { completed, total } => {
-            format!("Batch in progress — {completed}/{total} requests done. No need to wait on it — go do other work and `get` this handle again later (it can take minutes to hours; the handle keeps).")
+            format!("Batch in progress — {completed}/{total} requests done. No need to wait on it — go do other work and `job_get` this handle again later (it can take minutes to hours; the handle keeps).")
         }
         BatchPoll::Cancelling => {
             "Batch is being canceled; poll again for the final per-item results.".to_string()
@@ -483,7 +483,7 @@ pub fn render_list(
         }
     }
     if !entries.is_empty() {
-        s.push_str("\n\nPoll one with `get <handle>`; cancel with `cancel <handle>`.");
+        s.push_str("\n\nPoll one with `job_get <handle>`; cancel with `job_cancel <handle>`.");
     }
     if !truncated.is_empty() {
         s.push_str(&format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -643,8 +643,8 @@ impl Config {
 
     /// Whether canonical cast `name` is the configured default — comparing against the
     /// *resolved* default, so an alias default (`server.cast = "claude"`) still matches
-    /// its canonical cast (`anthropic`). The roster renderers (`casts_section`,
-    /// `append_cast_roster`) get canonical names from [`usable_casts`](Self::usable_casts),
+    /// its canonical cast (`anthropic`). The roster renderer (`casts_section`) gets
+    /// canonical names from [`usable_casts`](Self::usable_casts),
     /// so a bare `name == default_cast` string compare would silently drop the
     /// `(default)` tag whenever the default was set by an alias. An unresolvable default
     /// (can't happen post-load, validated there) reads as "nothing is default".

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,8 +1,8 @@
 //! In-memory async-`consult` job registry — backs `consult_submit` and the shared
-//! `get` / `cancel` / `list` verbs (which also serve batch handles).
+//! `job_get` / `job_cancel` / `job_list` verbs (which also serve batch handles).
 //!
 //! The async counterpart to the synchronous `consult`: `consult_submit` returns a job
-//! id immediately, the consultation runs as a spawned task, and `get` collects the
+//! id immediately, the consultation runs as a spawned task, and `job_get` collects the
 //! answer when it lands. This is the *same* diskless, persistence-shaped state as
 //! [`crate::session::SessionStore`] — an `Arc<Mutex<LruCache>>`, capacity-LRU, no TTL,
 //! the mutex never held across an `.await` — only the value is a job's live status
@@ -15,10 +15,10 @@
 //! `server.rs` and this module stays offline-testable with trivial futures.
 //!
 //! **Eviction is capacity-LRU, like sessions** — a job is dropped only when a newer
-//! submit pushes it past the cap as the least-recently-used; touching it (`get`/
-//! `cancel`) promotes it. A still-*running* job that gets evicted is **aborted** (its
+//! submit pushes it past the cap as the least-recently-used; touching it (`job_get`/
+//! `job_cancel`) promotes it. A still-*running* job that gets evicted is **aborted** (its
 //! `Job` drop aborts the task): once the store drops a job its id is unreachable
-//! (`get`/`cancel` return not-found), so letting an orphaned consult run on would just
+//! (`job_get`/`job_cancel` return not-found), so letting an orphaned consult run on would just
 //! burn provider tokens against a cell nobody can read. The spawned task owns its own
 //! `Arc` of the status cell, so the cell stays valid until the task actually stops —
 //! no panic, no disk.
@@ -43,7 +43,7 @@ pub struct JobResult {
     pub report: Option<String>,
 }
 
-/// Where a job is in its lifecycle, as one `get` sees it.
+/// Where a job is in its lifecycle, as one `job_get` sees it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JobState {
     /// The spawned task is still working.
@@ -53,7 +53,7 @@ pub enum JobState {
     /// The consultation failed; the string is the already-rendered failure text
     /// (detail + guidance), so the tool layer wraps it without re-classifying.
     Failed(String),
-    /// `cancel` aborted the task before it finished.
+    /// `job_cancel` aborted the task before it finished.
     Canceled,
 }
 
@@ -65,13 +65,13 @@ pub struct JobSnapshot {
     pub label: String,
     pub age: Duration,
     /// The most recent progress beat — `(one-liner, beat count)` — for a still-running
-    /// job, or `None` if it hasn't emitted yet (or already finished). `get`/`list` echo
-    /// it so a poller sees forward motion without reaching for `wait`. See
+    /// job, or `None` if it hasn't emitted yet (or already finished). `job_get`/`job_list`
+    /// echo it so a poller sees forward motion without reaching for `job_wait`. See
     /// [`crate::progress::ProgressLog`].
     pub last_progress: Option<(String, u64)>,
 }
 
-/// What `cancel` did, so the tool layer can word the reply honestly.
+/// What `job_cancel` did, so the tool layer can word the reply honestly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CancelOutcome {
     /// The job was running and is now aborted + marked canceled.
@@ -92,7 +92,7 @@ struct Job {
     label: String,
     started: Instant,
     /// The job's progress recorder — the same [`ProgressLog`] the spawned consult emits
-    /// through, so `get`/`list` can echo the latest beat. Shared (`Arc`) with the running
+    /// through, so `job_get`/`job_list` can echo the latest beat. Shared (`Arc`) with the running
     /// task's sink; reading `latest()` here never blocks the task (a tiny `Mutex`).
     progress: Arc<ProgressLog>,
 }
@@ -102,8 +102,8 @@ impl Drop for Job {
     /// the whole store goes away. Dropping an `AbortHandle` does *not* abort the task on
     /// its own, so without this an evicted-but-still-running consult would run to
     /// completion against an unreachable cell, burning provider tokens for an answer no
-    /// `get` can ever return. A finished or already-canceled job's abort is a harmless
-    /// no-op. `get`/`cancel`/`list` only clone the `Arc<Job>` transiently under the store
+    /// `job_get` can ever return. A finished or already-canceled job's abort is a harmless
+    /// no-op. `job_get`/`job_cancel`/`job_list` only clone the `Arc<Job>` transiently under the store
     /// lock, so this fires on the *last* reference — true unreachability — not on a poll.
     fn drop(&mut self) {
         self.abort.abort();
@@ -113,7 +113,7 @@ impl Drop for Job {
 /// A drop guard for the spawned task: if the task's future ends *without* landing a
 /// result — a panic (we build `panic = unwind`, so tokio catches it and the state would
 /// otherwise sit at `Running` forever) or an abort that drops the future at its await
-/// point — record a terminal failure instead of leaving `get` to report "still running"
+/// point — record a terminal failure instead of leaving `job_get` to report "still running"
 /// with no end. The task disarms it on the normal path so it never overwrites a real
 /// outcome. On an *abort* the cell is usually unreachable anyway (canceled, or evicted),
 /// so the write is harmless; on a *panic* of a still-live job it's the difference between
@@ -161,7 +161,7 @@ impl JobStore {
 
     /// Spawn `fut` as a job and return its id immediately. `label` is the human-facing
     /// cast/model summary a poll line shows; `progress` is the recorder the running phase
-    /// emits through, kept so `get`/`list` can echo the latest beat (pass it the *same*
+    /// emits through, kept so `job_get`/`job_list` can echo the latest beat (pass it the *same*
     /// `Arc` the consult's `ConsultConfig.progress` holds). The future's `Ok`/`Err`
     /// becomes the job's terminal `Done`/`Failed` state; an abort (via
     /// [`cancel`](Self::cancel)) leaves it `Canceled` because the task never runs its tail.
@@ -191,7 +191,7 @@ impl JobStore {
             let outcome = fut.await;
             {
                 let mut s = task_state.lock().expect("job state mutex poisoned");
-                // Only land the result if a `cancel` didn't race in while we were
+                // Only land the result if a `job_cancel` didn't race in while we were
                 // finishing — a caller who asked to cancel gets `Canceled`, not a
                 // surprise late answer.
                 if matches!(*s, JobState::Running) {
@@ -204,14 +204,14 @@ impl JobStore {
 
                     // Completion signal at **Warn** — kaibo's "the calling model should
                     // see this" level (not severity): a finished/failed job is exactly
-                    // what a `wait` drains by default, and the `mcp_log` bridge also
+                    // what a `job_wait` drains by default, and the `mcp_log` bridge also
                     // mirrors it to a watching client. Still advisory — no MCP primitive
-                    // wakes the agent, so polling/`wait` stays the contract. (A canceled
+                    // wakes the agent, so polling/`job_wait` stays the contract. (A canceled
                     // job never reaches here — its task is aborted — no ping for it.)
                     if succeeded {
-                        tracing::warn!(target: "kaibo::jobs", job = %task_id, "async job finished — collect it with `get`");
+                        tracing::warn!(target: "kaibo::jobs", job = %task_id, "async job finished — collect it with `job_get`");
                     } else {
-                        tracing::warn!(target: "kaibo::jobs", job = %task_id, "async job failed — `get` it for the reason");
+                        tracing::warn!(target: "kaibo::jobs", job = %task_id, "async job failed — `job_get` it for the reason");
                     }
                 }
             }
@@ -275,7 +275,7 @@ impl JobStore {
     }
 
     /// Snapshot every live job, most-recently-touched first — the order the unified
-    /// `list` shows them. A read: it promotes nothing and takes no job's state lock for
+    /// `job_list` shows them. A read: it promotes nothing and takes no job's state lock for
     /// longer than the clone.
     pub fn list(&self) -> Vec<(String, JobSnapshot)> {
         self.lock()
@@ -323,7 +323,7 @@ mod tests {
         Arc::new(ProgressLog::silent())
     }
 
-    /// Poll `get` until the job leaves `Running`, or panic after a generous bound — the
+    /// Poll `job_get` until the job leaves `Running`, or panic after a generous bound — the
     /// spawned task needs a runtime tick to land its result, so tests can't read it
     /// synchronously right after `submit`. Returns the terminal state.
     async fn await_terminal(store: &JobStore, id: &str) -> JobState {

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -117,18 +117,15 @@ pub fn kaibo_instructions(schemas: &[ToolSchema]) -> String {
 /// them — the menu of teams reads before the kaish syntax wall, where a host that
 /// truncates won't drop it.
 fn kaibo_lead() -> &'static str {
-    "kaibo (解剖) — ask a question about a codebase and get a grounded, cited \
-     answer. kaibo reads the project READ-ONLY through a kaish shell and never \
-     modifies files or runs external commands. It finds and reads the relevant, \
-     current code itself — point it at a project and say what you did or want to \
-     know (what you changed and why, the behavior in question); it locates the \
-     spans. You don't need to paste files or a diff: prose about your intent is \
-     worth more than a dump kaibo would just re-read from disk. Reach for \
-     `consult` first — a capable model investigates and hands back the answer, \
-     not the transcript. kaibo also exposes `oneshot` (a thin, toolless second \
-     opinion when you already own the context) and `run_kaish` (drive the \
-     read-only shell yourself), each gated independently and described in its \
-     own schema, so a given server may advertise only some."
+    "kaibo (解剖) — grounded, cited answers about a codebase from a model outside \
+     your own family. DeepSeek, Gemini, Anthropic, or a local model reads the \
+     project READ-ONLY and answers with file:line citations. Say in prose what you \
+     did or want to know — kaibo finds and reads the current code itself; no \
+     pasted files or diffs needed. `consult` is the front door. `oneshot` is a \
+     toolless second opinion when you own the context. `run_kaish` drives the \
+     read-only shell directly. Work you don't wait on: `consult_submit` and \
+     `batch_submit` return handles; `job_wait`/`job_get`/`job_list`/`job_cancel` \
+     manage them."
 }
 
 /// The kaish onboarding spine — the mental model, operating contract, live builtin
@@ -266,12 +263,10 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
 
     format!(
         "## Casts\n\
-         A cast is the model team that staffs a consultation; pass `cast=<name>` on a \
-         call to pick one. Usable right now (resolved at startup — reconnect after a \
-         config or key change):\n\
-         {lines}\n\n\
-         `kaibo://config` is canonical for what's configured — every cast and backend \
-         (with aliases), the gated tools, and sandbox limits.\n\n"
+         A cast is the model team that staffs a consultation; pass `cast=<name>`. \
+         Usable right now (resolved at startup — reconnect after a config or key \
+         change; `kaibo://config` lists every configured cast, not just these):\n\
+         {lines}\n\n"
     )
 }
 
@@ -288,8 +283,16 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
 /// Used by `get_info` so every `initialize` handshake surfaces the server's
 /// containment posture. Unit-testable: pass your own `Config`, `allowed_set`, and
 /// `usability` rather than fabricating a `RequestContext` or reading the environment.
+///
+/// `_schemas` is unused here: Claude Code hard-truncates a server's `instructions`
+/// at exactly 2048 characters (measured live, per-server, hardcoded), and the huge
+/// kaish onboarding reference [`kaish_reference`] would compose from `schemas` blew
+/// that budget on its own — before `## Scope`, the containment/trust posture, ever
+/// got a chance to render. So the resident handshake no longer composes the
+/// reference at all; it stays reachable at `kaibo://kaish/*` and inside the shell
+/// via `help`. The parameter is kept (not removed) so call sites don't change.
 pub fn kaibo_instructions_with_scope(
-    schemas: &[ToolSchema],
+    _schemas: &[ToolSchema],
     config: &Config,
     allowed_set: &[PathBuf],
     default_root: Option<&Path>,
@@ -302,12 +305,12 @@ pub fn kaibo_instructions_with_scope(
         CastUsability::Unconfigured => format!("{}\n\n", setup_section(config)),
         CastUsability::Ready | CastUsability::LocalUnverified => String::new(),
     };
-    // Menu before reference: the lead (what kaibo is + tools), then the live cast
-    // roster, then the kaish onboarding spine. A caller's first decision is "which
-    // team", so it precedes the syntax detail — and survives a host that truncates.
+    // Lead, then the live cast roster, then Scope directly — no kaish reference in
+    // between. A caller's first decision is "which team"; Scope is the containment
+    // posture every handshake must carry, so it now sits right after Casts instead
+    // of below the reference wall a truncating host would drop it behind.
     let lead = kaibo_lead();
     let casts = casts_section(config, usable_casts);
-    let reference = kaish_reference(schemas);
 
     // Scope section: always accurate, never ambiguous. Report the *effective* default
     // root (an explicit `--root`, or the launch cwd kaibo inferred), and tag the
@@ -329,16 +332,15 @@ pub fn kaibo_instructions_with_scope(
     format!(
         "{setup}{lead}\n\n\
          {casts}\
-         {reference}\n\n\
          ## Scope\n\
-         This server's path containment is always on. A per-call `path` must \
-         canonicalize to at-or-under one of the allowed trees below.\n\n\
+         Read-only, always: kaibo never writes and cannot run external commands. A \
+         per-call `path` must canonicalize to at-or-under one of these allowed trees:\n\n\
          {root_line}\n\
          - **Allowed trees:**\n\
          {allowed_lines}\n\n\
-         Read `kaibo://config` for the full resolved runtime configuration — \
-         default cast, gated tools, sandbox limits, and every backend and cast \
-         (with their aliases)."
+         Go deeper without spending a turn: `kaibo://config` (full resolved config — \
+         casts, backends, gated tools, sandbox limits), `kaibo://tools` (attachments, \
+         overrides, the async workflow), `kaibo://kaish/*` (shell syntax and idioms)."
     )
 }
 
@@ -385,6 +387,7 @@ pub fn kaibo_sandbox_doc() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{Cast, ModelSlot};
 
     #[test]
     fn core_layers_the_canonical_contract_under_the_kaibo_addendum() {
@@ -437,14 +440,14 @@ mod tests {
             kaibo_lead()
         );
         assert!(
-            lead.contains("reads the relevant"),
+            lead.contains("finds and reads the current code"),
             "lead must say kaibo finds and reads the code itself:\n{}",
             kaibo_lead()
         );
-        // consult is the tool to reach for first; the others surface via schema.
+        // consult is the front door; the others surface via schema.
         assert!(
-            lead.contains("reach for `consult` first"),
-            "lead must foreground `consult` as the first reach:\n{}",
+            lead.contains("`consult` is the front door"),
+            "lead must foreground `consult` as the front door:\n{}",
             kaibo_lead()
         );
     }
@@ -595,10 +598,12 @@ mod tests {
             !text.contains("gemini"),
             "an unconfigured cast must not be advertised as usable:\n{text}"
         );
-        // Points at the config resource as canonical for what's configured.
+        // Points at the config resource for the full configured state — the roster
+        // lists usable casts only, and `kaibo://config` has every one (surfaced in
+        // the Casts aside and, authoritatively, in the Scope "go deeper" pointers).
         assert!(
-            text.contains("canonical") && text.contains("kaibo://config"),
-            "Casts section must point at kaibo://config as canonical:\n{text}"
+            text.contains("kaibo://config"),
+            "handshake must point at kaibo://config for the full configured state:\n{text}"
         );
     }
 
@@ -702,12 +707,13 @@ mod tests {
         );
     }
 
-    /// Menu before reference: the cast roster precedes the kaish onboarding spine, so
-    /// a caller reads "which team" before the syntax wall — and a host that truncates
-    /// the instructions keeps the menu. The lead still opens. Fails if the order is
-    /// reverted to onboarding-then-casts.
+    /// The resident handshake dropped the huge kaish onboarding reference entirely —
+    /// it blew Claude Code's 2048-char instructions budget and buried `## Scope`
+    /// below the truncation point. Order is now lead → casts → scope, and the old
+    /// reference marker must not appear at all. Fails while `kaish_reference` is
+    /// still composed into `kaibo_instructions_with_scope`.
     #[test]
-    fn casts_section_precedes_the_kaish_reference() {
+    fn scope_follows_casts_and_the_kaish_reference_is_gone() {
         let config = Config::builtin();
         let usable = vec![("anthropic".to_string(), CastUsability::Ready)];
         let text = kaibo_instructions_with_scope(
@@ -720,20 +726,89 @@ mod tests {
             &usable,
         );
         let casts_at = text.find("## Casts").expect("has a Casts section");
-        let kaish_at = text
-            .find("The shell is kaish")
-            .expect("has the kaish reference");
+        let scope_at = text.find("## Scope").expect("has a Scope section");
         let lead_at = text.find("kaibo (解剖)").expect("opens with the lead");
         assert!(
-            lead_at < casts_at && casts_at < kaish_at,
-            "order must be lead → casts → kaish reference (got lead={lead_at}, \
-             casts={casts_at}, kaish={kaish_at}):\n{text}"
+            lead_at < casts_at && casts_at < scope_at,
+            "order must be lead → casts → scope (got lead={lead_at}, casts={casts_at}, \
+             scope={scope_at}):\n{text}"
+        );
+        assert!(
+            !text.contains("The shell is kaish"),
+            "the resident handshake must drop the kaish onboarding reference \
+             entirely — it no longer fits the truncation budget:\n{text}"
         );
     }
 
     /// A couple of builtins so the onboarding spine renders in ordering tests.
     fn sample_schemas_for_ordering() -> Vec<ToolSchema> {
         vec![ToolSchema::new("cat", "Read a file")]
+    }
+
+    /// Claude Code truncates a server's MCP `instructions` at exactly 2048
+    /// characters — measured live against a running server; it's a per-server,
+    /// hardcoded client-side cap, not an MCP-spec limit and not configurable. Past
+    /// that boundary the calling model never sees the rest, which is exactly how
+    /// `## Scope` — the containment/trust posture — used to go missing behind the
+    /// huge kaish onboarding reference. This drives a *representative* roster (10
+    /// casts: the 6 built-ins plus 4 more spanning default/local-unverified/batch)
+    /// through the full resident handshake and asserts it fits. Fails against
+    /// today's layout (the resident kaish reference blows the budget on its own).
+    #[test]
+    fn instructions_fit_claude_code_budget() {
+        let mut config = Config::builtin(); // anthropic, deepseek, gemini,
+                                             // openai-local, gemini-batch, anthropic-batch
+        for (name, backend, id) in [
+            ("chimera", "anthropic", "claude-haiku-4-5"),
+            ("glm", "openai-local", "GLM-4.5-Air-UD-Q4K-XL-GGUF"),
+            ("qwen", "openai-local", "Qwen3-Coder-Next-GGUF"),
+            ("zorak", "openai-local", "gemma4-26b"),
+        ] {
+            config.casts.insert(
+                name.to_string(),
+                Cast {
+                    name: name.to_string(),
+                    slots: std::collections::BTreeMap::from([(
+                        ModelRole::Synth,
+                        ModelSlot::bare(backend, id),
+                    )]),
+                    batch: false,
+                },
+            );
+        }
+
+        // A realistic usable-casts mix: the interactive built-ins, both batch
+        // lanes (tagged `batch` off the config's own `batch` flag), and a spread
+        // of local/unverified entries — 10 lines total, not the 6-cast minimum.
+        let usable = vec![
+            ("anthropic".to_string(), CastUsability::Ready),
+            ("deepseek".to_string(), CastUsability::Ready),
+            ("gemini".to_string(), CastUsability::Ready),
+            ("gemini-batch".to_string(), CastUsability::Ready),
+            ("anthropic-batch".to_string(), CastUsability::Ready),
+            ("chimera".to_string(), CastUsability::Ready),
+            ("glm".to_string(), CastUsability::LocalUnverified),
+            ("qwen".to_string(), CastUsability::LocalUnverified),
+            ("zorak".to_string(), CastUsability::LocalUnverified),
+            ("openai-local".to_string(), CastUsability::LocalUnverified),
+        ];
+
+        let text = kaibo_instructions_with_scope(
+            &[],
+            &config,
+            &[PathBuf::from("/home/amy/src/some-project")],
+            Some(Path::new("/home/amy/src/some-project")),
+            true,
+            CastUsability::Ready,
+            &usable,
+        );
+
+        let len = text.chars().count();
+        assert!(
+            len < 2048,
+            "handshake must fit Claude Code's 2048-char instructions budget \
+             (measured live, per-server, hardcoded), got {len} chars:\n{text}"
+        );
     }
 
     #[test]

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -101,21 +101,10 @@ pub fn topics() -> Vec<(&'static str, &'static str)> {
     list_topics()
 }
 
-/// kaibo's MCP `instructions:` — what a host hands a model before its first call.
-///
-/// Composes kaish-help's `agent_onboarding` recipe (the mental model, the operating
-/// contract, and the live builtin index from `schemas`) so the onboarding tracks
-/// kaish upstream, then frames it as kaibo: read-only, four tools, and where to
-/// learn more. The canonical block carries the "how kaish works" spine; we add only
-/// what's kaibo's.
-pub fn kaibo_instructions(schemas: &[ToolSchema]) -> String {
-    format!("{}\n\n{}", kaibo_lead(), kaish_reference(schemas))
-}
-
-/// The opening paragraph: what kaibo is and the tool menu. Split out from the kaish
-/// reference so the scope-aware handshake can slot the `## Casts` roster *between*
-/// them — the menu of teams reads before the kaish syntax wall, where a host that
-/// truncates won't drop it.
+/// The opening paragraph of the handshake: what kaibo is and the tool menu. Split out
+/// so [`kaibo_instructions_with_scope`] can slot the `## Casts` roster *between* it and
+/// `## Scope` — the menu of teams reads before scope, and both sit above the point a
+/// truncating host (Claude Code's 2048-char cap) would cut.
 fn kaibo_lead() -> &'static str {
     "kaibo (解剖) — grounded, cited answers about a codebase from a model outside \
      your own family. DeepSeek, Gemini, Anthropic, or a local model reads the \
@@ -126,24 +115,6 @@ fn kaibo_lead() -> &'static str {
      read-only shell directly. Work you don't wait on: `consult_submit` and \
      `batch_submit` return handles; `job_wait`/`job_get`/`job_list`/`job_cancel` \
      manage them."
-}
-
-/// The kaish onboarding spine — the mental model, operating contract, live builtin
-/// index, and where to read more. Reference material: it follows the cast menu in
-/// the handshake because "what can I run" is reusable detail, not the first choice
-/// a caller makes.
-fn kaish_reference(schemas: &[ToolSchema]) -> String {
-    let onboarding = compose(&Recipe::agent_onboarding(), &SchemaContent::new(schemas));
-    format!(
-        "The shell is kaish. Here is how it works:\n\n\
-         {onboarding}\n\n\
-         ## Learn more kaish\n\
-         Read the `kaibo://kaish/*` resources to go deeper without spending a tool \
-         turn — `kaibo://kaish/syntax`, `kaibo://kaish/builtins`, `kaibo://kaish/vfs`, \
-         `kaibo://kaish/scatter`, and the rest — or `kaibo://kaish/builtin/<name>` for \
-         one builtin. `kaibo://kaish/sandbox` states kaibo's read-only contract and \
-         exit codes. It's all in the shell too: `help`, `help syntax`, `help <builtin>`."
-    )
 }
 
 /// The setup-guidance block prepended to the instructions when the default cast has
@@ -183,23 +154,17 @@ fn setup_section(config: &Config) -> String {
 
     format!(
         "## Setup needed — no model provider configured\n\
-         kaibo's default cast `{cast}` has no usable API key, so `consult` and \
-         `oneshot` can't reach a model yet. `run_kaish` works right now — it drives \
-         the read-only shell with no model in the loop — so you can browse the code while \
-         you set a key.\n\n\
-         Give the default cast a key. Prefer an **environment variable** or a **key file** \
-         — kaibo reads either at startup, so the key stays out of this conversation:\n\
+         kaibo's default cast `{cast}` has no usable API key, so `consult`/`oneshot` \
+         can't reach a model yet. `run_kaish` works now (read-only shell, no model), so \
+         you can browse the code meanwhile.\n\n\
+         Give the cast a key via an **environment variable** or **key file** — kaibo \
+         reads either at startup, so it stays out of the chat (set it in your shell; \
+         don't paste it to the model):\n\
          {backends}\n\n\
-         Keep the API key out of the chat: set the env var or key file yourself in your \
-         shell, don't paste it to the model (if you do, that's your call — kaibo doesn't \
-         need to see it). Then **reconnect the kaibo MCP server** so it re-reads the \
-         environment and config — they're read once at startup. In Claude Code: run `/mcp` \
-         and reconnect kaibo; other hosts have their own reload.\n\n\
-         Prefer a different provider? Pass `provider=\"<name>\"` on a call (a backend or \
-         cast — e.g. a local keyless endpoint), or set `cast` in config. The full annotated \
-         example is the `kaibo://config/example` resource; it belongs at \
-         `~/.config/kaibo/config.toml` (or `$XDG_CONFIG_HOME/kaibo/config.toml`). Read \
-         `kaibo://config` for the current resolved state.",
+         Then **reconnect the kaibo MCP server** so it re-reads the environment — in \
+         Claude Code run `/mcp`; other hosts have their own reload. Prefer another \
+         provider? The annotated `kaibo://config/example` resource (→ \
+         `~/.config/kaibo/config.toml`) shows every backend and cast.",
         cast = config.default_cast,
     )
 }
@@ -284,15 +249,13 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
 /// containment posture. Unit-testable: pass your own `Config`, `allowed_set`, and
 /// `usability` rather than fabricating a `RequestContext` or reading the environment.
 ///
-/// `_schemas` is unused here: Claude Code hard-truncates a server's `instructions`
-/// at exactly 2048 characters (measured live, per-server, hardcoded), and the huge
-/// kaish onboarding reference [`kaish_reference`] would compose from `schemas` blew
-/// that budget on its own — before `## Scope`, the containment/trust posture, ever
-/// got a chance to render. So the resident handshake no longer composes the
-/// reference at all; it stays reachable at `kaibo://kaish/*` and inside the shell
-/// via `help`. The parameter is kept (not removed) so call sites don't change.
+/// The resident handshake carries no kaish onboarding reference: Claude Code
+/// hard-truncates a server's `instructions` at exactly 2048 characters (measured
+/// live, per-server, hardcoded), and the onboarding spine blew that budget on its own
+/// — before `## Scope`, the containment/trust posture, could render. The shell stays
+/// reachable through `run_kaish`'s own description, the `kaibo://kaish/*` resources,
+/// and `help` inside a script.
 pub fn kaibo_instructions_with_scope(
-    _schemas: &[ToolSchema],
     config: &Config,
     allowed_set: &[PathBuf],
     default_root: Option<&Path>,
@@ -495,7 +458,6 @@ mod tests {
     fn instructions_lead_with_setup_when_unconfigured() {
         let config = Config::builtin(); // default cast "anthropic"
         let text = kaibo_instructions_with_scope(
-            &[],
             &config,
             &[PathBuf::from("/tmp")],
             None,
@@ -539,7 +501,6 @@ mod tests {
         let config = Config::builtin();
         for usability in [CastUsability::Ready, CastUsability::LocalUnverified] {
             let text = kaibo_instructions_with_scope(
-                &[],
                 &config,
                 &[PathBuf::from("/tmp")],
                 None,
@@ -568,7 +529,6 @@ mod tests {
             ("mylocal".to_string(), CastUsability::LocalUnverified),
         ];
         let text = kaibo_instructions_with_scope(
-            &[],
             &config,
             &[PathBuf::from("/tmp")],
             None,
@@ -620,7 +580,6 @@ mod tests {
             ("gemini-batch".to_string(), CastUsability::Ready),
         ];
         let text = kaibo_instructions_with_scope(
-            &[],
             &config,
             &[PathBuf::from("/tmp")],
             None,
@@ -661,7 +620,6 @@ mod tests {
         config.default_cast = "claude".to_string(); // alias → canonical `anthropic`
         let usable = vec![("anthropic".to_string(), CastUsability::Ready)];
         let text = kaibo_instructions_with_scope(
-            &[],
             &config,
             &[PathBuf::from("/tmp")],
             None,
@@ -689,7 +647,6 @@ mod tests {
         // path a real explorer-only cast takes, without fabricating one in the config.
         let usable = vec![("explorer-only".to_string(), CastUsability::Ready)];
         let text = kaibo_instructions_with_scope(
-            &[],
             &config,
             &[PathBuf::from("/tmp")],
             None,
@@ -710,14 +667,12 @@ mod tests {
     /// The resident handshake dropped the huge kaish onboarding reference entirely —
     /// it blew Claude Code's 2048-char instructions budget and buried `## Scope`
     /// below the truncation point. Order is now lead → casts → scope, and the old
-    /// reference marker must not appear at all. Fails while `kaish_reference` is
-    /// still composed into `kaibo_instructions_with_scope`.
+    /// reference marker ("The shell is kaish") must not appear at all.
     #[test]
     fn scope_follows_casts_and_the_kaish_reference_is_gone() {
         let config = Config::builtin();
         let usable = vec![("anthropic".to_string(), CastUsability::Ready)];
         let text = kaibo_instructions_with_scope(
-            &sample_schemas_for_ordering(),
             &config,
             &[PathBuf::from("/tmp")],
             None,
@@ -738,11 +693,6 @@ mod tests {
             "the resident handshake must drop the kaish onboarding reference \
              entirely — it no longer fits the truncation budget:\n{text}"
         );
-    }
-
-    /// A couple of builtins so the onboarding spine renders in ordering tests.
-    fn sample_schemas_for_ordering() -> Vec<ToolSchema> {
-        vec![ToolSchema::new("cat", "Read a file")]
     }
 
     /// Claude Code truncates a server's MCP `instructions` at exactly 2048
@@ -794,7 +744,6 @@ mod tests {
         ];
 
         let text = kaibo_instructions_with_scope(
-            &[],
             &config,
             &[PathBuf::from("/home/amy/src/some-project")],
             Some(Path::new("/home/amy/src/some-project")),
@@ -808,6 +757,36 @@ mod tests {
             len < 2048,
             "handshake must fit Claude Code's 2048-char instructions budget \
              (measured live, per-server, hardcoded), got {len} chars:\n{text}"
+        );
+    }
+
+    /// The *unconfigured* (fresh-install) handshake must fit the same 2048-char budget:
+    /// it prepends [`setup_section`] (per-backend key instructions) and renders no cast
+    /// roster, so it's a different budget shape than the configured case above — and the
+    /// same failure mode (a truncating host drops `## Scope`) applies. Uses the built-in
+    /// default cast (`anthropic`, one backend), the real fresh-install scenario. A custom
+    /// default cast naming many backends could still overflow — that's an operator edge
+    /// we can't bound here — but the shipped default must fit.
+    #[test]
+    fn unconfigured_instructions_fit_claude_code_budget() {
+        let config = Config::builtin(); // default cast "anthropic", one backend
+        let text = kaibo_instructions_with_scope(
+            &config,
+            &[PathBuf::from("/home/amy/src/some-project")],
+            Some(Path::new("/home/amy/src/some-project")),
+            true,
+            CastUsability::Unconfigured,
+            &[], // nothing usable yet — the setup banner owns this case
+        );
+        let len = text.chars().count();
+        assert!(
+            text.contains("Setup needed"),
+            "the unconfigured handshake must lead with the setup banner:\n{text}"
+        );
+        assert!(
+            len < 2048,
+            "the fresh-install handshake must fit the 2048-char budget too, got \
+             {len} chars:\n{text}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ struct Args {
     #[arg(long)]
     no_run_kaish: bool,
 
-    /// Don't advertise `batch_submit`. The shared `get`/`cancel`/`list` verbs remain as
+    /// Don't advertise `batch_submit`. The shared `job_get`/`job_cancel`/`job_list` verbs remain as
     /// long as `consult` is on (they also collect consult jobs); they drop only when both
     /// `--no-batch` and `--no-consult` are set.
     #[arg(long)]
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
     // before then — startup — buffer here and flush when draining begins, so the
     // client sees them too.
     let (log_tx, log_rx) = tokio::sync::mpsc::unbounded_channel();
-    // The pull-side ring: the bridge layer tees kaibo-target records here so the `wait`
+    // The pull-side ring: the bridge layer tees kaibo-target records here so the `job_wait`
     // tool can drain them on demand (the same records it streams to the client). Created
     // before the subscriber so the layer and the handler share one ring. Bounded — old
     // records age out; it's a convenience, not the authoritative job state.

--- a/src/mcp_log.rs
+++ b/src/mcp_log.rs
@@ -24,14 +24,14 @@
 //! **kaibo's level convention — audience, not severity.** Within the `kaibo` target
 //! tree, levels route a record to *who needs it*, not how dire it is:
 //! - **Error** — a real kaibo error: to the watching client, to the calling model's
-//!   `wait` drain, and to stderr.
+//!   `job_wait` drain, and to stderr.
 //! - **Warn = "the calling model should see this"** — salient/actionable (a job
 //!   finished or failed, the research budget ran out), *not* a dire warning. This is
-//!   the level `wait` returns to the model by default. Any kaibo code (and kaish, via
+//!   the level `job_wait` returns to the model by default. Any kaibo code (and kaish, via
 //!   a future hook) marks something for the model's attention by emitting it at Warn.
 //! - **Info** — the watchable narrative: each kaish command, sweep, and milestone (see
 //!   [`TracingSink`](crate::progress::TracingSink)). The user's live "watch it work"
-//!   view; the model only pulls it into `wait` on request.
+//!   view; the model only pulls it into `job_wait` on request.
 //! - **Debug** — the true firehose, off by default.
 //!
 //! The convention is safe to assert here because [`KAIBO_TARGET`] filtering means
@@ -124,12 +124,12 @@ impl LogRecord {
 
 /// A bounded, in-memory ring of recent [`LogRecord`]s — the pull side of the bridge.
 /// The same events the [`McpBridgeLayer`] streams to a watching client are teed here so
-/// the calling model can *drain* them on demand via the `wait` tool, filtered to the
+/// the calling model can *drain* them on demand via the `job_wait` tool, filtered to the
 /// level it cares about (Warn+ by default — kaibo's "the model should see this" bar).
 ///
 /// Capacity-bounded (oldest dropped), per session, deliver-once: a drained record is
-/// removed. It is **not** load-bearing — `get`/`list` stay the authoritative source of a
-/// job's state; a record that ages out just means the model uses `get`. `Clone` shares
+/// removed. It is **not** load-bearing — `job_get`/`job_list` stay the authoritative source of a
+/// job's state; a record that ages out just means the model uses `job_get`. `Clone` shares
 /// one `Arc<Mutex<_>>` + `Notify`, so the layer (which pushes) and the handler (which
 /// drains) hold the same ring. The mutex is only ever held for `VecDeque` ops, never
 /// across an `.await`.
@@ -154,7 +154,7 @@ impl NotificationBuffer {
 
     /// Append a record, dropping the oldest if at capacity, and wake one waiter. Called
     /// from the sync layer, so it never blocks or awaits. `notify_one` stores a permit if
-    /// no one is waiting yet, so a push that races a `wait`'s registration isn't missed.
+    /// no one is waiting yet, so a push that races a `job_wait`'s registration isn't missed.
     fn push(&self, record: LogRecord) {
         {
             let mut q = self.lock();
@@ -194,11 +194,11 @@ impl NotificationBuffer {
     }
 
     /// Drop any buffered record carrying `job = <id>` — the completion ping a finished
-    /// job pushed (`jobs.rs`, at **Warn**). Once that job is collected via `get`, the ping
-    /// is stale news: left in the ring it would make the *next* `wait` return instantly on
-    /// old activity instead of blocking for something new (the "`wait` returns too fast"
-    /// bug). Idempotent — a ping a live `wait` already drained leaves nothing to remove —
-    /// and scoped to the one id, so an *uncollected* job's ping still wakes a later `wait`.
+    /// job pushed (`jobs.rs`, at **Warn**). Once that job is collected via `job_get`, the ping
+    /// is stale news: left in the ring it would make the *next* `job_wait` return instantly on
+    /// old activity instead of blocking for something new (the "`job_wait` returns too fast"
+    /// bug). Idempotent — a ping a live `job_wait` already drained leaves nothing to remove —
+    /// and scoped to the one id, so an *uncollected* job's ping still wakes a later `job_wait`.
     pub fn discard_job_pings(&self, id: &str) {
         self.lock()
             .retain(|rec| rec.fields.get("job").and_then(Value::as_str) != Some(id));
@@ -219,10 +219,10 @@ impl NotificationBuffer {
     }
 
     /// The streaming core behind [`wait_drain`]: drain every record at or above
-    /// `drain_floor`, hand each to `on_drained` (the `wait` tool streams the Info-level
+    /// `drain_floor`, hand each to `on_drained` (the `job_wait` tool streams the Info-level
     /// narrative to the client's progress channel here), and *return* those at or above
     /// `return_floor` (capped at `limit`). It blocks until a returnable record lands or
-    /// the deadline passes — so a default `wait` streams the narrative the whole time and
+    /// the deadline passes — so a default `job_wait` streams the narrative the whole time and
     /// returns only when something the model should act on (a completion) arrives.
     ///
     /// `drain_floor` ≤ `return_floor`: the caller drains *down to* what it streams (Info)
@@ -269,7 +269,7 @@ impl NotificationBuffer {
         }
     }
 
-    /// Records currently buffered. For tests and the `wait` footer.
+    /// Records currently buffered. For tests and the `job_wait` footer.
     pub fn len(&self) -> usize {
         self.lock().len()
     }
@@ -337,7 +337,7 @@ impl Visit for FieldVisitor {
 pub struct McpBridgeLayer {
     tx: UnboundedSender<LogRecord>,
     /// The pull-side ring, teed alongside the push channel: the same record streamed to
-    /// the client is buffered for the `wait` tool to drain. `None` when no buffer is
+    /// the client is buffered for the `job_wait` tool to drain. `None` when no buffer is
     /// wired (e.g. a test subscriber).
     buffer: Option<NotificationBuffer>,
 }
@@ -348,7 +348,7 @@ impl McpBridgeLayer {
     }
 
     /// Tee each mirrored record into `buffer` as well as the client channel, so the
-    /// calling model can drain it via `wait`.
+    /// calling model can drain it via `job_wait`.
     pub fn with_buffer(mut self, buffer: NotificationBuffer) -> Self {
         self.buffer = Some(buffer);
         self
@@ -373,7 +373,7 @@ impl<S: Subscriber> Layer<S> for McpBridgeLayer {
             message: visitor.message.unwrap_or_default(),
             fields: visitor.fields,
         };
-        // Tee to the pull-side ring (for `wait`) before the push channel (for the
+        // Tee to the pull-side ring (for `job_wait`) before the push channel (for the
         // streaming client). Both are infallible/non-blocking — never panic in a log path.
         if let Some(buffer) = &self.buffer {
             buffer.push(record.clone());
@@ -522,7 +522,7 @@ mod tests {
 
     /// A finished job's completion ping (carrying `job=<id>`) is retired when that job is
     /// collected — but only that job's ping. The bug it guards: a stale ping left in the
-    /// ring makes the next `wait` return instantly instead of blocking for new work.
+    /// ring makes the next `job_wait` return instantly instead of blocking for new work.
     #[test]
     fn discard_job_pings_drops_only_the_named_jobs_ping() {
         fn ping(job: &str) -> LogRecord {
@@ -531,7 +531,7 @@ mod tests {
             LogRecord {
                 level: LoggingLevel::Warning,
                 target: "kaibo::jobs".into(),
-                message: format!("async job finished — collect it with `get` ({job})"),
+                message: format!("async job finished — collect it with `job_get` ({job})"),
                 fields,
             }
         }
@@ -552,7 +552,7 @@ mod tests {
         assert_eq!(
             left,
             vec![
-                "async job finished — collect it with `get` (job-2)".to_string(),
+                "async job finished — collect it with `job_get` (job-2)".to_string(),
                 "a jobless warn".to_string(),
             ]
         );

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -88,14 +88,14 @@ impl ProgressSink for NullSink {
 /// the `kaibo::consult` target. An *async* phase has no live MCP peer to push progress
 /// notifications to, so this is how it stays legible: the `mcp_log` bridge mirrors these
 /// `tracing` events to a watching client (the live "watch it work" view sync `consult`
-/// gave), and the notification ring buffer tees them for `wait`.
+/// gave), and the notification ring buffer tees them for `job_wait`.
 ///
 /// Levels follow kaibo's convention — **Warn = "promote to the calling model"**, Info =
 /// the watchable narrative — *not* severity:
 /// - `KaishRun`, the sweep events, and phase start/finish → **Info**: each shell command
 ///   and milestone, the user's continuous view.
 /// - `TurnCapReached` → **Warn**: the caller should know the research budget ran out and
-///   the answer was written early, so it surfaces in the model's `wait` drain.
+///   the answer was written early, so it surfaces in the model's `job_wait` drain.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TracingSink;
 
@@ -114,9 +114,9 @@ impl ProgressSink for TracingSink {
 
 /// A [`ProgressSink`] decorator that remembers the most recent beat while teeing each
 /// event to an inner sink. An async `consult` job streams its progress to the caller
-/// through `wait` (the inner [`TracingSink`] → notification ring); a caller polling with
-/// `get` reads no stream, so the job also holds one of these and `get` echoes
-/// [`latest`](Self::latest) inline. Records *and* forwards — the `wait`/`mcp_log` view is
+/// through `job_wait` (the inner [`TracingSink`] → notification ring); a caller polling with
+/// `job_get` reads no stream, so the job also holds one of these and `job_get` echoes
+/// [`latest`](Self::latest) inline. Records *and* forwards — the `job_wait`/`mcp_log` view is
 /// unchanged. State is a tiny `Mutex` (last message + beat count); `emit` stays sync and
 /// infallible per the [`ProgressSink`] contract.
 #[derive(Debug)]
@@ -129,14 +129,14 @@ pub struct ProgressLog {
 struct ProgressState {
     /// The most recent event's glanceable one-liner, or `None` before the first beat.
     latest: Option<String>,
-    /// How many beats have fired — lets `get` show forward motion ("step 7") even when
+    /// How many beats have fired — lets `job_get` show forward motion ("step 7") even when
     /// two polls land on the same kind of beat.
     steps: u64,
 }
 
 impl ProgressLog {
     /// Wrap `inner`, recording each event before forwarding it. Pass [`NullSink`] for a
-    /// record-only log with nowhere to tee (what a test or a no-`wait` client uses).
+    /// record-only log with nowhere to tee (what a test or a no-`job_wait` client uses).
     pub fn new(inner: Arc<dyn ProgressSink>) -> Self {
         Self {
             inner,
@@ -144,13 +144,13 @@ impl ProgressLog {
         }
     }
 
-    /// A record-only log: nothing downstream, just the latest beat for `get` to echo.
+    /// A record-only log: nothing downstream, just the latest beat for `job_get` to echo.
     pub fn silent() -> Self {
         Self::new(Arc::new(NullSink))
     }
 
     /// The most recent beat's one-liner and the running beat count, or `None` if the
-    /// phase hasn't emitted yet. `get` renders this as the "currently …" tail on a
+    /// phase hasn't emitted yet. `job_get` renders this as the "currently …" tail on a
     /// still-running job.
     pub fn latest(&self) -> Option<(String, u64)> {
         let s = self.state.lock().expect("progress log mutex poisoned");
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn progress_log_step_count_advances_on_a_repeated_event_kind() {
-        // The step count is the "forward motion" signal `get` shows, so it must advance on
+        // The step count is the "forward motion" signal `job_get` shows, so it must advance on
         // *every* beat — including two of the same kind in a row (two `KaishRun`s), where
         // the message alone wouldn't tell a poller anything moved.
         let log = ProgressLog::silent();
@@ -331,8 +331,8 @@ mod tests {
 
     #[test]
     fn progress_log_tees_every_event_to_its_inner_sink() {
-        // A counting sink proves the decorator forwards, so the `wait`/mcp_log stream is
-        // untouched when a job also records for `get`.
+        // A counting sink proves the decorator forwards, so the `job_wait`/mcp_log stream is
+        // untouched when a job also records for `job_get`.
         #[derive(Debug, Default)]
         struct Counter(std::sync::atomic::AtomicUsize);
         impl ProgressSink for Counter {
@@ -345,7 +345,7 @@ mod tests {
         log.emit(PhaseEvent::SweepFinished);
         log.emit(PhaseEvent::PhaseFinished { phase: "consult" });
         assert_eq!(counter.0.load(std::sync::atomic::Ordering::SeqCst), 2);
-        // And it still recorded the last one for `get`.
+        // And it still recorded the last one for `job_get`.
         assert_eq!(log.latest(), Some(("consult complete".to_string(), 2)));
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2111,7 +2111,6 @@ impl rmcp::ServerHandler for KaiboHandler {
             // at initialize — the same point the rest of config is bound; reconnecting
             // is what re-reads a newly-set key.
             instructions: Some(kaibo_instructions_with_scope(
-                &self.tool_schemas,
                 &self.config,
                 &self.allowed_set,
                 self.default_root.as_deref(),
@@ -4541,26 +4540,6 @@ mod tests {
         assert_eq!(sc["report"], "", "an empty report is surfaced honestly");
     }
 
-    #[test]
-    fn instructions_compose_the_canonical_onboarding_and_point_at_resources() {
-        use crate::kaish_syntax::kaibo_instructions;
-        let text = kaibo_instructions(&sample_schemas());
-        assert!(
-            text.contains("kaibo"),
-            "instructions should introduce kaibo"
-        );
-        // The canonical onboarding spine from kaish-help.
-        assert!(
-            text.contains("How kaish works"),
-            "instructions should embed the kaish-help foundations:\n{text}"
-        );
-        // The progressive-learning pointer.
-        assert!(
-            text.contains("kaibo://kaish/"),
-            "instructions should point at the kaish resources"
-        );
-    }
-
     // --- kaibo://config/example resource tests -------------------------------
 
     /// The embedded config example is listed and readable, and — the drift guard —
@@ -4950,14 +4929,12 @@ mod tests {
     /// added and get_info wires it in.
     #[test]
     fn instructions_scope_section_names_allowed_paths() {
-        let schemas = sample_schemas();
         let allowed = vec![
             std::path::PathBuf::from("/projects/myapp"),
             std::path::PathBuf::from("/data/shared"),
         ];
         let config = Config::builtin();
         let text = kaibo_instructions_with_scope(
-            &schemas,
             &config,
             &allowed,
             None,
@@ -4985,12 +4962,10 @@ mod tests {
     /// must NOT tag it as inferred.
     #[test]
     fn instructions_scope_section_names_default_root() {
-        let schemas = sample_schemas();
         let config = Config::builtin();
         let root = std::path::PathBuf::from("/projects/myapp");
         let allowed = vec![root.clone()];
         let text = kaibo_instructions_with_scope(
-            &schemas,
             &config,
             &allowed,
             Some(&root),
@@ -5012,12 +4987,10 @@ mod tests {
     /// the caller can tell it wasn't configured by hand.
     #[test]
     fn instructions_scope_section_tags_inferred_default_root() {
-        let schemas = sample_schemas();
         let config = Config::builtin();
         let root = std::path::PathBuf::from("/work/space");
         let allowed = vec![root.clone()];
         let text = kaibo_instructions_with_scope(
-            &schemas,
             &config,
             &allowed,
             Some(&root),
@@ -5038,11 +5011,9 @@ mod tests {
     /// When no default root applies the scope section must be honest about it.
     #[test]
     fn instructions_scope_section_states_no_default_root_when_absent() {
-        let schemas = sample_schemas();
         let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp")];
         let text = kaibo_instructions_with_scope(
-            &schemas,
             &config,
             &allowed,
             None,

--- a/src/server.rs
+++ b/src/server.rs
@@ -182,8 +182,8 @@ pub struct ConsultInput {
     pub attach: Vec<String>,
 }
 
-/// Arguments to the unified `get` / `cancel` tools: one handle that addresses either
-/// kind of async work. See [`ConsultInput`] for the `deny_unknown_fields` rationale.
+/// The handle addressing one piece of async work — a durable batch or a
+/// session-scoped background job. kaibo routes by the handle's shape.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct HandleInput {
@@ -193,9 +193,8 @@ pub struct HandleInput {
     pub handle: String,
 }
 
-/// Arguments to the `oneshot` tool. See [`ConsultInput`] for the
-/// `deny_unknown_fields` rationale. No `path`: oneshot reads no project — it's a
-/// thin, toolless completion, so the caller owns any context the model needs.
+/// Arguments to `oneshot`. No `path`: oneshot reads no project — a thin, toolless
+/// completion, so the caller owns any context the model needs.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct OneshotInput {
@@ -227,7 +226,7 @@ pub struct OneshotInput {
 }
 
 /// Arguments to `batch_submit`. Many prompts, one cast/model — they all ride one
-/// provider batch. See [`ConsultInput`] for the `deny_unknown_fields` rationale.
+/// provider batch.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BatchSubmitInput {
@@ -258,7 +257,7 @@ pub struct BatchSubmitInput {
     pub backend: Option<String>,
 }
 
-/// Arguments to the unified `list`: an optional backend to scope the *batch* portion
+/// Arguments to `job_list`: an optional backend to scope the *batch* portion
 /// of the listing to. Live consult jobs (in-memory, not backend-bound) are always
 /// listed regardless.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -277,14 +276,13 @@ pub struct ListInput {
     pub all: bool,
 }
 
-/// Arguments to the `wait` tool. See [`ConsultInput`] for the `deny_unknown_fields`
-/// rationale.
+/// Arguments to `job_wait`.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct WaitInput {
     /// How long to block, in seconds (default 60). No clamp — your client's tool-call
     /// timeout and your ability to interrupt are the real bounds; over 3600 is a loud
-    /// error. For a long park, prefer calling `wait` again over one giant block.
+    /// error. For a long park, prefer calling `job_wait` again over one giant block.
     #[serde(default)]
     pub timeout_secs: Option<u64>,
 
@@ -305,8 +303,7 @@ pub struct WaitInput {
     pub handles: Vec<String>,
 }
 
-/// Arguments to the `run_kaish` tool. See [`ConsultInput`] for the
-/// `deny_unknown_fields` rationale.
+/// Arguments to `run_kaish`.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RunKaishInput {
@@ -336,10 +333,11 @@ pub struct KaiboHandler {
     /// per-request handler clones all share one cache (see [`SessionStore`]).
     sessions: SessionStore,
     /// In-flight + collectable async consultations (`consult_submit`, collected via the
-    /// shared `get`/`cancel`/`list`). Same `Arc<Mutex<LruCache>>` shape as `sessions`, so
-    /// the per-request handler clones all share one registry (see [`JobStore`]).
+    /// shared `job_get`/`job_cancel`/`job_list`). Same `Arc<Mutex<LruCache>>` shape as
+    /// `sessions`, so the per-request handler clones all share one registry (see
+    /// [`JobStore`]).
     jobs: JobStore,
-    /// The pull-side notification ring the `wait` tool drains — the same kaibo-target
+    /// The pull-side notification ring the `job_wait` tool drains — the same kaibo-target
     /// records the `mcp_log` bridge streams to the client, teed for on-demand pull.
     /// `new` seeds an unwired default (nothing pushes to it); `main` swaps in the shared
     /// ring via [`with_notifications`](Self::with_notifications) so the bridge layer feeds
@@ -404,47 +402,6 @@ fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, tools: &[&str], casts
     }
 }
 
-/// Append the live cast roster to each named tool's `description` — the resident
-/// prose a host always shows, where `inject_cast_enum`'s param `enum` and the
-/// handshake list (which a host may truncate) don't reliably land. This is what
-/// lets an agent that hears "have deepseek review" index straight to a kaibo tool:
-/// the team names sit in the description text its tool-picker reads. The default
-/// cast is flagged so a bare call's team is legible. `casts` is the per-lane roster
-/// (same split as the enum), so the advertised menu matches what the tool accepts;
-/// skipped when empty, the same "no valid value" guard as the enum.
-fn append_cast_roster(
-    router: &mut ToolRouter<KaiboHandler>,
-    tools: &[&str],
-    casts: &[String],
-    config: &Config,
-) {
-    if casts.is_empty() {
-        return;
-    }
-    let menu = casts
-        .iter()
-        .map(|c| {
-            // Resolve before tagging: an alias default (`server.cast = "claude"`) must
-            // still flag its canonical cast — the same alias/default trap `casts_section`
-            // hit. `casts` holds canonical names, so `is_default_cast` compares like to
-            // like.
-            if config.is_default_cast(c) {
-                format!("{c} (default)")
-            } else {
-                c.clone()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    for name in tools {
-        let Some(route) = router.map.get_mut(*name) else {
-            continue;
-        };
-        let base = route.attr.description.as_deref().unwrap_or_default();
-        route.attr.description = Some(format!("{base} Casts ready now: {menu}.").into());
-    }
-}
-
 #[tool_router]
 impl KaiboHandler {
     /// Build the handler from a resolved [`Config`]. Snapshots the kernel's builtin
@@ -470,21 +427,21 @@ impl KaiboHandler {
             // `consult_submit` is the async sibling of `consult` — same capability, a
             // submit/collect surface rather than a blocking one — so it shares the
             // `consult` gate. (docs/issues.md tracks a dedicated flag if anyone needs
-            // only one shape.) The verbs that *collect* its handles (`get`/`cancel`/
-            // `list`) are shared with batch and gated below.
+            // only one shape.) The verbs that *collect* its handles (`job_get`/
+            // `job_cancel`/`job_list`) are shared with batch and gated below.
             (gating.consult, "consult_submit"),
             (gating.oneshot, "oneshot"),
             (gating.run_kaish, "run_kaish"),
             // `--no-batch` drops `batch_submit`; the shared collect verbs live below.
             (gating.batch, "batch_submit"),
-            // `get`/`cancel`/`list` manage *both* batch and consult handles, so they
-            // stay as long as *either* capability is on, and drop only when both are
-            // gated off. Routing by handle shape inside each verb refuses a handle whose
-            // own capability is disabled.
-            (gating.batch || gating.consult, "get"),
-            (gating.batch || gating.consult, "cancel"),
-            (gating.batch || gating.consult, "list"),
-            (gating.batch || gating.consult, "wait"),
+            // `job_get`/`job_cancel`/`job_list`/`job_wait` manage *both* batch and
+            // consult handles, so they stay as long as *either* capability is on, and
+            // drop only when both are gated off. Routing by handle shape inside each
+            // verb refuses a handle whose own capability is disabled.
+            (gating.batch || gating.consult, "job_get"),
+            (gating.batch || gating.consult, "job_cancel"),
+            (gating.batch || gating.consult, "job_list"),
+            (gating.batch || gating.consult, "job_wait"),
         ] {
             if !enabled {
                 assert!(
@@ -576,16 +533,27 @@ impl KaiboHandler {
             &interactive_usable,
         );
         inject_cast_enum(&mut tool_router, &["batch_submit"], &batch_usable);
-        // ...and name that same roster in the resident prose, so an agent that hears
-        // "have deepseek review" indexes to a kaibo tool from the description it always
-        // reads, not only the param enum the tool-picker may skim past.
-        append_cast_roster(
-            &mut tool_router,
-            &["consult", "consult_submit", "oneshot"],
-            &interactive_usable,
-            &config,
-        );
-        append_cast_roster(&mut tool_router, &["batch_submit"], &batch_usable, &config);
+        // The `cast` enum (just above) is now the one authoritative per-lane roster —
+        // the resident-prose roster this used to also append (`append_cast_roster`) was
+        // redundant with it and has been dropped; see `docs/devlog.md`.
+
+        // Pin `consult` resident under Claude Code's tool-schema deferral: a host may
+        // defer every tool's schema to names-only until first use, but a `_meta`
+        // `anthropic/alwaysLoad: true` opts a tool out. `consult` is kaibo's front
+        // door — pinning it means the calling model still sees its description (what
+        // it does, when to reach for it instead) with no lookup round-trip, even on a
+        // host that defers everything else. Narrow and explicit: only `consult` is
+        // pinned, so an unused `oneshot`/`run_kaish`/etc. still bills nothing until
+        // the caller actually reaches for it. A no-op if `--no-consult` already
+        // dropped the route.
+        if let Some(route) = tool_router.map.get_mut("consult") {
+            let mut meta = Meta::new();
+            meta.insert(
+                "anthropic/alwaysLoad".to_string(),
+                serde_json::Value::Bool(true),
+            );
+            route.attr.meta = Some(meta);
+        }
 
         let sessions = SessionStore::new(config.defaults.session_capacity);
         // Async-consult jobs get their own cap: a held job result (answer + optional
@@ -600,7 +568,7 @@ impl KaiboHandler {
             jobs,
             // An unwired default — nothing pushes to it until `main` swaps in the shared
             // ring the bridge layer feeds (see `with_notifications`). So a handler built
-            // for a test has a valid, empty buffer and `wait` simply drains nothing.
+            // for a test has a valid, empty buffer and `job_wait` simply drains nothing.
             notifications: crate::mcp_log::NotificationBuffer::new(512),
             mcp_log_level: Arc::new(AtomicU8::new(mcp_log::rank(mcp_log::DEFAULT_LEVEL))),
             allowed_set: Arc::new(allowed),
@@ -610,7 +578,7 @@ impl KaiboHandler {
     }
 
     /// Swap in the shared notification ring `main` also handed the bridge layer, so the
-    /// `wait` tool drains the records the layer pushes. A builder (not a `new` param) to
+    /// `job_wait` tool drains the records the layer pushes. A builder (not a `new` param) to
     /// keep `new(config)` unchanged for the many call sites and tests.
     pub fn with_notifications(mut self, buffer: crate::mcp_log::NotificationBuffer) -> Self {
         self.notifications = buffer;
@@ -1288,17 +1256,16 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Ask a model *outside your own family* about a codebase and get a \
-            grounded, cited answer — kaibo is the door to a second opinion from DeepSeek, \
-            Gemini, Anthropic, or a local model. A capable model drives a read-only shell: \
-            it reads precise spans, delegates broad sweeps to a fast explorer sub-agent, \
-            and answers with concrete `file:line` citations. Describe in prose what you \
-            did or want to know — kaibo finds and reads the real, current source itself, so \
-            your intent matters more than a pasted diff. Pick the answering team with \
-            `cast`; pass a stable `session_id` for a multi-turn thread; `attach` workspace \
-            files to focus it. Read-only — it never modifies the project. For a thin answer \
-            with no codebase access use `oneshot`; to run it in the background use \
-            `consult_submit`. See `kaibo://tools` for attachments, casts, and overrides."
+        description = "Ask a model outside your own family about a codebase — code review, \
+            debugging, architecture, \"what does this change break\" — and get a grounded \
+            answer with `file:line` citations. A capable model (DeepSeek, Gemini, \
+            Anthropic, or local — pick with `cast`) drives a READ-ONLY shell over the \
+            project: it reads the real, current source, delegates broad sweeps to a fast \
+            explorer, and answers with evidence, never modifying anything. Describe your \
+            intent in prose; kaibo locates the code itself, so you don't paste files or \
+            diffs. `attach` puts specific files in front of it; `session_id` threads a \
+            multi-turn consultation. For a toolless opinion use `oneshot`; to run in the \
+            background use `consult_submit`."
     )]
     async fn consult(
         &self,
@@ -1406,14 +1373,12 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Submit a `consult` and get a `job-N` handle back immediately — kaibo \
-            runs it in the background. The async sibling of `consult` (same investigation, \
-            same args). Reach for it to run several consults at once (a cross-model study: \
-            submit one per cast, collect them all) or when a deep consult would otherwise \
-            block you: submit, go do other work, then `wait` parks for results / `get` the \
-            answer (`cancel` stops it, `list` shows what's in flight). The job lives for \
-            this server session only — collect it before you reconnect. For an answer in \
-            this turn, use `consult`. See `kaibo://tools` for the async workflow."
+        description = "Run a `consult` in the background: same read-only investigation, \
+            same arguments, but returns a `job-N` handle immediately. Fan out a \
+            cross-model study (one submit per cast, collect them all) or keep working \
+            while a deep consult runs. `job_wait` parks for results, `job_get` fetches \
+            them, `job_cancel` stops one. Handles live for this server session only. \
+            For an answer in this turn, use `consult`."
     )]
     async fn consult_submit(
         &self,
@@ -1457,10 +1422,10 @@ impl KaiboHandler {
         // An async job has no live MCP peer to push progress notifications to, so route
         // its liveness onto the `tracing` stream: the `mcp_log` bridge mirrors it to a
         // watching client (the live view sync `consult` had) and the notification buffer
-        // tees it for `wait`. The `ProgressLog` decorator wraps that `TracingSink` so the
-        // job *also* remembers the latest beat — `get`/`list` echo it inline, a second
-        // channel for a poller who isn't using `wait`. The job below keeps a clone of this
-        // exact handle, so what it reads is what the running phase emitted.
+        // tees it for `job_wait`. The `ProgressLog` decorator wraps that `TracingSink` so
+        // the job *also* remembers the latest beat — `job_get`/`job_list` echo it inline,
+        // a second channel for a poller who isn't using `job_wait`. The job below keeps a
+        // clone of this exact handle, so what it reads is what the running phase emitted.
         let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
         let cfg = ConsultConfig {
             explorer_max_turns: input
@@ -1517,29 +1482,28 @@ impl KaiboHandler {
                     })
                 }
                 // Render the failure to its final text here (classification + guidance),
-                // so `get` wraps a ready string without re-deriving anything.
+                // so `job_get` wraps a ready string without re-deriving anything.
                 Err(e) => Err(consultation_failure_text("consult", &cast_name, e)),
             }
         });
 
         let msg = format!(
             "Submitted consultation `{job_id}` on cast `{}`. It runs in the \
-             background — go do other work and `get {job_id}` for the answer; \
-             `cancel {job_id}` stops it. Nothing to wait on now.",
+             background — go do other work and `job_get {job_id}` for the answer; \
+             `job_cancel {job_id}` stops it. Nothing to wait on now.",
             cast.name
         );
         Ok(CallToolResult::success(vec![Content::text(msg)]))
     }
 
     #[tool(
-        description = "Ask a model *outside your own family* a thin, direct question — \
-            prompt in, answer out, no codebase access and no tools. The counterpart to \
-            `consult`: use `oneshot` when you already own the context (you've pasted or \
-            `attach`ed what's needed, or the question is general); use `consult` when kaibo \
-            should investigate a codebase. Pick the answering team with `cast` — kaibo runs \
-            its capable (synth) model; you own any context the model needs. To fan many \
-            prompts offline, use `batch_submit`. See `kaibo://tools` for attachments and \
-            overrides."
+        description = "Ask a model outside your own family a direct question — prompt in, \
+            answer out. No tools, no codebase access: the second-opinion primitive for \
+            when you already own the context. Paste what's needed, or `attach` whole \
+            files (kaibo inlines them, so their bytes never cross your context). Pick \
+            the answering team with `cast`. When kaibo should investigate the code \
+            itself, use `consult`; to fan many prompts offline at batch prices, use \
+            `batch_submit`."
     )]
     async fn oneshot(
         &self,
@@ -1595,14 +1559,13 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Run a kaish (sh-like) script against the read-only project; returns \
-            exit code + stdout + stderr. Read generously with line numbers — `cat -n FILE` \
-            for a whole file (reach for it first), `grep -rn PATTERN .` to locate across \
-            files, `cat -n FILE | sed -n '40,80p'` for a slice — and compose builtins with \
-            pipes (grep/jq/awk/find/…). Read-only: writes and external commands are refused \
-            (exit 126 = blocked, 124 = timed out); each call starts fresh at the project \
-            root. See `kaibo://tools` and the `kaibo://kaish/*` resources (or `help` in the \
-            script) for kaish idioms and the bash habits that don't carry over."
+        description = "Run a kaish (sh-like) script against the READ-ONLY project; \
+            returns exit code + stdout + stderr. Read generously with line numbers — \
+            `cat -n FILE` for a whole file, `grep -rn PATTERN .` to locate across \
+            files — and compose builtins with pipes (grep/jq/awk/find/...). Writes \
+            and external commands are refused (exit 126 = blocked, 124 = timed out); \
+            each call starts fresh at the project root. See `kaibo://kaish/*` (or \
+            `help` in the script) for idioms and the bash habits that don't carry over."
     )]
     pub async fn run_kaish(
         &self,
@@ -1668,7 +1631,7 @@ impl KaiboHandler {
         crate::batch::poller(backend).map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
     }
 
-    /// The set of backend names `list` should query. An explicit `backend` scopes
+    /// The set of backend names `job_list` should query. An explicit `backend` scopes
     /// to that one (resolved by name/alias, and refused loudly if its kind has no batch
     /// lane). Omitted, it's every configured batch-capable backend, sorted — the orphan-
     /// recovery default. No batch-capable backend at all is a clear parameter error, not an
@@ -1711,16 +1674,12 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Submit a batch of tool-less questions to run *offline* at max \
-            thinking, and get back a durable `backend/provider-id` handle — the async \
-            sibling of `oneshot`. Fan many prompts (or one hard question) at a top-tier \
-            model on the provider's cheaper batch lane without holding a call open per \
-            answer. Each prompt is self-contained (no codebase access, no tools) — include \
-            the context each needs, or `attach` files. Runs the cast's synth model on a \
-            batch-capable backend (point `cast`/`model` at one, or get a clear refusal \
-            naming them). Fire-and-forget: submit, go do other work, then `get` the handle \
-            (`cancel` stops it, `list` finds a lost one, `wait` parks for results). The \
-            handle survives a server restart. See `kaibo://tools` for the async workflow."
+        description = "Fan self-contained prompts to a top-tier model on the provider's \
+            batch lane — offline, max thinking, half price. Like `oneshot`, no tools \
+            and no codebase access: each prompt carries its own context, or `attach` \
+            files shared by all. Returns a durable `backend/provider-id` handle that \
+            survives restarts: submit, go work, then `job_wait`/`job_get`. Needs a \
+            batch-capable cast/backend (you get a clear refusal naming them otherwise)."
     )]
     pub async fn batch_submit(
         &self,
@@ -1785,8 +1744,8 @@ impl KaiboHandler {
         let handle = format!("{backend_name}/{provider_id}");
         let msg = format!(
             "Submitted batch `{handle}` — {} prompt(s) on cast `{}` (model `{}`). \
-             Poll it with `get {handle}` (it'll show progress, then per-item answers when \
-             done); stop it with `cancel {handle}`.",
+             Poll it with `job_get {handle}` (it'll show progress, then per-item answers \
+             when done); stop it with `job_cancel {handle}`.",
             items.len(),
             cast.name,
             model
@@ -1795,15 +1754,13 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Collect a submitted async job by its handle — the one surface for \
-            both `batch_submit` and `consult_submit`. kaibo tells the two apart by handle \
-            shape (`backend/provider-id` is a durable batch; `job-N` is an in-memory \
-            consult) and returns a progress line while it works, the full result once it's \
-            done (batch: every item's answer, labelled by index, per-item failures \
-            surfaced). Collect occasionally, not in a tight loop — nothing is lost by \
-            waiting. See `kaibo://tools` for the async workflow."
+        description = "Collect async work by handle — a batch (`backend/provider-id`) \
+            or a background job (`job-N`). Returns a progress line while it runs, the \
+            full result once done (batches: every item's answer, per-item failures \
+            surfaced). Collect occasionally rather than in a tight loop — nothing is \
+            lost by waiting."
     )]
-    async fn get(
+    async fn job_get(
         &self,
         Parameters(input): Parameters<HandleInput>,
     ) -> Result<CallToolResult, McpError> {
@@ -1811,7 +1768,7 @@ impl KaiboHandler {
             self.ensure_batch_enabled(&input.handle)?;
             let (backend_name, provider_id) = parse_batch_handle(&input.handle)?;
             let provider = self.batch_poller(backend_name)?;
-            let span = tracing::info_span!("get", handle = %input.handle);
+            let span = tracing::info_span!("job_get", handle = %input.handle);
             let poll = provider
                 .poll(provider_id)
                 .instrument(span)
@@ -1825,12 +1782,12 @@ impl KaiboHandler {
         self.ensure_consult_enabled(&input.handle)?;
         match self.jobs.get(&input.handle) {
             Some(snap) => {
-                // Collecting a terminal job retires its completion ping from the `wait`
-                // ring — otherwise that stale Warn lingers and the next `wait` returns on
-                // it immediately instead of blocking for new work. A Running job has no
-                // ping yet; a Canceled one never emitted one — both are no-ops, so this is
-                // safe to call unconditionally, but we scope it to the terminal states the
-                // ping actually exists for.
+                // Collecting a terminal job retires its completion ping from the
+                // `job_wait` ring — otherwise that stale Warn lingers and the next
+                // `job_wait` returns on it immediately instead of blocking for new work.
+                // A Running job has no ping yet; a Canceled one never emitted one — both
+                // are no-ops, so this is safe to call unconditionally, but we scope it to
+                // the terminal states the ping actually exists for.
                 if matches!(snap.state, JobState::Done(_) | JobState::Failed(_)) {
                     self.notifications.discard_job_pings(&input.handle);
                 }
@@ -1849,13 +1806,12 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Stop a running async job by its handle — works for both kinds \
-            (`backend/provider-id` batch or `job-N` consult). A batch stops scheduling new \
-            requests (any in flight finish); a consult aborts the investigation; `get` it \
-            afterward for the final state. A job that already finished is left alone. See \
-            `kaibo://tools` for the async workflow."
+        description = "Stop a running async job by handle — a batch stops scheduling \
+            new items (in-flight ones finish); a background job aborts its \
+            investigation. `job_get` it afterward for the final state. A job that \
+            already finished is left alone."
     )]
-    async fn cancel(
+    async fn job_cancel(
         &self,
         Parameters(input): Parameters<HandleInput>,
     ) -> Result<CallToolResult, McpError> {
@@ -1863,15 +1819,15 @@ impl KaiboHandler {
             self.ensure_batch_enabled(&input.handle)?;
             let (backend_name, provider_id) = parse_batch_handle(&input.handle)?;
             let provider = self.batch_poller(backend_name)?;
-            let span = tracing::info_span!("cancel", handle = %input.handle);
+            let span = tracing::info_span!("job_cancel", handle = %input.handle);
             provider
                 .cancel(provider_id)
                 .instrument(span)
                 .await
                 .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
             return Ok(CallToolResult::success(vec![Content::text(format!(
-                "Requested cancellation of batch `{}`. `get` it for the final per-item \
-                 results.",
+                "Requested cancellation of batch `{}`. `job_get` it for the final \
+                 per-item results.",
                 input.handle
             ))]));
         }
@@ -1879,7 +1835,7 @@ impl KaiboHandler {
         let msg = match self.jobs.cancel(&input.handle) {
             CancelOutcome::Canceled => format!("Canceled consultation `{}`.", input.handle),
             CancelOutcome::AlreadyFinished => format!(
-                "Consultation `{}` had already finished — `get` it for the answer.",
+                "Consultation `{}` had already finished — `job_get` it for the answer.",
                 input.handle
             ),
             CancelOutcome::Unknown => {
@@ -1897,15 +1853,13 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "List your async work — the consult jobs in flight this session and \
-            the batches the providers still know about — each with a ready-to-use handle \
-            for `get`/`cancel`. The way back to a batch whose handle you lost (kaibo holds \
-            no state — the provider's own list is the source of truth). By default the \
-            batches section shows the last 24h; pass `all: true` for the full history. \
-            `backend` scopes only the batches section. An unreachable backend is reported, \
-            not hidden. See `kaibo://tools` for the async workflow."
+        description = "List your async work: background jobs in flight this session, \
+            and the batches the providers still know about (last 24h by default; \
+            `all: true` for everything) — each with a ready handle for \
+            `job_get`/`job_cancel`. This is the way back to a batch whose handle you \
+            lost — the provider's own list is the source of truth."
     )]
-    async fn list(
+    async fn job_list(
         &self,
         Parameters(input): Parameters<ListInput>,
     ) -> Result<CallToolResult, McpError> {
@@ -1933,7 +1887,7 @@ impl KaiboHandler {
                         // per-item-failure ethos, at the backend grain).
                         let listed = match self.batch_poller(&name) {
                             Ok(provider) => {
-                                let span = tracing::info_span!("list", backend = %name);
+                                let span = tracing::info_span!("job_list", backend = %name);
                                 provider.list().instrument(span).await
                             }
                             Err(e) => Err(anyhow::anyhow!("{}", e.message)),
@@ -1970,7 +1924,7 @@ impl KaiboHandler {
                     sections.push(crate::batch::render_list(&entries, &errors, &truncated));
                     if hidden > 0 {
                         sections.push(format!(
-                            "({hidden} batch(es) older than 24h hidden — `list` with \
+                            "({hidden} batch(es) older than 24h hidden — `job_list` with \
                              `all: true` to see the full history.)"
                         ));
                     }
@@ -1985,17 +1939,13 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Block briefly for your async work to make progress, then return \
-            what happened — the way to *productively park* instead of blind-polling `get`. \
-            Submit consults and batches, do your other work, then `wait`: it blocks up to \
-            `timeout_secs` (you choose; no clamp) and returns as soon as something lands or \
-            on a clean timeout. By default it hands back what kaibo flagged for you (a job \
-            finished or failed) plus which consults are still running; `level:\"info\"` \
-            also pulls the watchable narrative (each kaish command, sweep, milestone). Name \
-            batch `handles` to fold their status in. `get`/`list` are the source of truth; \
-            nothing here wakes you, and nothing is lost by waiting. See `kaibo://tools`."
+        description = "Park for async work to make progress: blocks up to \
+            `timeout_secs` and returns as soon as a job finishes or fails, or on a \
+            clean timeout — the productive alternative to polling `job_get`. \
+            `level:\"info\"` adds the live narrative (each shell command, sweep, \
+            milestone); name batch `handles` to fold their status in."
     )]
-    async fn wait(
+    async fn job_wait(
         &self,
         Parameters(input): Parameters<WaitInput>,
         peer: Peer<RoleServer>,
@@ -2009,8 +1959,8 @@ impl KaiboHandler {
                 return Err(McpError::invalid_params(
                     format!(
                         "timeout_secs {t} is over 3600 (1h) — pass a smaller value, or \
-                         call `wait` again each time it returns; a single block is capped \
-                         by your client's tool-call timeout anyway."
+                         call `job_wait` again each time it returns; a single block is \
+                         capped by your client's tool-call timeout anyway."
                     ),
                     None,
                 ));
@@ -2071,9 +2021,9 @@ impl KaiboHandler {
             if !is_batch_handle(h) {
                 continue;
             }
-            // Respect batch gating, like `get`/`cancel` — don't poll a batch handle on a
-            // server that has batch turned off. A per-handle note, not a hard error: it
-            // never sinks the rest of the `wait`.
+            // Respect batch gating, like `job_get`/`job_cancel` — don't poll a batch
+            // handle on a server that has batch turned off. A per-handle note, not a
+            // hard error: it never sinks the rest of the `job_wait`.
             if let Err(e) = self.ensure_batch_enabled(h) {
                 batch_lines.push(format!("{h} — {}", e.message));
                 continue;
@@ -2099,8 +2049,9 @@ impl KaiboHandler {
         ))]))
     }
 
-    /// Refuse a batch-shaped handle when batch is gated off — `get`/`cancel` survive as
-    /// long as *either* capability is on, so a handle can arrive for a disabled one.
+    /// Refuse a batch-shaped handle when batch is gated off — `job_get`/`job_cancel`
+    /// survive as long as *either* capability is on, so a handle can arrive for a
+    /// disabled one.
     fn ensure_batch_enabled(&self, handle: &str) -> Result<(), McpError> {
         if self.config.tools.batch {
             return Ok(());
@@ -2531,24 +2482,25 @@ at once, or when a deep job would otherwise block you.
 
 One small surface drives both kinds:
 
-- **`get <handle>`** collects a job — a progress line while it works, the full answer once
-  it's done (batch: every item's answer, labelled by index, per-item failures surfaced).
-- **`cancel <handle>`** stops a running job. A job that already finished is left alone.
-- **`list`** shows everything: consult jobs in flight this session, and the batches the
-  providers still know about — the way back to a handle you've lost. By default the
+- **`job_get <handle>`** collects a job — a progress line while it works, the full answer
+  once it's done (batch: every item's answer, labelled by index, per-item failures
+  surfaced).
+- **`job_cancel <handle>`** stops a running job. A job that already finished is left alone.
+- **`job_list`** shows everything: consult jobs in flight this session, and the batches
+  the providers still know about — the way back to a handle you've lost. By default the
   batches section shows the last 24h (anything older is done and still collectible by its
   handle); pass `all: true` for the full history.
-- **`wait`** is how you *productively park*: submit your async work, do your other work,
-  then call `wait` to block briefly (up to `timeout_secs` — your choice, to a 3600s
-  ceiling) and return as soon
+- **`job_wait`** is how you *productively park*: submit your async work, do your other
+  work, then call `job_wait` to block briefly (up to `timeout_secs` — your choice, to a
+  3600s ceiling) and return as soon
   as something lands — or on a clean timeout. By default it hands back what kaibo flagged
   for you (a job finished or failed); pass `level: \"info\"` to also pull in the watchable
   narrative — each kaish command, sweep, and milestone the agents ran.
 
 This is a fire-and-forget lane. Submit, then go do other work — don't sit in a tight
-poll/sleep loop holding your turn open. `wait` when you're ready to spend a minute;
-`get`/`list` are the source of truth. Nothing here wakes you, and nothing is lost by
-waiting — the handles keep.
+poll/sleep loop holding your turn open. `job_wait` when you're ready to spend a minute;
+`job_get`/`job_list` are the source of truth. Nothing here wakes you, and nothing is lost
+by waiting — the handles keep.
 
 ## Driving the read-only shell (`run_kaish`)
 
@@ -3145,7 +3097,7 @@ fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) -> CallToolRe
 /// The rendered failure text (detail + classified guidance) for a consultation that
 /// errored — the body of [`consultation_failed`], split out so the async path
 /// ([`consult_submit`]) can store a ready string in a [`JobState::Failed`] and the
-/// unified `get` wrap it without re-classifying.
+/// unified `job_get` wrap it without re-classifying.
 fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> String {
     let detail = format!("{err:#}");
     let guidance = match classify_failure(&err) {
@@ -3167,8 +3119,8 @@ fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> Stri
 }
 
 /// Render a still-running job's latest progress beat as an inline phrase, or `""` before
-/// the first beat lands. Echoes the same one-liner `wait` streams (e.g. "exploring: …"),
-/// so a caller polling with `get` sees forward motion — `step N` advances every beat even
+/// the first beat lands. Echoes the same one-liner `job_wait` streams (e.g. "exploring: …"),
+/// so a caller polling with `job_get` sees forward motion — `step N` advances every beat even
 /// when two polls catch the same kind of event. See [`crate::progress::ProgressLog`].
 fn running_beat(last_progress: &Option<(String, u64)>) -> String {
     match last_progress {
@@ -3177,7 +3129,7 @@ fn running_beat(last_progress: &Option<(String, u64)>) -> String {
     }
 }
 
-/// Render an async consultation job for the unified `get`: a status line while it runs,
+/// Render an async consultation job for the unified `job_get`: a status line while it runs,
 /// the grounded answer (and optional report) when it's done, the stored failure text on
 /// error, or a canceled notice. Mirrors the synchronous `consult` result shape so an
 /// agent reads the same thing whether it asked synchronously or collected a job.
@@ -3185,7 +3137,7 @@ fn render_job(id: &str, snap: JobSnapshot) -> CallToolResult {
     match snap.state {
         JobState::Running => CallToolResult::success(vec![Content::text(format!(
             "Consultation `{id}` is still running — {} ({}s elapsed){}. No need to wait: go \
-             do other work and `get` it again later.",
+             do other work and `job_get` it again later.",
             snap.label,
             snap.age.as_secs(),
             running_beat(&snap.last_progress),
@@ -3214,12 +3166,12 @@ fn render_job(id: &str, snap: JobSnapshot) -> CallToolResult {
 /// Which kind of async work a handle addresses. A batch handle carries a `/`
 /// (`backend/provider-id`); a consult job id (`job-N`) never does, and a backend name
 /// carries no `/` either (enforced at config load), so the presence of a `/` is an
-/// unambiguous batch-vs-consult discriminator for the unified `get`/`cancel` verbs.
+/// unambiguous batch-vs-consult discriminator for the unified `job_get`/`job_cancel` verbs.
 fn is_batch_handle(handle: &str) -> bool {
     handle.contains('/')
 }
 
-/// Map a `wait` `level` string to a [`mcp_log::rank`] floor. `warn` (the default) is
+/// Map a `job_wait` `level` string to a [`mcp_log::rank`] floor. `warn` (the default) is
 /// kaibo's "the calling model should see this" bar — salience, not severity.
 fn wait_level_floor(level: Option<&str>) -> Result<u8, McpError> {
     let l = match level.unwrap_or("warn").to_ascii_lowercase().as_str() {
@@ -3237,7 +3189,7 @@ fn wait_level_floor(level: Option<&str>) -> Result<u8, McpError> {
     Ok(crate::mcp_log::rank(l))
 }
 
-/// A short, readable tag for a record's level in `wait` output.
+/// A short, readable tag for a record's level in `job_wait` output.
 fn wait_level_label(level: LoggingLevel) -> &'static str {
     match level {
         LoggingLevel::Debug => "debug",
@@ -3251,8 +3203,8 @@ fn wait_level_label(level: LoggingLevel) -> &'static str {
     }
 }
 
-/// One-line status for a batch poll, for the `wait` footer — not the full results (`get`
-/// the handle for those).
+/// One-line status for a batch poll, for the `job_wait` footer — not the full results
+/// (`job_get` the handle for those).
 fn batch_poll_brief(poll: &crate::batch::BatchPoll) -> String {
     match poll {
         crate::batch::BatchPoll::Pending { completed, total } => {
@@ -3260,13 +3212,13 @@ fn batch_poll_brief(poll: &crate::batch::BatchPoll) -> String {
         }
         crate::batch::BatchPoll::Cancelling => "canceling".to_string(),
         crate::batch::BatchPoll::Done(answers) => {
-            format!("complete — {} result(s); `get` it", answers.len())
+            format!("complete — {} result(s); `job_get` it", answers.len())
         }
         crate::batch::BatchPoll::Failed { state, .. } => format!("ended ({state})"),
     }
 }
 
-/// Render a `wait` result: the drained activity records (each tagged by level), any
+/// Render a `job_wait` result: the drained activity records (each tagged by level), any
 /// gentle batch-poll lines, and a footer naming the consult jobs still running.
 fn render_wait(
     records: &[crate::mcp_log::LogRecord],
@@ -3299,18 +3251,18 @@ fn render_wait(
         s.push_str(&format!("Still running: {}.", running.join(", ")));
     }
     s.push_str(
-        " `get <handle>` to collect a finished one, `list` for the full picture, or \
-         `wait` again to keep parking.",
+        " `job_get <handle>` to collect a finished one, `job_list` for the full picture, or \
+         `job_wait` again to keep parking.",
     );
     s
 }
 
-/// The default `list` recency window: 24h. A provider's offline SLA is ≤24h, so an
+/// The default `job_list` recency window: 24h. A provider's offline SLA is ≤24h, so an
 /// older batch is done and still collectible by its handle — trimming it saves the
 /// caller tokens without losing anything actionable.
 const BATCH_RECENCY_WINDOW_SECS: i64 = 24 * 3600;
 
-/// Unix epoch seconds now, for the `list` recency window — read once per `list` call and
+/// Unix epoch seconds now, for the `job_list` recency window — read once per `job_list` call and
 /// passed into [`batch_within_window`], not re-read per item. A pre-epoch system clock
 /// (impossible in practice) reads as 0, which keeps everything: fail-open, never hide a
 /// batch on a clock glitch. From `SystemTime`, so chrono's `clock` feature stays off.
@@ -3321,7 +3273,7 @@ fn now_epoch_secs() -> i64 {
         .unwrap_or(0)
 }
 
-/// Is this batch within `window_secs` of `now_epoch`? The `list` recency filter, with
+/// Is this batch within `window_secs` of `now_epoch`? The `job_list` recency filter, with
 /// `now` injected so the keep/drop boundary is testable without the clock and the clock
 /// is read once per call rather than per item. A batch kaibo can't date (no or
 /// unparseable `created_at`) is kept, not silently hidden — losing sight of a batch is
@@ -3338,7 +3290,7 @@ fn batch_within_window(it: &crate::batch::BatchListItem, now_epoch: i64, window_
     }
 }
 
-/// Render the consult-jobs section of `list`: the in-memory async consultations this
+/// Render the consult-jobs section of `job_list`: the in-memory async consultations this
 /// session, newest-first, each with its handle and a one-line state. Empty is itself
 /// informative ("none"), so the section always renders.
 fn render_jobs_section(jobs: &[(String, JobSnapshot)]) -> String {
@@ -3351,13 +3303,13 @@ fn render_jobs_section(jobs: &[(String, JobSnapshot)]) -> String {
             JobState::Running => {
                 format!("running, {}s{}", snap.age.as_secs(), running_beat(&snap.last_progress))
             }
-            JobState::Done(_) => "done — `get` it for the answer".to_string(),
-            JobState::Failed(_) => "failed — `get` it for the reason".to_string(),
+            JobState::Done(_) => "done — `job_get` it for the answer".to_string(),
+            JobState::Failed(_) => "failed — `job_get` it for the reason".to_string(),
             JobState::Canceled => "canceled".to_string(),
         };
         s.push_str(&format!("\n  {id} — {} [{state}]", snap.label));
     }
-    s.push_str("\n\nCollect one with `get <job-id>`; stop one with `cancel <job-id>`.");
+    s.push_str("\n\nCollect one with `job_get <job-id>`; stop one with `job_cancel <job-id>`.");
     s
 }
 
@@ -3606,7 +3558,7 @@ mod tests {
         let recs = vec![crate::mcp_log::LogRecord {
             level: LoggingLevel::Warning,
             target: "kaibo::jobs".into(),
-            message: "async job finished — collect it with `get`".into(),
+            message: "async job finished — collect it with `job_get`".into(),
             fields: serde_json::Map::new(),
         }];
         let out = render_wait(&recs, &[], &jobs, std::time::Duration::from_secs(60));
@@ -3685,7 +3637,7 @@ mod tests {
         }
     }
 
-    /// The `list` recency filter's keep/drop boundary, with `now` pinned so it doesn't
+    /// The `job_list` recency filter's keep/drop boundary, with `now` pinned so it doesn't
     /// depend on the wall clock. `now` = 2026-06-24T18:00:00Z (epoch 1782756000).
     #[test]
     fn batch_recency_window_keeps_recent_and_undateable_drops_old() {
@@ -3770,44 +3722,41 @@ mod tests {
         }
     }
 
-    /// The live roster also lands in the *prose* description — the text a host always
-    /// shows and an agent's tool-picker actually skims — with the default cast flagged.
-    /// This is what lets "have deepseek review" index to a kaibo tool. Driven through a
-    /// keyless local gemini backend and an explicit default so the assertion holds
-    /// regardless of which API keys the test env carries.
+    /// `consult` is the front door: pinning it `anthropic/alwaysLoad` means the calling
+    /// model sees its description even when the host defers tool schemas to names-only,
+    /// with no extra lookup round-trip. `oneshot` is the negative control — it must NOT
+    /// carry the pin, proving the meta is targeted at `consult` alone, not stamped
+    /// server-wide.
     #[test]
-    fn consultation_tools_name_the_live_roster_in_their_description() {
-        let h = handler_from_toml(
-            r#"
-            [server]
-            cast = "myinteractive"
-
-            [backends.gem]
-            kind = "gemini"
-            key_optional = true
-
-            [casts.myinteractive]
-            explorer = "gem/some-lite"
-            synth = "gem/some-flash"
-            "#,
+    fn consult_is_pinned_always_load() {
+        let h = KaiboHandler::new(Config::builtin()).expect("handler builds");
+        let consult_meta = h
+            .tool_router
+            .get("consult")
+            .expect("consult advertised")
+            .meta
+            .clone()
+            .expect("consult must carry _meta");
+        assert_eq!(
+            consult_meta.get("anthropic/alwaysLoad"),
+            Some(&serde_json::Value::Bool(true)),
+            "consult must be pinned resident under schema deferral, got {consult_meta:?}"
         );
-        for tool in ["consult", "consult_submit", "oneshot"] {
-            let desc = h
-                .tool_router
-                .get(tool)
-                .expect("tool advertised")
-                .description
-                .clone()
-                .unwrap_or_default();
-            assert!(
-                desc.contains("Casts ready now:"),
-                "{tool}: description should carry the live roster, got:\n{desc}"
-            );
-            assert!(
-                desc.contains("myinteractive (default)"),
-                "{tool}: description should flag the default cast, got:\n{desc}"
-            );
-        }
+
+        let oneshot_meta = h
+            .tool_router
+            .get("oneshot")
+            .expect("oneshot advertised")
+            .meta
+            .clone();
+        let oneshot_pinned = oneshot_meta
+            .as_ref()
+            .and_then(|m| m.get("anthropic/alwaysLoad"))
+            == Some(&serde_json::Value::Bool(true));
+        assert!(
+            !oneshot_pinned,
+            "only consult should be pinned, but oneshot carries the pin too: {oneshot_meta:?}"
+        );
     }
 
     /// The cast roster splits by lane on the advertised `cast` enums: the interactive
@@ -3946,85 +3895,6 @@ mod tests {
         );
     }
 
-    /// The roster split by lane lands in the prose too — the mirror of
-    /// `cast_enums_split_by_lane`: an interactive tool's description names the interactive
-    /// cast and never a batch cast, and `batch_submit`'s description names the batch cast
-    /// and never an interactive one, so the advertised prose can't tempt an agent toward a
-    /// cast that lane will refuse. Keyless local gemini backend so both lanes are usable
-    /// offline (without it the batch append hits the empty-guard and the split goes
-    /// untested).
-    #[test]
-    fn roster_splits_by_lane_in_descriptions() {
-        let h = handler_from_toml(
-            r#"
-            [backends.gem]
-            kind = "gemini"
-            key_optional = true
-
-            [casts.mybatch]
-            batch = true
-            synth = "gem/some-pro"
-
-            [casts.myinteractive]
-            explorer = "gem/some-lite"
-            synth = "gem/some-flash"
-            "#,
-        );
-        let desc_of = |tool: &str| -> String {
-            h.tool_router
-                .get(tool)
-                .expect("tool advertised")
-                .description
-                .clone()
-                .unwrap_or_default()
-                .into_owned()
-        };
-        for tool in ["consult", "consult_submit", "oneshot"] {
-            let d = desc_of(tool);
-            assert!(
-                d.contains("myinteractive"),
-                "{tool} description should name the interactive cast, got:\n{d}"
-            );
-            assert!(
-                !d.contains("mybatch"),
-                "{tool} description must not name a batch cast, got:\n{d}"
-            );
-        }
-        let batch = desc_of("batch_submit");
-        assert!(
-            batch.contains("mybatch"),
-            "batch_submit description should name the batch cast, got:\n{batch}"
-        );
-        assert!(
-            !batch.contains("myinteractive"),
-            "batch_submit description must not name an interactive cast, got:\n{batch}"
-        );
-    }
-
-    /// `append_cast_roster` shares `inject_cast_enum`'s empty guard: an empty roster (no
-    /// cast can reach a model) leaves the description byte-for-byte untouched, so a
-    /// keyless-everything server never appends a vacuous "Casts ready now: ." to its tools.
-    #[test]
-    fn empty_roster_leaves_descriptions_unchanged() {
-        let mut router = KaiboHandler::tool_router();
-        let desc = |r: &ToolRouter<KaiboHandler>| -> String {
-            r.get("consult")
-                .expect("tool present")
-                .description
-                .clone()
-                .unwrap_or_default()
-                .into_owned()
-        };
-        let before = desc(&router);
-        append_cast_roster(&mut router, &["consult", "oneshot"], &[], &Config::builtin());
-        let after = desc(&router);
-        assert_eq!(before, after, "an empty roster must not alter the description");
-        assert!(
-            !after.contains("Casts ready now"),
-            "an empty roster must not append the roster line:\n{after}"
-        );
-    }
-
     /// A per-model slot `preamble` wins over the global `[prompts].<phase>`, and the
     /// synth slot feeds *both* capable-model phases (the `consult` driver and the
     /// toolless `oneshot`) — the "its own, even if a copy" shape: same value today,
@@ -4107,13 +3977,13 @@ mod tests {
         );
     }
 
-    /// A job's completion ping (a Warn carrying `job=<id>`) sits in the `wait` ring until
-    /// drained. Collecting that job with `get` must retire its ping — otherwise the ping
-    /// lingers and the next `wait` returns on it instantly instead of blocking for new
-    /// work (the "`wait` returns too fast" bug). An *uncollected* job's ping is untouched,
-    /// so it still wakes a later `wait`.
+    /// A job's completion ping (a Warn carrying `job=<id>`) sits in the `job_wait` ring
+    /// until drained. Collecting that job with `job_get` must retire its ping —
+    /// otherwise the ping lingers and the next `job_wait` returns on it instantly
+    /// instead of blocking for new work (the "`job_wait` returns too fast" bug). An
+    /// *uncollected* job's ping is untouched, so it still wakes a later `job_wait`.
     #[tokio::test]
-    async fn get_on_a_terminal_job_retires_its_wait_ping() {
+    async fn job_get_on_a_terminal_job_retires_its_wait_ping() {
         use crate::jobs::JobResult;
         use crate::mcp_log::LogRecord;
         use rmcp::model::LoggingLevel;
@@ -4124,7 +3994,7 @@ mod tests {
             LogRecord {
                 level: LoggingLevel::Warning,
                 target: "kaibo::jobs".into(),
-                message: format!("async job finished — collect it with `get` ({job})"),
+                message: format!("async job finished — collect it with `job_get` ({job})"),
                 fields,
             }
         }
@@ -4143,7 +4013,7 @@ mod tests {
                 report: None,
             })
         });
-        // Both must reach a terminal state before `get` will evict (Running has no ping).
+        // Both must reach a terminal state before `job_get` will evict (Running has no ping).
         for id in [&collected, &other] {
             for _ in 0..1000 {
                 match h.jobs.get(id).map(|s| s.state) {
@@ -4156,14 +4026,14 @@ mod tests {
         h.notifications.push_record(ping(&collected));
         h.notifications.push_record(ping(&other));
 
-        h.get(Parameters(HandleInput {
+        h.job_get(Parameters(HandleInput {
             handle: collected.clone(),
         }))
         .await
-        .expect("get collects the finished job");
+        .expect("job_get collects the finished job");
 
         // The collected job's ping is gone; the uncollected one's survives to wake a
-        // later `wait`.
+        // later `job_wait`.
         let left: Vec<String> = h
             .notifications
             .drain(crate::mcp_log::rank(LoggingLevel::Warning), 20)

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -9,19 +9,20 @@ use kaibo::config::Config;
 use kaibo::server::{KaiboHandler, ToolGating};
 
 /// Every advertised tool, sorted (the order `advertised_tools` returns). `consult` and
-/// `batch` each carry a `*_submit` under their own flag; the collect verbs `get`/
-/// `cancel`/`list`/`wait` are *shared* — they manage both kinds of handle and stay
-/// advertised as long as either capability is on, so they belong to neither flag.
+/// `batch` each carry a `*_submit` under their own flag; the collect verbs `job_get`/
+/// `job_cancel`/`job_list`/`job_wait` are *shared* — they manage both kinds of handle
+/// and stay advertised as long as either capability is on, so they belong to neither
+/// flag.
 const ALL_TOOLS: [&str; 9] = [
     "batch_submit",
-    "cancel",
     "consult",
     "consult_submit",
-    "get",
-    "list",
+    "job_cancel",
+    "job_get",
+    "job_list",
+    "job_wait",
     "oneshot",
     "run_kaish",
-    "wait",
 ];
 
 fn advertised(gating: ToolGating) -> Vec<String> {
@@ -40,13 +41,13 @@ fn default_advertises_all_tools() {
 #[test]
 fn each_flag_removes_exactly_its_own_tools() {
     // Each flag and the tool route(s) it drops *exclusively*. The shared collect verbs
-    // `get`/`cancel`/`list` belong to neither flag alone — gating one capability leaves
-    // them because the other still needs them — so they appear in no row's removed-set
-    // and are covered by the "every other tool remains" check below.
+    // `job_get`/`job_cancel`/`job_list` belong to neither flag alone — gating one
+    // capability leaves them because the other still needs them — so they appear in no
+    // row's removed-set and are covered by the "every other tool remains" check below.
     let cases: [(&[&str], ToolGating); 4] = [
         (
             // `--no-consult` drops the blocking `consult` and the async `consult_submit`;
-            // `get`/`cancel`/`list` stay (batch still uses them).
+            // `job_get`/`job_cancel`/`job_list` stay (batch still uses them).
             &["consult", "consult_submit"],
             ToolGating {
                 consult: false,
@@ -68,8 +69,8 @@ fn each_flag_removes_exactly_its_own_tools() {
             },
         ),
         (
-            // `--no-batch` drops only `batch_submit`; `get`/`cancel`/`list` stay (consult
-            // still uses them).
+            // `--no-batch` drops only `batch_submit`; `job_get`/`job_cancel`/`job_list`
+            // stay (consult still uses them).
             &["batch_submit"],
             ToolGating {
                 batch: false,
@@ -95,12 +96,13 @@ fn each_flag_removes_exactly_its_own_tools() {
     }
 }
 
-/// The shared collect verbs (`get`/`cancel`/`list`) are gated by *either* capability:
-/// they stay while batch or consult is on, and drop only when both are off. A naive
-/// single-flag gate would fail the "stays with the other capability on" cases.
+/// The shared collect verbs (`job_get`/`job_cancel`/`job_list`) are gated by *either*
+/// capability: they stay while batch or consult is on, and drop only when both are
+/// off. A naive single-flag gate would fail the "stays with the other capability on"
+/// cases.
 #[test]
 fn shared_collect_verbs_track_both_capabilities() {
-    const VERBS: [&str; 4] = ["get", "cancel", "list", "wait"];
+    const VERBS: [&str; 4] = ["job_get", "job_cancel", "job_list", "job_wait"];
 
     // consult on, batch off — the verbs still serve consult jobs.
     let consult_only = advertised(ToolGating {


### PR DESCRIPTION
Arc 1 of the model-facing text rework (`docs/desc-and-schema-tuning.md`). One holistic pass over every piece of text kaibo shows the *calling* agent — reviewed as one composition because that's how a caller reads it.

## Why
A caller's-seat audit found the resident handshake and tool surface aren't what we designed for. Claude Code truncates a server's MCP `instructions` at exactly **2048 characters** (measured, per-server, hardcoded), so kaibo's `## Scope` posture — the read-only/containment trust surface — sat *below* the kaish reference and never reached the model. Claude Code also defers tool schemas to names-only, so tool **names** are load-bearing and the instructions double as the tool-search retrieval index.

## What changed
- **Handshake** (`kaish_syntax.rs`): reordered to lead → `## Casts` → `## Scope`, and the kaish onboarding reference **leaves the resident text entirely** (`run_kaish`'s description + the `kaibo://kaish/*` resources carry the shell). Scope now sits above the fold. New **budget test** pins the whole handshake < 2048 chars against a representative 10-cast config (measured **1926**), plus a Scope-ordering test — both failing-first against the old layout. The fresh-install (unconfigured) banner was compressed and is budget-tested too (**1970** < 2048 — it was 2451, which would have truncated Scope on a fresh install).
- **Renames (breaking):** `get`/`list`/`wait`/`cancel` → `job_get`/`job_list`/`job_wait`/`job_cancel`. The `job_` prefix self-namespaces even in hosts that flatten tool names. Blast radius is retrained habits and allowlists (`mcp__kaibo__get` → new name) — worth doing before the audience widens.
- **Descriptions:** all 9 rewritten to open with retrieval keys and **stand alone** (Claude Desktop shows the model no instructions at all), dropping the `kaibo://tools` tails. The "Casts ready now: …" prose roster is gone — the per-lane `cast` param enum is the sole authoritative home. `consult` is pinned resident via `_meta["anthropic/alwaysLoad"]` so the front door is legible even under schema deferral.
- **Schema hygiene:** unresolvable `[ConsultInput]` rustdoc links stripped from shipped input-struct docs.
- **AGENTS.md:** the "Client-facing text" bullet now carries the measured host numbers so every future agent inherits the ceiling.

`explore`/`deliberate` (and their mentions in the lead) intentionally do **not** appear — they ship with their own tools in arc 2. No phantom tools in `tools/list`.

## Review
Cross-family review via kaibo's own `consult` (DeepSeek, run over this worktree, holistic — no diff handed to it). It caught two stray old tool names in `batch.rs` narration, the now-dead onboarding composition, and the untested unconfigured-budget path (which was genuinely over 2048). All folded into the `review:` commit.

## Tests
Full suite green (lib 282 + all integration suites); clippy clean (7 pre-existing warnings, all in untouched files). Renames covered in `tests/gating.rs`; budget/ordering/pin tests are failing-first.