### PR TITLE
Per-slot lane (batch | direct): the config foundation for explore/deliberate

### DIFF
--- a/docs/casts.md
+++ b/docs/casts.md
@@ -193,7 +193,10 @@ is provable with no network.
 `ModelRole`, `ModelSlot`, `ModelCaps`, `ModelShape`, `run_phase`, sessions,
 the sandbox, and path containment. The rewrite is the layer above them. (`ModelRole`
 was later pruned of its production roles — `image`/`tts` — when image generation was
-dropped; see the devlog 2026-06-28 entry.)
+dropped; see the devlog 2026-06-28 entry. `ModelSlot` later gained a `lane` field —
+`Cast` lost its whole-cast `batch: bool` when batch-ness moved to a per-slot
+property, so a cast can pair an interactive explorer with an offline synth; the
+synth slot's lane now classifies the cast, per `docs/config.md`.)
 
 ## Build order / TDD seams
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -316,16 +316,33 @@ synth    = "claude/claude-sonnet-4-6"        # no per-model prompt → [prompts]
 explorer = "gpt/gpt-5-mini"
 synth    = "gpt/gpt-5"
 
-# --- A custom batch cast: the offline `batch_submit` lane (max thinking). `batch = true`
-#     declares it; it needs a synth slot on a batch-capable backend (Anthropic or Gemini)
-#     and runs the synth alone (no explorer). The built-in anthropic-batch / gemini-batch
-#     casts are the same shape. Gemini Pro especially earns this lane: interactively it's
-#     refusal-prone on security framing and 503s under load, but batch sidesteps both — so
-#     reach for Pro batch-only (the built-in `gemini-batch` cast, or a custom one like this). ---
+# --- A custom batch cast: the offline `batch_submit` lane (max thinking). `lane = "batch"`
+#     on the SYNTH SLOT declares it (lane is a per-slot property, not a cast-level one —
+#     it needs a synth slot on a batch-capable backend, Anthropic or Gemini). The built-in
+#     `batch = true` spelling below is backward-compat sugar for exactly this: it sets the
+#     synth slot's lane, nothing more. The built-in anthropic-batch / gemini-batch casts are
+#     the same shape and, like this one, run the synth alone (no explorer) — but that's a
+#     choice, not a rule: a cast MAY pair an interactive explorer with an offline synth (the
+#     `deliberate` shape), since the lane lives on the slot, not the whole cast. Gemini Pro
+#     especially earns this lane: interactively it's refusal-prone on security framing and
+#     503s under load, but batch sidesteps both — so reach for Pro batch-only (the built-in
+#     `gemini-batch` cast, or a custom one like this). ---
 
 [casts.pro-batch]
 batch    = true
 synth    = "gemini/gemini-pro-latest"        # batch-capable synth (Anthropic | Gemini); Pro is batch-only
+# Equivalent, spelled directly on the slot (no cast-level sugar):
+#   synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch" }
+
+# --- The other offline lane, `lane = "direct"`: one long completion kaibo runs itself
+#     against a big LOCAL model (no async provider API, no `batch = true` sugar for this
+#     one — spell it on the slot). Reserved for offline deliberation over a big model that's
+#     too slow to run inside a live tool loop but has no batch endpoint; no tool consumes a
+#     `direct` synth yet, so this cast is forward-declared, not yet callable. ---
+
+[casts.local-direct]
+explorer = "gemma/Gemma-4-E4B-it-GGUF"       # an interactive explorer may sit beside an offline synth
+synth    = { backend = "gemma", id = "Big-Local-70B-GGUF", lane = "direct" }
 
 # ---------------------------------------------------------------------------
 # [context] — "house rules" files spliced into every consultation tool's preamble

--- a/docs/config.md
+++ b/docs/config.md
@@ -205,19 +205,33 @@ The `[defaults]` knobs themselves:
 Four backends and four same-named single-backend casts ship **in code** and
 reproduce kaibo's historical behavior exactly, so a **missing config file is not
 an error**. Two extra built-in casts ship for the offline batch lane —
-`gemini-batch` (synth Gemini Pro) and `anthropic-batch` (synth Claude Opus). Both
-declare `batch = true`, which staffs `batch_submit` *only*: the interactive tools
-(`consult`/`oneshot`) refuse a batch cast, and `batch_submit` refuses a non-batch
-cast, so a big offline-tuned model is never run interactively by accident (and vice
-versa). A batch cast carries **synth only** (batch is toolless) and its synth must
-sit on a batch-capable backend (Anthropic or Gemini) — declaring `batch = true`
-elsewhere is a loud load error. The TOML *merges over* this registry by name: set
-one field on a built-in to retarget it (the `batch` flag is sticky — retuning
-`gemini-batch`'s model leaves it batch), or add brand-new backends and casts. The
+`gemini-batch` (synth Gemini Pro) and `anthropic-batch` (synth Claude Opus). Lane is
+a **per-slot** property, not a cast-level one: each carries a synth slot whose
+`lane = "batch"`, which staffs `batch_submit` *only*: the interactive tools
+(`consult`/`oneshot`) refuse a cast whose synth is on an offline lane, and
+`batch_submit` refuses a cast whose synth isn't specifically `lane = "batch"`, so a
+big offline-tuned model is never run interactively by accident (and vice versa). A
+`batch`-lane synth must sit on a batch-capable backend (Anthropic or Gemini) —
+declaring `lane = "batch"` on a slot elsewhere is a loud load error, and so is a
+lane on an *explorer* slot (the explorer always runs interactively). Because lane
+lives on the slot, a cast MAY pair an interactive explorer with an offline synth —
+the built-in batch casts stay synth-only by choice (batch is toolless, so an
+explorer would be dead weight), not by a rule. `batch = true` at the cast level is
+backward-compat sugar: it sets the synth slot's `lane = "batch"`, nothing more —
+there's exactly one internal representation of lane (the slot field). The TOML
+*merges over* this registry by name: set one field on a built-in to retarget it (a
+slot's `lane` is sticky across a bare re-declaration of its model — retuning
+`gemini-batch`'s id leaves it batch), or add brand-new backends and casts. The
 built-in alias names register at **both** levels — as cast aliases (so
 `cast = "claude"` resolves) and backend aliases (so a slot ref `claude/<id>`
 resolves) — and are reserved: naming a new backend or cast after one is a loud
 collision error.
+
+A second offline lane, `lane = "direct"`, is also validated and rendered: one long
+completion kaibo drives itself against a big *local* model — no async provider API,
+just a slower plain call. It's reserved for offline deliberation over a model too
+slow for a live tool loop; no tool routes to a `direct` synth yet, so declaring one
+today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submit`.
 
 | backend | kind | base_url | key env / file | aliases |
 |---|---|---|---|---|
@@ -226,14 +240,14 @@ collision error.
 | `gemini` | gemini | — | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
 | `openai-local` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
 
-| cast | explorer | synth | batch |
+| cast | explorer | synth | synth lane |
 |---|---|---|---|
 | `anthropic` | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-4-6` | |
 | `deepseek` | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` | |
 | `gemini` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-3.5-flash` | |
 | `openai-local` | `openai-local/Gemma-4-E4B-it-GGUF` | `openai-local/Gemma-4-26B-A4B-it-GGUF` | |
-| `gemini-batch` | — | `gemini/gemini-pro-latest` | ✓ |
-| `anthropic-batch` | — | `anthropic/claude-opus-4-8` | ✓ |
+| `gemini-batch` | — | `gemini/gemini-pro-latest` | `batch` |
+| `anthropic-batch` | — | `anthropic/claude-opus-4-8` | `batch` |
 
 ### The chimera payoff
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -33,8 +33,14 @@ rewritten to the doc's target drafts, `consult` pinned resident via
 enum is the sole roster home), rustdoc cross-refs stripped from shipped schemas, and
 the AGENTS.md client-facing budget guidance.
 
-**Arc 2 — still open (`explore` + `deliberate`):** the config lane reshape first
-(per-slot lane `batch | direct`; today's batch casts become the degenerate case), then
+**Arc 2 — in progress (`explore` + `deliberate`):** the config lane reshape **shipped**
+— `Lane` (`batch | direct`) now lives on `ModelSlot`, not `Cast`; `Cast::batch` is gone;
+`batch = true` is backward-compat sugar normalized onto the synth slot's `lane` at load;
+today's built-in batch casts are the synth-only degenerate case, and a cast may now pair
+an interactive explorer with an offline synth (the `deliberate` shape). `direct` is
+validated, rendered (`kaibo://config`), and load-tested, but forward-declared — no tool
+routes to it yet, so a `direct` cast sits in neither the interactive nor the
+`batch_submit` `cast` enum, and is dropped from the handshake roster. Still open: then
 `explore` (a new `run_phase` composition over `report_preamble` — not a re-mount of the
 RunExplore sub-agent), then `deliberate` (dossier → offline synth, two lanes; the
 two-stage handle crosses the disjoint `job-N` / `backend/provider-id` namespaces — the

--- a/src/config.rs
+++ b/src/config.rs
@@ -1356,10 +1356,11 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
     }
     // The offline batch lane's built-in casts (synth slot `lane = Batch`): staffed by
     // a single big, slow, capable synth — the model whose latency is *free* in batch
-    // but near-unusable interactively. They carry synth only: batch is a toolless
-    // oneshot (no explorer sweep), and the interactive tools that used an explorer now
-    // refuse an offline cast outright, so an explorer slot here would be dead weight
-    // advertising a consult-usability the lane no longer has.
+    // but near-unusable interactively. They carry synth only, because `batch_submit` is
+    // a toolless oneshot (no explorer sweep). A *user* cast may pair an interactive
+    // explorer with an offline synth — that's the `deliberate` shape, valid since the
+    // per-slot lane reshape — but these built-ins have no dossier phase to staff, so an
+    // explorer slot here would just be dead weight.
     //
     // gemini-batch synths Gemini Pro via the `gemini-pro-latest` *alias*, deliberately
     // not a pinned preview id: pinned Pro previews get retired out from under us (a live

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::consult::{ModelCaps, PromptOverrides, ThinkingStyleOverride};
 use crate::context::ContextConfig;
@@ -177,6 +177,48 @@ impl std::str::FromStr for ModelRole {
 
 // --- Slots ------------------------------------------------------------------
 
+/// How a model slot runs. `None` on a slot means interactive (the default — the
+/// synth answers inside a live tool loop). An offline lane returns a handle the
+/// caller collects later:
+/// - `Batch`  — the provider's async batch API (durable `backend/provider-id` handle).
+/// - `Direct` — one long completion kaibo runs itself (a big local model taking the
+///   time it takes); session-scoped `job-N` handle.
+///
+/// Lane lives on the **slot**, not the cast: a `deliberate` cast can pair an
+/// interactive explorer with an offline synth, and the synth slot's lane is what
+/// classifies the whole cast for the batch/interactive tool split (see
+/// [`Config::cast_offline_lane`]). `Direct` is forward-declared here — validated,
+/// parsed, and rendered — but no tool routes to it yet (see `server.rs`
+/// `reject_offline_cast`/the roster split).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Lane {
+    Batch,
+    Direct,
+}
+
+impl std::str::FromStr for Lane {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "batch" => Ok(Self::Batch),
+            "direct" => Ok(Self::Direct),
+            other => Err(anyhow!("lane {other:?} is not one of batch|direct")),
+        }
+    }
+}
+
+impl Lane {
+    /// The TOML spelling (`lane = "…"`), used in load-error messages and the
+    /// `kaibo://config` render.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Batch => "batch",
+            Self::Direct => "direct",
+        }
+    }
+}
+
 /// One entry in a cast's role table: which backend serves it, the model id, plus
 /// per-slot capability pins and tunables. In TOML a slot is a `"backend/model-id"`
 /// string (the common case) or a table (`{ backend = "…", id = "…", vision = true,
@@ -208,6 +250,11 @@ pub struct ModelSlot {
     /// server, winning over the per-phase `[prompts]` and the built-in. `None` →
     /// fall back to those. A per-call model override (a `bare` slot) carries none.
     pub preamble: Option<String>,
+    /// How this slot runs: `None` is interactive (the default), `Some(Lane::Batch)`
+    /// or `Some(Lane::Direct)` is offline — see [`Lane`]. Load validation
+    /// (`Config::merge`) requires a lane to sit on a synth slot; an explorer with a
+    /// lane is a loud error (the explorer always runs interactively).
+    pub lane: Option<Lane>,
 }
 
 impl ModelSlot {
@@ -225,6 +272,7 @@ impl ModelSlot {
             effort: None,
             thinking_style: None,
             preamble: None,
+            lane: None,
         }
     }
 
@@ -438,13 +486,6 @@ pub struct Cast {
     pub name: String,
     /// The role table: which slot serves each [`ModelRole`].
     pub slots: BTreeMap<ModelRole, ModelSlot>,
-    /// Positively declares this cast for the offline batch lane: `batch = true`
-    /// staffs `batch_submit` *only*. Its synth is a big, slow, expensive model tuned
-    /// for free batch latency (Gemini Pro, Claude Opus), so running it through an
-    /// interactive tool loop (`consult`/`oneshot`) is the wrong-and-costly mistake —
-    /// the gate refuses the mix in both directions (`server.rs`). Default `false`
-    /// (interactive); the batch-capable-synth requirement is checked at config load.
-    pub batch: bool,
 }
 
 impl Cast {
@@ -458,6 +499,13 @@ impl Cast {
     pub fn require_slot(&self, role: ModelRole) -> Result<&ModelSlot> {
         self.slot(role)
             .ok_or_else(|| anyhow!("cast {:?} has no {} slot", self.name, role.key()))
+    }
+
+    /// This cast's offline lane, read off its **synth** slot — the synth slot
+    /// classifies the whole cast (an explorer always runs interactively, so its
+    /// lane is never the question). `None` means no synth, or an interactive synth.
+    pub fn synth_lane(&self) -> Option<Lane> {
+        self.slot(ModelRole::Synth).and_then(|s| s.lane)
     }
 }
 
@@ -633,12 +681,19 @@ impl Config {
         ))
     }
 
-    /// Whether `name` (a canonical cast name) is declared for the batch lane. Used to
-    /// partition the live roster onto the right tools' `cast` enums — batch casts to
-    /// `batch_submit`, the rest to the interactive tools. A name not in the registry
-    /// reads as non-batch (the caller already worked from canonical keys).
+    /// The offline lane `name` (a canonical cast name) runs on, read off its synth
+    /// slot (see [`Cast::synth_lane`]). `None` means no synth, or an interactive
+    /// synth. A name not in the registry reads as `None` (the caller already worked
+    /// from canonical keys).
+    pub fn cast_offline_lane(&self, name: &str) -> Option<Lane> {
+        self.casts.get(name).and_then(Cast::synth_lane)
+    }
+
+    /// Whether `name` is declared for the batch lane specifically. Used to partition
+    /// the live roster onto the right tools' `cast` enums — batch casts to
+    /// `batch_submit`, the rest to the interactive tools.
     pub fn cast_is_batch(&self, name: &str) -> bool {
-        self.casts.get(name).is_some_and(|c| c.batch)
+        self.cast_offline_lane(name) == Some(Lane::Batch)
     }
 
     /// Whether canonical cast `name` is the configured default — comparing against the
@@ -919,20 +974,47 @@ impl Config {
             let cast = casts.entry(name.clone()).or_insert_with(|| Cast {
                 name: name.clone(),
                 slots: BTreeMap::new(),
-                batch: false,
             });
-            // `batch` is sticky: omitting it leaves a built-in batch cast batch (so a
-            // file can retune `gemini-batch`'s model without un-batching it); set it
-            // explicitly to declare or clear the lane.
-            if let Some(b) = rc.batch {
-                cast.batch = b;
-            }
             for (role, raw_slot) in rc.slots() {
-                let slot = raw_slot
+                let mut slot = raw_slot
                     .clone()
                     .into_slot()
                     .with_context(|| format!("cast {name:?} {} slot", role.key()))?;
+                // A slot's `lane` is sticky across a bare re-declaration of its model:
+                // retuning `gemini-batch`'s synth id without repeating `lane = "batch"`
+                // must not silently revert it to interactive — mirrors the old
+                // cast-level `batch` flag's stickiness, now scoped to the slot that
+                // actually carries the lane. An explicit `lane` on the new declaration
+                // (or no prior slot at this role) always wins outright.
+                if slot.lane.is_none() {
+                    if let Some(prev) = cast.slots.get(&role) {
+                        slot.lane = prev.lane;
+                    }
+                }
                 cast.slots.insert(role, slot);
+            }
+            // Backward-compat sugar: `batch = true` at cast level normalizes onto the
+            // synth slot's `lane` — there is exactly ONE internal representation of
+            // lane (the slot field); this just translates the old spelling into it.
+            // Applied after the slot merge above so it sees this stanza's synth slot.
+            // `batch = false` (or omitting the key) is a no-op, not a clear — there's no
+            // "un-batch" flag, only the slot's own `lane`.
+            if let Some(true) = rc.batch {
+                let synth = cast.slots.get_mut(&ModelRole::Synth).ok_or_else(|| {
+                    anyhow!(
+                        "cast {name:?}: batch = true needs a synth slot \
+                         (batch_submit runs the synth model)"
+                    )
+                })?;
+                match synth.lane {
+                    None => synth.lane = Some(Lane::Batch),
+                    Some(Lane::Batch) => {} // idempotent
+                    Some(other) => bail!(
+                        "cast {name:?}: `batch = true` conflicts with the synth slot's \
+                         `lane = {:?}`",
+                        other.as_str()
+                    ),
+                }
             }
             for alias in rc.aliases.into_iter().flatten() {
                 cast_file_aliases.push((alias, name.clone()));
@@ -942,7 +1024,7 @@ impl Config {
         // Resolve every slot's backend ref through the alias map (stored canonical),
         // and validate the slot. Unknown backend → loud error naming the known set.
         for cast in casts.values_mut() {
-            let Cast { name, slots, batch } = cast;
+            let Cast { name, slots } = cast;
             for (role, slot) in slots.iter_mut() {
                 if !backends.contains_key(&slot.backend) {
                     match backend_aliases.get(&slot.backend) {
@@ -990,27 +1072,40 @@ impl Config {
                         t.max_tokens
                     );
                 }
-            }
-            // A batch cast is staffed by `batch_submit` — a toolless oneshot on the synth
-            // slot — so it MUST carry a synth slot whose backend actually has a batch API.
-            // Catch the misdeclaration loudly at load (a `batch = true` deepseek cast, say),
-            // not as a baffling refusal or a 400 at submit time.
-            if *batch {
-                let synth = slots.get(&ModelRole::Synth).ok_or_else(|| {
-                    anyhow!(
-                        "cast {name:?}: batch = true needs a synth slot \
-                         (batch_submit runs the synth model)"
-                    )
-                })?;
-                let kind = backends[&synth.backend].kind;
-                if !crate::batch::batch_supported(kind) {
-                    bail!(
-                        "cast {name:?}: batch = true but the synth backend {:?} ({}) has no \
-                         batch API — batch casts must synth a batch-capable backend ({})",
-                        synth.backend,
-                        kind.canonical_name(),
-                        crate::batch::supported_kinds_list(),
-                    );
+                // A slot's lane needs a fitting role and backend, caught here rather
+                // than as a baffling refusal or a 400 at submit/deliberate time. The
+                // explorer always runs interactively (a `deliberate` cast pairs it with
+                // an *offline* synth, never the other way round), so a lane on an
+                // explorer slot is a loud error regardless of kind. `Batch` needs the
+                // provider's own async batch API; `Direct` (kaibo running one long
+                // completion itself) accepts any backend that resolves at all — no
+                // "batch cast must be synth-only" constraint here, so an interactive
+                // explorer may freely sit beside an offline synth (the `deliberate`
+                // shape); the built-in batch casts stay synth-only by construction, not
+                // by a rule enforced here.
+                if let Some(lane) = slot.lane {
+                    if *role != ModelRole::Synth {
+                        bail!(
+                            "cast {name:?}: the {} slot declares lane = {:?}, but only a \
+                             synth slot may run offline — the explorer always runs \
+                             interactively",
+                            role.key(),
+                            lane.as_str()
+                        );
+                    }
+                    if lane == Lane::Batch && !crate::batch::batch_supported(kind) {
+                        bail!(
+                            "cast {name:?}: synth lane = \"batch\" but the synth backend \
+                             {:?} ({}) has no batch API — a batch synth must sit on a \
+                             batch-capable backend ({})",
+                            slot.backend,
+                            kind.canonical_name(),
+                            crate::batch::supported_kinds_list(),
+                        );
+                    }
+                    // `Direct` needs nothing further: the backend already resolved above,
+                    // and a direct completion has no provider-side capability to check —
+                    // it's kaibo driving one ordinary call itself, just slower.
                 }
             }
         }
@@ -1257,21 +1352,14 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
             (ModelRole::Explorer, ModelSlot::bare(&name, explorer)),
             (ModelRole::Synth, ModelSlot::bare(&name, synth)),
         ]);
-        m.insert(
-            name.clone(),
-            Cast {
-                name,
-                slots,
-                batch: false,
-            },
-        );
+        m.insert(name.clone(), Cast { name, slots });
     }
-    // The offline batch lane's built-in casts (`batch = true`): staffed by a single
-    // big, slow, capable synth — the model whose latency is *free* in batch but
-    // near-unusable interactively. They carry synth only: batch is a toolless oneshot
-    // (no explorer sweep), and the interactive tools that used an explorer now refuse a
-    // batch cast outright, so an explorer slot here would be dead weight advertising a
-    // consult-usability the lane no longer has.
+    // The offline batch lane's built-in casts (synth slot `lane = Batch`): staffed by
+    // a single big, slow, capable synth — the model whose latency is *free* in batch
+    // but near-unusable interactively. They carry synth only: batch is a toolless
+    // oneshot (no explorer sweep), and the interactive tools that used an explorer now
+    // refuse an offline cast outright, so an explorer slot here would be dead weight
+    // advertising a consult-usability the lane no longer has.
     //
     // gemini-batch synths Gemini Pro via the `gemini-pro-latest` *alias*, deliberately
     // not a pinned preview id: pinned Pro previews get retired out from under us (a live
@@ -1284,9 +1372,11 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
             name: gemini_batch,
             slots: BTreeMap::from([(
                 ModelRole::Synth,
-                ModelSlot::bare("gemini", "gemini-pro-latest"),
+                ModelSlot {
+                    lane: Some(Lane::Batch),
+                    ..ModelSlot::bare("gemini", "gemini-pro-latest")
+                },
             )]),
-            batch: true,
         },
     );
     // anthropic-batch synths Claude Opus — the Anthropic analogue of Gemini Pro, the big
@@ -1300,9 +1390,11 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
             name: anthropic_batch,
             slots: BTreeMap::from([(
                 ModelRole::Synth,
-                ModelSlot::bare("anthropic", "claude-opus-4-8"),
+                ModelSlot {
+                    lane: Some(Lane::Batch),
+                    ..ModelSlot::bare("anthropic", "claude-opus-4-8")
+                },
             )]),
-            batch: true,
         },
     );
     m
@@ -1552,9 +1644,12 @@ impl RawBackend {
 #[serde(deny_unknown_fields)]
 struct RawCast {
     aliases: Option<Vec<String>>,
-    /// Declares the cast for the offline batch lane (`batch_submit` only). Absent
-    /// reads as `false` for a fresh cast; on a built-in batch cast it's omitted to
-    /// keep the existing flag, set explicitly to flip it. See [`Cast::batch`].
+    /// Backward-compat sugar for the synth slot's `lane = "batch"` (`batch_submit`
+    /// only). `Some(true)` normalizes onto the synth slot's [`Lane`] at merge time —
+    /// see the cast-merge loop in [`Config::merge`]; there is exactly one internal
+    /// representation of lane (the slot field), this is purely an input spelling.
+    /// `Some(false)` and absent are both no-ops — there is no "un-batch" flag, only
+    /// the slot's own `lane`.
     batch: Option<bool>,
     explorer: Option<RawSlot>,
     synth: Option<RawSlot>,
@@ -1619,6 +1714,10 @@ struct RawSlotTable {
     effort: Option<String>,
     thinking_style: Option<String>,
     preamble: Option<String>,
+    /// How this slot runs — `"batch"` or `"direct"`; absent means interactive. See
+    /// [`Lane`]. Only meaningful on a synth slot; an explorer slot with a lane is a
+    /// loud load error (checked in `Config::merge`, after backend resolution).
+    lane: Option<String>,
 }
 
 impl RawSlot {
@@ -1646,6 +1745,7 @@ impl RawSlot {
                     .map(str::parse)
                     .transpose()
                     .context("thinking_style")?,
+                lane: t.lane.as_deref().map(str::parse).transpose().context("lane")?,
                 // Same loud-on-empty rule as `[prompts]`: a blank per-model prompt
                 // is never intended, and silently running it would strip the role
                 // framing with no signal. Drop the key to fall back.
@@ -2433,15 +2533,16 @@ mod tests {
     }
 
     /// All four interactive built-in casts exist, each single-backend with
-    /// explorer+synth, and none is flagged for the batch lane.
+    /// explorer+synth, and none has a synth on an offline lane.
     #[test]
     fn all_four_builtin_casts_resolve() {
         let cfg = Config::builtin();
         for name in ["anthropic", "deepseek", "gemini", "openai-local"] {
             let cast = cfg.resolve_cast(name).unwrap();
-            assert!(
-                !cast.batch,
-                "interactive built-in {name:?} must not be a batch cast"
+            assert_eq!(
+                cast.synth_lane(),
+                None,
+                "interactive built-in {name:?} must have an interactive synth"
             );
             for role in [ModelRole::Explorer, ModelRole::Synth] {
                 let slot = cast.require_slot(role).unwrap();
@@ -2450,16 +2551,20 @@ mod tests {
         }
     }
 
-    /// The built-in batch casts positively declare `batch = true`, carry **synth only**
-    /// (batch is a toolless oneshot — an explorer slot would be dead weight), and synth a
-    /// batch-capable backend. Pins the lane's shape so an accidental explorer slot or a
-    /// dropped flag fails here.
+    /// The built-in batch casts' synth slots positively declare `lane = Batch`, carry
+    /// **synth only** (batch is a toolless oneshot — an explorer slot would be dead
+    /// weight), and synth a batch-capable backend. Pins the lane's shape so an
+    /// accidental explorer slot or a dropped lane fails here.
     #[test]
     fn builtin_batch_casts_are_synth_only_and_flagged() {
         let cfg = Config::builtin();
         for (name, backend) in [("gemini-batch", "gemini"), ("anthropic-batch", "anthropic")] {
             let cast = cfg.resolve_cast(name).unwrap();
-            assert!(cast.batch, "{name:?} must declare batch = true");
+            assert_eq!(
+                cast.synth_lane(),
+                Some(Lane::Batch),
+                "{name:?} must declare its synth slot's lane = batch"
+            );
             assert!(
                 cast.slot(ModelRole::Explorer).is_none(),
                 "{name:?} is a batch cast — toolless, so it carries no explorer slot"
@@ -2511,9 +2616,10 @@ mod tests {
         );
     }
 
-    /// `batch` round-trips from `[casts.<name>]`: a fresh cast defaults non-batch, an
-    /// explicit `batch = true` (on a batch-capable synth) declares the lane, and the flag
-    /// is sticky over a built-in — retuning `gemini-batch`'s model leaves it batch.
+    /// `batch` round-trips from `[casts.<name>]`: a fresh cast defaults interactive, an
+    /// explicit `batch = true` (on a batch-capable synth) sets the synth slot's
+    /// `lane = Batch`, and it's sticky over a built-in — retuning `gemini-batch`'s model
+    /// (a bare re-declaration, no `lane` repeated) leaves the synth slot batch.
     #[test]
     fn batch_flag_parses_defaults_false_and_is_sticky() {
         let cfg = Config::from_toml_str(
@@ -2530,23 +2636,134 @@ mod tests {
             "#,
         )
         .unwrap();
-        assert!(
-            !cfg.resolve_cast("fresh").unwrap().batch,
-            "absent batch ⇒ false"
+        assert_eq!(
+            cfg.resolve_cast("fresh").unwrap().synth_lane(),
+            None,
+            "absent batch ⇒ interactive synth"
         );
-        assert!(
-            cfg.resolve_cast("declared").unwrap().batch,
-            "batch = true ⇒ true"
+        assert_eq!(
+            cfg.resolve_cast("declared").unwrap().synth_lane(),
+            Some(Lane::Batch),
+            "batch = true ⇒ synth lane = batch"
         );
         let gb = cfg.resolve_cast("gemini-batch").unwrap();
-        assert!(
-            gb.batch,
-            "retuning a built-in batch cast leaves it batch (sticky)"
+        assert_eq!(
+            gb.synth_lane(),
+            Some(Lane::Batch),
+            "retuning a built-in batch cast's synth id leaves its lane batch (sticky)"
         );
         assert_eq!(
             gb.require_slot(ModelRole::Synth).unwrap().id,
             "gemini-3-pro-preview",
             "the file override reached the synth slot"
+        );
+    }
+
+    /// A slot table's `lane = "direct"` parses to `Some(Lane::Direct)` — the offline,
+    /// non-batch lane for a big local model kaibo runs itself.
+    #[test]
+    fn slot_lane_direct_parses() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.mydirect]
+            synth = { backend = "openai-local", id = "big-local-model", lane = "direct" }
+            "#,
+        )
+        .unwrap();
+        let cast = cfg.resolve_cast("mydirect").unwrap();
+        assert_eq!(cast.synth_lane(), Some(Lane::Direct));
+    }
+
+    /// A slot table's `lane = "batch"` parses and validates cleanly on a batch-capable
+    /// backend — the table-form spelling of the same lane the `batch = true` sugar sets.
+    #[test]
+    fn slot_lane_batch_parses_and_validates() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.mybatch]
+            synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch" }
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.resolve_cast("mybatch").unwrap().synth_lane(),
+            Some(Lane::Batch)
+        );
+    }
+
+    /// `batch = true` conflicting with an explicit, different synth `lane` is a loud
+    /// load error naming the cast and both lanes — silently picking one would run the
+    /// wrong lane's tool against the operator's actual intent.
+    #[test]
+    fn batch_sugar_conflicting_with_explicit_direct_lane_is_a_load_error() {
+        let err = Config::from_toml_str(
+            r#"
+            [casts.bad]
+            batch = true
+            synth = { backend = "openai-local", id = "m", lane = "direct" }
+            "#,
+        )
+        .expect_err("batch = true conflicting with an explicit lane = direct must not load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("bad") && msg.contains("batch") && msg.contains("direct"),
+            "load error must name the cast and both conflicting lanes, got: {msg}"
+        );
+    }
+
+    /// A cast may pair an interactive explorer with an offline (`batch`) synth — the
+    /// `deliberate` shape this reshape exists to enable. Dropped the old "batch casts
+    /// are synth-only" constraint at validation: the built-in batch casts stay
+    /// synth-only by construction, but a custom cast may add an explorer.
+    #[test]
+    fn interactive_explorer_with_batch_synth_is_legal() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.mydeliberate]
+            explorer = "anthropic/claude-haiku-4-5"
+            synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch" }
+            "#,
+        )
+        .unwrap();
+        let cast = cfg.resolve_cast("mydeliberate").unwrap();
+        assert_eq!(cast.synth_lane(), Some(Lane::Batch));
+        assert!(cast.slot(ModelRole::Explorer).is_some());
+    }
+
+    /// A `lane` on an EXPLORER slot is a loud load error: the explorer always runs
+    /// interactively, so declaring it offline is a misdeclaration, not a valid shape.
+    #[test]
+    fn lane_on_explorer_slot_is_a_load_error() {
+        let err = Config::from_toml_str(
+            r#"
+            [casts.bad]
+            explorer = { backend = "gemini", id = "m", lane = "batch" }
+            synth = "gemini/gemini-pro-latest"
+            "#,
+        )
+        .expect_err("a lane on the explorer slot must not load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("bad") && msg.contains("explorer"),
+            "load error must name the cast and the explorer slot, got: {msg}"
+        );
+    }
+
+    /// A bad `lane` value is a clear parse error naming the valid spellings —
+    /// same discipline as `thinking_style`.
+    #[test]
+    fn bad_lane_value_is_a_clear_parse_error() {
+        let err = Config::from_toml_str(
+            r#"
+            [casts.bad]
+            synth = { backend = "gemini", id = "m", lane = "sideways" }
+            "#,
+        )
+        .expect_err("an unknown lane value must not load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("sideways") && msg.contains("batch") && msg.contains("direct"),
+            "parse error must name the bad value and the valid ones, got: {msg}"
         );
     }
 

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -23,7 +23,7 @@ use kaish_kernel::help::{
 };
 use kaish_kernel::tools::ToolSchema;
 
-use crate::config::{CastUsability, Config, ModelRole};
+use crate::config::{CastUsability, Config, Lane, ModelRole};
 
 /// The kaibo-specific half of the core: the read-only boundary, the exit-code
 /// contract, the no-cwd rule, and the line-number idioms that make citations
@@ -190,6 +190,12 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
     }
     let lines: String = usable
         .iter()
+        // A `direct`-lane cast is forward-declared (validated, rendered on
+        // `kaibo://config`) but no tool consumes it yet — the same reason it's absent
+        // from both `inject_cast_enum` partitions in `server.rs`. Advertising it here
+        // would name a cast every tool refuses, so drop it from the roster until a
+        // tool routes to it.
+        .filter(|(name, _)| config.cast_offline_lane(name) != Some(Lane::Direct))
         .map(|(name, state)| {
             let mut tags = Vec::new();
             if config.is_default_cast(name) {
@@ -608,6 +614,43 @@ mod tests {
         );
     }
 
+    /// A `direct`-lane cast is forward-declared (validated, rendered on
+    /// `kaibo://config`) but no tool routes to it yet, so the handshake roster must not
+    /// advertise it — an agent reading `## Casts` should never see a cast every tool
+    /// refuses. Mirrors the `direct`-lane exclusion from both `inject_cast_enum`
+    /// partitions in `server.rs`.
+    #[test]
+    fn casts_section_excludes_a_direct_lane_cast() {
+        let config = Config::from_toml_str(
+            r#"
+            [casts.mydirect]
+            synth = { backend = "openai-local", id = "big-local-model", lane = "direct" }
+            "#,
+        )
+        .unwrap();
+        let usable = vec![
+            ("anthropic".to_string(), CastUsability::Ready),
+            ("mydirect".to_string(), CastUsability::LocalUnverified),
+        ];
+        let text = kaibo_instructions_with_scope(
+            &config,
+            &[PathBuf::from("/tmp")],
+            None,
+            false,
+            CastUsability::Ready,
+            &usable,
+        );
+        assert!(
+            text.contains("anthropic"),
+            "the interactive cast must still render:\n{text}"
+        );
+        assert!(
+            !text.contains("mydirect"),
+            "a direct-lane cast must not appear in the roster (no tool routes to it \
+             yet):\n{text}"
+        );
+    }
+
     /// The `(default)` tag survives a default cast set by *alias*. `usable_casts`
     /// yields canonical names (`anthropic`), but an operator may write
     /// `server.cast = "claude"` (an alias) — a raw `name == default_cast` would compare
@@ -722,7 +765,6 @@ mod tests {
                         ModelRole::Synth,
                         ModelSlot::bare(backend, id),
                     )]),
-                    batch: false,
                 },
             );
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tracing::Instrument;
 
-use crate::config::{Backend, Cast, Config, ModelRole, ModelSlot};
+use crate::config::{Backend, Cast, Config, Lane, ModelRole, ModelSlot};
 use crate::consult::{
     Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides, consult, oneshot,
 };
@@ -520,13 +520,21 @@ impl KaiboHandler {
             .into_iter()
             .map(|(name, _)| name)
             .collect();
-        // A batch cast (`batch = true`) staffs `batch_submit` *only*, so the rosters split
-        // by lane: the interactive tools advertise the non-batch casts, `batch_submit`
-        // advertises the batch ones. The gate enforces the same split at call time; this
-        // just keeps the advertised menu honest so an agent doesn't pick a cast its tool
-        // will refuse.
-        let (batch_usable, interactive_usable): (Vec<String>, Vec<String>) =
-            usable.into_iter().partition(|n| config.cast_is_batch(n));
+        // A cast's synth lane (`Config::cast_offline_lane`, read off the synth slot)
+        // splits the roster three ways: interactive (no lane) → consult/consult_submit/
+        // oneshot; `Batch` → batch_submit; `Direct` → *neither* — it's forward-declared
+        // (validated, rendered) but no tool consumes an offline-direct synth yet, so it
+        // would silently pass either gate's schema without a route. A future PR adds its
+        // tool and this three-way split gains a third `inject_cast_enum` call. The gate
+        // enforces the same split at call time; this just keeps the advertised menu
+        // honest so an agent doesn't pick a cast its tool will refuse.
+        let (interactive_usable, offline_usable): (Vec<String>, Vec<String>) = usable
+            .into_iter()
+            .partition(|n| config.cast_offline_lane(n).is_none());
+        let batch_usable: Vec<String> = offline_usable
+            .into_iter()
+            .filter(|n| config.cast_is_batch(n))
+            .collect();
         inject_cast_enum(
             &mut tool_router,
             &["consult", "consult_submit", "oneshot"],
@@ -1121,44 +1129,65 @@ impl KaiboHandler {
             .map_err(|e| McpError::invalid_params(e.to_string(), None))
     }
 
-    /// Refuse an interactive tool (`consult`/`consult_submit`/`oneshot`) on a batch cast.
-    /// A `batch = true` cast's synth is a big, slow, expensive model
-    /// tuned for free offline batch latency (Gemini Pro, Claude Opus); driving it through
-    /// an interactive tool loop is the wrong-and-costly mistake this gate exists to stop.
-    /// Points the caller at the lane that fits.
-    fn reject_batch_cast(&self, cast: &Cast, tool: &str) -> Result<(), McpError> {
-        if cast.batch {
-            return Err(McpError::invalid_params(
+    /// Refuse an interactive tool (`consult`/`consult_submit`/`oneshot`) on a cast whose
+    /// synth runs on an offline lane. A `Batch` synth is a big, slow, expensive model
+    /// tuned for free offline batch latency (Gemini Pro, Claude Opus); a `Direct` synth
+    /// is a big local model kaibo runs itself, taking the time it takes — either way,
+    /// driving it through an interactive tool loop is the wrong-and-costly mistake this
+    /// gate exists to stop. Points the caller at the lane that fits.
+    fn reject_offline_cast(&self, cast: &Cast, tool: &str) -> Result<(), McpError> {
+        match cast.synth_lane() {
+            Some(Lane::Batch) => Err(McpError::invalid_params(
                 format!(
-                    "cast `{}` is a batch cast (batch = true) — submit it with `batch_submit`, \
-                     not `{tool}`. Its synth is a big, slow model tuned for free offline batch \
-                     latency; running it interactively would be slow and expensive. Pick a \
-                     non-batch cast for `{tool}`.",
+                    "cast `{}`'s synth runs on the `batch` lane — submit it with \
+                     `batch_submit`, not `{tool}`. It's a big, slow model tuned for free \
+                     offline batch latency; running it interactively would be slow and \
+                     expensive. Pick an interactive cast for `{tool}`.",
                     cast.name
                 ),
                 None,
-            ));
+            )),
+            Some(Lane::Direct) => Err(McpError::invalid_params(
+                format!(
+                    "cast `{}`'s synth runs offline (`lane = \"direct\"`) — interactive \
+                     tools need an interactive synth. Pick an interactive cast for `{tool}`.",
+                    cast.name
+                ),
+                None,
+            )),
+            None => Ok(()),
         }
-        Ok(())
     }
 
-    /// Refuse `batch_submit` on a non-batch cast — the other half of the lane split. A
-    /// batch cast must positively declare `batch = true`, so an ordinary interactive cast
-    /// is never silently batched (an accidental Opus/Pro batch is just as costly the other
-    /// way). Points the caller at the built-in batch casts.
+    /// Refuse `batch_submit` on a cast whose synth isn't on the `batch` lane
+    /// specifically — the other half of the lane split. A batch cast must positively
+    /// declare `lane = "batch"` on its synth slot, so an ordinary interactive cast is
+    /// never silently batched (an accidental Opus/Pro batch is just as costly the other
+    /// way), and a `direct` cast — offline, but not batch — gets its own honest
+    /// message rather than the generic "not a batch cast" one. Points the caller at
+    /// the built-in batch casts.
     fn require_batch_cast(&self, cast: &Cast) -> Result<(), McpError> {
-        if !cast.batch {
-            return Err(McpError::invalid_params(
+        match cast.synth_lane() {
+            Some(Lane::Batch) => Ok(()),
+            Some(Lane::Direct) => Err(McpError::invalid_params(
                 format!(
-                    "cast `{}` is not a batch cast — `batch_submit` needs a cast that declares \
-                     `batch = true` (the built-ins `gemini-batch`, `anthropic-batch`, or your \
-                     own in config.toml). For an interactive answer, use `consult`/`oneshot`.",
+                    "cast `{}`'s synth runs on the `direct` lane, not `batch` — \
+                     `batch_submit` needs a synth slot with `lane = \"batch\"`.",
                     cast.name
                 ),
                 None,
-            ));
+            )),
+            None => Err(McpError::invalid_params(
+                format!(
+                    "cast `{}` is not a batch cast — `batch_submit` needs a cast whose synth \
+                     slot declares `lane = \"batch\"` (the built-ins `gemini-batch`, \
+                     `anthropic-batch`, or your own in config.toml). For an interactive \
+                     answer, use `consult`/`oneshot`.",
+                    cast.name
+                ),
+                None,
+            )),
         }
-        Ok(())
     }
 
     /// Apply a per-call model override to one of `cast`'s slots.
@@ -1277,7 +1306,7 @@ impl KaiboHandler {
         // Resolve the cast, layer per-call model overrides onto the clone, then
         // resolve each phase's slot into its own arm (client + request shape).
         let mut cast = self.resolve_cast(input.cast)?;
-        self.reject_batch_cast(&cast, "consult")?;
+        self.reject_offline_cast(&cast, "consult")?;
         self.apply_model_override(
             &mut cast,
             ModelRole::Explorer,
@@ -1389,7 +1418,7 @@ impl KaiboHandler {
         // refusable work (bad cast, bad path, missing key) happens *here*, synchronously,
         // so a bad submit is a clean error, not a job that fails on poll.
         let mut cast = self.resolve_cast(input.cast)?;
-        self.reject_batch_cast(&cast, "consult_submit")?;
+        self.reject_offline_cast(&cast, "consult_submit")?;
         self.apply_model_override(
             &mut cast,
             ModelRole::Explorer,
@@ -1512,7 +1541,7 @@ impl KaiboHandler {
         meta: Meta,
     ) -> Result<CallToolResult, McpError> {
         let mut cast = self.resolve_cast(input.cast)?;
-        self.reject_batch_cast(&cast, "oneshot")?;
+        self.reject_offline_cast(&cast, "oneshot")?;
         self.apply_model_override(
             &mut cast,
             ModelRole::Synth,
@@ -2735,6 +2764,10 @@ fn render_config_resource(
         /// operator's own framing). Absent when unset.
         #[serde(skip_serializing_if = "Option::is_none")]
         preamble: Option<String>,
+        /// How this slot runs — `"batch"` or `"direct"`; absent (the common case)
+        /// means interactive. Only ever set on a synth slot (load-validated).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        lane: Option<&'static str>,
         /// Per-slot tunables that *are* set here but this slot's resolved request shape
         /// will never send — the honest no-op flag. A `thinking_budget` on an
         /// effort-driven or toggle-less model, an `effort` on a budget model, a
@@ -2800,6 +2833,7 @@ fn render_config_resource(
                         effort,
                         thinking_style,
                         preamble,
+                        lane,
                     } = slot;
                     let caps = config
                         .slot_caps(slot)
@@ -2834,6 +2868,7 @@ fn render_config_resource(
                             effort: effort.clone(),
                             thinking_style: thinking_style.map(|s| format!("{s:?}").to_lowercase()),
                             preamble: preamble.clone(),
+                            lane: lane.map(Lane::as_str),
                             inert_tunables,
                         },
                     )
@@ -3760,15 +3795,17 @@ mod tests {
 
     /// The cast roster splits by lane on the advertised `cast` enums: the interactive
     /// tools list non-batch casts, `batch_submit` lists batch casts — so an agent reading
-    /// the schema never offers a cast the tool will refuse. Driven through a keyless local
-    /// gemini backend so both a batch and an interactive cast are usable regardless of
-    /// which API keys the test env carries.
+    /// the schema never offers a cast the tool will refuse. A `direct`-lane cast belongs
+    /// to neither enum yet — it's forward-declared (validated, rendered) but no tool
+    /// routes to it (see the roster-split comment in `KaiboHandler::new`). Driven through
+    /// a keyless local gemini backend so all three casts are usable regardless of which
+    /// API keys the test env carries.
     #[test]
     fn cast_enums_split_by_lane() {
         let h = handler_from_toml(
             r#"
-            # A keyless (placeholder) batch-capable backend so both casts are "usable"
-            # offline — the partition is exercised with teeth, not trivially empty.
+            # A keyless (placeholder) batch-capable backend so all three casts are
+            # "usable" offline — the partition is exercised with teeth, not trivially empty.
             [backends.gem]
             kind = "gemini"
             key_optional = true
@@ -3780,6 +3817,9 @@ mod tests {
             [casts.myinteractive]
             explorer = "gem/some-lite"
             synth = "gem/some-flash"
+
+            [casts.mydirect]
+            synth = { backend = "gem", id = "some-big-local", lane = "direct" }
             "#,
         );
         let enum_of = |tool: &str| -> Vec<String> {
@@ -3808,6 +3848,11 @@ mod tests {
                 !casts.iter().any(|c| c == "mybatch"),
                 "{tool} enum must not list a batch cast, got {casts:?}"
             );
+            assert!(
+                !casts.iter().any(|c| c == "mydirect"),
+                "{tool} enum must not list a direct-lane cast (no tool routes to it \
+                 yet), got {casts:?}"
+            );
         }
         let batch = enum_of("batch_submit");
         assert!(
@@ -3818,26 +3863,50 @@ mod tests {
             !batch.iter().any(|c| c == "myinteractive"),
             "batch_submit enum must not list an interactive cast, got {batch:?}"
         );
+        assert!(
+            !batch.iter().any(|c| c == "mydirect"),
+            "batch_submit enum must not list a direct-lane cast, got {batch:?}"
+        );
     }
 
-    /// The lane gate's two halves, tested directly: an interactive tool refuses a batch
-    /// cast (naming the cast and `batch_submit`), and `batch_submit` refuses a non-batch
-    /// cast — while each accepts the cast that fits its lane.
+    /// The lane gate's two halves, tested directly: an interactive tool refuses an
+    /// offline cast (batch OR direct, naming the cast and the right route), and
+    /// `batch_submit` refuses both a non-batch (interactive) cast and a `direct` cast
+    /// with a distinct honest message — while each accepts the cast that fits its lane.
     #[test]
     fn lane_gate_refuses_the_wrong_lane() {
-        let h = handler();
+        let h = handler_from_toml(
+            r#"
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.mydirect]
+            synth = { backend = "gem", id = "some-big-local", lane = "direct" }
+            "#,
+        );
         let batch = h.config.resolve_cast("gemini-batch").unwrap().clone();
+        let direct = h.config.resolve_cast("mydirect").unwrap().clone();
         let interactive = h.config.resolve_cast("anthropic").unwrap().clone();
 
         let err = h
-            .reject_batch_cast(&batch, "consult")
+            .reject_offline_cast(&batch, "consult")
             .expect_err("an interactive tool must refuse a batch cast");
         let msg = format!("{err:?}");
         assert!(
             msg.contains("gemini-batch") && msg.contains("batch_submit"),
             "refusal should name the cast and point at batch_submit, got: {msg}"
         );
-        assert!(h.reject_batch_cast(&interactive, "consult").is_ok());
+
+        let err = h
+            .reject_offline_cast(&direct, "consult")
+            .expect_err("an interactive tool must refuse a direct cast too");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("mydirect") && msg.contains("direct"),
+            "refusal should name the cast and its lane, got: {msg}"
+        );
+        assert!(h.reject_offline_cast(&interactive, "consult").is_ok());
 
         let err = h
             .require_batch_cast(&interactive)
@@ -3845,6 +3914,15 @@ mod tests {
         assert!(
             format!("{err:?}").contains("not a batch cast"),
             "refusal should explain the cast isn't a batch cast"
+        );
+
+        let err = h
+            .require_batch_cast(&direct)
+            .expect_err("batch_submit must refuse a direct-lane cast, not treat it as batch");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("mydirect") && msg.contains("direct") && msg.contains("batch"),
+            "refusal should name the cast and explain it's direct, not batch, got: {msg}"
         );
         assert!(h.require_batch_cast(&batch).is_ok());
     }

--- a/tests/attach.rs
+++ b/tests/attach.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::path::Path;
 
 use kaibo::attach::Attachment;
-use kaibo::config::{Cast, Config, ModelRole, ModelSlot};
+use kaibo::config::{Cast, Config, Lane, ModelRole, ModelSlot};
 use kaibo::server::{BatchSubmitInput, KaiboHandler};
 use rmcp::handler::server::wrapper::Parameters;
 use tempfile::tempdir;
@@ -227,17 +227,17 @@ async fn image_attachment_to_blind_synth_is_refused() {
     config.root = Some(root.path().to_path_buf());
     let mut slot = ModelSlot::bare("anthropic", "claude-sonnet-4-6");
     slot.vision = Some(false);
+    // `lane = Some(Batch)`: this exercises `batch_submit`, which now refuses a
+    // non-batch cast before the vision gate. Anthropic is batch-capable, so the cast
+    // is valid; the vision pin is what we're actually testing here.
+    slot.lane = Some(Lane::Batch);
     let mut slots = BTreeMap::new();
     slots.insert(ModelRole::Synth, slot);
     config.casts.insert(
         "blindcast".to_string(),
-        // `batch = true`: this exercises `batch_submit`, which now refuses a non-batch
-        // cast before the vision gate. Anthropic is batch-capable, so the cast is valid;
-        // the vision pin is what we're actually testing here.
         Cast {
             name: "blindcast".to_string(),
             slots,
-            batch: true,
         },
     );
     let handler = KaiboHandler::new(config).expect("handler builds");


### PR DESCRIPTION
Arc 2 PR-1 of `docs/desc-and-schema-tuning.md`. Reshapes "batch-ness" from a whole-cast boolean into a per-slot lane so a cast can pair an *interactive* explorer with an *offline* synth — the shape `deliberate` needs.

## What changed
- `Lane { Batch, Direct }` now lives on `ModelSlot` (`lane: Option<Lane>`, `None` = interactive). The **synth** slot's lane classifies the cast. `Cast::batch` is gone — one internal representation of lane (the slot field).
- **`Batch`** = the provider's async batch API (durable `backend/provider-id` handle). **`Direct`** = one long completion kaibo runs itself (a big local model taking the time it takes; session-scoped `job-N`). `Direct` is **forward-declared**: validated, rendered at `kaibo://config`, load-tested — but no tool routes to it yet (deliberate lands next), so a direct cast sits in neither the interactive nor the batch `cast` enum and is dropped from the handshake roster.
- **Backward compatible:** `batch = true` at cast level is now sugar, normalized onto the synth slot's lane at load (a conflict with an explicit slot `lane` is a loud error). Existing configs load identically; the sticky-lane behavior preserves a built-in batch cast's lane when you retune its model via a bare ref. A slot table can now say `lane = "batch"|"direct"`.
- **Validation is per-slot:** a lane on an *explorer* slot is refused (the explorer always runs interactively); a `Batch` synth needs a batch-capable backend (as before); a `Direct` synth needs any resolvable backend. The old "a batch cast must be synth-only" rule is dropped — an interactive explorer may now sit beside an offline synth (the deliberate shape).
- Gates/roster follow the synth lane: `reject_batch_cast` → `reject_offline_cast` (distinct honest messages for batch vs direct), `batch_submit` requires `lane = "batch"` specifically, the `cast` enum splits three ways, and `kaibo://config` now surfaces each slot's lane.
- Docs (`config.md`, `casts.md`, `config.example.toml`) updated for the per-slot lane; `docs/issues.md` records PR-1.

## Review
Cross-family via kaibo's own `consult` (DeepSeek, holistic over this worktree). Verdict: solid — the three-way split is airtight, no lane leaks into the wrong bucket, no config path silently loses a lane, backward compat preserved. It flagged one stale comment (fixed in the `review:` commit) and a test-coverage nicety (explorer-only override of a built-in batch cast) best added alongside the deliberate tool that exercises it.

## Tests
Full suite green (289 lib + all integration); clippy clean (7 pre-existing warnings, unchanged). 9 new/migrated config tests cover lane parsing, the `batch = true` sugar + conflict, the deliberate-shaped cast, explorer-lane refusal, and the three-way enum split; teeth verified by neutering checks and watching the tests fail.