### PR TITLE
explore: the evidence-gathering half of consult, as its own tool (Arc 2 PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ the git log. Each later release appends a new section at the top.
   job emits a soft notification on the MCP logging channel (a clue for a client watching
   the log stream) — advisory only, since no MCP primitive wakes the calling agent;
   collecting by handle stays the contract.
+- **`explore`** — the evidence-gathering half of `consult`, exposed on its own: a fast,
+  cheap explorer model sweeps the project READ-ONLY and hands back the *cited report
+  itself* — a summary of findings, the relevant `file:line` locations, and the trail it
+  followed — with no synthesis on top. Reach for it to map unfamiliar code, or to build a
+  grounded survey you'll reason over yourself (or feed to another model), when you want the
+  map rather than the conclusion. It reads the repo itself like `consult`, so it takes the
+  same `path` / `cast` / `explorer_model` (+ `explorer_backend`) / `explorer_max_turns`
+  arguments; being single-phase, it has no synth args, `attach`, `context`, or `session_id`.
+  The report carries the same provenance footer, naming the cast and the explorer that
+  surveyed. Gated independently by `--no-explore`. For a synthesized answer, use `consult`.
 - **`oneshot`** — a thin, direct second opinion from a model outside your family:
   prompt in, answer out, no codebase access and no tools, exactly one upstream
   request. The counterpart to `consult` for when you already own the context (you've

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -33,21 +33,31 @@ rewritten to the doc's target drafts, `consult` pinned resident via
 enum is the sole roster home), rustdoc cross-refs stripped from shipped schemas, and
 the AGENTS.md client-facing budget guidance.
 
-**Arc 2 — in progress (`explore` + `deliberate`):** the config lane reshape **shipped**
-— `Lane` (`batch | direct`) now lives on `ModelSlot`, not `Cast`; `Cast::batch` is gone;
+**Arc 2 — in progress (`deliberate` remains):** the config lane reshape **shipped** —
+`Lane` (`batch | direct`) now lives on `ModelSlot`, not `Cast`; `Cast::batch` is gone;
 `batch = true` is backward-compat sugar normalized onto the synth slot's `lane` at load;
 today's built-in batch casts are the synth-only degenerate case, and a cast may now pair
 an interactive explorer with an offline synth (the `deliberate` shape). `direct` is
 validated, rendered (`kaibo://config`), and load-tested, but forward-declared — no tool
 routes to it yet, so a `direct` cast sits in neither the interactive nor the
-`batch_submit` `cast` enum, and is dropped from the handshake roster. Still open: then
-`explore` (a new `run_phase` composition over `report_preamble` — not a re-mount of the
-RunExplore sub-agent), then `deliberate` (dossier → offline synth, two lanes; the
-two-stage handle crosses the disjoint `job-N` / `backend/provider-id` namespaces — the
-job record should carry its batch handle after submit). Persistence stays out of scope
-(local `deliberate` jobs are session-scoped `job-N`, said loudly in the schema). The
-`explore`/`deliberate` descriptions are already drafted in the plan doc; they ship with
-their tools. Delete this entry when arc 2 ships.
+`batch_submit` `cast` enum, and is dropped from the handshake roster.
+
+`explore` **shipped** — the evidence-gathering half of `consult`, exposed as its own
+tool: a single explorer phase over the read-only project returning the cited report
+*verbatim* (no synth). It's a new `run_phase` composition — the inner `arm.run` was
+extracted to a shared `run_explore_phase` seam that both the nested `explore′`
+(`RunExplore::call`) and the top-level `explore_with` call, so the sweep bracket +
+reports-sink push stay with the sub-agent while `explore` is self-contained. Skips
+`reject_offline_cast` deliberately (it runs the *explorer* arm, which is interactive by
+construction — a lane on an explorer slot is a load error), gated by `--no-explore`,
+cross-family reviewed (DeepSeek + Gemini, both merge-ready).
+
+Still open: `deliberate` (dossier → offline synth, two lanes; the two-stage handle
+crosses the disjoint `job-N` / `backend/provider-id` namespaces — the job record should
+carry its batch handle after submit). Persistence stays out of scope (local `deliberate`
+jobs are session-scoped `job-N`, said loudly in the schema). The `deliberate` description
+is already drafted in the plan doc; it ships with the tool. Delete this entry when
+`deliberate` ships (arc 2 done).
 
 Note (arc-1 follow-on, low priority): the composed `agent_onboarding` mental-model view
 is no longer produced anywhere — arc 1 deleted `kaibo_instructions`/`kaish_reference`

--- a/src/config.rs
+++ b/src/config.rs
@@ -1223,6 +1223,9 @@ impl Config {
         if disable.consult {
             self.tools.consult = false;
         }
+        if disable.explore {
+            self.tools.explore = false;
+        }
         if disable.oneshot {
             self.tools.oneshot = false;
         }
@@ -1255,6 +1258,7 @@ impl Config {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ToolDisables {
     pub consult: bool,
+    pub explore: bool,
     pub oneshot: bool,
     pub run_kaish: bool,
     pub batch: bool,
@@ -1565,6 +1569,7 @@ struct RawServer {
 #[serde(deny_unknown_fields)]
 struct RawTools {
     consult: Option<bool>,
+    explore: Option<bool>,
     oneshot: Option<bool>,
     run_kaish: Option<bool>,
     batch: Option<bool>,
@@ -1940,6 +1945,7 @@ fn merge_tools(raw: RawTools) -> ToolGating {
     let d = ToolGating::default();
     ToolGating {
         consult: raw.consult.unwrap_or(d.consult),
+        explore: raw.explore.unwrap_or(d.explore),
         oneshot: raw.oneshot.unwrap_or(d.oneshot),
         run_kaish: raw.run_kaish.unwrap_or(d.run_kaish),
         batch: raw.batch.unwrap_or(d.batch),
@@ -1995,6 +2001,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     let tools = server.tools.get_or_insert_with(Default::default);
     if env_flag(get, "KAIBO_NO_CONSULT") {
         tools.consult = Some(false);
+    }
+    if env_flag(get, "KAIBO_NO_EXPLORE") {
+        tools.explore = Some(false);
     }
     if env_flag(get, "KAIBO_NO_ONESHOT") {
         tools.oneshot = Some(false);

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -1318,6 +1318,44 @@ where
         })
 }
 
+/// Run the explorer phase once and return its cited report. The explorer [`Arm`]
+/// drives a fresh `{run_kaish}` toolset over a spawned kernel, bounded by
+/// `max_turns`, and hands back the curated report the [`report_preamble`] shape
+/// asks for. This is the one seam both callers of the explorer share: the nested
+/// `explore′` sub-agent inside [`consult_with`] (via [`RunExplore::call`]) and the
+/// top-level `explore` tool (via [`explore_with`]).
+///
+/// `preamble` is already resolved (the report shape + `[orientation]` + house
+/// rules) — this fn is just the inner `arm.run`, so preamble composition and the
+/// progress bracket stay with each caller. A fresh kernel per tool build ([`run_phase`]
+/// may build a second for the turn-cap recovery turn); the shared `progress` sink is
+/// handed to `run_kaish` so the sweep's own reads surface too. `!Send` care (an
+/// invariant): the kernel stays on its `KaishWorker` thread and never crosses the
+/// `.await`.
+pub(crate) async fn run_explore_phase(
+    arm: &Arm,
+    preamble: &str,
+    question: &str,
+    root: PathBuf,
+    sandbox: &SandboxConfig,
+    max_turns: usize,
+    progress: &Arc<dyn ProgressSink>,
+) -> Result<String> {
+    arm.run(
+        preamble,
+        Message::user(question.to_string()),
+        max_turns,
+        progress.as_ref(),
+        &|| -> Result<Vec<Box<dyn ToolDyn>>> {
+            Ok(vec![traced(RunKaish::with_progress(
+                KaishWorker::spawn_with(&root, sandbox.clone())?,
+                progress.clone(),
+            ))])
+        },
+    )
+    .await
+}
+
 /// `explore′` — the explorer unit wrapped as a rig [`Tool`] the consult loop can
 /// call. Its `call` runs a *nested* agent: the explorer [`Arm`] (a cheap model,
 /// possibly on a different backend than the driver) driving `{run_kaish}` over a
@@ -1426,25 +1464,20 @@ impl Tool for RunExplore {
         self.progress.emit(PhaseEvent::SweepStarted {
             question: args.question.clone(),
         });
-        // Reuse the one loop — explore′ is just the explorer arm's run_phase.
-        // A fresh kernel per worker build (the §2.1 cost note: a KaishWorker per
-        // explore′; run_phase may build a second for the turn-cap recovery turn).
-        // The sub-agent's `run_kaish` carries the same sink, so its reads surface too.
-        let result = self
-            .arm
-            .run(
-                &self.preamble,
-                Message::user(args.question),
-                self.max_turns,
-                self.progress.as_ref(),
-                &|| -> Result<Vec<Box<dyn ToolDyn>>> {
-                    Ok(vec![traced(RunKaish::with_progress(
-                        KaishWorker::spawn_with(&self.root, self.sandbox.clone())?,
-                        self.progress.clone(),
-                    ))])
-                },
-            )
-            .await;
+        // Reuse the one seam — explore′ is just the shared explorer phase, run on the
+        // sub-agent's arm with its resolved preamble. The sweep bracket
+        // (started/finished) and the reports-sink push stay here (consult-loop
+        // specific); `run_explore_phase` is only the inner `arm.run`.
+        let result = run_explore_phase(
+            &self.arm,
+            &self.preamble,
+            &args.question,
+            self.root.clone(),
+            &self.sandbox,
+            self.max_turns,
+            &self.progress,
+        )
+        .await;
         self.progress.emit(PhaseEvent::SweepFinished);
         let report = result.map_err(|e| RunExploreError(format!("{e:#}")))?;
         // Lock poisoning means another delegation panicked — surface it, don't mask.
@@ -1746,6 +1779,36 @@ fn consult_tools(
         tools.push(traced(ViewImage::new(worker, root.to_path_buf())));
     }
     Ok(tools)
+}
+
+/// Run the `explore` tool: the evidence-gathering half of `consult`, surfaced on
+/// its own. One explorer arm sweeps `root` read-only over `{run_kaish}` and returns
+/// its cited report *verbatim* — no synth, no session, no attachments (explore reads
+/// the repo itself). The report shape is [`report_preamble`], resolved through the
+/// same [`phase_preamble`] layering `consult_tools` gives the nested `explore′`, so
+/// a `[prompts].explorer` override, `[orientation]`, and house rules all reach it.
+pub(crate) async fn explore_with(
+    question: &str,
+    root: PathBuf,
+    explorer: &Arm,
+    cfg: &ConsultConfig,
+) -> Result<String> {
+    let preamble = phase_preamble(
+        cfg.prompts.explorer.as_deref(),
+        report_preamble,
+        cfg.orientation.as_deref(),
+        cfg.house_rules.as_deref(),
+    );
+    run_explore_phase(
+        explorer,
+        &preamble,
+        question,
+        root,
+        &cfg.sandbox,
+        cfg.explorer_max_turns,
+        &cfg.progress,
+    )
+    .await
 }
 
 /// Run a `consult` over two resolved arms.
@@ -2432,6 +2495,137 @@ mod tests {
                 .contains("second tool, `explore`"),
             "driver got the consult preamble: {:?}",
             synth_reqs[0].preamble
+        );
+    }
+
+    /// The `explore` tool's phase, surfaced directly: `explore_with` runs ONE
+    /// explorer arm over `{run_kaish}` against the real repo and returns the
+    /// explorer's cited report *verbatim* — no synth, no second phase. Mirrors the
+    /// consult e2e above but for the exposed evidence-gathering half. If the phase
+    /// ever synthesized an answer instead of surfacing the report, the marker
+    /// wouldn't survive; and the explorer must run on the report (explorer-role)
+    /// preamble, not a driver preamble.
+    #[tokio::test]
+    async fn explore_with_runs_the_single_explorer_phase_and_returns_the_report() {
+        const EXPLORER: &str = "cheap-explorer";
+        const REPORT: &str = "EXPLORER_REPORT: src/foo.rs:1 fn target_marker";
+
+        let client = ScriptedClient::builder()
+            // A single-phase sweep: grep once against real kaish, then write the report.
+            .on_model(EXPLORER, |req| {
+                // Explorer-only — `run_kaish`, and no nested `explore′` (explore is one phase).
+                assert!(has_tool(req, "run_kaish"), "explorer must have run_kaish");
+                assert!(
+                    !has_tool(req, "explore"),
+                    "explore is single-phase — no nested explore′"
+                );
+                let seen = transcript_text(req);
+                if !seen.contains("target_marker() {}") {
+                    Ok(tool_call_response(
+                        "t-grep",
+                        "run_kaish",
+                        json!({ "script": "grep -rn target_marker src" }),
+                    ))
+                } else {
+                    Ok(text_response(REPORT))
+                }
+            })
+            .build();
+
+        let dir = project_with_marker();
+        let cfg = ConsultConfig::default();
+
+        let report = explore_with(
+            "Where is target_marker defined?",
+            dir.path().to_path_buf(),
+            &arm(&client, EXPLORER),
+            &cfg,
+        )
+        .await
+        .expect("scripted explore should succeed");
+
+        // The teeth: the result IS the explorer's report, surfaced verbatim — not a
+        // synthesized answer. A synth phase would have replaced the marker.
+        assert!(
+            report.contains("EXPLORER_REPORT"),
+            "explore must return the explorer's report itself, got: {report:?}"
+        );
+
+        // Routing: the one arm ran on the report (explorer-role) preamble.
+        let reqs = client.requests_for(EXPLORER);
+        assert!(!reqs.is_empty(), "explorer model was actually invoked");
+        assert!(
+            reqs[0]
+                .preamble
+                .as_deref()
+                .unwrap_or("")
+                .contains("code explorer"),
+            "explorer got the report preamble: {:?}",
+            reqs[0].preamble
+        );
+    }
+
+    /// The `explore` phase is a *single* sweep, not a nested delegation — so its
+    /// progress shape is the explorer's own reads reaching the sink directly, with
+    /// **no** `SweepStarted`/`SweepFinished` bracket (that bracket is `RunExplore`'s,
+    /// emitted only when the consult driver delegates a sub-agent). This is the teeth
+    /// for the seam split: if the bracket ever migrated from `RunExplore::call` into
+    /// the shared `run_explore_phase`, a `SweepStarted` would appear here and this
+    /// test fails; and if the sink weren't threaded through, the explorer's `run_kaish`
+    /// read would be missing.
+    #[tokio::test]
+    async fn explore_progress_surfaces_the_read_with_no_sweep_bracket() {
+        const EXPLORER: &str = "cheap-explorer";
+
+        let client = ScriptedClient::builder()
+            .on_model(EXPLORER, |req| {
+                if !transcript_text(req).contains("exit:") {
+                    Ok(tool_call_response(
+                        "t-grep",
+                        "run_kaish",
+                        json!({ "script": "grep -rn target_marker src" }),
+                    ))
+                } else {
+                    Ok(text_response("EXPLORER_REPORT: src/foo.rs:1"))
+                }
+            })
+            .build();
+
+        let dir = project_with_marker();
+        let sink = Arc::new(RecordingSink::default());
+        let cfg = ConsultConfig {
+            progress: sink.clone(),
+            ..ConsultConfig::default()
+        };
+
+        explore_with(
+            "Where is target_marker defined?",
+            dir.path().to_path_buf(),
+            &arm(&client, EXPLORER),
+            &cfg,
+        )
+        .await
+        .expect("scripted explore should succeed");
+
+        let events = sink.events();
+        // The explorer's own read reached the sink (single-phase threading works).
+        assert!(
+            events.contains(&PhaseEvent::KaishRun {
+                script: "grep -rn target_marker src".into()
+            }),
+            "the explorer's read must surface through the single phase: {events:?}"
+        );
+        // No sweep bracket: explore is not a sub-agent delegation. A migrated bracket
+        // would light these up.
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, PhaseEvent::SweepStarted { .. })),
+            "explore is single-phase — no SweepStarted bracket belongs here: {events:?}"
+        );
+        assert!(
+            !events.contains(&PhaseEvent::SweepFinished),
+            "explore is single-phase — no SweepFinished bracket belongs here: {events:?}"
         );
     }
 

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -110,7 +110,8 @@ fn kaibo_lead() -> &'static str {
      your own family. DeepSeek, Gemini, Anthropic, or a local model reads the \
      project READ-ONLY and answers with file:line citations. Say in prose what you \
      did or want to know — kaibo finds and reads the current code itself; no \
-     pasted files or diffs needed. `consult` is the front door. `oneshot` is a \
+     pasted files or diffs needed. `consult` is the front door. `explore` \
+     returns a cited survey report instead of an answer. `oneshot` is a \
      toolless second opinion when you own the context. `run_kaish` drives the \
      read-only shell directly. Work you don't wait on: `consult_submit` and \
      `batch_submit` return handles; `job_wait`/`job_get`/`job_list`/`job_cancel` \

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,10 @@ struct Args {
     #[arg(long)]
     no_consult: bool,
 
+    /// Don't advertise the `explore` tool.
+    #[arg(long)]
+    no_explore: bool,
+
     /// Don't advertise the `oneshot` tool.
     #[arg(long)]
     no_oneshot: bool,
@@ -129,6 +133,7 @@ async fn main() -> Result<()> {
         args.cast.clone(),
         ToolDisables {
             consult: args.no_consult,
+            explore: args.no_explore,
             oneshot: args.no_oneshot,
             run_kaish: args.no_run_kaish,
             batch: args.no_batch,

--- a/src/server.rs
+++ b/src/server.rs
@@ -30,7 +30,7 @@ use tracing::Instrument;
 
 use crate::config::{Backend, Cast, Config, Lane, ModelRole, ModelSlot};
 use crate::consult::{
-    Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides, consult, oneshot,
+    Arm, ConsultConfig, ModelCaps, ModelShape, PromptOverrides, consult, explore_with, oneshot,
 };
 use crate::explorer::format_output;
 use crate::jobs::{CancelOutcome, JobResult, JobSnapshot, JobState, JobStore};
@@ -80,6 +80,9 @@ const CONFIG_EXAMPLE_TOML: &str = include_str!("../docs/config.example.toml");
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ToolGating {
     pub consult: bool,
+    /// The single-phase `explore` sweep — its own gate, independent of `consult`
+    /// (which carries its own explorer inside the driver loop).
+    pub explore: bool,
     pub oneshot: bool,
     pub run_kaish: bool,
     /// The batch capability (submit/get/cancel/list) — one gate over all the verbs:
@@ -92,6 +95,7 @@ impl Default for ToolGating {
     fn default() -> Self {
         Self {
             consult: true,
+            explore: true,
             oneshot: true,
             run_kaish: true,
             batch: true,
@@ -102,7 +106,7 @@ impl Default for ToolGating {
 impl ToolGating {
     /// True iff every tool is disabled — the zero-tool server we refuse to start.
     pub fn all_disabled(&self) -> bool {
-        !self.consult && !self.oneshot && !self.run_kaish && !self.batch
+        !self.consult && !self.explore && !self.oneshot && !self.run_kaish && !self.batch
     }
 }
 
@@ -180,6 +184,41 @@ pub struct ConsultInput {
     /// whole files a change touched. See `kaibo://tools`.
     #[serde(default)]
     pub attach: Vec<String>,
+}
+
+/// Arguments to the `explore` tool: a single-phase explorer sweep. Explorer-only —
+/// no synth, session, context, or attachments (explore reads the repo itself and
+/// returns the cited report, not a synthesized answer).
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExploreInput {
+    /// What to survey or map. Say in prose what you want charted — kaibo's explorer
+    /// locates and reads the real, current code itself and reports back with citations.
+    pub question: String,
+
+    /// Absolute path to the project to explore. Optional when the server has a default
+    /// root; must be at-or-under an allowed tree (`kaibo://config` shows the set).
+    #[serde(default)]
+    pub path: Option<String>,
+
+    /// Which cast (model team) runs this call; omit for the server's default. Pick from
+    /// this param's `enum`; `kaibo://config` lists every cast and backend.
+    #[serde(default)]
+    pub cast: Option<String>,
+
+    /// Override the explorer (investigation) model id. See `kaibo://tools` for override
+    /// semantics (ids are verbatim; pair with `explorer_backend` to also retarget).
+    #[serde(default)]
+    pub explorer_model: Option<String>,
+
+    /// Run the explorer override on this backend (name or alias). Requires
+    /// `explorer_model`. See `kaibo://tools`.
+    #[serde(default)]
+    pub explorer_backend: Option<String>,
+
+    /// Max tool-loop turns for the explorer sweep (default 50).
+    #[serde(default)]
+    pub explorer_max_turns: Option<usize>,
 }
 
 /// The handle addressing one piece of async work — a durable batch or a
@@ -430,6 +469,8 @@ impl KaiboHandler {
             // only one shape.) The verbs that *collect* its handles (`job_get`/
             // `job_cancel`/`job_list`) are shared with batch and gated below.
             (gating.consult, "consult_submit"),
+            // The single-phase explorer sweep — its own gate.
+            (gating.explore, "explore"),
             (gating.oneshot, "oneshot"),
             (gating.run_kaish, "run_kaish"),
             // `--no-batch` drops `batch_submit`; the shared collect verbs live below.
@@ -537,7 +578,7 @@ impl KaiboHandler {
             .collect();
         inject_cast_enum(
             &mut tool_router,
-            &["consult", "consult_submit", "oneshot"],
+            &["consult", "consult_submit", "explore", "oneshot"],
             &interactive_usable,
         );
         inject_cast_enum(&mut tool_router, &["batch_submit"], &batch_usable);
@@ -1526,6 +1567,71 @@ impl KaiboHandler {
     }
 
     #[tool(
+        description = "Survey a codebase and get back a structured, cited report — not an \
+            answer. A fast, cheap model sweeps the project READ-ONLY (grep, whole-file \
+            reads) and returns a summary of findings, the relevant locations with \
+            `file:line`, and the trail it followed. The evidence-gathering half of \
+            `consult`, exposed directly: map unfamiliar code, or assemble a cited survey \
+            to reason over yourself. For a synthesized answer instead, use `consult`."
+    )]
+    async fn explore(
+        &self,
+        Parameters(input): Parameters<ExploreInput>,
+        peer: Peer<RoleServer>,
+        meta: Meta,
+    ) -> Result<CallToolResult, McpError> {
+        let root = self.resolve_root(input.path)?;
+        // Resolve the cast, then layer a per-call explorer override onto the clone.
+        // Deliberately NO `reject_offline_cast`: explore runs the *explorer* arm
+        // interactively, so a deliberate/direct cast's explorer is perfectly valid —
+        // explore only needs an explorer slot, resolved next (a synth-only batch cast
+        // has none and `arm` errors clearly).
+        let mut cast = self.resolve_cast(input.cast)?;
+        self.apply_model_override(
+            &mut cast,
+            ModelRole::Explorer,
+            input.explorer_model.as_deref(),
+            input.explorer_backend.as_deref(),
+            "explorer_model",
+            "explorer_backend",
+        )?;
+        let explorer = self.arm(&cast, ModelRole::Explorer)?;
+        let progress = progress_sink(peer, &meta);
+        let defaults = &self.config.defaults;
+        let cfg = ConsultConfig {
+            explorer_max_turns: input
+                .explorer_max_turns
+                .unwrap_or(defaults.explorer_max_turns),
+            // Single-phase: no synth runs, so `synth_max_turns` is inert here.
+            synth_max_turns: defaults.synth_max_turns,
+            sandbox: self.config.sandbox.clone(),
+            progress: progress.clone(),
+            house_rules: self.house_rules(&root)?,
+            prompts: self.resolved_prompts(&cast),
+            orientation: self.orientation(&root).await?,
+            // explore reads the repo itself — no caller attachments.
+            attachments: Vec::new(),
+        };
+
+        let span = tracing::info_span!("explore", cast = %cast.name, explorer_model = %explorer.model);
+        progress.emit(PhaseEvent::PhaseStarted { phase: "explore" });
+        let report = match explore_with(&input.question, root, &explorer, &cfg)
+            .instrument(span)
+            .await
+        {
+            Ok(report) => report,
+            // A provider/model-loop failure is a clean tool-result error, same as `consult`.
+            Err(e) => return Ok(consultation_failed("explore", &cast.name, e)),
+        };
+        progress.emit(PhaseEvent::PhaseFinished { phase: "explore" });
+
+        // The report IS the text (no structured_content). Provenance names the one arm
+        // that produced it, so a cross-model study sees which explorer surveyed.
+        let report = with_provenance(report, &cast.name, &[("explorer", &explorer.model)]);
+        Ok(CallToolResult::success(vec![Content::text(report)]))
+    }
+
+    #[tool(
         description = "Ask a model outside your own family a direct question — prompt in, \
             answer out. No tools, no codebase access: the second-opinion primitive for \
             when you already own the context. Paste what's needed, or `attach` whole \
@@ -2489,6 +2595,18 @@ configured backend; pair it with the matching `*_backend` (`synth_backend`, `bac
 to retarget the slot to a different connection wholesale — which also lets you fill a role
 the cast doesn't otherwise carry.
 
+## Survey the code, or get an answer: `explore` vs `consult`
+
+`consult` hands back an *answer* — a capable model investigates and concludes. `explore`
+hands back the *evidence*: it's the fast, cheap explorer half of `consult`, run on its
+own, so you get the structured cited report — a summary of findings, the relevant
+`file:line` locations, and the trail the explorer followed — with no synthesis on top.
+Reach for `explore` to map unfamiliar code, or to assemble a grounded survey you'll reason
+over yourself (or hand to another model). It reads the repo itself, like `consult`, so the
+same `path` / `cast` / `explorer_model` / `explorer_backend` arguments apply; there's no
+`attach`, `context`, or `session_id` — those belong to the synthesizing tools. When you
+want the conclusion rather than the map, use `consult`.
+
 ## Answer now, or hand off and collect later
 
 Each investigation/answer tool comes in a synchronous form and an async sibling. Use the
@@ -2643,6 +2761,7 @@ fn render_config_resource(
     #[derive(Serialize)]
     struct ToolsDoc {
         consult: bool,
+        explore: bool,
         oneshot: bool,
         run_kaish: bool,
         batch: bool,
@@ -2883,6 +3002,7 @@ fn render_config_resource(
     // render-or-skip decision instead of silently vanishing from the resource.
     let &ToolGating {
         consult,
+        explore,
         oneshot,
         run_kaish,
         batch,
@@ -2933,6 +3053,7 @@ fn render_config_resource(
         },
         tools: ToolsDoc {
             consult,
+            explore,
             oneshot,
             run_kaish,
             batch,

--- a/tests/cast_param.rs
+++ b/tests/cast_param.rs
@@ -7,7 +7,7 @@
 //! silent drop into the default cast (serde drops unknown fields, a textbook silent
 //! fallback). These tests pin that end state.
 
-use kaibo::server::{ConsultInput, OneshotInput, RunKaishInput};
+use kaibo::server::{ConsultInput, ExploreInput, OneshotInput, RunKaishInput};
 use serde_json::json;
 
 #[test]
@@ -19,6 +19,10 @@ fn cast_is_the_canonical_spelling_and_optional() {
     let o: OneshotInput = serde_json::from_value(json!({ "prompt": "q", "cast": "chimera" }))
         .expect("oneshot takes cast");
     assert_eq!(o.cast.as_deref(), Some("chimera"));
+
+    let e: ExploreInput = serde_json::from_value(json!({ "question": "q", "cast": "chimera" }))
+        .expect("explore takes cast");
+    assert_eq!(e.cast.as_deref(), Some("chimera"));
 
     // Omitting it entirely falls through to the server's default cast.
     let d: ConsultInput =
@@ -52,6 +56,19 @@ fn a_typoed_argument_is_a_loud_error_not_a_silent_default_run() {
         .expect_err("oneshot rejects unknown fields");
     serde_json::from_value::<RunKaishInput>(json!({ "script": "ls", "paht": "/tmp" }))
         .expect_err("run_kaish rejects unknown fields");
+    // explore's single-phase surface holds it too: a misspelled explorer override
+    // must fault, not silently run the configured explorer.
+    let err = serde_json::from_value::<ExploreInput>(
+        json!({ "question": "q", "explorer_modle": "claude-haiku-4-5" }),
+    )
+    .expect_err("a typo'd explore argument must be rejected");
+    assert!(
+        err.to_string().contains("explorer_modle"),
+        "the error must name the unknown field, got: {err}"
+    );
+    // A synth-side arg has no home on explore (single-phase) — it must not vanish.
+    serde_json::from_value::<ExploreInput>(json!({ "question": "q", "synth_model": "x" }))
+        .expect_err("explore has no synth args — synth_model must not silently vanish");
 }
 
 /// The `provider` tombstone: with the transitional alias removed, a client still

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -873,6 +873,7 @@ fn cli_cast_wins_over_env_and_file() {
     assert_eq!(c.root.as_deref(), Some(std::path::Path::new("/tmp/proj")));
     // Only oneshot is dropped; the rest stay enabled.
     assert!(c.tools.consult);
+    assert!(c.tools.explore);
     assert!(!c.tools.oneshot);
     assert!(c.tools.run_kaish);
 }

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -13,10 +13,11 @@ use kaibo::server::{KaiboHandler, ToolGating};
 /// `job_cancel`/`job_list`/`job_wait` are *shared* — they manage both kinds of handle
 /// and stay advertised as long as either capability is on, so they belong to neither
 /// flag.
-const ALL_TOOLS: [&str; 9] = [
+const ALL_TOOLS: [&str; 10] = [
     "batch_submit",
     "consult",
     "consult_submit",
+    "explore",
     "job_cancel",
     "job_get",
     "job_list",
@@ -44,13 +45,22 @@ fn each_flag_removes_exactly_its_own_tools() {
     // `job_get`/`job_cancel`/`job_list` belong to neither flag alone — gating one
     // capability leaves them because the other still needs them — so they appear in no
     // row's removed-set and are covered by the "every other tool remains" check below.
-    let cases: [(&[&str], ToolGating); 4] = [
+    let cases: [(&[&str], ToolGating); 5] = [
         (
             // `--no-consult` drops the blocking `consult` and the async `consult_submit`;
             // `job_get`/`job_cancel`/`job_list` stay (batch still uses them).
             &["consult", "consult_submit"],
             ToolGating {
                 consult: false,
+                ..Default::default()
+            },
+        ),
+        (
+            // `--no-explore` drops the single-phase `explore` sweep and nothing else —
+            // it's its own gate, independent of consult's driver+explorer loop.
+            &["explore"],
+            ToolGating {
+                explore: false,
                 ..Default::default()
             },
         ),
@@ -147,6 +157,7 @@ fn shared_collect_verbs_track_both_capabilities() {
 fn all_disabled_is_detected() {
     let none_on = ToolGating {
         consult: false,
+        explore: false,
         oneshot: false,
         run_kaish: false,
         batch: false,
@@ -179,6 +190,7 @@ fn all_tools_disabled_refuses_to_start() {
         .env("XDG_CONFIG_HOME", empty_config.path())
         .args([
             "--no-consult",
+            "--no-explore",
             "--no-oneshot",
             "--no-run-kaish",
             "--no-batch",


### PR DESCRIPTION
## What

Adds a first-class `explore` MCP tool: a **single explorer phase** over the read-only project that returns the explorer's structured, cited report *verbatim* (SummaryOfFindings / RelevantLocations / ExplorationTrace) — no synthesis on top. It's the evidence-gathering half of `consult`, exposed on its own, for mapping unfamiliar code or assembling a grounded survey you'll reason over yourself.

Rounds out the ladder the tool surface teaches:
`run_kaish` (no model) → **`explore`** (cheap model, report) → `consult` (capable model, answer) → `deliberate` (heavyweight, offline — arc 2 PR 3, not yet).

This is **Arc 2 PR 2** of the model-facing surface effort (`docs/desc-and-schema-tuning.md`); PR 1 (the per-slot lane reshape, #38) is the config foundation this builds on.

## Decisions

- **Not a re-mount of the in-loop `explore′`.** `explore` is its own `run_phase` composition using `report_preamble` + `{run_kaish}`. The inner `arm.run` was extracted to a shared `run_explore_phase` seam that *both* the nested `RunExplore::call` (sub-agent inside consult's loop) and the top-level `explore_with` call — so there's one copy of the loop. The sweep bracket and reports-sink push stay in `RunExplore`; `explore` is self-contained and owns its own `PhaseStarted/Finished` bracket.
- **Deliberately skips `reject_offline_cast`.** explore runs the *explorer* arm, which is interactive by construction (a lane on an explorer slot is a load error; `reject_offline_cast` only checks the synth lane). A deliberate/direct-shaped cast's interactive explorer is valid for explore; a synth-only batch cast has no explorer slot and `arm()` errors clearly.
- **Single-phase surface.** `ExploreInput` carries only `path` / `cast` / `explorer_*` — no synth args, `attach`, `context`, or `session_id`. `deny_unknown_fields` keeps a misplaced synth arg a loud error, not a silent default run.
- **Its own gate:** `--no-explore` / `KAIBO_NO_EXPLORE` / `[tools].explore`, independent of `consult`.
- Provenance names the one explorer that surveyed. Handshake lead, `kaibo://tools`, and CHANGELOG gain the explore-vs-consult framing (handshake still measures under the 2048-char Claude Code budget — the budget tests stay green).

## Review

Cross-family review through kaibo itself (holistic, no diff handed over):
- **DeepSeek** (`consult`) — sound; clean extraction, complete gating, offline-cast skip structurally safe, `!Send` invariant holds, test has teeth.
- **Gemini** (`consult_submit`) — "flawless addition," merge-ready.

Both flagged only **test-coverage symmetry**, addressed in this PR:
- an `ExploreInput` `deny_unknown_fields` case in `tests/cast_param.rs` (a typo'd `explorer_modle` / a stray `synth_model` must fault);
- a `RecordingSink` test pinning that `explore` emits **no** sweep bracket (guards the seam split — a migrated bracket would light up here) while the explorer's own `run_kaish` read still surfaces.

## Tests

Full suite green (lib 291 + all integration suites), clippy clean on touched files (pre-existing warnings in `telemetry.rs`/`no_write_path.rs` only). New: `explore_with_runs_the_single_explorer_phase_and_returns_the_report`, `explore_progress_surfaces_the_read_with_no_sweep_bracket`, `--no-explore` gating, `ExploreInput` schema cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)