### PR TITLE
deliberate: explore → offline synth, two lanes (batch | direct) — Arc 2 PR 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ the git log. Each later release appends a new section at the top.
   arguments; being single-phase, it has no synth args, `attach`, `context`, or `session_id`.
   The report carries the same provenance footer, naming the cast and the explorer that
   surveyed. Gated independently by `--no-explore`. For a synthesized answer, use `consult`.
+- **`deliberate`** — a top model's deepest reasoning on your codebase without holding a
+  session open: `explore → offline synth`. A fast model first investigates READ-ONLY and
+  builds a cited dossier (you wait for this — the same live sweep `explore` runs), then a
+  heavyweight synth reasons over that evidence *offline*. The synth's lane (a per-slot
+  property of its cast) picks the mechanism: **`batch`** — a frontier model on the
+  provider's batch lane (max thinking, half price), returning a durable `backend/provider-id`
+  handle the moment the dossier is submitted (collect it any time, even after a restart);
+  or **`direct`** — one long completion on a big *local* model, returning a session-scoped
+  `job-N` (`job_wait`/`job_get` it; a restart loses it). Needs a cast pairing an interactive
+  explorer with an offline synth (the example config's `fable`, `gemini-deliberate`, or
+  `local-direct`) — `deliberate`'s `cast` enum lists the usable ones and `kaibo://config`
+  shows each cast's lane. Reads the repo itself, so it takes `path` / `cast` /
+  `explorer_model` / `synth_model` (+ `_backend`s); the offline synth is a single turn, so
+  no `attach` / `context` / `session_id`. Gated independently by `--no-deliberate`. This is
+  the tool that finally routes the `direct` lane the per-slot lane reshape introduced. For
+  an answer this turn, use `consult`.
 - **`oneshot`** — a thin, direct second opinion from a model outside your family:
   prompt in, answer out, no codebase access and no tools, exactly one upstream
   request. The counterpart to `consult` for when you already own the context (you've

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -334,14 +334,33 @@ synth    = "gemini/gemini-pro-latest"        # batch-capable synth (Anthropic | 
 # Equivalent, spelled directly on the slot (no cast-level sugar):
 #   synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch" }
 
+# --- DELIBERATE casts: an interactive explorer PLUS an offline synth. `deliberate` runs
+#     the explorer live to build a cited dossier, then hands dossier+question to the offline
+#     synth to reason over — a frontier model's deepest pass without holding a session open.
+#     The synth's lane picks the offline mechanism: `batch` (a provider batch, half price,
+#     durable handle) below, or `direct` (one long LOCAL completion) further down. Unlike the
+#     synth-only batch casts above, these carry BOTH slots — the explorer is what makes it a
+#     deliberate cast rather than a plain batch one. ---
+
+# Fable on the batch lane, with a Sonnet explorer building the dossier.
+[casts.fable]
+explorer = "anthropic/claude-sonnet-4-6"
+synth    = { backend = "anthropic", id = "claude-fable-5", lane = "batch" }
+
+# Gemini Pro deliberating on the batch lane, with a cheap Flash-Lite explorer.
+[casts.gemini-deliberate]
+explorer = "gemini/gemini-flash-lite-latest"
+synth    = { backend = "gemini", id = "gemini-pro-latest", lane = "batch" }
+
 # --- The other offline lane, `lane = "direct"`: one long completion kaibo runs itself
 #     against a big LOCAL model (no async provider API, no `batch = true` sugar for this
-#     one — spell it on the slot). Reserved for offline deliberation over a big model that's
-#     too slow to run inside a live tool loop but has no batch endpoint; no tool consumes a
-#     `direct` synth yet, so this cast is forward-declared, not yet callable. ---
+#     one — spell it on the slot). For offline deliberation over a big model that's too slow
+#     to run inside a live tool loop and has no batch endpoint. `deliberate` consumes it: it
+#     builds the dossier with the interactive explorer, then runs the direct synth as one
+#     long local completion under a session-scoped `job-N` handle. ---
 
 [casts.local-direct]
-explorer = "gemma/Gemma-4-E4B-it-GGUF"       # an interactive explorer may sit beside an offline synth
+explorer = "gemma/Gemma-4-E4B-it-GGUF"       # an interactive explorer beside an offline synth
 synth    = { backend = "gemma", id = "Big-Local-70B-GGUF", lane = "direct" }
 
 # ---------------------------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,6 +696,19 @@ impl Config {
         self.cast_offline_lane(name) == Some(Lane::Batch)
     }
 
+    /// Whether canonical cast `name` can staff a `deliberate` call: an **offline
+    /// synth** (batch *or* direct lane) paired with an **explorer** slot to build the
+    /// dossier. A synth-only batch cast (no explorer — `gemini-batch`/`anthropic-batch`)
+    /// can't: it has no dossier phase. An interactive cast (no offline synth) belongs to
+    /// `consult`, not here. This is the third roster partition the per-slot lane reshape
+    /// enabled — and the one that finally routes a `Direct` synth (unreachable until
+    /// `deliberate` shipped).
+    pub fn cast_can_deliberate(&self, name: &str) -> bool {
+        self.casts.get(name).is_some_and(|c| {
+            c.synth_lane().is_some() && c.slot(ModelRole::Explorer).is_some()
+        })
+    }
+
     /// Whether canonical cast `name` is the configured default — comparing against the
     /// *resolved* default, so an alias default (`server.cast = "claude"`) still matches
     /// its canonical cast (`anthropic`). The roster renderer (`casts_section`) gets
@@ -1226,6 +1239,9 @@ impl Config {
         if disable.explore {
             self.tools.explore = false;
         }
+        if disable.deliberate {
+            self.tools.deliberate = false;
+        }
         if disable.oneshot {
             self.tools.oneshot = false;
         }
@@ -1259,6 +1275,7 @@ impl Config {
 pub struct ToolDisables {
     pub consult: bool,
     pub explore: bool,
+    pub deliberate: bool,
     pub oneshot: bool,
     pub run_kaish: bool,
     pub batch: bool,
@@ -1570,6 +1587,7 @@ struct RawServer {
 struct RawTools {
     consult: Option<bool>,
     explore: Option<bool>,
+    deliberate: Option<bool>,
     oneshot: Option<bool>,
     run_kaish: Option<bool>,
     batch: Option<bool>,
@@ -1946,6 +1964,7 @@ fn merge_tools(raw: RawTools) -> ToolGating {
     ToolGating {
         consult: raw.consult.unwrap_or(d.consult),
         explore: raw.explore.unwrap_or(d.explore),
+        deliberate: raw.deliberate.unwrap_or(d.deliberate),
         oneshot: raw.oneshot.unwrap_or(d.oneshot),
         run_kaish: raw.run_kaish.unwrap_or(d.run_kaish),
         batch: raw.batch.unwrap_or(d.batch),
@@ -2004,6 +2023,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if env_flag(get, "KAIBO_NO_EXPLORE") {
         tools.explore = Some(false);
+    }
+    if env_flag(get, "KAIBO_NO_DELIBERATE") {
+        tools.deliberate = Some(false);
     }
     if env_flag(get, "KAIBO_NO_ONESHOT") {
         tools.oneshot = Some(false);

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -1811,6 +1811,53 @@ pub(crate) async fn explore_with(
     .await
 }
 
+/// Frame a built dossier + the original question into the offline synth's single
+/// user turn — the whole of what `deliberate`'s heavyweight synth reasons over, on
+/// either lane (a batch item's prompt, or the direct lane's one local completion).
+/// Pure, so the wire shape is pinned without a network.
+///
+/// The framing installs the deliberate posture: the dossier is *trusted* investigated
+/// evidence (a fast explorer read the real spans and cited them), so the synth spends
+/// its one offline turn reasoning the question all the way through, not re-verifying
+/// cites it can't cheaply re-derive — and names the edge of the evidence rather than
+/// guessing past it (the "thin dossier deliberating on air" failure the spec warns of).
+pub fn deliberation_prompt(question: &str, dossier: &str) -> String {
+    format!(
+        "A fast explorer investigated this codebase READ-ONLY and assembled the dossier \
+         below — spans it read from the real, current source, cited by `file:line`. Trust \
+         those citations as accurate and deliberate deeply over the question using this \
+         evidence: reason it all the way through, and say where the evidence runs out. If \
+         the dossier leaves a load-bearing detail open, reason under a stated assumption \
+         and flag what would change if it's wrong, rather than guessing silently.\n\n\
+         ## Question\n{question}\n\n## Dossier\n{dossier}"
+    )
+}
+
+/// Run `deliberate`'s offline synth on the **direct** lane: one long, toolless local
+/// completion over the dossier. Same shape as [`oneshot`] (empty toolset, a single
+/// turn — exactly one upstream request) but on the offline-synth preamble and framing
+/// the dossier as trusted evidence. The arm points at a big local model whose backend
+/// `request_timeout` is expected to stretch to hours; kaibo runs the one completion and
+/// waits — the provider (a llama.cpp-class server) queues, kaibo doesn't. `system` is
+/// the resolved offline-synth preamble (shared with batch via [`batch_system_prompt`]).
+pub async fn deliberate_direct(
+    question: &str,
+    dossier: &str,
+    synth: &Arm,
+    system: &str,
+    progress: &Arc<dyn ProgressSink>,
+) -> Result<String> {
+    synth
+        .run(
+            system,
+            Message::user(deliberation_prompt(question, dossier)),
+            1,
+            progress.as_ref(),
+            &|| Ok(Vec::new()),
+        )
+        .await
+}
+
 /// Run a `consult` over two resolved arms.
 ///
 /// One loop, two tools — no rigid explorer→synth hand-off. The capable model
@@ -2627,6 +2674,67 @@ mod tests {
             !events.contains(&PhaseEvent::SweepFinished),
             "explore is single-phase — no SweepFinished bracket belongs here: {events:?}"
         );
+    }
+
+    /// The deliberation prompt is the whole context the offline synth reasons over, so
+    /// pin its shape: both the question and the dossier survive, the question is read
+    /// before the evidence, and the trust-the-cites posture is installed (the guard
+    /// against a synth burning its one turn re-verifying, or deliberating on air).
+    #[test]
+    fn deliberation_prompt_carries_question_then_dossier_and_frames_trust() {
+        let p = deliberation_prompt("Is the retry path safe?", "src/retry.rs:12 fn retry()");
+        assert!(p.contains("Is the retry path safe?"), "question present: {p}");
+        assert!(p.contains("src/retry.rs:12 fn retry()"), "dossier present: {p}");
+        let q = p.find("## Question").expect("has a Question section");
+        let d = p.find("## Dossier").expect("has a Dossier section");
+        assert!(q < d, "the question is framed before the dossier evidence: {p}");
+        assert!(
+            p.contains("Trust") && p.contains("evidence"),
+            "installs the trusted-evidence posture: {p}"
+        );
+    }
+
+    /// The `direct` lane: `deliberate_direct` runs the offline synth as ONE toolless
+    /// turn over the dossier and returns its deliberation. Teeth: the synth must be
+    /// toolless (no `run_kaish`/`explore` — it reasons over the handed dossier, it
+    /// does not investigate), the dossier must reach it, and the result is the synth's
+    /// answer. This is the local-lane execution the `direct` cast finally routes to.
+    #[tokio::test]
+    async fn deliberate_direct_runs_one_toolless_turn_over_the_dossier() {
+        const SYNTH: &str = "big-local-synth";
+
+        let client = ScriptedClient::builder()
+            .on_model(SYNTH, |req| {
+                assert!(
+                    !has_tool(req, "run_kaish") && !has_tool(req, "explore"),
+                    "the direct synth deliberates toolless over the dossier"
+                );
+                let seen = transcript_text(req);
+                assert!(
+                    seen.contains("DOSSIER_MARKER"),
+                    "the built dossier must reach the synth: {seen}"
+                );
+                Ok(text_response("DELIBERATION: the retry path is safe because …"))
+            })
+            .build();
+
+        let cfg = ConsultConfig::default();
+        let out = deliberate_direct(
+            "Is the retry path safe?",
+            "src/retry.rs:12 DOSSIER_MARKER fn retry()",
+            &arm(&client, SYNTH),
+            "You are a capable model answering a hard question offline.",
+            &cfg.progress,
+        )
+        .await
+        .expect("scripted direct deliberation should succeed");
+
+        assert!(
+            out.contains("DELIBERATION"),
+            "returns the synth's deliberation verbatim: {out}"
+        );
+        // Exactly one upstream request — the single offline turn, no follow-up.
+        assert_eq!(client.requests_for(SYNTH).len(), 1, "one toolless completion");
     }
 
     /// Progress reaches the *deep* loop. The same delegate-then-read flow as the e2e

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -113,9 +113,10 @@ fn kaibo_lead() -> &'static str {
      pasted files or diffs needed. `consult` is the front door. `explore` \
      returns a cited survey report instead of an answer. `oneshot` is a \
      toolless second opinion when you own the context. `run_kaish` drives the \
-     read-only shell directly. Work you don't wait on: `consult_submit` and \
-     `batch_submit` return handles; `job_wait`/`job_get`/`job_list`/`job_cancel` \
-     manage them."
+     read-only shell directly. Work you don't wait on: `deliberate` reasons \
+     offline over an investigated dossier (a frontier or big-local model); \
+     `consult_submit` and `batch_submit` return handles; \
+     `job_wait`/`job_get`/`job_list`/`job_cancel` manage them."
 }
 
 /// The setup-guidance block prepended to the instructions when the default cast has
@@ -156,14 +157,14 @@ fn setup_section(config: &Config) -> String {
     format!(
         "## Setup needed — no model provider configured\n\
          kaibo's default cast `{cast}` has no usable API key, so `consult`/`oneshot` \
-         can't reach a model yet. `run_kaish` works now (read-only shell, no model), so \
-         you can browse the code meanwhile.\n\n\
+         can't reach a model. `run_kaish` works now (read-only shell, no model) to \
+         browse the code meanwhile.\n\n\
          Give the cast a key via an **environment variable** or **key file** — kaibo \
-         reads either at startup, so it stays out of the chat (set it in your shell; \
-         don't paste it to the model):\n\
+         reads either at startup, kept out of the chat (set it in your shell, not \
+         pasted to the model):\n\
          {backends}\n\n\
-         Then **reconnect the kaibo MCP server** so it re-reads the environment — in \
-         Claude Code run `/mcp`; other hosts have their own reload. Prefer another \
+         Then **reconnect the kaibo MCP server** so it re-reads the environment \
+         (Claude Code: `/mcp`; other hosts: their own reload). Prefer another \
          provider? The annotated `kaibo://config/example` resource (→ \
          `~/.config/kaibo/config.toml`) shows every backend and cast.",
         cast = config.default_cast,
@@ -191,11 +192,11 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
     }
     let lines: String = usable
         .iter()
-        // A `direct`-lane cast is forward-declared (validated, rendered on
-        // `kaibo://config`) but no tool consumes it yet — the same reason it's absent
-        // from both `inject_cast_enum` partitions in `server.rs`. Advertising it here
-        // would name a cast every tool refuses, so drop it from the roster until a
-        // tool routes to it.
+        // A `direct`-lane cast is kept out of this *resident* roster to hold the 2048-char
+        // budget: `deliberate` now routes to it (its `cast` enum lists the deliberate-usable
+        // direct casts authoritatively, and `kaibo://config` renders every cast), so it's
+        // not unadvertised — just not in the always-billed handshake summary, which stays
+        // synth-voice-focused. The batch deliberate casts still appear here (tagged `batch`).
         .filter(|(name, _)| config.cast_offline_lane(name) != Some(Lane::Direct))
         .map(|(name, state)| {
             let mut tags = Vec::new();
@@ -235,9 +236,9 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
 
     format!(
         "## Casts\n\
-         A cast is the model team that staffs a consultation; pass `cast=<name>`. \
-         Usable right now (resolved at startup — reconnect after a config or key \
-         change; `kaibo://config` lists every configured cast, not just these):\n\
+         A cast is the model team that answers; pass `cast=<name>`. Usable now \
+         (resolved at startup — reconnect after config/key changes; `kaibo://config` \
+         lists all configured, not just these):\n\
          {lines}\n\n"
     )
 }
@@ -308,9 +309,9 @@ pub fn kaibo_instructions_with_scope(
          {root_line}\n\
          - **Allowed trees:**\n\
          {allowed_lines}\n\n\
-         Go deeper without spending a turn: `kaibo://config` (full resolved config — \
-         casts, backends, gated tools, sandbox limits), `kaibo://tools` (attachments, \
-         overrides, the async workflow), `kaibo://kaish/*` (shell syntax and idioms)."
+         More without spending a turn: `kaibo://config` (full config — casts, backends, \
+         tools, limits), `kaibo://tools` (attachments, overrides, async), \
+         `kaibo://kaish/*` (shell idioms)."
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,10 @@ struct Args {
     #[arg(long)]
     no_explore: bool,
 
+    /// Don't advertise the `deliberate` tool.
+    #[arg(long)]
+    no_deliberate: bool,
+
     /// Don't advertise the `oneshot` tool.
     #[arg(long)]
     no_oneshot: bool,
@@ -134,6 +138,7 @@ async fn main() -> Result<()> {
         ToolDisables {
             consult: args.no_consult,
             explore: args.no_explore,
+            deliberate: args.no_deliberate,
             oneshot: args.no_oneshot,
             run_kaish: args.no_run_kaish,
             batch: args.no_batch,

--- a/src/server.rs
+++ b/src/server.rs
@@ -83,6 +83,10 @@ pub struct ToolGating {
     /// The single-phase `explore` sweep — its own gate, independent of `consult`
     /// (which carries its own explorer inside the driver loop).
     pub explore: bool,
+    /// The `deliberate` tool (explore → offline synth) — its own gate. The offline
+    /// deliberation rides the batch (or job) collect verbs, but the tool that *starts*
+    /// one is gated here, independent of `consult`/`batch`.
+    pub deliberate: bool,
     pub oneshot: bool,
     pub run_kaish: bool,
     /// The batch capability (submit/get/cancel/list) — one gate over all the verbs:
@@ -96,6 +100,7 @@ impl Default for ToolGating {
         Self {
             consult: true,
             explore: true,
+            deliberate: true,
             oneshot: true,
             run_kaish: true,
             batch: true,
@@ -106,7 +111,12 @@ impl Default for ToolGating {
 impl ToolGating {
     /// True iff every tool is disabled — the zero-tool server we refuse to start.
     pub fn all_disabled(&self) -> bool {
-        !self.consult && !self.explore && !self.oneshot && !self.run_kaish && !self.batch
+        !self.consult
+            && !self.explore
+            && !self.deliberate
+            && !self.oneshot
+            && !self.run_kaish
+            && !self.batch
     }
 }
 
@@ -217,6 +227,54 @@ pub struct ExploreInput {
     pub explorer_backend: Option<String>,
 
     /// Max tool-loop turns for the explorer sweep (default 50).
+    #[serde(default)]
+    pub explorer_max_turns: Option<usize>,
+}
+
+/// Arguments to the `deliberate` tool: `explore → offline synth`. The explorer runs
+/// live to build a cited dossier (you wait for this — minutes), then the offline synth
+/// deliberates over it. No `session_id`/`attach`/`context`: deliberate reads the repo
+/// itself, and the synth is a single offline turn (so no `synth_max_turns`).
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DeliberateInput {
+    /// The hard question to reason through. Say in prose what you want deliberated —
+    /// kaibo's explorer locates and reads the real, current code to build the dossier
+    /// the offline synth then reasons over.
+    pub question: String,
+
+    /// Absolute path to the project. Optional when the server has a default root; must
+    /// be at-or-under an allowed tree (`kaibo://config` shows the set).
+    #[serde(default)]
+    pub path: Option<String>,
+
+    /// Which cast runs this call; omit for the server's default. A deliberate cast pairs
+    /// an interactive explorer with an OFFLINE synth (batch|direct lane) — pick from this
+    /// param's `enum`; `kaibo://config` lists every cast and its lane.
+    #[serde(default)]
+    pub cast: Option<String>,
+
+    /// Override the explorer (dossier-building) model id. See `kaibo://tools` for
+    /// override semantics; pair with `explorer_backend` to also retarget.
+    #[serde(default)]
+    pub explorer_model: Option<String>,
+
+    /// Run the explorer override on this backend (name or alias). Requires
+    /// `explorer_model`. See `kaibo://tools`.
+    #[serde(default)]
+    pub explorer_backend: Option<String>,
+
+    /// Override the synth (deliberating) model id. Its lane (batch|direct) still comes
+    /// from the cast's synth slot. Pair with `synth_backend` to also retarget.
+    #[serde(default)]
+    pub synth_model: Option<String>,
+
+    /// Run the synth override on this backend (name or alias). Requires `synth_model`.
+    /// See `kaibo://tools`.
+    #[serde(default)]
+    pub synth_backend: Option<String>,
+
+    /// Max tool-loop turns for the dossier-building explorer sweep (default 50).
     #[serde(default)]
     pub explorer_max_turns: Option<usize>,
 }
@@ -471,18 +529,22 @@ impl KaiboHandler {
             (gating.consult, "consult_submit"),
             // The single-phase explorer sweep — its own gate.
             (gating.explore, "explore"),
+            // `deliberate` starts an offline deliberation; its own gate. The collect
+            // verbs it hands off to (batch or job) live below, gated by their capability.
+            (gating.deliberate, "deliberate"),
             (gating.oneshot, "oneshot"),
             (gating.run_kaish, "run_kaish"),
             // `--no-batch` drops `batch_submit`; the shared collect verbs live below.
             (gating.batch, "batch_submit"),
             // `job_get`/`job_cancel`/`job_list`/`job_wait` manage *both* batch and
-            // consult handles, so they stay as long as *either* capability is on, and
-            // drop only when both are gated off. Routing by handle shape inside each
-            // verb refuses a handle whose own capability is disabled.
-            (gating.batch || gating.consult, "job_get"),
-            (gating.batch || gating.consult, "job_cancel"),
-            (gating.batch || gating.consult, "job_list"),
-            (gating.batch || gating.consult, "job_wait"),
+            // consult handles — and now `deliberate` handles too (batch on its batch
+            // lane, `job-N` on its direct lane) — so they stay as long as *any* of the
+            // three producers is on, and drop only when all are gated off. Routing by
+            // handle shape inside each verb refuses a handle whose producer is disabled.
+            (gating.batch || gating.consult || gating.deliberate, "job_get"),
+            (gating.batch || gating.consult || gating.deliberate, "job_cancel"),
+            (gating.batch || gating.consult || gating.deliberate, "job_list"),
+            (gating.batch || gating.consult || gating.deliberate, "job_wait"),
         ] {
             if !enabled {
                 assert!(
@@ -561,20 +623,27 @@ impl KaiboHandler {
             .into_iter()
             .map(|(name, _)| name)
             .collect();
-        // A cast's synth lane (`Config::cast_offline_lane`, read off the synth slot)
-        // splits the roster three ways: interactive (no lane) → consult/consult_submit/
-        // oneshot; `Batch` → batch_submit; `Direct` → *neither* — it's forward-declared
-        // (validated, rendered) but no tool consumes an offline-direct synth yet, so it
-        // would silently pass either gate's schema without a route. A future PR adds its
-        // tool and this three-way split gains a third `inject_cast_enum` call. The gate
-        // enforces the same split at call time; this just keeps the advertised menu
-        // honest so an agent doesn't pick a cast its tool will refuse.
+        // A cast's synth lane (`Config::cast_offline_lane`, read off the synth slot) plus
+        // whether it carries an explorer splits the roster by which tools it can serve:
+        //   - interactive (no lane) → consult/consult_submit/explore/oneshot;
+        //   - `Batch` synth        → batch_submit (synth-only) AND, with an explorer, deliberate;
+        //   - `Direct` synth       → deliberate (with an explorer). No longer stranded —
+        //     `deliberate` is the tool the per-slot lane reshape promised for the direct lane.
+        // The batch and deliberate views OVERLAP (a deliberate-shaped batch cast like `fable`
+        // serves both), so they're filtered by ref, not a partition. The gate enforces the
+        // same split at call time; this keeps the advertised menu honest.
         let (interactive_usable, offline_usable): (Vec<String>, Vec<String>) = usable
             .into_iter()
             .partition(|n| config.cast_offline_lane(n).is_none());
         let batch_usable: Vec<String> = offline_usable
-            .into_iter()
+            .iter()
             .filter(|n| config.cast_is_batch(n))
+            .cloned()
+            .collect();
+        let deliberate_usable: Vec<String> = offline_usable
+            .iter()
+            .filter(|n| config.cast_can_deliberate(n))
+            .cloned()
             .collect();
         inject_cast_enum(
             &mut tool_router,
@@ -582,6 +651,7 @@ impl KaiboHandler {
             &interactive_usable,
         );
         inject_cast_enum(&mut tool_router, &["batch_submit"], &batch_usable);
+        inject_cast_enum(&mut tool_router, &["deliberate"], &deliberate_usable);
         // The `cast` enum (just above) is now the one authoritative per-lane roster —
         // the resident-prose roster this used to also append (`append_cast_roster`) was
         // redundant with it and has been dropped; see `docs/devlog.md`.
@@ -1231,6 +1301,29 @@ impl KaiboHandler {
         }
     }
 
+    /// Refuse `deliberate` on a cast without an **offline synth**. deliberate =
+    /// explore → offline synth, so the synth must run on the batch or direct lane
+    /// (an interactive synth belongs to `consult`). The other half — a *missing
+    /// explorer* — is caught when the explorer arm is resolved (`arm` errors, naming
+    /// the gap), the same way `explore` leans on it; here we only need the synth-lane
+    /// half. A synth-only batch cast (`anthropic-batch`) passes this but fails at the
+    /// explorer resolve, which is the honest error (no dossier phase to staff).
+    fn require_deliberate_cast(&self, cast: &Cast) -> Result<(), McpError> {
+        match cast.synth_lane() {
+            Some(_) => Ok(()),
+            None => Err(McpError::invalid_params(
+                format!(
+                    "cast `{}` has no offline synth — `deliberate` needs a cast pairing an \
+                     interactive explorer with a synth on the `batch` or `direct` lane (the \
+                     example config's `fable`/`gemini-deliberate`/`local-direct`, or your \
+                     own). For an answer this turn, use `consult`.",
+                    cast.name
+                ),
+                None,
+            )),
+        }
+    }
+
     /// Apply a per-call model override to one of `cast`'s slots.
     ///
     /// The model id rides *verbatim* — an id containing `/` (HuggingFace-style
@@ -1632,6 +1725,202 @@ impl KaiboHandler {
     }
 
     #[tool(
+        description = "Put a top model's deepest reasoning on your codebase without holding \
+            a session open. A fast model first investigates the project READ-ONLY and \
+            assembles a cited dossier (you wait for this — minutes); a heavyweight synth \
+            then deliberates offline over that evidence — a frontier model on the \
+            provider's batch lane (max thinking, half price) or a big local model taking \
+            the time it takes. Returns a durable handle once the dossier is built; keep \
+            working, then `job_wait`/`job_get` it. Best for hard questions worth hours — a \
+            design review, a gnarly bug, \"is this abstraction right\". For an answer this \
+            turn, use `consult`."
+    )]
+    async fn deliberate(
+        &self,
+        Parameters(input): Parameters<DeliberateInput>,
+        peer: Peer<RoleServer>,
+        meta: Meta,
+    ) -> Result<CallToolResult, McpError> {
+        let root = self.resolve_root(input.path)?;
+        let mut cast = self.resolve_cast(input.cast)?;
+        // deliberate = explore → OFFLINE synth. Require the synth on an offline lane
+        // here; the other half — a present, interactive explorer — is enforced when the
+        // explorer arm resolves below (a synth-only batch cast has no explorer slot and
+        // `arm` errors clearly, the honest "no dossier phase to staff" refusal).
+        self.require_deliberate_cast(&cast)?;
+        // Capture the deliberation lane NOW, before any `synth_model` override: an
+        // override replaces the synth slot with a *bare* (laneless) one — it retargets the
+        // model, not the offline mechanism — so reading `synth_lane()` afterward would lose
+        // batch|direct. The lane is a property of the *cast* the caller chose; the override
+        // only swaps which model fills the slot.
+        let lane = cast
+            .synth_lane()
+            .expect("require_deliberate_cast guaranteed an offline synth");
+        self.apply_model_override(
+            &mut cast,
+            ModelRole::Explorer,
+            input.explorer_model.as_deref(),
+            input.explorer_backend.as_deref(),
+            "explorer_model",
+            "explorer_backend",
+        )?;
+        self.apply_model_override(
+            &mut cast,
+            ModelRole::Synth,
+            input.synth_model.as_deref(),
+            input.synth_backend.as_deref(),
+            "synth_model",
+            "synth_backend",
+        )?;
+        let explorer = self.arm(&cast, ModelRole::Explorer)?;
+        let explorer_model = explorer.model.clone();
+
+        // Stage 1 — build the dossier synchronously, on the live progress sink: the
+        // caller waits through this bounded (minutes) explorer sweep, exactly as `explore`
+        // does, so a thin/failed dossier is a clean error *before* any offline tokens are
+        // spent. Only the deliberation (Stage 2) is handed off async.
+        let progress = progress_sink(peer, &meta);
+        let defaults = &self.config.defaults;
+        let cfg = ConsultConfig {
+            explorer_max_turns: input
+                .explorer_max_turns
+                .unwrap_or(defaults.explorer_max_turns),
+            // The offline synth is a single turn (batch item / one direct completion), so
+            // synth_max_turns is inert — carried only to satisfy the shared config.
+            synth_max_turns: defaults.synth_max_turns,
+            sandbox: self.config.sandbox.clone(),
+            progress: progress.clone(),
+            house_rules: self.house_rules(&root)?,
+            prompts: self.resolved_prompts(&cast),
+            orientation: self.orientation(&root).await?,
+            // deliberate reads the repo itself — no caller attachments.
+            attachments: Vec::new(),
+        };
+        let span = tracing::info_span!("deliberate.dossier", cast = %cast.name, explorer_model = %explorer_model);
+        progress.emit(PhaseEvent::PhaseStarted { phase: "deliberate.dossier" });
+        let dossier = match explore_with(&input.question, root, &explorer, &cfg)
+            .instrument(span)
+            .await
+        {
+            Ok(d) => d,
+            Err(e) => return Ok(consultation_failed("deliberate", &cast.name, e)),
+        };
+        progress.emit(PhaseEvent::PhaseFinished { phase: "deliberate.dossier" });
+
+        // Stage 2 — hand the dossier to the offline synth. Its lane picks the mechanism
+        // and the handle; both share the offline-synth preamble (`batch_system_prompt`,
+        // overridable via `[prompts].batch`).
+        let system = crate::consult::batch_system_prompt(self.config.prompts.batch.as_deref());
+        match lane {
+            Lane::Batch => {
+                self.deliberate_batch(&cast, &explorer_model, &input.question, &dossier, &system)
+                    .await
+            }
+            Lane::Direct => {
+                self.deliberate_direct_job(&cast, &explorer_model, &input.question, &dossier, &system)
+            }
+        }
+    }
+
+    /// Stage 2, batch lane: submit the dossier+question as a one-item provider batch
+    /// (max thinking, half price) and hand back the durable `backend/provider-id` handle.
+    /// The dossier phase already ran, so this is only the submit — reusing the same
+    /// `batch::submitter` + shaping `batch_submit` uses, minus the vision gate (deliberate
+    /// carries no attachments; the dossier is text in the item prompt).
+    async fn deliberate_batch(
+        &self,
+        cast: &Cast,
+        explorer_model: &str,
+        question: &str,
+        dossier: &str,
+        system: &str,
+    ) -> Result<CallToolResult, McpError> {
+        let (slot, backend, _caps) = self.batch_synth(cast)?;
+        let backend_name = backend.name.clone();
+        let model = slot.id.clone();
+        let provider = crate::batch::submitter(backend, slot, &self.config.defaults)
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
+        let items = vec![crate::batch::BatchItem {
+            custom_id: "0".to_string(),
+            prompt: crate::consult::deliberation_prompt(question, dossier),
+        }];
+        let span = tracing::info_span!("deliberate.batch", cast = %cast.name, model = %model);
+        let provider_id = provider
+            .submit(system, &[], &items)
+            .instrument(span)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        let handle = format!("{backend_name}/{provider_id}");
+        let msg = format!(
+            "Dossier built (explorer `{explorer_model}`) and handed to the batch lane as \
+             `{handle}` — cast `{}`, synth `{model}` at max thinking. It deliberates offline; \
+             collect it with `job_get {handle}` (durable — survives restart), or stop it with \
+             `job_cancel {handle}`. Nothing to wait on now.",
+            cast.name
+        );
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    }
+
+    /// Stage 2, direct lane: spawn a session-scoped `job-N` that runs the big LOCAL synth
+    /// as one long toolless completion over the dossier. No provider handle exists on this
+    /// lane, so the job stays `job-N` end to end (said loudly in the reply — a restart
+    /// loses it, matching the standing no-daemon decision). Mirrors `consult_submit`'s
+    /// spawn, but the background work is `deliberate_direct`, not the consult loop.
+    fn deliberate_direct_job(
+        &self,
+        cast: &Cast,
+        explorer_model: &str,
+        question: &str,
+        dossier: &str,
+        system: &str,
+    ) -> Result<CallToolResult, McpError> {
+        let synth = self.arm(cast, ModelRole::Synth)?;
+        let synth_model = synth.model.clone();
+        // Same progress plumbing as consult_submit: a job has no live peer, so route
+        // liveness onto `tracing` and let the ProgressLog remember the latest beat for
+        // `job_get`/`job_list`. The sink handed to the phase is the same Arc the job
+        // snapshots, so what it reads is what the completion emitted.
+        let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
+        let sink: Arc<dyn ProgressSink> = progress_log.clone();
+        let cast_name = cast.name.clone();
+        let explorer_model = explorer_model.to_string();
+        let question = question.to_string();
+        let dossier = dossier.to_string();
+        let system = system.to_string();
+        let label =
+            format!("cast `{cast_name}` deliberate (direct synth `{synth_model}`)");
+
+        let job_id = self.jobs.submit(label, progress_log, async move {
+            match crate::consult::deliberate_direct(&question, &dossier, &synth, &system, &sink)
+                .await
+            {
+                Ok(answer) => Ok(JobResult {
+                    answer: with_provenance(
+                        answer,
+                        &cast_name,
+                        &[
+                            ("explorer", explorer_model.as_str()),
+                            ("synth", synth_model.as_str()),
+                        ],
+                    ),
+                    report: None,
+                }),
+                Err(e) => Err(consultation_failure_text("deliberate", &cast_name, e)),
+            }
+        });
+
+        let msg = format!(
+            "Dossier built; the direct (local) synth is now deliberating offline as \
+             `{job_id}` — cast `{}`. This is one long local completion (it can take a \
+             while): `job_wait {job_id}` parks for it, `job_get {job_id}` collects, \
+             `job_cancel {job_id}` stops it. Session-scoped — the job lives for this \
+             server session only.",
+            cast.name
+        );
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    }
+
+    #[tool(
         description = "Ask a model outside your own family a direct question — prompt in, \
             answer out. No tools, no codebase access: the second-opinion primitive for \
             when you already own the context. Paste what's needed, or `attach` whole \
@@ -2000,8 +2289,9 @@ impl KaiboHandler {
     ) -> Result<CallToolResult, McpError> {
         let mut sections: Vec<String> = Vec::new();
 
-        // Consult jobs first — in-memory, this session, always shown when consult is on.
-        if self.config.tools.consult {
+        // In-memory jobs first — this session. `consult_submit` AND `deliberate`'s direct
+        // lane both land here, so show the section when either produces jobs.
+        if self.config.tools.consult || self.config.tools.deliberate {
             sections.push(render_jobs_section(&self.jobs.list()));
         }
 
@@ -2010,7 +2300,7 @@ impl KaiboHandler {
         // `backend`) becomes a *section note*, not a hard error — so it never sinks the
         // consult-jobs section above it. (A local-only setup with batch on but no
         // hosted backend is the common case here.)
-        if self.config.tools.batch {
+        if self.config.tools.batch || self.config.tools.deliberate {
             match self.batch_backends(input.backend.as_deref()) {
                 Ok(backends) => {
                     let mut entries: Vec<(String, crate::batch::BatchListItem)> = Vec::new();
@@ -2184,31 +2474,34 @@ impl KaiboHandler {
         ))]))
     }
 
-    /// Refuse a batch-shaped handle when batch is gated off — `job_get`/`job_cancel`
-    /// survive as long as *either* capability is on, so a handle can arrive for a
-    /// disabled one.
+    /// Refuse a batch-shaped handle only when *no tool that produces one* is enabled —
+    /// `job_get`/`job_cancel` survive as long as any producer is on, so a handle can
+    /// arrive for a producer that's off. A `backend/id` handle comes from `batch_submit`
+    /// OR `deliberate`'s batch lane, so either capability keeps it collectible.
     fn ensure_batch_enabled(&self, handle: &str) -> Result<(), McpError> {
-        if self.config.tools.batch {
+        if self.config.tools.batch || self.config.tools.deliberate {
             return Ok(());
         }
         Err(McpError::invalid_params(
             format!(
-                "`{handle}` looks like a batch handle (`backend/id`), but batch is \
-                 disabled on this server (--no-batch)."
+                "`{handle}` looks like a batch handle (`backend/id`), but nothing that \
+                 produces one is enabled on this server (--no-batch --no-deliberate)."
             ),
             None,
         ))
     }
 
-    /// Refuse a consult-job handle (`job-N`) when consult is gated off.
+    /// Refuse a `job-N` handle only when no tool that produces one is enabled. A `job-N`
+    /// comes from `consult_submit` OR `deliberate`'s direct lane, so either keeps it
+    /// collectible.
     fn ensure_consult_enabled(&self, handle: &str) -> Result<(), McpError> {
-        if self.config.tools.consult {
+        if self.config.tools.consult || self.config.tools.deliberate {
             return Ok(());
         }
         Err(McpError::invalid_params(
             format!(
-                "`{handle}` looks like a consult job (`job-N`), but consult is disabled \
-                 on this server (--no-consult)."
+                "`{handle}` looks like a background job (`job-N`), but nothing that \
+                 produces one is enabled on this server (--no-consult --no-deliberate)."
             ),
             None,
         ))
@@ -2607,6 +2900,30 @@ same `path` / `cast` / `explorer_model` / `explorer_backend` arguments apply; th
 `attach`, `context`, or `session_id` — those belong to the synthesizing tools. When you
 want the conclusion rather than the map, use `consult`.
 
+## Deepest reasoning, offline: `deliberate`
+
+`deliberate` is `explore → offline synth`: a fast model builds a cited dossier (you wait
+for this — the same live explorer sweep `explore` runs, minutes), then a heavyweight synth
+reasons over that evidence *offline*, so you don't hold a session open for the slow part.
+Reach for it on a hard question worth the wait — a design review, a gnarly bug, \"is this
+abstraction right\".
+
+The synth's **lane** (a per-slot property of the cast) picks the mechanism and the handle:
+
+- **`batch`** — a frontier model on the provider's batch lane (max thinking, half price).
+  `deliberate` returns a durable `backend/provider-id` handle the moment the dossier is
+  submitted; collect the deliberation with `job_get` any time, even after a restart.
+- **`direct`** — one long completion on a big *local* model (no batch API; it takes the
+  time it takes). Returns a session-scoped `job-N`; `job_wait`/`job_get` it. Session-scoped
+  means a server restart loses it — collect it in the same session.
+
+A deliberate cast pairs an interactive explorer with an offline synth (e.g. the example
+config's `fable`, `gemini-deliberate`, or `local-direct`); `kaibo://config` shows each
+cast's lane. Because the synth is toolless and can't come back for more, the dossier is
+built whole up front — deliberate reads the repo itself, so it takes `path` / `cast` /
+`explorer_model` / `synth_model` (+ their `*_backend`s), but no `attach` / `context` /
+`session_id`. For an answer this turn, use `consult`.
+
 ## Answer now, or hand off and collect later
 
 Each investigation/answer tool comes in a synchronous form and an async sibling. Use the
@@ -2762,6 +3079,7 @@ fn render_config_resource(
     struct ToolsDoc {
         consult: bool,
         explore: bool,
+        deliberate: bool,
         oneshot: bool,
         run_kaish: bool,
         batch: bool,
@@ -3003,6 +3321,7 @@ fn render_config_resource(
     let &ToolGating {
         consult,
         explore,
+        deliberate,
         oneshot,
         run_kaish,
         batch,
@@ -3054,6 +3373,7 @@ fn render_config_resource(
         tools: ToolsDoc {
             consult,
             explore,
+            deliberate,
             oneshot,
             run_kaish,
             batch,
@@ -3914,18 +4234,19 @@ mod tests {
         );
     }
 
-    /// The cast roster splits by lane on the advertised `cast` enums: the interactive
-    /// tools list non-batch casts, `batch_submit` lists batch casts — so an agent reading
-    /// the schema never offers a cast the tool will refuse. A `direct`-lane cast belongs
-    /// to neither enum yet — it's forward-declared (validated, rendered) but no tool
-    /// routes to it (see the roster-split comment in `KaiboHandler::new`). Driven through
-    /// a keyless local gemini backend so all three casts are usable regardless of which
-    /// API keys the test env carries.
+    /// The cast roster splits by lane AND by whether a cast carries an explorer, across
+    /// the advertised `cast` enums: interactive tools list non-offline casts;
+    /// `batch_submit` lists batch synths (explorer or not); `deliberate` lists offline
+    /// casts that ALSO have an explorer (its dossier phase). So a deliberate-shaped batch
+    /// cast (`mydeliberate`) rides both batch and deliberate; a synth-only batch cast
+    /// (`mybatch`) rides batch only; a synth-only `direct` cast (`mydirect`) rides none
+    /// (no explorer → nothing to build its dossier). Driven through a keyless local gemini
+    /// backend so every cast is usable regardless of the test env's API keys.
     #[test]
     fn cast_enums_split_by_lane() {
         let h = handler_from_toml(
             r#"
-            # A keyless (placeholder) batch-capable backend so all three casts are
+            # A keyless (placeholder) batch-capable backend so all casts are
             # "usable" offline — the partition is exercised with teeth, not trivially empty.
             [backends.gem]
             kind = "gemini"
@@ -3941,6 +4262,10 @@ mod tests {
 
             [casts.mydirect]
             synth = { backend = "gem", id = "some-big-local", lane = "direct" }
+
+            [casts.mydeliberate]
+            explorer = "gem/some-lite"
+            synth = { backend = "gem", id = "some-pro", lane = "batch" }
             "#,
         );
         let enum_of = |tool: &str| -> Vec<String> {
@@ -3959,35 +4284,44 @@ mod tests {
                 })
                 .unwrap_or_default()
         };
-        for tool in ["consult", "consult_submit", "oneshot"] {
+        for tool in ["consult", "consult_submit", "oneshot", "explore"] {
             let casts = enum_of(tool);
             assert!(
                 casts.iter().any(|c| c == "myinteractive"),
                 "{tool} enum should list the interactive cast, got {casts:?}"
             );
-            assert!(
-                !casts.iter().any(|c| c == "mybatch"),
-                "{tool} enum must not list a batch cast, got {casts:?}"
-            );
-            assert!(
-                !casts.iter().any(|c| c == "mydirect"),
-                "{tool} enum must not list a direct-lane cast (no tool routes to it \
-                 yet), got {casts:?}"
-            );
+            for offline in ["mybatch", "mydirect", "mydeliberate"] {
+                assert!(
+                    !casts.iter().any(|c| c == offline),
+                    "{tool} enum must not list the offline cast {offline}, got {casts:?}"
+                );
+            }
         }
         let batch = enum_of("batch_submit");
+        // Both batch synths (explorer or not) can be batch_submit'd — it's synth-only.
         assert!(
-            batch.iter().any(|c| c == "mybatch"),
-            "batch_submit enum should list the batch cast, got {batch:?}"
+            batch.iter().any(|c| c == "mybatch") && batch.iter().any(|c| c == "mydeliberate"),
+            "batch_submit enum should list both batch synths, got {batch:?}"
         );
+        for not_batch in ["myinteractive", "mydirect"] {
+            assert!(
+                !batch.iter().any(|c| c == not_batch),
+                "batch_submit enum must not list {not_batch}, got {batch:?}"
+            );
+        }
+        let deliberate = enum_of("deliberate");
+        // Only the offline-synth-WITH-explorer cast staffs a deliberation.
         assert!(
-            !batch.iter().any(|c| c == "myinteractive"),
-            "batch_submit enum must not list an interactive cast, got {batch:?}"
+            deliberate.iter().any(|c| c == "mydeliberate"),
+            "deliberate enum should list the explorer+offline-synth cast, got {deliberate:?}"
         );
-        assert!(
-            !batch.iter().any(|c| c == "mydirect"),
-            "batch_submit enum must not list a direct-lane cast, got {batch:?}"
-        );
+        for not_deliberate in ["mybatch", "mydirect", "myinteractive"] {
+            assert!(
+                !deliberate.iter().any(|c| c == not_deliberate),
+                "deliberate enum must not list {not_deliberate} (no explorer, or interactive \
+                 synth), got {deliberate:?}"
+            );
+        }
     }
 
     /// The lane gate's two halves, tested directly: an interactive tool refuses an
@@ -4046,6 +4380,69 @@ mod tests {
             "refusal should name the cast and explain it's direct, not batch, got: {msg}"
         );
         assert!(h.require_batch_cast(&batch).is_ok());
+
+        // `deliberate` needs an OFFLINE synth (batch OR direct). It only checks the synth
+        // lane here — the missing-explorer half is caught at the explorer arm resolve — so
+        // an interactive cast is refused (pointed at consult) while both offline lanes pass.
+        let err = h
+            .require_deliberate_cast(&interactive)
+            .expect_err("deliberate must refuse a cast with an interactive synth");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("anthropic") && msg.contains("consult"),
+            "refusal should name the cast and point at consult, got: {msg}"
+        );
+        assert!(
+            h.require_deliberate_cast(&batch).is_ok(),
+            "a batch synth is an offline synth — the explorer gap (if any) is the arm's job"
+        );
+        assert!(
+            h.require_deliberate_cast(&direct).is_ok(),
+            "a direct synth is an offline synth — deliberate's local lane"
+        );
+    }
+
+    /// `deliberate` is a third producer of async handles (a `backend/id` batch on its
+    /// batch lane, a `job-N` on its direct lane), so the runtime collect-guards must keep
+    /// its handles collectible even with `--no-consult --no-batch` — the per-handle mirror
+    /// of the advertisement test in tests/gating.rs. And with deliberate *also* off, no
+    /// producer remains, so both guards refuse.
+    #[test]
+    fn deliberate_keeps_its_handles_collectible() {
+        let deliberate_only = |deliberate: bool| {
+            let mut config = Config::builtin();
+            config.tools = ToolGating {
+                consult: false,
+                batch: false,
+                deliberate,
+                explore: true,
+                oneshot: true,
+                run_kaish: true,
+            };
+            KaiboHandler::new(config).expect("handler builds")
+        };
+
+        // deliberate on, consult+batch off: both handle shapes stay collectible.
+        let h = deliberate_only(true);
+        assert!(
+            h.ensure_batch_enabled("anthropic/msgbatch_x").is_ok(),
+            "a deliberate batch handle must stay collectible with --no-batch"
+        );
+        assert!(
+            h.ensure_consult_enabled("job-1").is_ok(),
+            "a deliberate direct `job-N` must stay collectible with --no-consult"
+        );
+
+        // deliberate off too: no producer remains, so each guard refuses its shape.
+        let off = deliberate_only(false);
+        assert!(
+            off.ensure_batch_enabled("anthropic/msgbatch_x").is_err(),
+            "with every batch producer off, a batch handle is refused"
+        );
+        assert!(
+            off.ensure_consult_enabled("job-1").is_err(),
+            "with every job producer off, a `job-N` is refused"
+        );
     }
 
     /// The gate is wired into the live `batch_submit` handler and fires *before* any

--- a/src/server.rs
+++ b/src/server.rs
@@ -173,11 +173,11 @@ pub struct ConsultInput {
     #[serde(default)]
     pub session_id: Option<String>,
 
-    /// Max tool-loop turns for each delegated `explore′` sweep (default 50).
+    /// Max tool-loop turns for each delegated `explore′` sweep (default 100).
     #[serde(default)]
     pub explorer_max_turns: Option<usize>,
 
-    /// Max tool-loop turns for the consult driver loop itself (default 100).
+    /// Max tool-loop turns for the consult driver loop itself (default 200).
     #[serde(default)]
     pub synth_max_turns: Option<usize>,
 
@@ -226,7 +226,7 @@ pub struct ExploreInput {
     #[serde(default)]
     pub explorer_backend: Option<String>,
 
-    /// Max tool-loop turns for the explorer sweep (default 50).
+    /// Max tool-loop turns for the explorer sweep (default 100).
     #[serde(default)]
     pub explorer_max_turns: Option<usize>,
 }
@@ -274,7 +274,7 @@ pub struct DeliberateInput {
     #[serde(default)]
     pub synth_backend: Option<String>,
 
-    /// Max tool-loop turns for the dossier-building explorer sweep (default 50).
+    /// Max tool-loop turns for the dossier-building explorer sweep (default 100).
     #[serde(default)]
     pub explorer_max_turns: Option<usize>,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1324,6 +1324,44 @@ impl KaiboHandler {
         }
     }
 
+    /// Resolve `deliberate`'s offline lane and apply the per-call model overrides, in the
+    /// one order that's correct. The lane is captured from the *chosen cast* **before** the
+    /// overrides run, because `apply_model_override` replaces a slot with a *bare* (laneless)
+    /// one — an override retargets the model, never the offline mechanism — so reading
+    /// `synth_lane()` afterward would silently lose batch|direct (and hit the `.expect`).
+    /// Assumes [`require_deliberate_cast`](Self::require_deliberate_cast) already passed, so
+    /// the synth lane is `Some`; the sole caller enforces that first. Returns the captured
+    /// lane; `cast` carries the overrides on return.
+    fn deliberation_lane_with_overrides(
+        &self,
+        cast: &mut Cast,
+        explorer_model: Option<&str>,
+        explorer_backend: Option<&str>,
+        synth_model: Option<&str>,
+        synth_backend: Option<&str>,
+    ) -> Result<Lane, McpError> {
+        let lane = cast
+            .synth_lane()
+            .expect("require_deliberate_cast guaranteed an offline synth");
+        self.apply_model_override(
+            cast,
+            ModelRole::Explorer,
+            explorer_model,
+            explorer_backend,
+            "explorer_model",
+            "explorer_backend",
+        )?;
+        self.apply_model_override(
+            cast,
+            ModelRole::Synth,
+            synth_model,
+            synth_backend,
+            "synth_model",
+            "synth_backend",
+        )?;
+        Ok(lane)
+    }
+
     /// Apply a per-call model override to one of `cast`'s slots.
     ///
     /// The model id rides *verbatim* — an id containing `/` (HuggingFace-style
@@ -1748,29 +1786,15 @@ impl KaiboHandler {
         // explorer arm resolves below (a synth-only batch cast has no explorer slot and
         // `arm` errors clearly, the honest "no dossier phase to staff" refusal).
         self.require_deliberate_cast(&cast)?;
-        // Capture the deliberation lane NOW, before any `synth_model` override: an
-        // override replaces the synth slot with a *bare* (laneless) one — it retargets the
-        // model, not the offline mechanism — so reading `synth_lane()` afterward would lose
-        // batch|direct. The lane is a property of the *cast* the caller chose; the override
-        // only swaps which model fills the slot.
-        let lane = cast
-            .synth_lane()
-            .expect("require_deliberate_cast guaranteed an offline synth");
-        self.apply_model_override(
+        // Capture the lane and apply per-call overrides in the one correct order (the
+        // capture must precede the overrides — see the helper). Extracted so a test can
+        // pin that a `synth_model` override never drops batch|direct.
+        let lane = self.deliberation_lane_with_overrides(
             &mut cast,
-            ModelRole::Explorer,
             input.explorer_model.as_deref(),
             input.explorer_backend.as_deref(),
-            "explorer_model",
-            "explorer_backend",
-        )?;
-        self.apply_model_override(
-            &mut cast,
-            ModelRole::Synth,
             input.synth_model.as_deref(),
             input.synth_backend.as_deref(),
-            "synth_model",
-            "synth_backend",
         )?;
         let explorer = self.arm(&cast, ModelRole::Explorer)?;
         let explorer_model = explorer.model.clone();
@@ -4442,6 +4466,49 @@ mod tests {
         assert!(
             off.ensure_consult_enabled("job-1").is_err(),
             "with every job producer off, a `job-N` is refused"
+        );
+    }
+
+    /// The lane-capture invariant, pinned: a per-call `synth_model` override retargets the
+    /// model but must NOT change deliberate's offline lane. `apply_model_override` replaces
+    /// the synth slot with a bare (laneless) one, so `deliberation_lane_with_overrides`
+    /// captures the lane *before* overriding — this test fails (wrong lane, or a panic on
+    /// the `.expect`) if that order is ever reversed. Also proves the capture is load-bearing:
+    /// the slot really does go laneless, and the override really does take effect.
+    #[test]
+    fn deliberate_lane_survives_a_synth_model_override() {
+        let h = handler_from_toml(
+            r#"
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.mydeliberate]
+            explorer = "gem/some-lite"
+            synth    = { backend = "gem", id = "some-pro", lane = "batch" }
+            "#,
+        );
+        let mut cast = h.config.resolve_cast("mydeliberate").unwrap().clone();
+        // A synth_model override — this is what replaces the slot with a bare, laneless one.
+        let lane = h
+            .deliberation_lane_with_overrides(&mut cast, None, None, Some("some-other-pro"), None)
+            .expect("override applies cleanly");
+        assert_eq!(
+            lane,
+            Lane::Batch,
+            "a synth_model override must not drop the batch lane"
+        );
+        // The capture was load-bearing: the override left the synth slot laneless...
+        assert_eq!(
+            cast.synth_lane(),
+            None,
+            "the override replaced the synth slot with a bare (laneless) one"
+        );
+        // ...and it did retarget the model.
+        assert_eq!(
+            cast.slot(ModelRole::Synth).map(|s| s.id.as_str()),
+            Some("some-other-pro"),
+            "the synth_model override took effect"
         );
     }
 

--- a/tests/cast_param.rs
+++ b/tests/cast_param.rs
@@ -7,7 +7,7 @@
 //! silent drop into the default cast (serde drops unknown fields, a textbook silent
 //! fallback). These tests pin that end state.
 
-use kaibo::server::{ConsultInput, ExploreInput, OneshotInput, RunKaishInput};
+use kaibo::server::{ConsultInput, DeliberateInput, ExploreInput, OneshotInput, RunKaishInput};
 use serde_json::json;
 
 #[test]
@@ -23,6 +23,10 @@ fn cast_is_the_canonical_spelling_and_optional() {
     let e: ExploreInput = serde_json::from_value(json!({ "question": "q", "cast": "chimera" }))
         .expect("explore takes cast");
     assert_eq!(e.cast.as_deref(), Some("chimera"));
+
+    let b: DeliberateInput = serde_json::from_value(json!({ "question": "q", "cast": "fable" }))
+        .expect("deliberate takes cast");
+    assert_eq!(b.cast.as_deref(), Some("fable"));
 
     // Omitting it entirely falls through to the server's default cast.
     let d: ConsultInput =
@@ -69,6 +73,18 @@ fn a_typoed_argument_is_a_loud_error_not_a_silent_default_run() {
     // A synth-side arg has no home on explore (single-phase) — it must not vanish.
     serde_json::from_value::<ExploreInput>(json!({ "question": "q", "synth_model": "x" }))
         .expect_err("explore has no synth args — synth_model must not silently vanish");
+    // deliberate carries both explorer and synth overrides, but a session_id (it has no
+    // session) or a typo must still fault, not run on defaults.
+    serde_json::from_value::<DeliberateInput>(json!({ "question": "q", "session_id": "s" }))
+        .expect_err("deliberate has no session — session_id must not silently vanish");
+    let err = serde_json::from_value::<DeliberateInput>(
+        json!({ "question": "q", "synth_modle": "claude-fable-5" }),
+    )
+    .expect_err("a typo'd deliberate argument must be rejected");
+    assert!(
+        err.to_string().contains("synth_modle"),
+        "the error must name the unknown field, got: {err}"
+    );
 }
 
 /// The `provider` tombstone: with the transitional alias removed, a client still

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -874,6 +874,7 @@ fn cli_cast_wins_over_env_and_file() {
     // Only oneshot is dropped; the rest stay enabled.
     assert!(c.tools.consult);
     assert!(c.tools.explore);
+    assert!(c.tools.deliberate);
     assert!(!c.tools.oneshot);
     assert!(c.tools.run_kaish);
 }

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -13,10 +13,11 @@ use kaibo::server::{KaiboHandler, ToolGating};
 /// `job_cancel`/`job_list`/`job_wait` are *shared* — they manage both kinds of handle
 /// and stay advertised as long as either capability is on, so they belong to neither
 /// flag.
-const ALL_TOOLS: [&str; 10] = [
+const ALL_TOOLS: [&str; 11] = [
     "batch_submit",
     "consult",
     "consult_submit",
+    "deliberate",
     "explore",
     "job_cancel",
     "job_get",
@@ -45,7 +46,7 @@ fn each_flag_removes_exactly_its_own_tools() {
     // `job_get`/`job_cancel`/`job_list` belong to neither flag alone — gating one
     // capability leaves them because the other still needs them — so they appear in no
     // row's removed-set and are covered by the "every other tool remains" check below.
-    let cases: [(&[&str], ToolGating); 5] = [
+    let cases: [(&[&str], ToolGating); 6] = [
         (
             // `--no-consult` drops the blocking `consult` and the async `consult_submit`;
             // `job_get`/`job_cancel`/`job_list` stay (batch still uses them).
@@ -61,6 +62,15 @@ fn each_flag_removes_exactly_its_own_tools() {
             &["explore"],
             ToolGating {
                 explore: false,
+                ..Default::default()
+            },
+        ),
+        (
+            // `--no-deliberate` drops only `deliberate` — the collect verbs it hands off
+            // to (batch/job) stay, gated by their own capability.
+            &["deliberate"],
+            ToolGating {
+                deliberate: false,
                 ..Default::default()
             },
         ),
@@ -106,49 +116,43 @@ fn each_flag_removes_exactly_its_own_tools() {
     }
 }
 
-/// The shared collect verbs (`job_get`/`job_cancel`/`job_list`) are gated by *either*
-/// capability: they stay while batch or consult is on, and drop only when both are
-/// off. A naive single-flag gate would fail the "stays with the other capability on"
-/// cases.
+/// The shared collect verbs (`job_get`/`job_cancel`/`job_list`/`job_wait`) are gated by
+/// *any handle producer*: `consult_submit` and `batch_submit` — and `deliberate`, which
+/// produces both a `job-N` (direct lane) and a `backend/provider-id` (batch lane). They
+/// stay while any of the three is on, and drop only when all are off. A gate that knew
+/// only batch+consult would strand a `deliberate`-only server's handles.
 #[test]
-fn shared_collect_verbs_track_both_capabilities() {
+fn shared_collect_verbs_track_all_handle_producers() {
     const VERBS: [&str; 4] = ["job_get", "job_cancel", "job_list", "job_wait"];
 
-    // consult on, batch off — the verbs still serve consult jobs.
-    let consult_only = advertised(ToolGating {
-        batch: false,
-        ..Default::default()
-    });
-    for v in VERBS {
-        assert!(
-            consult_only.contains(&v.to_string()),
-            "{v} must remain with consult on (it collects consult jobs)"
-        );
+    // Each producer alone must keep the verbs — its handles need collecting.
+    for (label, only) in [
+        ("consult", ToolGating { batch: false, deliberate: false, ..Default::default() }),
+        ("batch", ToolGating { consult: false, deliberate: false, ..Default::default() }),
+        // deliberate alone: it's the case the old batch+consult gate would have stranded.
+        ("deliberate", ToolGating { batch: false, consult: false, ..Default::default() }),
+    ] {
+        let tools = advertised(only);
+        for v in VERBS {
+            assert!(
+                tools.contains(&v.to_string()),
+                "{v} must remain with {label} on (it collects {label}'s handles)"
+            );
+        }
     }
 
-    // batch on, consult off — the verbs still serve batches.
-    let batch_only = advertised(ToolGating {
-        consult: false,
-        ..Default::default()
-    });
-    for v in VERBS {
-        assert!(
-            batch_only.contains(&v.to_string()),
-            "{v} must remain with batch on (it collects batches)"
-        );
-    }
-
-    // Both off — nothing to collect, so the verbs drop. (run_kaish/oneshot keep the
-    // server a valid, non-empty surface.)
-    let neither = advertised(ToolGating {
+    // All three producers off — nothing to collect, so the verbs drop. (run_kaish/oneshot
+    // keep the server a valid, non-empty surface.)
+    let none = advertised(ToolGating {
         batch: false,
         consult: false,
+        deliberate: false,
         ..Default::default()
     });
     for v in VERBS {
         assert!(
-            !neither.contains(&v.to_string()),
-            "{v} must drop when both batch and consult are off"
+            !none.contains(&v.to_string()),
+            "{v} must drop when every handle producer (batch/consult/deliberate) is off"
         );
     }
 }
@@ -158,6 +162,7 @@ fn all_disabled_is_detected() {
     let none_on = ToolGating {
         consult: false,
         explore: false,
+        deliberate: false,
         oneshot: false,
         run_kaish: false,
         batch: false,
@@ -191,6 +196,7 @@ fn all_tools_disabled_refuses_to_start() {
         .args([
             "--no-consult",
             "--no-explore",
+            "--no-deliberate",
             "--no-oneshot",
             "--no-run-kaish",
             "--no-batch",


### PR DESCRIPTION
## What

Adds `deliberate` — a heavyweight model's deepest reasoning on a codebase without holding a session open. It's `explore → offline synth`, and it closes **Arc 2** plus the ladder the tool surface teaches: `run_kaish` → `explore` → `consult` → **`deliberate`**.

## Design (Amy's steer simplified the original spec)

The plan doc floated a *two-stage handle* that transitions `job-N` → `backend/provider-id` at submit. Amy's steer — **block through the explore phase, release after the offline work starts** — collapses that entirely:

- **Block through the dossier.** `deliberate` runs the explorer sweep *synchronously* (the same live `explore_with` phase, minutes), so a thin or failed dossier is a clean error **before** any offline tokens are spent. Only the deliberation is async.
- **The synth's lane picks the mechanism AND the handle** — so each lane returns its *natural single-namespace* handle and the `is_batch_handle` dispatch seam is **untouched** (no handle crosses namespaces mid-life):
  - **`batch`** → submit a one-item provider batch (max thinking, half price), return a durable `backend/provider-id` immediately; collect via `job_get` any time, even after a restart.
  - **`direct`** → spawn a session-scoped `job-N` running one long toolless **local** completion. This is the tool that finally routes the `direct` lane the per-slot lane reshape (#38) introduced.

## Reuse over new machinery

- dossier phase = `explore_with`;
- batch submit = `batch::submitter` + `deliberation_prompt` (a pure builder, unit-pinned);
- direct completion = `deliberate_direct` (the `oneshot` shape on the offline-synth preamble);
- both lanes share `batch_system_prompt`.

A deliberate cast pairs an interactive explorer with an offline synth: `cast_can_deliberate` gates it, a third `inject_cast_enum` partition advertises it, and the example config gains `fable` (Sonnet→Fable-5, batch), `gemini-deliberate` (Flash-Lite→Pro, batch), and `local-direct` (direct).

**Subtlety fixed:** `override_model` replaces a slot with a *bare* (laneless) one, so the handler captures the lane from the cast **before** applying any `synth_model` override and dispatches on the captured lane.

## Handshake budget

`deliberate` joins the lead's async clause; the Casts intro, Scope pointer, and unconfigured setup banner were **compressed** to hold Claude Code's 2048-char cap (both `instructions_fit_claude_code_budget` tests stay green). Plus a new `kaibo://tools` "Deepest reasoning, offline" section, tool description, `--no-deliberate` gate, and CHANGELOG entry.

## Review — the hard look this arc gets

Cross-family via kaibo itself (DeepSeek + Gemini, holistic, no diff):
- **Gemini** — no correctness issues; confirmed the lane-capture fix, the roster split, and that budget compression lost no meaning.
- **DeepSeek** — caught a **real gating gap**: `deliberate` is a *third* producer of async handles (batch on its batch lane, `job-N` on its direct lane), but the collect verbs (`job_get`/`job_cancel`/`job_list`/`job_wait`), their per-handle guards (`ensure_batch_enabled`/`ensure_consult_enabled`), and `job_list`'s two sections only knew batch+consult — so `--no-batch`/`--no-consult` combos could strand a `deliberate` handle. **Fixed at all five sites** and pinned with two tests (`shared_collect_verbs_track_all_handle_producers`, `deliberate_keeps_its_handles_collectible`).

## Tests

Full suite green (lib + all integration), clippy clean on touched files. New: `deliberation_prompt`, `deliberate_direct`, the strengthened `cast_enums_split_by_lane` (now covers the deliberate enum), `require_deliberate_cast` in `lane_gate_refuses_the_wrong_lane`, `deliberate_keeps_its_handles_collectible`, the reworked collect-verb gating test, `--no-deliberate` gating, and `DeliberateInput` schema cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)