### PR TITLE
Batch-provider injection seam: test the batch handlers offline

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -104,6 +104,48 @@ planned.
 
 ## P2 — Focused fixes & hardening
 
+### Codebase health review (Fable-5 + Gemini Pro, dogfooded 2026-07-02)
+A whole-`src/` health review by Fable-5 (via `batch_submit` + `attach`) plus a lifecycle
+review by Gemini Pro (via `deliberate`). Verdict: healthy, with two swollen organs
+(`server.rs`, `consult.rs`) and archaeological layers from heavy refactoring. Two findings
+were fixed in the deliberate PR (the drifted `max_turns` schema defaults; a test pinning
+`deliberate`'s lane-capture-before-override). The rest, roughly in value order:
+
+- **Batch-provider injection seam + offline handler tests — IN FLIGHT** (`feat/batch-injection-seam`).
+  The batch handlers (`batch_submit`, `deliberate_batch`, the batch arms of `job_get`/
+  `job_list`/`job_cancel`) call `crate::batch::submitter`/`poller` directly, so — unlike the
+  consult side, fully offline-tested via `Arm::new` — they have no handler-level coverage.
+  Route them through a factory field on `KaiboHandler` (default = the real fns), inject
+  `ScriptedBatch`. Fable's "thinnest coverage relative to blast radius." Delete when it ships.
+- **Unify the lane→tool partition.** Which cast serves which tool is derived independently
+  in ~4 places (`inject_cast_enum`'s three rosters, the `reject_offline_cast`/
+  `require_batch_cast`/`require_deliberate_cast` gates, `casts_section`'s direct-filter). A
+  single `Config` source + a consistency test would stop them drifting; the `deliberate`
+  work made it a 3-way split.
+- **Vestiges / finish-the-migration cleanups.** `credentials.rs` dead code (`load`,
+  `openai_key`, `resolve_openai_key`) + the duplicate alias table in `ProviderKind::FromStr`
+  (parallel to `config.rs::builtin_aliases`); finish the `batch_http_client` migration
+  (`Arm::from_slot` and `telemetry.rs::init` still hand-roll the timeout+`ensure_crypto_provider`
+  block); exhaustive-destructure `apply_raw_env`/`merge_defaults` so a new `Defaults` field
+  can't silently miss its env/merge line (the `render_config_resource` discipline, applied to
+  the config layer); `supported_kinds_list()`'s hand-maintained `ProviderKind` array.
+- **Module splits (architecture-scale, own PRs, sequence deliberately).** `consult.rs` →
+  `shaping` (`ModelShape`/`ModelCaps`/the id-classifiers/`default_models` — the provider-drift
+  knowledge) + `engine` (`Arm`/`PhaseRunner`/`run_phase`/the view_image break-rewrite) +
+  `prompts` (the preambles/`phase_preamble`/`consult_user_prompt`/`deliberation_prompt`).
+  `server.rs` → extract the containment boundary (`resolve_root`/`contained`/attachment
+  resolvers) into its own doc-headed module, plus `render_config_resource` and the job/batch
+  renderers. Split the `ConsultConfig` grab-bag (its own comments admit fields ride it only
+  because it's "the one bundle already threaded everywhere"; `explore`/`deliberate` fill it
+  with fields their comments call inert).
+- **`deliberate` dossier vs. caller timeout (Gemini).** The dossier builds synchronously, so a
+  caller with a tight tool-call timeout can drop the connection before the durable handle
+  returns; the job still runs. Mitigation: echo the question into `job_list` so a timed-out
+  caller re-finds the handle (dovetails the "self-describing batch results" bullet under the
+  batch-hardening P3 entry). A more invasive option — async dossier returning `job-N`
+  immediately — trades away the batch lane's cross-restart durability; don't without the
+  persistence decision.
+
 ### Upstream kaish-vfs: `LocalFs::list` hard-fails when an entry vanishes mid-walk
 `kaish-vfs` `LocalFs::list` (`src/local.rs`, 0.9.0) enumerates a directory with
 `read_dir`, then calls `symlink_metadata` on *each* entry and propagates any error with

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1178,6 +1178,44 @@ pub fn poller(backend: &Backend) -> Result<Arc<dyn BatchProvider>> {
     }
 }
 
+/// The seam that lets the batch *handlers* be tested offline. `KaiboHandler` holds one of
+/// these and builds every provider through it, so a test can swap the real
+/// network-client builders ([`submitter`]/[`poller`]) for a double returning a
+/// [`ScriptedBatch`] — closing the handler-level coverage gap that the free-function
+/// call sites left (the consult side already injects via `Arm::new`). The two methods
+/// mirror the free functions exactly; production is [`LiveBatchProviders`].
+pub trait BatchProviderFactory: Send + Sync {
+    /// A model-bearing provider for submitting a batch (mirrors [`submitter`]).
+    fn submitter(
+        &self,
+        backend: &Backend,
+        slot: &ModelSlot,
+        defaults: &Defaults,
+    ) -> Result<Arc<dyn BatchProvider>>;
+
+    /// A poll/cancel/list-only provider (mirrors [`poller`]).
+    fn poller(&self, backend: &Backend) -> Result<Arc<dyn BatchProvider>>;
+}
+
+/// The production factory: the real `submitter`/`poller`, building network clients. The
+/// default a server runs on; only tests substitute another.
+pub struct LiveBatchProviders;
+
+impl BatchProviderFactory for LiveBatchProviders {
+    fn submitter(
+        &self,
+        backend: &Backend,
+        slot: &ModelSlot,
+        defaults: &Defaults,
+    ) -> Result<Arc<dyn BatchProvider>> {
+        submitter(backend, slot, defaults)
+    }
+
+    fn poller(&self, backend: &Backend) -> Result<Arc<dyn BatchProvider>> {
+        poller(backend)
+    }
+}
+
 #[cfg(test)]
 mod test_double {
     use super::*;
@@ -1267,10 +1305,31 @@ mod test_double {
             Ok(self.listing.clone())
         }
     }
+
+    /// A [`BatchProviderFactory`] that hands the *same* [`ScriptedBatch`] to every
+    /// submit and poll — so a handler test drives one double across a batch's whole
+    /// lifecycle (submit here, then `job_get`/`job_cancel`/`job_list` re-address it).
+    /// The backend/slot/defaults are ignored; the double is pre-scripted.
+    pub struct ScriptedBatchProviders(pub Arc<ScriptedBatch>);
+
+    impl BatchProviderFactory for ScriptedBatchProviders {
+        fn submitter(
+            &self,
+            _backend: &Backend,
+            _slot: &ModelSlot,
+            _defaults: &Defaults,
+        ) -> Result<Arc<dyn BatchProvider>> {
+            Ok(self.0.clone())
+        }
+
+        fn poller(&self, _backend: &Backend) -> Result<Arc<dyn BatchProvider>> {
+            Ok(self.0.clone())
+        }
+    }
 }
 
 #[cfg(test)]
-pub use test_double::ScriptedBatch;
+pub use test_double::{ScriptedBatch, ScriptedBatchProviders};
 
 #[cfg(test)]
 mod tests {

--- a/src/server.rs
+++ b/src/server.rs
@@ -460,6 +460,12 @@ pub struct KaiboHandler {
     /// configured explicitly. Surfaced as "(inferred from launch cwd)" in the scope
     /// section and `kaibo://config` so the boundary stays legible.
     default_root_inferred: bool,
+    /// How the batch handlers build provider clients — the injection seam. `new` seeds
+    /// [`LiveBatchProviders`](crate::batch::LiveBatchProviders) (the real network
+    /// builders); tests swap in a scripted double via
+    /// [`with_batch_providers`](Self::with_batch_providers) to exercise the submit/poll
+    /// handler wiring offline. `Arc<dyn …>` so the derived `Clone` shares one factory.
+    batch_providers: Arc<dyn crate::batch::BatchProviderFactory>,
 }
 
 /// Inject `casts` as a JSON-Schema `enum` on the `cast` parameter of every
@@ -693,6 +699,8 @@ impl KaiboHandler {
             allowed_set: Arc::new(allowed),
             default_root: Arc::new(default_root),
             default_root_inferred,
+            // The real network-client builders; tests swap in a scripted double.
+            batch_providers: Arc::new(crate::batch::LiveBatchProviders),
         })
     }
 
@@ -701,6 +709,19 @@ impl KaiboHandler {
     /// keep `new(config)` unchanged for the many call sites and tests.
     pub fn with_notifications(mut self, buffer: crate::mcp_log::NotificationBuffer) -> Self {
         self.notifications = buffer;
+        self
+    }
+
+    /// Swap in a batch-provider factory — the seam that lets tests drive the batch
+    /// handlers (`batch_submit`, `deliberate`'s batch lane, the `job_*` batch arms) with a
+    /// scripted double instead of real network clients. A builder, like
+    /// [`with_notifications`](Self::with_notifications), so `new(config)` stays unchanged.
+    #[cfg(test)]
+    pub fn with_batch_providers(
+        mut self,
+        providers: Arc<dyn crate::batch::BatchProviderFactory>,
+    ) -> Self {
+        self.batch_providers = providers;
         self
     }
 
@@ -1862,7 +1883,7 @@ impl KaiboHandler {
         let (slot, backend, _caps) = self.batch_synth(cast)?;
         let backend_name = backend.name.clone();
         let model = slot.id.clone();
-        let provider = crate::batch::submitter(backend, slot, &self.config.defaults)
+        let provider = self.batch_providers.submitter(backend, slot, &self.config.defaults)
             .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
         let items = vec![crate::batch::BatchItem {
             custom_id: "0".to_string(),
@@ -2076,7 +2097,9 @@ impl KaiboHandler {
             .config
             .resolve_backend(backend_name)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-        crate::batch::poller(backend).map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
+        self.batch_providers
+            .poller(backend)
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))
     }
 
     /// The set of backend names `job_list` should query. An explicit `backend` scopes
@@ -2161,7 +2184,7 @@ impl KaiboHandler {
         self.gate_image_attachments(caps.vision, &attachments, &model, &cast.name)?;
         // Now build the network client (resolves the key); a batch-incapable backend is
         // refused honestly here.
-        let provider = crate::batch::submitter(backend, slot, &self.config.defaults)
+        let provider = self.batch_providers.submitter(backend, slot, &self.config.defaults)
             .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
         let items: Vec<crate::batch::BatchItem> = input
             .prompts
@@ -4193,6 +4216,34 @@ mod tests {
             .expect("handler builds")
     }
 
+    /// The joined text of a successful `CallToolResult` — for asserting on a handler's
+    /// reply message.
+    fn result_text(r: CallToolResult) -> String {
+        r.content
+            .into_iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// A keyless config with both a synth-only batch cast (`mybatch`) and a
+    /// deliberate-shaped batch cast (`mydeliberate`, explorer + batch synth). Keyless so
+    /// the *real* provider build would need no key anyway; tests inject a scripted factory
+    /// so no network is touched regardless.
+    const BATCH_CASTS_TOML: &str = r#"
+        [backends.gem]
+        kind = "gemini"
+        key_optional = true
+
+        [casts.mybatch]
+        batch = true
+        synth = "gem/some-pro"
+
+        [casts.mydeliberate]
+        explorer = "gem/some-lite"
+        synth    = { backend = "gem", id = "some-pro", lane = "batch" }
+    "#;
+
     /// The live cast roster is stamped onto each consultation tool's `cast` param as
     /// a JSON-Schema `enum`, so an agent reads the menu off the schema it fills
     /// arguments from — the fix for casts being discoverable only in handshake prose
@@ -4531,6 +4582,160 @@ mod tests {
         assert!(
             format!("{err:?}").contains("not a batch cast"),
             "the handler must reject before building any provider client"
+        );
+    }
+
+    /// `batch_submit` end to end, offline through the injected factory: the handler
+    /// resolves the batch cast, mints the `backend/provider-id` handle, and hands each
+    /// prompt to the provider as its own indexed item. Closes the handler-level gap the
+    /// direct `batch::submitter` call left (the consult side already tests via `Arm::new`).
+    #[tokio::test]
+    async fn batch_submit_submits_through_the_injected_factory() {
+        let scripted = Arc::new(crate::batch::ScriptedBatch::new("msgbatch_x", vec![]));
+        let h = handler_from_toml(BATCH_CASTS_TOML).with_batch_providers(Arc::new(
+            crate::batch::ScriptedBatchProviders(scripted.clone()),
+        ));
+
+        let out = h
+            .batch_submit(Parameters(BatchSubmitInput {
+                prompts: vec!["first".into(), "second".into()],
+                attach: vec![],
+                cast: Some("mybatch".into()),
+                model: None,
+                backend: None,
+            }))
+            .await
+            .expect("scripted batch_submit succeeds");
+
+        assert!(
+            result_text(out).contains("gem/msgbatch_x"),
+            "the reply namespaces the scripted id under the cast's backend"
+        );
+        // Both prompts reached the provider, one item each, indexed 0..N.
+        let submits = scripted.submits();
+        assert_eq!(submits.len(), 1, "one batch submitted");
+        let items = &submits[0].2;
+        assert_eq!(
+            items.iter().map(|i| i.prompt.as_str()).collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+        assert_eq!(
+            items.iter().map(|i| i.custom_id.as_str()).collect::<Vec<_>>(),
+            vec!["0", "1"],
+            "items carry their index as custom_id"
+        );
+    }
+
+    /// `deliberate`'s BATCH lane, tested directly — no explorer, no network. `deliberate_batch`
+    /// takes an already-built dossier and submits it as ONE item whose prompt is the
+    /// `deliberation_prompt` (question + dossier), passing the offline-synth system prompt
+    /// through and returning the durable handle. This is the batch-lane wiring `deliberate`
+    /// added, now covered offline.
+    #[tokio::test]
+    async fn deliberate_batch_lane_submits_the_dossier_as_one_item() {
+        let scripted = Arc::new(crate::batch::ScriptedBatch::new("msgbatch_d", vec![]));
+        let h = handler_from_toml(BATCH_CASTS_TOML).with_batch_providers(Arc::new(
+            crate::batch::ScriptedBatchProviders(scripted.clone()),
+        ));
+        let cast = h.config.resolve_cast("mydeliberate").unwrap().clone();
+
+        let out = h
+            .deliberate_batch(
+                &cast,
+                "gem/some-lite",
+                "Is the retry safe?",
+                "DOSSIER: src/x.rs:1 fn retry",
+                "offline-synth-system",
+            )
+            .await
+            .expect("scripted deliberate_batch succeeds");
+
+        assert!(
+            result_text(out).contains("gem/msgbatch_d"),
+            "the reply carries the durable batch handle"
+        );
+        let submits = scripted.submits();
+        assert_eq!(submits.len(), 1, "the dossier is one batch");
+        let (system, attach, items) = &submits[0];
+        assert_eq!(system, "offline-synth-system", "the system prompt passes through");
+        assert!(attach.is_empty(), "deliberate carries no attachments — the dossier is the prompt");
+        assert_eq!(items.len(), 1, "one item — the dossier, not fanned");
+        assert!(
+            items[0].prompt.contains("Is the retry safe?")
+                && items[0].prompt.contains("DOSSIER: src/x.rs:1 fn retry"),
+            "the one item is the deliberation_prompt — question AND dossier: {}",
+            items[0].prompt
+        );
+    }
+
+    /// `job_get`'s batch arm polls through the factory: a scripted `Done` renders the
+    /// item answers. Proves the collect path reaches the provider (not just the gate).
+    #[tokio::test]
+    async fn job_get_polls_a_batch_through_the_factory() {
+        let scripted = Arc::new(crate::batch::ScriptedBatch::new(
+            "msgbatch_x",
+            vec![crate::batch::BatchPoll::Done(vec![crate::batch::BatchAnswer {
+                custom_id: "0".into(),
+                text: Ok("THE DELIBERATION".into()),
+            }])],
+        ));
+        let h = handler_from_toml(BATCH_CASTS_TOML).with_batch_providers(Arc::new(
+            crate::batch::ScriptedBatchProviders(scripted.clone()),
+        ));
+
+        let out = h
+            .job_get(Parameters(HandleInput {
+                handle: "gem/msgbatch_x".into(),
+            }))
+            .await
+            .expect("scripted job_get succeeds");
+        assert!(
+            result_text(out).contains("THE DELIBERATION"),
+            "the batch's item answer is rendered"
+        );
+    }
+
+    /// `job_cancel` and `job_list`'s batch section also route through the factory — cancel
+    /// reaches the provider by id, and the listing renders the seeded batch.
+    #[tokio::test]
+    async fn job_cancel_and_list_reach_the_batch_through_the_factory() {
+        let scripted = Arc::new(
+            crate::batch::ScriptedBatch::new("msgbatch_x", vec![]).with_listing(
+                vec![crate::batch::BatchListItem {
+                    provider_id: "msgbatch_x".into(),
+                    status: "running".into(),
+                    completed: 0,
+                    total: 1,
+                    created_at: None,
+                }],
+                false,
+            ),
+        );
+        let h = handler_from_toml(BATCH_CASTS_TOML).with_batch_providers(Arc::new(
+            crate::batch::ScriptedBatchProviders(scripted.clone()),
+        ));
+
+        h.job_cancel(Parameters(HandleInput {
+            handle: "gem/msgbatch_x".into(),
+        }))
+        .await
+        .expect("scripted job_cancel succeeds");
+        assert_eq!(
+            scripted.canceled(),
+            vec!["msgbatch_x".to_string()],
+            "cancel reached the provider by id"
+        );
+
+        let out = h
+            .job_list(Parameters(ListInput {
+                all: false,
+                backend: Some("gem".into()),
+            }))
+            .await
+            .expect("scripted job_list succeeds");
+        assert!(
+            result_text(out).contains("msgbatch_x"),
+            "the seeded batch appears in the listing"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4624,6 +4624,12 @@ mod tests {
             vec!["0", "1"],
             "items carry their index as custom_id"
         );
+        // The offline-synth (batch) system prompt is submitted — not oneshot/consult's.
+        assert_eq!(
+            submits[0].0,
+            crate::consult::batch_system_prompt(None),
+            "the batch system prompt is passed through"
+        );
     }
 
     /// `deliberate`'s BATCH lane, tested directly — no explorer, no network. `deliberate_batch`
@@ -4660,6 +4666,7 @@ mod tests {
         assert_eq!(system, "offline-synth-system", "the system prompt passes through");
         assert!(attach.is_empty(), "deliberate carries no attachments — the dossier is the prompt");
         assert_eq!(items.len(), 1, "one item — the dossier, not fanned");
+        assert_eq!(items[0].custom_id, "0", "the single dossier item is custom_id 0");
         assert!(
             items[0].prompt.contains("Is the retry safe?")
                 && items[0].prompt.contains("DOSSIER: src/x.rs:1 fn retry"),
@@ -4738,6 +4745,11 @@ mod tests {
             "the seeded batch appears in the listing"
         );
     }
+
+    // (`job_wait`'s batch arm uses the same `batch_poller` choke-point these tests cover,
+    // but the handler takes a live `Peer<RoleServer>` for its notification drain, so a full
+    // offline handler test would need a fabricated peer — out of scope; the provider path
+    // itself is proven above.)
 
     /// An empty roster (no cast can reach a model) leaves `cast` enum-free: an empty
     /// `enum` would read as "no valid value" and wrongly forbid the optional field.


### PR DESCRIPTION
## What

Adds an injection seam so kaibo's **batch handlers can be tested offline** — the first health-review follow-up (from the 2026-07-02 Fable-5/Gemini dogfood, recorded in `docs/issues.md`).

The batch handlers (`batch_submit`, `deliberate`'s batch lane, and the `job_*` batch arms) called `crate::batch::submitter`/`poller` directly, building real network clients — so unlike the consult side (offline-tested via `Arm::new`) they had **no handler-level coverage**. Fable named this *"the thinnest coverage relative to blast radius,"* and `deliberate_batch` shipped in #40 untested.

## How

- **`BatchProviderFactory`** trait (`src/batch.rs`): two sync methods mirroring the free functions exactly — `submitter(backend, slot, defaults)` and `poller(backend)`.
- **`LiveBatchProviders`** — the production impl, a faithful one-line pass-through to the existing free functions. `KaiboHandler::new` seeds it; production has no path to swap it.
- **`ScriptedBatchProviders`** — a `#[cfg(test)]` double wrapping the existing `ScriptedBatch`, injected via a `#[cfg(test)] with_batch_providers` builder (mirrors `with_notifications`).
- `KaiboHandler` gains one `Arc<dyn BatchProviderFactory>` field; every provider build (the two `submitter` sites + the single `batch_poller` helper that all four collect verbs share) routes through it. No stray direct calls remain.

## Tests (the point)

Handler-level, offline, through the double:
- **`batch_submit`** end to end — handle minted (`backend/provider-id`), prompts become indexed items (`custom_id` 0..N), the batch system prompt is submitted.
- **`deliberate`'s batch lane** (`deliberate_batch` called directly with a fabricated dossier — no explorer/network) — the dossier becomes **one** item carrying the `deliberation_prompt` (question + dossier), the offline-synth system prompt passes through, no attachments leak, `custom_id` is `"0"`.
- **Collect arms** — `job_get` renders a scripted poll, `job_cancel` reaches the provider by id, `job_list` renders a seeded listing.

Out of scope (correctly, tested elsewhere or needs a live peer): the real network path (`batch.rs` unit tests), provider→`McpError` mapping, `deliberate`'s dossier phase, and `job_wait`'s handler glue (it takes a `Peer<RoleServer>`; its batch path is the same `batch_poller` choke-point these tests cover).

## Review

Cross-family via kaibo's own `consult` (DeepSeek, holistic, no diff): seam correct, complete, invisible to production; tests have teeth. It named three small gaps — two filled here (the system-prompt and `custom_id` assertions), the third (a `job_wait` test) left out with a note for the peer reason above.

Full suite green (lib 300 + all integration), clippy clean on touched files. Stacked on #40 (now merged); rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)