### PR TITLE
Single-source the lane→tool cast-enum partition (+ drift guard)

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -117,11 +117,16 @@ were fixed in the deliberate PR (the drifted `max_turns` schema defaults; a test
   consult side, fully offline-tested via `Arm::new` — they have no handler-level coverage.
   Route them through a factory field on `KaiboHandler` (default = the real fns), inject
   `ScriptedBatch`. Fable's "thinnest coverage relative to blast radius." Delete when it ships.
-- **Unify the lane→tool partition.** Which cast serves which tool is derived independently
-  in ~4 places (`inject_cast_enum`'s three rosters, the `reject_offline_cast`/
-  `require_batch_cast`/`require_deliberate_cast` gates, `casts_section`'s direct-filter). A
-  single `Config` source + a consistency test would stop them drifting; the `deliberate`
-  work made it a 3-way split.
+- **Lane→tool partition unified — SHIPPED.** The enum injection now reads one
+  `CAST_ENUM_RULES` table (`server.rs`), and `cast_enum_never_advertises_a_gated_cast`
+  binds the *shipped* enum to each tool's call-time gate, so the advertised menu and the
+  gate can't drift. Residual (a discoverability nicety, not drift): `explore` has no lane
+  gate — it runs whatever cast's explorer — so it *accepts* an offline-synth cast with an
+  explorer (a `deliberate`/`direct` cast), but its `cast` enum only advertises interactive
+  casts (`cast_is_interactive`). The enum is a safe *subset* of what the gate accepts, so
+  nothing offered is refused; widening it to `has-explorer` (a `cast_can_explore` predicate)
+  would offer deliberate/direct casts for standalone `explore` too. Deferred to the tool-
+  surface-alignment discussion (w/ Amy) — it's a surface decision, not a bug.
 - **Vestiges / finish-the-migration cleanups.** `credentials.rs` dead code (`load`,
   `openai_key`, `resolve_openai_key`) + the duplicate alias table in `ProviderKind::FromStr`
   (parallel to `config.rs::builtin_aliases`); finish the `batch_http_client` migration

--- a/src/config.rs
+++ b/src/config.rs
@@ -689,6 +689,16 @@ impl Config {
         self.casts.get(name).and_then(Cast::synth_lane)
     }
 
+    /// Whether canonical cast `name` serves the **interactive** tools (`consult`,
+    /// `consult_submit`, `explore`, `oneshot`) — i.e. its synth runs interactively (or it
+    /// carries no synth at all). The mirror of `reject_offline_cast`'s acceptance: an
+    /// offline synth belongs to `batch_submit`/`deliberate`, not the interactive tools.
+    /// One of the per-tool cast predicates the enum roster and the gates share (see
+    /// `server.rs::CAST_ENUM_RULES`).
+    pub fn cast_is_interactive(&self, name: &str) -> bool {
+        self.cast_offline_lane(name).is_none()
+    }
+
     /// Whether `name` is declared for the batch lane specifically. Used to partition
     /// the live roster onto the right tools' `cast` enums — batch casts to
     /// `batch_submit`, the rest to the interactive tools.

--- a/src/server.rs
+++ b/src/server.rs
@@ -468,21 +468,24 @@ pub struct KaiboHandler {
     batch_providers: Arc<dyn crate::batch::BatchProviderFactory>,
 }
 
-/// The single source mapping each cast-taking tool to the predicate that decides which
-/// *usable* casts its `cast` enum advertises — keyed on the cast's shape (synth lane +
-/// explorer, via the `Config::cast_is_*`/`cast_can_*` predicates). [`KaiboHandler::new`]
-/// injects the enums straight from this table, and
-/// `cast_enum_never_advertises_a_gated_cast` cross-checks the *shipped* enum against each
-/// tool's call-time gate — so the advertised menu and the gate that enforces it can't
-/// drift apart (the whole point of routing both through one place). A cast may match more
-/// than one rule (a deliberate-shaped batch cast like `fable` serves both `batch_submit`
-/// and `deliberate`); the rules are independent filters, not a partition. Keep this in
-/// step with the gates (`reject_offline_cast`/`require_batch_cast`/`require_deliberate_cast`)
-/// and the `advertised_tools()`/gating set — the consistency test is the guard.
 /// One `CAST_ENUM_RULES` entry: the tools sharing a cast eligibility, and the predicate
 /// (a `Config::cast_is_*`/`cast_can_*`) that decides which usable casts they advertise.
 type CastEnumRule = (&'static [&'static str], fn(&Config, &str) -> bool);
 
+/// The single source mapping each cast-taking tool to the predicate that decides which
+/// *usable* casts its `cast` enum advertises — keyed on the cast's shape (synth lane +
+/// explorer, via the `Config::cast_is_*`/`cast_can_*` predicates). [`KaiboHandler::new`]
+/// injects the enums straight from this table. A cast may match more than one rule (a
+/// deliberate-shaped batch cast like `fable` serves both `batch_submit` and `deliberate`);
+/// the rules are independent filters, not a partition.
+///
+/// Two tests guard it: `cast_enum_never_advertises_a_gated_cast` (no enum offers a cast its
+/// tool's gate — `reject_offline_cast`/`require_batch_cast`/`require_deliberate_cast` —
+/// would reject) and `every_cast_taking_tool_has_an_enum_rule` (no cast-taking tool ships
+/// without a rule, i.e. a silently-empty enum). `casts_section` (the handshake roster) is a
+/// *consumer* of the same `Config` predicates, not bound to this table: it renders a
+/// budget-limited display subset (it hides `Direct` casts) — a presentation choice distinct
+/// from tool eligibility.
 const CAST_ENUM_RULES: &[CastEnumRule] = &[
     (
         &["consult", "consult_submit", "explore", "oneshot"],
@@ -4495,6 +4498,39 @@ mod tests {
             }
         }
         assert!(checked > 0, "the guard checked nothing");
+    }
+
+    /// The completeness half of the single source: every advertised tool that TAKES a
+    /// `cast` argument must be covered by a `CAST_ENUM_RULES` entry — otherwise a future
+    /// cast-taking tool would ship with a silently-empty `cast` enum (never advertising its
+    /// roster, since `inject_cast_enum` is only called for tools named in the table). Reads
+    /// the shipped schemas (a `cast` *property* is present whether or not the enum is
+    /// populated), so adding a `cast` param without a rule fails here.
+    #[test]
+    fn every_cast_taking_tool_has_an_enum_rule() {
+        let h = handler();
+        let ruled: std::collections::HashSet<&str> = CAST_ENUM_RULES
+            .iter()
+            .flat_map(|(tools, _)| tools.iter().copied())
+            .collect();
+        let mut cast_taking = 0;
+        for tool in h.advertised_tools() {
+            let takes_cast = h
+                .tool_router
+                .get(&tool)
+                .and_then(|t| t.input_schema.get("properties"))
+                .and_then(|p| p.get("cast"))
+                .is_some();
+            if takes_cast {
+                cast_taking += 1;
+                assert!(
+                    ruled.contains(tool.as_str()),
+                    "tool `{tool}` takes a `cast` arg but no CAST_ENUM_RULES entry advertises \
+                     its roster — its enum would ship empty"
+                );
+            }
+        }
+        assert!(cast_taking > 0, "no cast-taking tool found — the guard is vacuous");
     }
 
     /// The lane gate's two halves, tested directly: an interactive tool refuses an

--- a/src/server.rs
+++ b/src/server.rs
@@ -468,6 +468,30 @@ pub struct KaiboHandler {
     batch_providers: Arc<dyn crate::batch::BatchProviderFactory>,
 }
 
+/// The single source mapping each cast-taking tool to the predicate that decides which
+/// *usable* casts its `cast` enum advertises — keyed on the cast's shape (synth lane +
+/// explorer, via the `Config::cast_is_*`/`cast_can_*` predicates). [`KaiboHandler::new`]
+/// injects the enums straight from this table, and
+/// `cast_enum_never_advertises_a_gated_cast` cross-checks the *shipped* enum against each
+/// tool's call-time gate — so the advertised menu and the gate that enforces it can't
+/// drift apart (the whole point of routing both through one place). A cast may match more
+/// than one rule (a deliberate-shaped batch cast like `fable` serves both `batch_submit`
+/// and `deliberate`); the rules are independent filters, not a partition. Keep this in
+/// step with the gates (`reject_offline_cast`/`require_batch_cast`/`require_deliberate_cast`)
+/// and the `advertised_tools()`/gating set — the consistency test is the guard.
+/// One `CAST_ENUM_RULES` entry: the tools sharing a cast eligibility, and the predicate
+/// (a `Config::cast_is_*`/`cast_can_*`) that decides which usable casts they advertise.
+type CastEnumRule = (&'static [&'static str], fn(&Config, &str) -> bool);
+
+const CAST_ENUM_RULES: &[CastEnumRule] = &[
+    (
+        &["consult", "consult_submit", "explore", "oneshot"],
+        Config::cast_is_interactive,
+    ),
+    (&["batch_submit"], Config::cast_is_batch),
+    (&["deliberate"], Config::cast_can_deliberate),
+];
+
 /// Inject `casts` as a JSON-Schema `enum` on the `cast` parameter of every
 /// consultation tool still in `router` (consult/oneshot — the tools whose `cast`
 /// selects the answering team). This surfaces the live roster
@@ -629,38 +653,22 @@ impl KaiboHandler {
             .into_iter()
             .map(|(name, _)| name)
             .collect();
-        // A cast's synth lane (`Config::cast_offline_lane`, read off the synth slot) plus
-        // whether it carries an explorer splits the roster by which tools it can serve:
-        //   - interactive (no lane) → consult/consult_submit/explore/oneshot;
-        //   - `Batch` synth        → batch_submit (synth-only) AND, with an explorer, deliberate;
-        //   - `Direct` synth       → deliberate (with an explorer). No longer stranded —
-        //     `deliberate` is the tool the per-slot lane reshape promised for the direct lane.
-        // The batch and deliberate views OVERLAP (a deliberate-shaped batch cast like `fable`
-        // serves both), so they're filtered by ref, not a partition. The gate enforces the
-        // same split at call time; this keeps the advertised menu honest.
-        let (interactive_usable, offline_usable): (Vec<String>, Vec<String>) = usable
-            .into_iter()
-            .partition(|n| config.cast_offline_lane(n).is_none());
-        let batch_usable: Vec<String> = offline_usable
-            .iter()
-            .filter(|n| config.cast_is_batch(n))
-            .cloned()
-            .collect();
-        let deliberate_usable: Vec<String> = offline_usable
-            .iter()
-            .filter(|n| config.cast_can_deliberate(n))
-            .cloned()
-            .collect();
-        inject_cast_enum(
-            &mut tool_router,
-            &["consult", "consult_submit", "explore", "oneshot"],
-            &interactive_usable,
-        );
-        inject_cast_enum(&mut tool_router, &["batch_submit"], &batch_usable);
-        inject_cast_enum(&mut tool_router, &["deliberate"], &deliberate_usable);
-        // The `cast` enum (just above) is now the one authoritative per-lane roster —
-        // the resident-prose roster this used to also append (`append_cast_roster`) was
-        // redundant with it and has been dropped; see `docs/devlog.md`.
+        // Advertise each tool's `cast` enum from the one `CAST_ENUM_RULES` table: a cast's
+        // shape (synth lane + explorer) decides which tools it serves, and each rule is an
+        // independent filter (the batch and deliberate views OVERLAP — a deliberate-shaped
+        // batch cast like `fable` serves both). Routing every enum through this table (and
+        // cross-checking it against the gates in the consistency test) is what keeps the
+        // advertised menu and the call-time gate from drifting apart. The `cast` enum is the
+        // one authoritative per-lane roster — the resident-prose roster this used to also
+        // append (`append_cast_roster`) was dropped as redundant; see `docs/devlog.md`.
+        for (tools, eligible) in CAST_ENUM_RULES {
+            let casts: Vec<String> = usable
+                .iter()
+                .filter(|n| eligible(&config, n))
+                .cloned()
+                .collect();
+            inject_cast_enum(&mut tool_router, tools, &casts);
+        }
 
         // Pin `consult` resident under Claude Code's tool-schema deferral: a host may
         // defer every tool's schema to names-only until first use, but a `_meta`
@@ -4397,6 +4405,96 @@ mod tests {
                  synth), got {deliberate:?}"
             );
         }
+    }
+
+    /// The anti-drift guard for the lane partition: whatever `CAST_ENUM_RULES` advertises
+    /// on a tool's `cast` enum, that tool's call-time GATE must accept — so the menu the
+    /// model picks from never offers a cast the handler would refuse. Reads the *shipped*
+    /// enum (not the rules table) and runs each advertised cast through the real gate, over
+    /// a fixture with every cast shape. If a future edit points a tool's enum at the wrong
+    /// predicate, or a gate tightens without the enum following, this fails.
+    #[test]
+    fn cast_enum_never_advertises_a_gated_cast() {
+        let h = handler_from_toml(
+            r#"
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.inter]                                      # explorer + interactive synth
+            explorer = "gem/lite"
+            synth    = "gem/flash"
+
+            [casts.oneshot_only]                               # synth-only, interactive
+            synth    = "gem/flash"
+
+            [casts.mybatch]                                    # synth-only batch
+            batch    = true
+            synth    = "gem/pro"
+
+            [casts.mydeliberate]                               # explorer + batch synth (both tools)
+            explorer = "gem/lite"
+            synth    = { backend = "gem", id = "pro", lane = "batch" }
+
+            [casts.mydirect]                                   # explorer + direct synth
+            explorer = "gem/lite"
+            synth    = { backend = "gem", id = "big", lane = "direct" }
+
+            [casts.mydirect_synthonly]                         # offline, no explorer → no tool
+            synth    = { backend = "gem", id = "big", lane = "direct" }
+            "#,
+        );
+        let enum_of = |tool: &str| -> Vec<String> {
+            h.tool_router
+                .get(tool)
+                .expect("tool advertised")
+                .input_schema
+                .get("properties")
+                .and_then(|p| p.get("cast"))
+                .and_then(|c| c.get("enum"))
+                .and_then(|e| e.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        // Each cast-taking tool's call-time acceptance, in one place beside the enum rules.
+        let gate_accepts = |tool: &str, cast: &Cast| -> bool {
+            match tool {
+                "consult" | "consult_submit" | "oneshot" => {
+                    h.reject_offline_cast(cast, tool).is_ok()
+                }
+                // `explore` has no lane gate — it runs whichever cast's explorer, so any cast
+                // is accepted (a missing explorer faults later at the arm resolve, not the gate).
+                "explore" => true,
+                "batch_submit" => h.require_batch_cast(cast).is_ok(),
+                "deliberate" => h.require_deliberate_cast(cast).is_ok(),
+                other => panic!("unmapped cast-taking tool `{other}` — add its gate here"),
+            }
+        };
+
+        let mut checked = 0;
+        for &(tools, _) in CAST_ENUM_RULES {
+            for &tool in tools {
+                let advertised = enum_of(tool);
+                assert!(
+                    !advertised.is_empty(),
+                    "the fixture must exercise `{tool}` — its enum is empty, so the guard is vacuous"
+                );
+                for name in advertised {
+                    let cast = h.config.resolve_cast(&name).expect("advertised cast resolves");
+                    assert!(
+                        gate_accepts(tool, cast),
+                        "tool `{tool}` advertises cast `{name}`, but its gate rejects it — \
+                         the enum and the gate have drifted"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+        assert!(checked > 0, "the guard checked nothing");
     }
 
     /// The lane gate's two halves, tested directly: an interactive tool refuses an


### PR DESCRIPTION
## What

Second health-review follow-up (after #41). Unifies the *"which cast is advertised on which tool's `cast` enum"* logic into one place, so it can't drift from the call-time gates that enforce it.

Fable's health review flagged this: which cast serves which tool was derived independently across ~4 sites (the inline enum filters in `KaiboHandler::new`, the three gates, `casts_section`'s roster filter), with nothing forcing the advertised menu and the enforcing gate to agree — and the `deliberate` work had just made it a 3-way split.

## How

- **`CAST_ENUM_RULES`** (`server.rs`) — one table pairing the tools that share a cast eligibility with the `Config` predicate that decides it:
  - `consult` / `consult_submit` / `explore` / `oneshot` → `cast_is_interactive` *(new — mirrors `reject_offline_cast`'s acceptance)*
  - `batch_submit` → `cast_is_batch`
  - `deliberate` → `cast_can_deliberate`
  `KaiboHandler::new` injects each enum by looping over the table. **Behavior-preserving** — the same casts are advertised per tool as before.
- **`cast_enum_never_advertises_a_gated_cast`** — the drift guard. It reads the *shipped* enum for every cast-taking tool and runs each advertised cast through that tool's *real* gate, over a fixture with every cast shape. Invariant: **the menu never offers a cast the handler would refuse** (enum ⊆ gate-accepts). Fails if a rule points at the wrong predicate, or a gate tightens without the enum following, or a new cast-taking tool is added without a gate mapping.

## Scope notes

- The gates keep their own per-lane refusal *messages* (they can't collapse to a boolean), but the test binds them to the enum.
- `casts_section`'s direct-cast roster filter stays **separate by design** — it's a resident-handshake-budget display choice, not tool eligibility.
- **Surfaced, not changed:** `explore` has no lane gate, so it *accepts* any cast with an explorer, but its enum advertises only interactive casts — a safe subset (nothing offered is refused). Widening it (`cast_can_explore`) would offer deliberate/direct casts for standalone `explore` too; left for the tool-surface-alignment discussion, noted in `docs/issues.md`.

Internal refactor (no user-visible change) → no CHANGELOG entry. Full suite green (lib 301 + integration), clippy clean on touched files. Cross-family review (DeepSeek) in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)