### PR TITLE
explore: advertise any cast with an explorer (deliberate/direct too)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,12 @@ the git log. Each later release appends a new section at the top.
   map rather than the conclusion. It reads the repo itself like `consult`, so it takes the
   same `path` / `cast` / `explorer_model` (+ `explorer_backend`) / `explorer_max_turns`
   arguments; being single-phase, it has no synth args, `attach`, `context`, or `session_id`.
-  The report carries the same provenance footer, naming the cast and the explorer that
-  surveyed. Gated independently by `--no-explore`. For a synthesized answer, use `consult`.
+  Because it runs *only* the explorer, its `cast` accepts **any cast with an explorer** —
+  not just interactive ones, but `deliberate`/`direct` casts too: point it at one to run
+  that team's (often smarter) explorer standalone, handy for sizing up an explorer or for a
+  stronger sweep than your own fast one. The report carries the same provenance footer,
+  naming the cast and the explorer that surveyed. Gated independently by `--no-explore`. For
+  a synthesized answer, use `consult`.
 - **`deliberate`** — a top model's deepest reasoning on your codebase without holding a
   session open: `explore → offline synth`. A fast model first investigates READ-ONLY and
   builds a cited dossier (you wait for this — the same live sweep `explore` runs), then a

--- a/src/config.rs
+++ b/src/config.rs
@@ -719,6 +719,21 @@ impl Config {
         })
     }
 
+    /// Whether canonical cast `name` can staff an `explore` call: it carries an **explorer**
+    /// slot — the *only* thing `explore` runs. Independent of the synth lane, because
+    /// `explore` never touches the synth: a `deliberate`/`direct` cast's explorer is as valid
+    /// as an interactive cast's (an explorer always runs interactively by construction). So
+    /// `explore` advertises *more* casts than the interactive tools — pointing it at a
+    /// deliberate cast runs that team's (often smarter) explorer standalone, handy for
+    /// evaluating the explorer or for a stronger sweep than the caller's own. A synth-only
+    /// cast (no explorer — `gemini-batch`/`oneshot`-only casts) can't, and is correctly
+    /// left out (it would fault at the explorer-arm resolve).
+    pub fn cast_can_explore(&self, name: &str) -> bool {
+        self.casts
+            .get(name)
+            .is_some_and(|c| c.slot(ModelRole::Explorer).is_some())
+    }
+
     /// Whether canonical cast `name` is the configured default — comparing against the
     /// *resolved* default, so an alias default (`server.cast = "claude"`) still matches
     /// its canonical cast (`anthropic`). The roster renderer (`casts_section`) gets

--- a/src/config.rs
+++ b/src/config.rs
@@ -689,12 +689,13 @@ impl Config {
         self.casts.get(name).and_then(Cast::synth_lane)
     }
 
-    /// Whether canonical cast `name` serves the **interactive** tools (`consult`,
-    /// `consult_submit`, `explore`, `oneshot`) — i.e. its synth runs interactively (or it
-    /// carries no synth at all). The mirror of `reject_offline_cast`'s acceptance: an
-    /// offline synth belongs to `batch_submit`/`deliberate`, not the interactive tools.
-    /// One of the per-tool cast predicates the enum roster and the gates share (see
-    /// `server.rs::CAST_ENUM_RULES`).
+    /// Whether canonical cast `name` serves the **interactive answer** tools (`consult`,
+    /// `consult_submit`, `oneshot`) — i.e. its synth runs interactively (or it carries no
+    /// synth at all). The mirror of `reject_offline_cast`'s acceptance: an offline synth
+    /// belongs to `batch_submit`/`deliberate`, not these. (`explore` is deliberately *not*
+    /// here — it runs only the explorer, so it takes any cast with one via
+    /// [`cast_can_explore`](Self::cast_can_explore), interactive or not.) One of the per-tool
+    /// cast predicates the enum roster and the gates share (see `server.rs::CAST_ENUM_RULES`).
     pub fn cast_is_interactive(&self, name: &str) -> bool {
         self.cast_offline_lane(name).is_none()
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -488,9 +488,13 @@ type CastEnumRule = (&'static [&'static str], fn(&Config, &str) -> bool);
 /// from tool eligibility.
 const CAST_ENUM_RULES: &[CastEnumRule] = &[
     (
-        &["consult", "consult_submit", "explore", "oneshot"],
+        &["consult", "consult_submit", "oneshot"],
         Config::cast_is_interactive,
     ),
+    // `explore` runs only the explorer, so it advertises *any* cast with one — including
+    // `deliberate`/`direct` casts, whose (often smarter) explorers are useful standalone.
+    // Its own rule, broader than the interactive tools' (which also need an interactive synth).
+    (&["explore"], Config::cast_can_explore),
     (&["batch_submit"], Config::cast_is_batch),
     (&["deliberate"], Config::cast_can_deliberate),
 ];
@@ -2955,8 +2959,11 @@ own, so you get the structured cited report — a summary of findings, the relev
 Reach for `explore` to map unfamiliar code, or to assemble a grounded survey you'll reason
 over yourself (or hand to another model). It reads the repo itself, like `consult`, so the
 same `path` / `cast` / `explorer_model` / `explorer_backend` arguments apply; there's no
-`attach`, `context`, or `session_id` — those belong to the synthesizing tools. When you
-want the conclusion rather than the map, use `consult`.
+`attach`, `context`, or `session_id` — those belong to the synthesizing tools. Since it runs
+*only* the explorer, its `cast` accepts any cast with an explorer — including `deliberate`/
+`direct` casts: point it at one to run that team's (often smarter, slower) explorer
+standalone, when you want a stronger sweep than your own fast one, or to size the explorer up.
+When you want the conclusion rather than the map, use `consult`.
 
 ## Deepest reasoning, offline: `deliberate`
 
@@ -4370,7 +4377,8 @@ mod tests {
                 })
                 .unwrap_or_default()
         };
-        for tool in ["consult", "consult_submit", "oneshot", "explore"] {
+        // The interactive tools need an interactive synth: only `myinteractive`.
+        for tool in ["consult", "consult_submit", "oneshot"] {
             let casts = enum_of(tool);
             assert!(
                 casts.iter().any(|c| c == "myinteractive"),
@@ -4382,6 +4390,23 @@ mod tests {
                     "{tool} enum must not list the offline cast {offline}, got {casts:?}"
                 );
             }
+        }
+        // `explore` runs only the explorer, so it advertises *every* cast with one —
+        // interactive AND offline-synth casts (`mydeliberate`) — but not the synth-only
+        // casts (`mybatch`, `mydirect`), which have no explorer to run.
+        let explore = enum_of("explore");
+        for with_explorer in ["myinteractive", "mydeliberate"] {
+            assert!(
+                explore.iter().any(|c| c == with_explorer),
+                "explore enum should list the explorer-bearing cast {with_explorer}, got {explore:?}"
+            );
+        }
+        for no_explorer in ["mybatch", "mydirect"] {
+            assert!(
+                !explore.iter().any(|c| c == no_explorer),
+                "explore enum must not list the synth-only cast {no_explorer} (no explorer), \
+                 got {explore:?}"
+            );
         }
         let batch = enum_of("batch_submit");
         // Both batch synths (explorer or not) can be batch_submit'd — it's synth-only.


### PR DESCRIPTION
## What

Widens the `explore` tool's advertised `cast` enum to **any cast with an explorer** — including `deliberate`/`direct` casts — not just interactive ones.

`explore` runs *only* the explorer arm (it deliberately skips `reject_offline_cast`), so a deliberate/direct cast's explorer is perfectly valid for it — and the handler already accepted them. But `explore` shared the interactive tools' enum rule (`cast_is_interactive`), so those casts were never *offered*. This fixes that, and a latent wart along with it.

## Why (Amy)

- **Evaluating deliberate explorers gets easier** — run just the explorer standalone via `explore`.
- **Smart deliberate explorers become useful to agents that already have a fast explorer** — point `explore` at a deliberate cast for a stronger sweep than your own.

## How

- New `Config::cast_can_explore(name)` — the cast has an explorer slot (any synth lane; an explorer always runs interactively by construction).
- `explore` gets its own `CAST_ENUM_RULES` entry keyed on it, split out from the interactive-tools rule.

**Also fixes a latent wart:** the old interactive-only enum advertised synth-only interactive casts that have *no* explorer and would fault at the arm resolve. Keying on `cast_can_explore` offers exactly the casts that work — explorer-bearing ones — and no others.

## Invariant

The drift guard holds: `explore` has no lane gate (accepts anything), so its enum is trivially ⊆ gate-accepts. `cast_enum_never_advertises_a_gated_cast` and `every_cast_taking_tool_has_an_enum_rule` carry over unchanged; `cast_enums_split_by_lane` now asserts `explore` lists explorer-bearing casts (interactive **and** deliberate) and excludes synth-only ones (`mybatch`, `mydirect`).

CHANGELOG + the `kaibo://tools` explore section note the capability. Full suite green (lib 301 + integration), clippy clean. Cross-family review (Gemini) in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)