### PR TITLE
feat(telemetry): tag run_kaish spans with exit code and output size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,7 +250,11 @@ the git log. Each later release appends a new section at the top.
   enhancement, so its absence just costs the model a few discovery turns it always
   could have taken.
 - **Multi-turn sessions** via `session_id`, and optional OTLP/HTTP trace export
-  (`[telemetry]`, off by default).
+  (`[telemetry]`, off by default). Each tool call emits a `tool` span naming the
+  tool and a short argument summary; a `run_kaish` span additionally carries
+  `kaish.exit_code` and `kaish.output_bytes`, so a trace can distinguish a read that
+  *truncated* (exit `3`) at the output cap — and forced narrow re-reads — from one the
+  model chose to slice, rather than every script reading as a plain success.
 - **A failed provider doesn't fail your turn.** When a model or its provider misbehaves
   (a 429/529 overload, a connection reset, a wedged backend that hits the
   `request_timeout`), `consult`/`oneshot` return a *clean tool-result error* naming the

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,34 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-07-02 — run_kaish spans carry the script's exit code + size
+
+Chasing a real question — the explorer is chatty, doing many small reads where one
+wide `cat -n` should do — we reached for a trace to tell *forced* narrow reads (a
+whole-file read truncated at the 64 KiB output cap) from *chosen* ones (the model
+slicing when it didn't need to). The trace couldn't answer it: `RunKaish::call`
+returns `Ok(format_output(&out))` for **every** kaish exit code (a non-zero *script*
+exit is normal output for the model, not a tool failure), so the `tool` span's
+`outcome` reads `ok` for a truncated read, a timeout, a blocked op — all of them. The
+exit code and size were buried in the output text, invisible to telemetry.
+
+Fixed at the source: `RunKaish::call` now calls `tool_span::record_kaish_result(out.code,
+out.stdout.len())`, tagging the enclosing `tool` span with `kaish.exit_code` and
+`kaish.output_bytes`. Everything needed was already in the `KaishOutput` snapshot
+(`code` + `stdout`) — no kaish-kernel change. The field *names* live in `tool_span.rs`
+beside their `field::Empty` declaration on the span (a caller can't silently mistype
+one); every non-kaish tool leaves them empty, so they don't export. We left the
+pre-truncation original size out of scope — kaish trails it in the output text, but
+`exit_code == 3` plus the follow-up reads in the trace already answer the read-size
+question, and pulling it out cleanly would be a kaish-dependent nice-to-have.
+
+TDD with teeth: a unit test drives the recorder through the real `Traced` wrapper, and
+an end-to-end test runs a real `RunKaish` over a worker with a 64-byte cap reading a
+file that overflows it, asserting `kaish.exit_code = 3` lands on the span. Both fail
+when the recorder is neutered (verified). This is groundwork for the explorer-prompt
+A/Bs (for-loop multi-file reads, batched `cat|sed`) — measure the contributing factor
+before changing the prompt.
+
 ## 2026-06-29 — kaish-kernel 0.10.0
 
 Bumped the published dep `0.9.0 → 0.10.0`. API-compatible this time — no kaibo call

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -93,6 +93,10 @@ impl Tool for RunKaish {
             .run(args.script)
             .await
             .map_err(|e| RunKaishError(e.to_string()))?;
+        // Tag the enclosing `tool` span with the script's exit code and delivered
+        // size — the `outcome` field can't, since a non-zero script exit is a normal
+        // result, not a tool error. This is what lets a trace see a truncated read.
+        crate::tool_span::record_kaish_result(out.code, out.stdout.len());
         Ok(format_output(&out))
     }
 }

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -5,6 +5,16 @@
 //! granularity the read-tool and orientation A/Bs both needed (the tool name alone
 //! couldn't separate a discovery `glob` from a `cat -n` read inside `run_kaish`).
 //!
+//! The `outcome` only says whether the tool *itself* worked — for `run_kaish` that's
+//! always `ok`, because a non-zero *script* exit is normal output handed to the model,
+//! not a tool failure (see `explorer.rs`). So the span carries two more optional fields
+//! a tool may fill about its result: `kaish.exit_code` (the script's exit — `3` is the
+//! head+tail truncation, `124` a timeout, `126` blocked) and `kaish.output_bytes` (the
+//! delivered stdout size). Recorded by `run_kaish` via [`record_kaish_result`]; left
+//! empty (and thus unexported) by every other tool. This is what lets a trace tell a
+//! `cat -n` that *truncated* and forced narrow re-reads from one the model chose to
+//! slice — the read-size question the explorer A/Bs turn on.
+//!
 //! It's *our* span on *our* tools, independent of what rig or a given provider
 //! instruments, so it lands the same on every backend. The wrapper sits at the
 //! `ToolDyn` seam (where `call` carries the raw JSON args) so it can summarize the
@@ -42,6 +52,11 @@ impl ToolDyn for Traced {
                 "gen_ai.tool.name" = %name,
                 "gen_ai.tool.arguments" = %summary,
                 outcome = field::Empty,
+                // Filled by `run_kaish` (via `record_kaish_result`) from inside the
+                // instrumented call — `Span::current()` is this span there. Every other
+                // tool leaves them empty, so they don't export.
+                "kaish.exit_code" = field::Empty,
+                "kaish.output_bytes" = field::Empty,
             );
             async {
                 let result = self.inner.call(args).await;
@@ -52,6 +67,19 @@ impl ToolDyn for Traced {
             .await
         })
     }
+}
+
+/// Record a `run_kaish` script's result onto the enclosing `tool` span — its exit
+/// code and delivered stdout size. Called from inside [`RunKaish::call`](crate::explorer),
+/// which runs under the [`Traced`] wrapper's span, so [`Span::current`] is that span
+/// and its pre-declared `kaish.*` fields fill in. Off the wrapped path (e.g. a direct
+/// worker call with no `tool` span current) this is a harmless no-op — best-effort
+/// observability, never load-bearing. The field names live *here*, with their
+/// declaration, so a caller can't silently mistype one.
+pub(crate) fn record_kaish_result(exit_code: i64, output_bytes: usize) {
+    let span = Span::current();
+    span.record("kaish.exit_code", exit_code);
+    span.record("kaish.output_bytes", output_bytes as u64);
 }
 
 /// Box a tool as a span-wrapped [`ToolDyn`] — the toolset-assembly drop-in for
@@ -197,8 +225,16 @@ mod tests {
         assert!(s.ends_with('…'), "marked truncated: {s}");
     }
 
-    /// One closed span as captured: (span name, tool name, arguments, outcome).
-    type CapturedSpan = (String, String, String, String);
+    /// One closed span as captured.
+    #[derive(Clone)]
+    struct CapturedSpan {
+        name: String,
+        tool: String,
+        args: String,
+        outcome: String,
+        kaish_exit: Option<i64>,
+        kaish_bytes: Option<u64>,
+    }
 
     /// Captures each [`CapturedSpan`] as its span closes.
     #[derive(Clone, Default)]
@@ -209,6 +245,8 @@ mod tests {
         tool: Option<String>,
         args: Option<String>,
         outcome: Option<String>,
+        kaish_exit: Option<i64>,
+        kaish_bytes: Option<u64>,
     }
     impl tracing::field::Visit for Grab {
         fn record_str(&mut self, f: &tracing::field::Field, v: &str) {
@@ -217,6 +255,17 @@ mod tests {
                 "gen_ai.tool.arguments" => self.args = Some(v.to_string()),
                 "outcome" => self.outcome = Some(v.to_string()),
                 _ => {}
+            }
+        }
+        // `run_kaish`'s result fields arrive as native numbers, not strings.
+        fn record_i64(&mut self, f: &tracing::field::Field, v: i64) {
+            if f.name() == "kaish.exit_code" {
+                self.kaish_exit = Some(v);
+            }
+        }
+        fn record_u64(&mut self, f: &tracing::field::Field, v: u64) {
+            if f.name() == "kaish.output_bytes" {
+                self.kaish_bytes = Some(v);
             }
         }
         // `%summary`/`%name` record via Display, which arrives as a debug value.
@@ -231,10 +280,13 @@ mod tests {
             }
         }
     }
+    #[derive(Default)]
     struct Stored {
         tool: String,
         args: String,
         outcome: String,
+        kaish_exit: Option<i64>,
+        kaish_bytes: Option<u64>,
     }
 
     impl<S: tracing::Subscriber + for<'a> LookupSpan<'a>> Layer<S> for Capture {
@@ -250,6 +302,8 @@ mod tests {
                 tool: g.tool.unwrap_or_default(),
                 args: g.args.unwrap_or_default(),
                 outcome: g.outcome.unwrap_or_default(),
+                kaish_exit: g.kaish_exit,
+                kaish_bytes: g.kaish_bytes,
             });
         }
         fn on_record(
@@ -258,11 +312,21 @@ mod tests {
             values: &tracing::span::Record<'_>,
             ctx: Context<'_, S>,
         ) {
+            // `outcome` and the `kaish.*` result fields all land here (recorded after
+            // the span opens), so merge whichever this record carried.
             let mut g = Grab::default();
             values.record(&mut g);
-            if let (Some(span), Some(o)) = (ctx.span(id), g.outcome) {
+            if let Some(span) = ctx.span(id) {
                 if let Some(st) = span.extensions_mut().get_mut::<Stored>() {
-                    st.outcome = o;
+                    if let Some(o) = g.outcome {
+                        st.outcome = o;
+                    }
+                    if g.kaish_exit.is_some() {
+                        st.kaish_exit = g.kaish_exit;
+                    }
+                    if g.kaish_bytes.is_some() {
+                        st.kaish_bytes = g.kaish_bytes;
+                    }
                 }
             }
         }
@@ -270,10 +334,14 @@ mod tests {
             let span = ctx.span(&id).unwrap();
             let name = span.name().to_string();
             // Pull owned values out before the extensions borrow ends, then push.
-            let row = span
-                .extensions()
-                .get::<Stored>()
-                .map(|st| (name, st.tool.clone(), st.args.clone(), st.outcome.clone()));
+            let row = span.extensions().get::<Stored>().map(|st| CapturedSpan {
+                name,
+                tool: st.tool.clone(),
+                args: st.args.clone(),
+                outcome: st.outcome.clone(),
+                kaish_exit: st.kaish_exit,
+                kaish_bytes: st.kaish_bytes,
+            });
             if let Some(row) = row {
                 self.0.lock().unwrap().push(row);
             }
@@ -309,11 +377,18 @@ mod tests {
             drop(_g);
             let spans = cap.0.lock().unwrap().clone();
             assert!(
-                spans.iter().any(|(n, tool, args, oc)| n == "tool"
-                    && tool == "echo"
-                    && args.contains("hi")
-                    && oc == "ok"),
-                "a `tool` span with name/args/outcome: {spans:?}"
+                spans.iter().any(|s| s.name == "tool"
+                    && s.tool == "echo"
+                    && s.args.contains("hi")
+                    && s.outcome == "ok"),
+                "a `tool` span with name/args/outcome"
+            );
+            // A non-kaish tool never fills the kaish result fields.
+            assert!(
+                spans
+                    .iter()
+                    .all(|s| s.kaish_exit.is_none() && s.kaish_bytes.is_none()),
+                "echo must leave the kaish result fields empty"
             );
         });
     }
@@ -334,8 +409,109 @@ mod tests {
             assert!(
                 spans
                     .iter()
-                    .any(|(n, tool, _args, oc)| n == "tool" && tool == "echo" && oc == "error"),
-                "a `tool` span tagged outcome=error: {spans:?}"
+                    .any(|s| s.name == "tool" && s.tool == "echo" && s.outcome == "error"),
+                "a `tool` span tagged outcome=error"
+            );
+        });
+    }
+
+    /// `record_kaish_result`, called from inside a wrapped tool's `call`, tags the
+    /// enclosing `tool` span with the script's exit code and delivered size — the
+    /// half `outcome` can't carry (a non-zero script exit is normal output, not a
+    /// tool error). A truncated read is `exit_code = 3`.
+    #[test]
+    fn run_kaish_records_exit_code_and_output_bytes() {
+        /// A stand-in for `run_kaish`: reports a truncated read the way the real tool
+        /// does, then returns normally (a truncation is `Ok`, never a tool error).
+        struct TruncatedRead;
+        #[derive(Deserialize)]
+        struct NoArgs {}
+        #[derive(Debug)]
+        struct Never;
+        impl std::fmt::Display for Never {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "never")
+            }
+        }
+        impl std::error::Error for Never {}
+        impl Tool for TruncatedRead {
+            const NAME: &'static str = "run_kaish";
+            type Error = Never;
+            type Args = NoArgs;
+            type Output = String;
+            async fn definition(&self, _prompt: String) -> ToolDefinition {
+                ToolDefinition {
+                    name: "run_kaish".into(),
+                    description: "run_kaish".into(),
+                    parameters: json!({}),
+                }
+            }
+            async fn call(&self, _args: Self::Args) -> Result<String, Never> {
+                super::record_kaish_result(3, 4321);
+                Ok("exit: 3\n".into())
+            }
+        }
+
+        serialized_capture(async {
+            let cap = Capture::default();
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
+
+            let tool = traced(TruncatedRead);
+            tool.call("{}".to_string()).await.unwrap();
+
+            drop(_g);
+            let spans = cap.0.lock().unwrap().clone();
+            assert!(
+                spans.iter().any(|s| s.name == "tool"
+                    && s.kaish_exit == Some(3)
+                    && s.kaish_bytes == Some(4321)),
+                "the tool span must carry kaish.exit_code=3 and kaish.output_bytes=4321"
+            );
+        });
+    }
+
+    /// End-to-end teeth: a real `RunKaish` over a real worker whose output cap is
+    /// tiny, reading a file that overflows it, must surface `exit_code = 3` on the
+    /// span — the whole point is a trace can see a *truncated* read. Proves the
+    /// wiring from `RunKaish::call` through `record_kaish_result` to the span, not
+    /// just the recorder in isolation.
+    #[test]
+    fn a_truncated_read_surfaces_exit_3_end_to_end() {
+        use crate::explorer::RunKaish;
+        use crate::sandbox::{KaishWorker, SandboxConfig};
+
+        serialized_capture(async {
+            let dir = tempfile::tempdir().unwrap();
+            // Comfortably past the 64-byte cap below, so `cat -n` truncates.
+            std::fs::write(dir.path().join("big.txt"), "x\n".repeat(200)).unwrap();
+            let worker = KaishWorker::spawn_with(
+                dir.path(),
+                SandboxConfig {
+                    output_limit_bytes: 64,
+                    ..SandboxConfig::default()
+                },
+            )
+            .unwrap();
+
+            let cap = Capture::default();
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
+
+            let tool = traced(RunKaish::new(worker));
+            let out = tool
+                .call(r#"{"script":"cat -n big.txt"}"#.to_string())
+                .await
+                .unwrap();
+            assert!(out.contains("exit: 3"), "the read truncated: {out}");
+
+            drop(_g);
+            let spans = cap.0.lock().unwrap().clone();
+            assert!(
+                spans
+                    .iter()
+                    .any(|s| s.name == "tool" && s.tool == "run_kaish" && s.kaish_exit == Some(3)),
+                "a truncated run_kaish read must record kaish.exit_code=3 on its span"
             );
         });
     }


### PR DESCRIPTION
## Why

We wanted a trace to answer a real question about the explorer: it's chatty, doing many small reads where one wide `cat -n` should do. Is a narrow read **forced** — a whole-file read that truncated at the 64 KiB output cap (exit `3`) — or **chosen**, the model slicing when it didn't need to?

A trace couldn't tell them apart. `RunKaish::call` returns `Ok(format_output(&out))` for *every* kaish exit code, because a non-zero **script** exit is normal output for the model, not a tool failure. So the `tool` span's `outcome` reads `ok` for a truncated read, a timeout (124), a blocked op (126) alike — and the exit code and output size stayed buried in the output text, invisible to telemetry.

## What

- `RunKaish::call` now tags the enclosing `tool` span with **`kaish.exit_code`** and **`kaish.output_bytes`** via a new `tool_span::record_kaish_result`.
- Both values were already in the `KaishOutput` snapshot (`code` + `stdout`) — **no kaish-kernel change**.
- The field *names* live beside their `field::Empty` declaration in `tool_span.rs`, so a caller can't silently mistype one. Every non-kaish tool leaves them empty, so they don't export.
- Off the wrapped path (a direct worker call with no `tool` span current) the recorder is a harmless no-op — best-effort observability, never load-bearing.

Out of scope: the *pre-truncation* original size. kaish trails it in the output text, but `exit_code == 3` plus the follow-up reads in the trace already answer the read-size question; pulling it out cleanly would be a kaish-dependent nice-to-have.

## Tests (TDD, with teeth)

- A unit test drives `record_kaish_result` through the real `Traced` wrapper.
- An end-to-end test runs a real `RunKaish` over a worker with a 64-byte output cap reading a file that overflows it, asserting `kaish.exit_code = 3` reaches the span.
- Both fail when the recorder is neutered (verified locally). Full suite green.

## Context

Groundwork for the explorer-prompt A/Bs (for-loop multi-file reads, batched `cat|sed`) — measure the contributing factor before changing the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)