### PR TITLE
One TLS client-build site: crate::tls::https_client

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -35,7 +35,6 @@
 //! commits to.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -700,16 +699,11 @@ impl BatchProvider for AnthropicBatch {
 /// endpoint), so batch addresses the service directly, as Anthropic does.
 const GEMINI_API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
 
-/// A reqwest client carrying the backend's per-request deadline, with ring installed
-/// before `.build()` (the TLS invariant — every client build site does this). Shared by
-/// both batch providers.
+/// A reqwest client carrying the backend's per-request deadline — the shared
+/// [`crate::tls::https_client`] is the one build site (ring installed, `rustls-no-provider`,
+/// no OpenSSL/C); this just supplies the backend's timeout. Used by both batch providers.
 fn batch_http_client(backend: &Backend) -> Result<reqwest::Client> {
-    crate::tls::ensure_crypto_provider();
-    reqwest::Client::builder()
-        .timeout(backend.request_timeout)
-        .connect_timeout(backend.request_timeout.min(Duration::from_secs(10)))
-        .build()
-        .map_err(|e| anyhow!("http client init: {e}"))
+    crate::tls::https_client(backend.request_timeout)
 }
 
 /// Read a (possibly string-encoded) count field. Gemini's `batchStats` numbers arrive as
@@ -1334,6 +1328,8 @@ pub use test_double::{ScriptedBatch, ScriptedBatchProviders};
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
     use crate::config::{Defaults, ModelSlot};
 
     #[test]

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -25,7 +25,6 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use rig_core::agent::{HookAction, PromptHook};
@@ -826,22 +825,11 @@ impl Arm {
         );
         let caps = ModelCaps::resolve(backend.kind, &slot.id, slot.vision);
 
-        // One HTTP backend carrying the per-request deadline. rig exposes no
-        // native timeout and its prompt loop is non-streaming, so a provider that
-        // connects but never responds would hang the whole call with no other
-        // brake — the 2026-06-06 wedge (~29 min; docs/issues.md). `timeout`
-        // bounds a single completion; `connect_timeout` fails a dead endpoint
-        // fast (capped at the deadline so a sub-10s backend timeout still
-        // dominates). Injected via rig's `.http_client(..)`.
-        //
-        // reqwest is built `rustls-no-provider`, so `.build()` below panics unless a
-        // process-default crypto provider is installed; do it now (idempotent).
-        crate::tls::ensure_crypto_provider();
-        let http = reqwest::Client::builder()
-            .timeout(backend.request_timeout)
-            .connect_timeout(backend.request_timeout.min(Duration::from_secs(10)))
-            .build()
-            .map_err(|e| anyhow!("http client init: {e}"))?;
+        // One HTTP backend carrying the per-request deadline, built by the shared
+        // `crate::tls::https_client` (ring installed, `rustls-no-provider`, no OpenSSL/C —
+        // the one client-build site). It bounds the otherwise-brakeless non-streaming call
+        // (the 2026-06-06 wedge; see the helper's doc). Injected via rig's `.http_client(..)`.
+        let http = crate::tls::https_client(backend.request_timeout)?;
 
         match backend.kind {
             ProviderKind::Anthropic => {
@@ -2080,6 +2068,8 @@ pub async fn consult(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
     use crate::session::SessionStore;
     use crate::test_support::{
         has_tool, is_finalize_turn, provider_error, text_response, tool_call_response,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -74,9 +74,10 @@ where
     // opentelemetry-otlp builds its own reqwest (blocking) client when we build the
     // exporter below, and — because reqwest is compiled `rustls-no-provider` (see
     // Cargo.toml / src/tls.rs) — that build panics unless a process-default crypto
-    // provider is already installed. This is a real client build site like the ones in
-    // consult.rs, so it installs ring the same way: anything else
-    // would abort the live binary on its first span export.
+    // provider is already installed. The OTel SDK owns that client build, so it can't
+    // route through `tls::https_client` like the provider clients do; it installs ring
+    // directly via the same `ensure_crypto_provider` seam. Anything else would abort the
+    // live binary on its first span export.
     crate::tls::ensure_crypto_provider();
 
     // HTTP/protobuf on the async reqwest client — reuses kaibo's reqwest 0.13 +

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -14,6 +14,9 @@
 //! exists because Cargo.toml enables rustls's `ring` feature (and not `aws_lc_rs`).
 
 use std::sync::Once;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
 
 /// Install ring as the process-wide default rustls [`CryptoProvider`], exactly once.
 ///
@@ -34,4 +37,26 @@ pub fn ensure_crypto_provider() {
             .install_default()
             .expect("install ring as the default rustls crypto provider");
     });
+}
+
+/// Build a reqwest HTTPS client carrying a per-request deadline — the **one**
+/// construction site for every provider client (rig completions and provider batches
+/// alike), so the `rustls-no-provider` + ring contract lives in exactly one place
+/// instead of being hand-rolled at each call site. Installs the ring provider first
+/// (idempotent; reqwest panics on a missing default rather than falling back to
+/// plaintext), then builds off the process-default rustls provider — no `native-tls`,
+/// no OpenSSL, no C.
+///
+/// The client is bounded because rig exposes no native timeout and its prompt loop is
+/// non-streaming: a backend that connects but never answers would otherwise hang the
+/// whole call with no brake (the 2026-06-06 ~29-min wedge; `docs/issues.md`).
+/// `timeout` caps a single completion; `connect_timeout` fails a dead endpoint fast,
+/// capped at the deadline so a sub-10s backend timeout still dominates.
+pub fn https_client(request_timeout: Duration) -> Result<reqwest::Client> {
+    ensure_crypto_provider();
+    reqwest::Client::builder()
+        .timeout(request_timeout)
+        .connect_timeout(request_timeout.min(Duration::from_secs(10)))
+        .build()
+        .map_err(|e| anyhow!("http client init: {e}"))
 }

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -24,11 +24,18 @@ fn reqwest_client_builds_once_the_ring_provider_is_installed() {
     kaibo::tls::ensure_crypto_provider();
 
     // A no-default-provider rustls connector resolves its provider from the process
-    // default during `build()`. This is the exact call consult.rs / image_gen.rs
-    // make; it succeeds only because ring is wired in and installed above.
+    // default during `build()`. This is the raw call under `tls::https_client`, the one
+    // build site consult + batch route through; it succeeds only because ring is wired in
+    // and installed above.
     reqwest::Client::builder()
         .build()
         .expect("reqwest client builds with the ring provider installed");
+
+    // The shared helper itself builds — it installs ring internally, so this holds even
+    // as the *sole* provider clients' build path. Guards the helper directly, not just the
+    // raw builder above.
+    kaibo::tls::https_client(std::time::Duration::from_secs(5))
+        .expect("tls::https_client builds a real reqwest client");
 
     // And the installed default really is a provider we put there (ring), not some
     // accidental fallback: a fresh ring provider must match the installed one.


### PR DESCRIPTION
## What

The one genuinely-real item from the "vestiges" bullet — *finish the `batch_http_client` migration*. `Arm::from_slot` (`consult.rs`) hand-rolled the exact reqwest-client build that `batch_http_client` (`batch.rs`) already factored: install `ring`, then a builder with the backend's `timeout` + a capped `connect_timeout`. Two copies of the code carrying the **`rustls-no-provider` + ring TLS contract** is one too many.

## How

Moved it into **`crate::tls::https_client(Duration) -> Result<reqwest::Client>`** — beside `ensure_crypto_provider`, whose doc already declares `tls.rs` the home of *"every real reqwest-client construction site."* Now there is literally **one** build site: `batch_http_client` delegates to it, and `Arm::from_slot` calls it directly. Fewer places to get the C-free contract wrong.

`telemetry.rs` is correctly left alone — it builds the OTLP exporter's *own* client (different config/purpose); only the shared `ensure_crypto_provider()` is common, which it already calls.

## Invariant (the point)

**Pure code move — no reqwest feature change, no Cargo.toml change, zero dependency delta.** Re-verified after:
- `cargo tree -i aws-lc-rs` / `aws-lc-sys` / `openssl-sys` / `native-tls` → **all "did not match" (absent)**
- `ring` present (v0.17.14); the only `openssl-*` in the tree is `openssl-probe` (pure-Rust cert-path discovery, pre-existing, *not* the `openssl-sys` C FFI)
- `tests/tls.rs` (a real client builds) green; full suite green (21 binaries); clippy clean

The `Duration` import moved from the lib scope of `batch.rs`/`consult.rs` into their test modules (only tests used it after the extraction).

Internal refactor, no user-visible change → no CHANGELOG. **Hard-look cross-family review (DeepSeek + Gemini) in progress**, per the TLS-change discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)