### PR TITLE
feat(prompts): explorer reads big files in wide spans, not tiny slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,15 @@ the git log. Each later release appends a new section at the top.
 - **Single self-contained binary** per platform; Linux builds are fully static
   (musl). TLS is rustls + ring — no OpenSSL, no aws-lc, no C toolchain.
 
+### Changed
+
+- **The explorer reads big files in fewer, wider passes.** Its guidance now gives a
+  file too large to read whole a first-class strategy — a few wide `sed` spans (a few
+  hundred lines each) instead of many tiny slices — so a `consult`/`explore` over large
+  sources spends noticeably fewer tool calls gathering the same evidence (measured: a
+  broad sweep dropped from 74 read/search calls to 46, reading the same big file in ~13
+  wide spans instead of ~22 fifteen-line ones). No behavior change on short files.
+
 ### Fixed
 
 - **The advertised cast roster marks the default even when it's set by an alias.**

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,30 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-07-02 — explorer reads big files in wide spans (A/B-validated)
+
+The explorer was chatty — many tiny reads. We instrumented it (PR #46's
+`kaish.exit_code`/`output_bytes` spans), traced two real deepseek sweeps, and found the
+cause: **the model slices big files into ~15-line reads by choice, not truncation** (the
+64 KiB cap never binds — 0–1 exit-3, every read well under it). `report_preamble`'s
+"most files are short / narrow-slice-after-truncation" gave a file too big to read whole
+no strategy, so the model defaulted to timid slicing.
+
+Fix (this change): give a big file a first-class **wide-span** strategy — `cat -n FILE |
+sed -n '1,400p'`, then `'401,800p'`, a few hundred lines a look. A/B (treatment binary
+swapped live, same questions, OTLP-measured): a broad sweep dropped **74 → 46** calls,
+reading `consult.rs` in **~13 wide spans (~100 lines each) instead of ~22 tiny ones**.
+Consistent across both test questions.
+
+Deliberately *not* included, though we tried them in the A/B: a `grep -E`-for-alternation
+steer and a `for f in …; do cat -n` batch idiom. The A/B showed the grep steer is
+**unreliable** — the model's GNU `grep 'a\|b'` reflex is too strong for one prose line
+(one run adopted `-E`, another ignored it and got *worse*, 12 failed greps). The real fix
+is upstream: **kaish#60** (support BRE `\|`), which also unlocks the multi-file batching
+the model reflexively attempts (`grep 'a\|b' f1 f2`). So this PR ships only the validated
+lever and leaves the grep line untouched. Ruled out entirely: a `slurp` tool / bigger read
+budget — the cap doesn't bind, so it would solve a problem we don't have.
+
 ## 2026-07-02 — run_kaish spans carry the script's exit code + size
 
 Chasing a real question — the explorer is chatty, doing many small reads where one

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -248,8 +248,9 @@ pub fn report_preamble() -> String {
          surgical slice would miss. A big file (`wc -l FILE` if unsure): read it in a \
          few WIDE spans — `cat -n FILE | sed -n '1,400p'`, then `'401,800p'` — a few \
          hundred lines a look, not fifteen; stepping through in wide passes beats a \
-         dozen surgical slices, and a whole-file read that comes back truncated \
-         (exit 3, a head+tail sample) was simply too big, so step through it this way. \
+         dozen surgical slices, and if a whole-file read comes back truncated (exit 3, \
+         a head+tail sample) it was simply too big for one look — cover it in wide \
+         spans instead. \
          To locate something across files, take the surrounding context in the same \
          call — `grep -rn -B4 -A8 PATTERN .` returns each match with the lines around \
          it, ready to understand.\n\n\

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -242,18 +242,17 @@ pub fn report_preamble() -> String {
          answer — so your work is to gather grounded evidence and cite it exactly. \
          {core}\n\n\
          HOW TO READ. Read for the whole picture in as few looks as possible — the \
-         context window is yours to fill, so favor wide looks over many narrow ones. \
-         A short file: read it WHOLE with `cat -n FILE` — one read hands you its \
-         imports, its context, and exact line numbers together, and surfaces what a \
-         surgical slice would miss. A big file (`wc -l FILE` if unsure): read it in a \
-         few WIDE spans — `cat -n FILE | sed -n '1,400p'`, then `'401,800p'` — a few \
-         hundred lines a look, not fifteen; stepping through in wide passes beats a \
-         dozen surgical slices, and if a whole-file read comes back truncated (exit 3, \
-         a head+tail sample) it was simply too big for one look — cover it in wide \
-         spans instead. \
-         To locate something across files, take the surrounding context in the same \
-         call — `grep -rn -B4 -A8 PATTERN .` returns each match with the lines around \
-         it, ready to understand.\n\n\
+         context window is yours to fill, so read in wide passes. A short file: read \
+         it WHOLE with `cat -n FILE` — one read hands you its imports, its context, \
+         and exact line numbers together. A big file (`wc -l FILE` if unsure): walk it \
+         in wide spans of a few hundred lines — `cat -n FILE | sed -n '1,400p'`, then \
+         `'401,800p'`, then `'801,1200p'` — so each look lands a whole run of related \
+         code together: a type with its impl, a function with the code around its call \
+         sites, an import block with what uses it. If a whole-file read comes back \
+         truncated (exit 3, a head+tail sample), it was too big for one look — walk it \
+         in those wide spans. To locate something across files, take the surrounding \
+         context in the same call — `grep -rn -B4 -A8 PATTERN .` returns each match \
+         with the lines around it, ready to understand.\n\n\
          HOW TO INVESTIGATE. Aim for the complete set of relevant locations. Follow \
          each key symbol to where it is defined and where it is used; chase anything \
          that puzzles you until it is clear — a confusing spot usually hides the \

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -256,7 +256,8 @@ pub fn report_preamble() -> String {
          HOW TO INVESTIGATE. Aim for the complete set of relevant locations. Follow \
          each key symbol to where it is defined and where it is used; chase anything \
          that puzzles you until it is clear — a confusing spot usually hides the \
-         thing you need. One thorough pass beats many shallow ones.\n\n\
+         thing you need. Follow each thread while you are already in the code, so one \
+         thorough pass leaves you the complete picture.\n\n\
          WHAT TO PRODUCE. A curated report for the synthesizer, in these sections:\n\
          - SummaryOfFindings: what you concluded, in a few sentences.\n\
          - RelevantLocations: for each location that matters — the concrete \

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -242,15 +242,17 @@ pub fn report_preamble() -> String {
          answer — so your work is to gather grounded evidence and cite it exactly. \
          {core}\n\n\
          HOW TO READ. Read for the whole picture in as few looks as possible — the \
-         context window is yours to fill, so favor one wide look over many narrow \
-         ones. When a file is central, read it WHOLE with `cat -n FILE`: reach for \
-         this first; most files are short, one full read hands you its imports, its \
-         context, and exact line numbers together, and it surfaces what a surgical \
-         slice would miss. To locate something across files, take the surrounding \
-         context in the same call — `grep -rn -B4 -A8 PATTERN .` returns each match \
-         with the lines around it, ready to understand. If a whole-file read comes \
-         back truncated (exit 3, a head+tail sample), the file was too big for one \
-         look — narrow to the part you need with `cat -n FILE | sed -n 'A,Bp'`.\n\n\
+         context window is yours to fill, so favor wide looks over many narrow ones. \
+         A short file: read it WHOLE with `cat -n FILE` — one read hands you its \
+         imports, its context, and exact line numbers together, and surfaces what a \
+         surgical slice would miss. A big file (`wc -l FILE` if unsure): read it in a \
+         few WIDE spans — `cat -n FILE | sed -n '1,400p'`, then `'401,800p'` — a few \
+         hundred lines a look, not fifteen; stepping through in wide passes beats a \
+         dozen surgical slices, and a whole-file read that comes back truncated \
+         (exit 3, a head+tail sample) was simply too big, so step through it this way. \
+         To locate something across files, take the surrounding context in the same \
+         call — `grep -rn -B4 -A8 PATTERN .` returns each match with the lines around \
+         it, ready to understand.\n\n\
          HOW TO INVESTIGATE. Aim for the complete set of relevant locations. Follow \
          each key symbol to where it is defined and where it is used; chase anything \
          that puzzles you until it is clear — a confusing spot usually hides the \
@@ -3750,11 +3752,15 @@ mod tests {
     #[test]
     fn report_preamble_keeps_the_reading_directive_and_report_shape() {
         let p = report_preamble();
-        // Reading strategy: read whole files, locate with a grep context buffer.
+        // Reading strategy: whole (short) files, wide spans for big ones, grep buffer.
         assert!(p.contains("cat -n FILE"), "whole-file read idiom: {p}");
         assert!(
             p.to_lowercase().contains("whole"),
             "the whole-file directive must survive: {p}"
+        );
+        assert!(
+            p.contains("sed -n '1,400p'"),
+            "big-file wide-span idiom: {p}"
         );
         assert!(
             p.contains("grep -rn -B4 -A8"),


### PR DESCRIPTION
## Why

The explorer was chatty — sweeping big source files in many tiny reads. Using #46's new `kaish.exit_code`/`output_bytes` tool-span fields, we traced two real deepseek explorer sweeps and found the cause: **the model slices big files into ~15-line reads by *choice*, not truncation.** The 64 KiB output cap never binds (0–1 exit-3, every read well under it), so a `slurp` tool / bigger read budget was **ruled out** — it would solve a problem we don't have.

The real gap: `report_preamble`'s "most files are short" + "on truncation, narrow to the part you need" gave a file *too big to read whole* no strategy, so the model defaulted to timid slicing.

## What

`report_preamble`'s **HOW TO READ** now splits short vs big:
- **short file** → read WHOLE with `cat -n FILE` (unchanged intent),
- **big file** (`wc -l` if unsure) → a few **WIDE** `sed` spans (`'1,400p'`, then `'401,800p'`), a few hundred lines a look, not fifteen; a truncated whole-file read (exit 3) is a cue to cover it in wide spans, not to narrow to a sliver.

The grep line is **unchanged**.

## Evidence (A/B)

Treatment binary swapped in live, same two questions, measured via OTLP:

| | baseline | treatment |
|---|---|---|
| broad sweep — total calls | 74 | **46** (−38%) |
| broad sweep — `consult.rs` reads | 22 tiny (~15 lines) | **13 wide (~100 lines)** |

The wide-span shift was consistent across both test questions.

## Deliberately scoped out

We A/B'd two more ideas and left them out:
- a **`grep -E` alternation steer** — unreliable (the GNU `grep 'a\|b'` reflex beats one prose line; one run adopted `-E`, another ignored it and got *worse*). The real fix is upstream: **tobert/kaish#60** (support BRE `\|`), which also unlocks the multi-file batching the model reflexively attempts.
- a **`for f in …; do cat -n` batch idiom** — never adopted; also subsumed by kaish#60.

## Review

Cross-family (Gemini via kaibo `oneshot`) read of the new preamble: validated the 400-line span anchor as the sweet spot for the 64 KiB cap, and flagged that the truncation clause implied restarting at line 1 — fixed in the `review:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)