### PR TITLE
prompts: positive-framing sweep + wide-span reading across the sibling blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,15 @@ the git log. Each later release appends a new section at the top.
 - **Single self-contained binary** per platform; Linux builds are fully static
   (musl). TLS is rustls + ring — no OpenSSL, no aws-lc, no C toolchain.
 
+### Changed
+
+- **The `consult` driver and the shared kaish cheatsheet describe reading in wide
+  passes**, matching the guidance the explorer got: a short file read whole, a big one
+  in a few hundred-line spans. Several preambles also drop negative-example phrasing
+  in favor of stating the wanted behavior directly. A `consult` over large sources
+  should spend fewer tool calls gathering the same evidence (same mechanism the
+  explorer change measured).
+
 ### Fixed
 
 - **The advertised cast roster marks the default even when it's set by an alias.**

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,31 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-07-02 — positive-framing sweep across the model-facing prompts
+
+Follow-on to the explorer wide-span change (PR #48). Amy's principle: if something's
+worth a negative example, double up on complementary *positive* ones instead — a "not X"
+names the very pathway we're trying to suppress (the CLAUDE.md positive-framing rule). We
+swept the sibling model-facing blocks for the same "not X / rather than X / beats X"
+phrasing and, where they carried explorer-like reading guidance, extended the wide-span
+framing:
+
+- **`consult_preamble`** (the driver reads code directly too): "pull a whole file rather
+  than a narrow slice … what a surgical read would miss" → read generously in wide passes,
+  a short file whole or a big one in a few hundred-line spans (`sed -n '1,400p'`, then
+  `'401,800p'`).
+- **`KAISH_SANDBOX_ADDENDUM`** (the shared cheatsheet every tool-driving preamble embeds)
+  and **`kaibo_sandbox_doc`** (the `kaibo://kaish/sandbox` resource): same wide-span,
+  positive rewrite; the old narrow `sed -n '40,80p'` example became a wide `'1,400p'` walk.
+- **`oneshot_preamble`** / **`deliberation_prompt`**: dropped "rather than guessing" — the
+  wanted behavior (name the gap so the caller can supply it / reason under a stated
+  assumption) is already said positively; `batch_preamble` had already been fixed this way,
+  these were the stragglers.
+
+No behavior measured (unlike #48's A/B), but the consult driver and cheatsheet now carry
+the same validated wide-span guidance, so a consult over big files should benefit from the
+same mechanism. The kaish `\|` grep habit is still routed upstream (kaish#60), untouched here.
+
 ## 2026-07-02 — run_kaish spans carry the script's exit code + size
 
 Chasing a real question — the explorer is chatty, doing many small reads where one

--- a/src/consult.rs
+++ b/src/consult.rs
@@ -1595,8 +1595,8 @@ pub fn oneshot_preamble() -> String {
      the question it sends from the material it provides and your own knowledge — \
      this call has no codebase access and no tools, so the caller owns the context. \
      Be precise and useful: reason over exactly what you were handed, and name \
-     explicitly anything you'd need that wasn't given rather than guessing it. Keep \
-     your claims grounded in the material and say where its edge is."
+     explicitly anything you'd need that wasn't given, so the caller can supply it \
+     next turn. Keep your claims grounded in the material and say where its edge is."
         .to_string()
 }
 
@@ -1822,10 +1822,10 @@ pub fn consult_preamble() -> String {
          curated report — RelevantLocations carrying `file:line`, key symbols, and \
          snippets. Reach for `explore` to cover breadth — find where a \
          thing lives, gather the relevant files — and use `run_kaish` to read the \
-         code yourself. When you read directly, read generously: pull a whole file \
-         with `cat -n FILE` rather than a narrow slice — the window is yours to \
-         fill, and one wide look often surfaces what a surgical read would miss. \
-         Build your answer from what \
+         code yourself. When you read directly, read generously in wide passes — a \
+         short file whole with `cat -n FILE`, a big one in spans of a few hundred \
+         lines (`cat -n FILE | sed -n '1,400p'`, then `'401,800p'`) — so each look \
+         lands the code in its context. Build your answer from what \
          they return: quote the key snippet, name its `file:line`, and let the \
          evidence carry the claim. Where the evidence settles the question, answer \
          it fully; where it reaches its edge, say so and name what would close the gap.\n\n\
@@ -1935,7 +1935,7 @@ pub fn deliberation_prompt(question: &str, dossier: &str) -> String {
          those citations as accurate and deliberate deeply over the question using this \
          evidence: reason it all the way through, and say where the evidence runs out. If \
          the dossier leaves a load-bearing detail open, reason under a stated assumption \
-         and flag what would change if it's wrong, rather than guessing silently.\n\n\
+         and flag what would change if it's wrong.\n\n\
          ## Question\n{question}\n\n## Dossier\n{dossier}"
     )
 }

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -35,13 +35,13 @@ pub const KAISH_SANDBOX_ADDENDUM: &str = "\
 In kaibo this shell runs over a READ-ONLY snapshot of one project, offline: writes, \
 `git`, `touch`, and external commands are refused, so just read. Browse with line \
 numbers so every citation is exact, and read generously — the context window is \
-yours to fill, so favor one wide look over many narrow ones; reading a whole file \
-often surfaces what a surgical slice would hide. `cat -n FILE` reads a file whole \
-with its line numbers — reach for it first; most files are short (`wc -l FILE` \
-confirms). To locate something across files, `grep -rn -B3 -A6 PATTERN .` returns \
-each match with the lines around it. A whole-file read that comes back truncated \
-(exit 3, a head+tail sample) was simply too big — re-read just the part you need \
-with a narrow span, `cat -n FILE | sed -n '40,80p'`. Each call starts at the project root; \
+yours to fill, so read in wide passes: `cat -n FILE` takes a short file whole with \
+its line numbers (`wc -l FILE` sizes it), and a big file goes in wide spans of a few \
+hundred lines, `cat -n FILE | sed -n '1,400p'` then `'401,800p'`. To locate \
+something across files, `grep -rn -B3 -A6 PATTERN .` returns each match with the \
+lines around it. A whole-file read that comes back truncated (exit 3, a head+tail \
+sample) was simply too big for one look — cover it in those wide spans. Each call \
+starts at the project root; \
 there is no persistent cwd. Read the exit code: 0 is success; 3 means the output \
 was too large and came back as a head+tail sample (not a failure); 124 means the \
 script was killed for running past its time budget; 126 means blocked by the \
@@ -325,12 +325,12 @@ pub fn kaibo_sandbox_doc() -> String {
          {KAISH_SANDBOX_ADDENDUM}\n\n\
          ## Browsing for exact citations\n\
          Lead with line numbers so every claim cites `file:line`, and read \
-         generously — favor a whole file over a narrow slice:\n\
-         - `cat -n FILE` — a whole file with line numbers; reach for it first\n\
+         generously in wide passes:\n\
+         - `cat -n FILE` — a short file whole, with line numbers; reach for it first\n\
          - `grep -rn PATTERN [PATH]` — matches with line numbers, across files\n\
          - `grep -rn -B3 -A6 PATTERN .` — matches with the lines around them\n\
          - `grep -rl PATTERN src` — just the file names that match\n\
-         - `cat -n FILE | sed -n '40,80p'` — a numbered span of a large file\n\n\
+         - `cat -n FILE | sed -n '1,400p'` — a wide span of a big file (walk it: then `'401,800p'`)\n\n\
          ## Read-only boundary\n\
          The project is mounted read-only and external commands are off, by \
          construction. Writes, `git`, `touch`, `spawn`/`exec`, and any external \
@@ -752,7 +752,7 @@ mod tests {
     #[test]
     fn instructions_fit_claude_code_budget() {
         let mut config = Config::builtin(); // anthropic, deepseek, gemini,
-                                             // openai-local, gemini-batch, anthropic-batch
+                                            // openai-local, gemini-batch, anthropic-batch
         for (name, backend, id) in [
             ("chimera", "anthropic", "claude-haiku-4-5"),
             ("glm", "openai-local", "GLM-4.5-Air-UD-Q4K-XL-GGUF"),


### PR DESCRIPTION
Follow-on to #48. Amy's principle: **if something's worth a negative example, double up on complementary positive ones instead** — a "not X" names the very pathway we're trying to suppress (the CLAUDE.md positive-framing rule). #48 applied this to the explorer's `report_preamble`; this sweeps the sibling model-facing blocks and, where they carry explorer-like *reading* guidance, extends the (A/B-validated) wide-span framing.

## Changes

- **`consult_preamble`** (the driver reads code directly too) — "pull a whole file **rather than a narrow slice** … what a surgical read **would miss**" → *read generously in wide passes: a short file whole, a big one in a few hundred-line `sed` spans.*
- **`KAISH_SANDBOX_ADDENDUM`** (shared cheatsheet every tool-driving preamble embeds) + **`kaibo_sandbox_doc`** (the `kaibo://kaish/sandbox` resource) — same wide-span positive rewrite; the old narrow `sed -n '40,80p'` example became a wide `'1,400p'` walk. Exit-code contract and the `cat -n` / `grep -rn` / `126` / `124` needles preserved.
- **`oneshot_preamble`** / **`deliberation_prompt`** — dropped "**rather than guessing**". The wanted behavior is already stated positively (oneshot: name the gap *so the caller can supply it next turn* — it's synchronous; deliberation: *reason under a stated assumption and flag what would change* — it has no next turn). `batch_preamble` was already fixed this way; these were the stragglers.

## Scope / notes

- No behavior measured here (unlike #48's A/B) — but the consult driver and shared cheatsheet now carry the same validated wide-span guidance, so a `consult` over big files should benefit from the same mechanism.
- The kaish `grep '\|'` habit stays routed upstream (**tobert/kaish#60**) — the grep guidance is untouched.
- Full lib suite green (308).

## Review

Cross-family (DeepSeek via kaibo `oneshot`) read of all four blocks: no residual negatives, the driver's short/big split doesn't over-push toward whole-file reads, and the oneshot-vs-deliberation (synchronous vs no-next-turn) nuance is preserved.

Sibling to #48 (both off `main`, non-overlapping regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)