### PR TITLE
refactor(consult): split the ConsultConfig grab-bag into a per-phase ladder

### DIFF
--- a/src/consult/config.rs
+++ b/src/consult/config.rs
@@ -1,0 +1,109 @@
+//! The per-phase config ladder, mirroring the tool ladder it drives
+//! (`run_kaish` → `explore` → `consult`, with `deliberate`'s dossier stage sharing
+//! the `explore` rung). Each rung adds exactly what its phase needs on top of the
+//! one below — so a phase's signature names its config type and that alone tells a
+//! reader what it touches, instead of every phase sharing one bundle and carrying
+//! fields inert to it (the shape this replaced: `explore`/`deliberate` filled
+//! `synth_max_turns`/`attachments` with dummies just to satisfy a two-phase
+//! `consult`'s type, and `oneshot` filled four).
+
+use std::sync::Arc;
+
+use crate::progress::{NullSink, ProgressSink};
+use crate::sandbox::SandboxConfig;
+
+use super::prompts::{ConsultAttachment, PromptOverrides};
+
+/// What every model-driven phase needs, no matter how thin: preamble layering
+/// (per-phase override, repo orientation, house rules — `resolve_phase_preamble`'s
+/// three inputs) and where liveness goes. `oneshot` — no tools, no project reads —
+/// needs exactly this and nothing more.
+#[derive(Debug, Clone)]
+pub struct PhaseContext {
+    /// Per-phase system-prompt overrides (`[prompts]`). `Default` is empty, so the
+    /// built-in preambles run unchanged. Server-set per call from the resolved
+    /// config. See [`PromptOverrides`].
+    pub prompts: PromptOverrides,
+    /// The static repo-orientation block (assembled `[orientation]` map), or `None`.
+    /// `Arc<str>` so cloning per phase is cheap. Server-set per call from the
+    /// resolved root (only for the exploring tools — `explore`/`consult`); `Default`
+    /// is `None`, so offline tests run the unchanged preamble.
+    pub orientation: Option<Arc<str>>,
+    /// Operator house rules (assembled `AGENTS.md` / user files) to splice into
+    /// each top-level tool's preamble, or `None` for the historical bare preamble.
+    /// `Arc<str>` so cloning per phase is cheap. The server fills it per call (it
+    /// needs the resolved root to read the files); the `Default` is `None`, so
+    /// every offline test runs the unchanged preamble.
+    pub house_rules: Option<Arc<str>>,
+    /// Where the phase's liveness goes: each delegated sweep and direct kaish read
+    /// emits a [`PhaseEvent`](crate::progress::PhaseEvent) here. The server installs
+    /// an adapter that renders these as MCP progress notifications when the caller
+    /// asked for them; otherwise it's [`NullSink`], a no-op — so a stateless
+    /// one-shot is byte-for-byte its old self.
+    pub progress: Arc<dyn ProgressSink>,
+}
+
+impl Default for PhaseContext {
+    fn default() -> Self {
+        Self {
+            prompts: PromptOverrides::default(),
+            orientation: None,
+            house_rules: None,
+            progress: Arc::new(NullSink),
+        }
+    }
+}
+
+/// What a read-only investigation needs on top of [`PhaseContext`]: sandbox limits
+/// for the kaish worker(s) it spawns, and how many turns one explorer sweep gets.
+/// `explore` and `deliberate`'s dossier stage need exactly this.
+#[derive(Debug, Clone)]
+pub struct ExploreConfig {
+    /// Preamble layering and liveness — shared with every other phase.
+    pub phase: PhaseContext,
+    /// Bounds each explorer sweep — it's cheap, let it rip.
+    pub explorer_max_turns: usize,
+    /// Read-only sandbox limits applied to every kaish worker this phase spawns.
+    pub sandbox: SandboxConfig,
+}
+
+impl Default for ExploreConfig {
+    fn default() -> Self {
+        Self {
+            phase: PhaseContext::default(),
+            explorer_max_turns: crate::config::Defaults::default().explorer_max_turns,
+            sandbox: SandboxConfig::default(),
+        }
+    }
+}
+
+/// The full two-phase `consult`: an investigation ([`ExploreConfig`]) plus what
+/// only the synth driver loop needs — how many turns its own loop gets, and the
+/// caller's attached files (named for the model to read itself, not inlined).
+#[derive(Debug, Clone)]
+pub struct ConsultConfig {
+    /// The investigation half: preamble/liveness plus explorer sweep bounds and
+    /// sandbox limits, shared verbatim with the standalone `explore` tool.
+    pub explore: ExploreConfig,
+    /// Bounds the recomposed consult's *whole* driver loop (it delegates sweeps AND
+    /// reads spans), so it must be generous — a multi-part question blew the old 8.
+    pub synth_max_turns: usize,
+    /// Caller-attached files, as **root-relative paths the model reads itself** — *not*
+    /// inlined bytes. Unlike `oneshot`/`batch` attach (toolless, so kaibo inlines),
+    /// `consult` has tools, so attach just *names* each file in the driver's prompt and
+    /// lets the model open it when it's ready: a text file with `cat -n`, an image with
+    /// `view_image` (per [`ConsultAttachment::is_image`]) — no upfront IO, the model builds
+    /// its narrative its own way. The server validates each path lands under the consult's
+    /// root and sniffs its type before filling this. `Default` is empty.
+    pub attachments: Vec<ConsultAttachment>,
+}
+
+impl Default for ConsultConfig {
+    fn default() -> Self {
+        Self {
+            explore: ExploreConfig::default(),
+            synth_max_turns: crate::config::Defaults::default().synth_max_turns,
+            attachments: Vec::new(),
+        }
+    }
+}

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -25,16 +25,16 @@ use crate::attach::Attachment;
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot};
 use crate::credentials::ProviderKind;
 use crate::explorer::RunKaish;
-use crate::progress::{NullSink, PhaseEvent, ProgressSink};
+use crate::progress::{PhaseEvent, ProgressSink};
 use crate::sandbox::{KaishWorker, SandboxConfig};
 use crate::session::{QaTurn, SessionStore};
 use crate::tool_span::traced;
 use crate::view_image::ViewImage;
 
-use super::prompts::{
-    consult_user_prompt, deliberation_prompt, resolve_phase_preamble, ConsultAttachment, Phase,
-    PromptOverrides,
-};
+use super::config::{ConsultConfig, ExploreConfig, PhaseContext};
+#[cfg(test)]
+use super::prompts::PromptOverrides;
+use super::prompts::{consult_user_prompt, deliberation_prompt, resolve_phase_preamble, Phase};
 use super::shaping::{ModelCaps, ModelShape};
 
 // --- The Arm seam ------------------------------------------------------------
@@ -284,64 +284,6 @@ impl Arm {
                 self.rewrites_view_image(),
             )
             .await
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ConsultConfig {
-    /// Bounds each cheap `explore′` sweep — it's cheap, let it rip.
-    pub explorer_max_turns: usize,
-    /// Bounds the recomposed consult's *whole* driver loop (it delegates sweeps AND
-    /// reads spans), so it must be generous — a multi-part question blew the old 8.
-    pub synth_max_turns: usize,
-    /// Read-only sandbox limits applied to every kaish worker this phase spawns.
-    pub sandbox: SandboxConfig,
-    /// Where the phase's liveness goes: each delegated sweep and direct kaish read
-    /// emits a [`PhaseEvent`] here. The server installs an adapter that renders these
-    /// as MCP progress notifications when the caller asked for them; otherwise it's
-    /// [`NullSink`], a no-op — so a stateless one-shot is byte-for-byte its old self.
-    /// It rides on `ConsultConfig` because that's the one bundle already threaded into
-    /// every phase fn and the toolset builders.
-    pub progress: Arc<dyn ProgressSink>,
-    /// Operator house rules (assembled `AGENTS.md` / user files) to splice into
-    /// each top-level tool's preamble, or `None` for the historical bare preamble.
-    /// `Arc<str>` so cloning `ConsultConfig` per phase is cheap. Rides here for the
-    /// same reason as `progress`: it's the one bundle already threaded everywhere.
-    /// The server fills it per call (it needs the resolved root to read the files);
-    /// the `Default` is `None`, so every offline test runs the unchanged preamble.
-    pub house_rules: Option<Arc<str>>,
-    /// Per-phase system-prompt overrides (`[prompts]`). `Default` is empty, so the
-    /// built-in preambles run unchanged. Server-set per call from the resolved
-    /// config. See [`PromptOverrides`].
-    pub prompts: PromptOverrides,
-    /// The static repo-orientation block (assembled `[orientation]` map), or `None`.
-    /// `Arc<str>` so cloning per phase is cheap. Server-set per call from the
-    /// resolved root (only for the exploring tools — `explore`/`consult`); `Default`
-    /// is `None`, so offline tests run the unchanged preamble.
-    pub orientation: Option<Arc<str>>,
-    /// Caller-attached files, as **root-relative paths the model reads itself** — *not*
-    /// inlined bytes. Unlike `oneshot`/`batch` attach (toolless, so kaibo inlines),
-    /// `consult` has tools, so attach just *names* each file in the driver's prompt and
-    /// lets the model open it when it's ready: a text file with `cat -n`, an image with
-    /// `view_image` (per [`ConsultAttachment::is_image`]) — no upfront IO, the model builds
-    /// its narrative its own way. The server validates each path lands under the consult's
-    /// root and sniffs its type before filling this. `Default` is empty.
-    pub attachments: Vec<ConsultAttachment>,
-}
-
-impl Default for ConsultConfig {
-    fn default() -> Self {
-        let d = crate::config::Defaults::default();
-        Self {
-            explorer_max_turns: d.explorer_max_turns,
-            synth_max_turns: d.synth_max_turns,
-            sandbox: SandboxConfig::default(),
-            progress: Arc::new(NullSink),
-            house_rules: None,
-            prompts: PromptOverrides::default(),
-            orientation: None,
-            attachments: Vec::new(),
-        }
     }
 }
 
@@ -965,7 +907,7 @@ pub async fn oneshot(
     prompt: &str,
     attachments: &[Attachment],
     arm: &Arm,
-    cfg: &ConsultConfig,
+    cfg: &PhaseContext,
 ) -> Result<String> {
     let user_prompt = crate::attach::with_text_context(attachments, prompt);
     let image_parts: Vec<UserContent> = attachments
@@ -1022,7 +964,7 @@ fn consult_tools(
 ) -> Result<Vec<Box<dyn ToolDyn>>> {
     // run_kaish for precise reads by the consult model itself — carries the sink so
     // the driver's own reads show up as progress alongside the delegated sweeps'.
-    let worker = KaishWorker::spawn_with(root, cfg.sandbox.clone())?;
+    let worker = KaishWorker::spawn_with(root, cfg.explore.sandbox.clone())?;
     // explore′ for delegated breadth: the same explore unit, wrapped as a tool,
     // pointed at the explorer arm — its own client, model, and request shape,
     // which may live on a different backend than the driver's. Bounded by
@@ -1031,23 +973,23 @@ fn consult_tools(
     // override-or-default + house rules, built once here rather than per sweep.
     let explorer_preamble: Arc<str> = Arc::from(resolve_phase_preamble(
         Phase::Explorer,
-        &cfg.prompts,
-        cfg.orientation.as_deref(),
-        cfg.house_rules.as_deref(),
+        &cfg.explore.phase.prompts,
+        cfg.explore.phase.orientation.as_deref(),
+        cfg.explore.phase.house_rules.as_deref(),
     ));
     let explore = RunExplore::new(
         explorer.clone(),
-        cfg.explorer_max_turns,
+        cfg.explore.explorer_max_turns,
         root,
-        cfg.sandbox.clone(),
+        cfg.explore.sandbox.clone(),
         reports,
-        cfg.progress.clone(),
+        cfg.explore.phase.progress.clone(),
         explorer_preamble,
     );
     let mut tools: Vec<Box<dyn ToolDyn>> = vec![
         traced(RunKaish::with_progress(
             worker.clone(),
-            cfg.progress.clone(),
+            cfg.explore.phase.progress.clone(),
         )),
         traced(explore),
     ];
@@ -1070,13 +1012,13 @@ pub(crate) async fn explore_with(
     question: &str,
     root: PathBuf,
     explorer: &Arm,
-    cfg: &ConsultConfig,
+    cfg: &ExploreConfig,
 ) -> Result<String> {
     let preamble = resolve_phase_preamble(
         Phase::Explorer,
-        &cfg.prompts,
-        cfg.orientation.as_deref(),
-        cfg.house_rules.as_deref(),
+        &cfg.phase.prompts,
+        cfg.phase.orientation.as_deref(),
+        cfg.phase.house_rules.as_deref(),
     );
     run_explore_phase(
         explorer,
@@ -1085,7 +1027,7 @@ pub(crate) async fn explore_with(
         root,
         &cfg.sandbox,
         cfg.explorer_max_turns,
-        &cfg.progress,
+        &cfg.phase.progress,
     )
     .await
 }
@@ -1136,13 +1078,13 @@ pub(crate) async fn consult_with(
         .run(
             &resolve_phase_preamble(
                 Phase::Consult,
-                &cfg.prompts,
-                cfg.orientation.as_deref(),
-                cfg.house_rules.as_deref(),
+                &cfg.explore.phase.prompts,
+                cfg.explore.phase.orientation.as_deref(),
+                cfg.explore.phase.house_rules.as_deref(),
             ),
             Message::user(user_prompt.to_string()),
             cfg.synth_max_turns,
-            cfg.progress.as_ref(),
+            cfg.explore.phase.progress.as_ref(),
             // Rebuilt per call (main loop, and again if run_phase forces a final
             // turn); every build shares the one `reports` sink so all explore′
             // sweeps aggregate.
@@ -1304,7 +1246,13 @@ mod tests {
             .on_model(SYNTH, |_req| Ok(text_response("done")))
             .build();
         let cfg = ConsultConfig {
-            house_rules: Some(Arc::from(MARKER)),
+            explore: ExploreConfig {
+                phase: PhaseContext {
+                    house_rules: Some(Arc::from(MARKER)),
+                    ..PhaseContext::default()
+                },
+                ..ExploreConfig::default()
+            },
             ..ConsultConfig::default()
         };
         consult_with(
@@ -1386,7 +1334,13 @@ mod tests {
 
         let dir = tempdir().unwrap();
         let cfg = ConsultConfig {
-            house_rules: Some(Arc::from(MARKER)),
+            explore: ExploreConfig {
+                phase: PhaseContext {
+                    house_rules: Some(Arc::from(MARKER)),
+                    ..PhaseContext::default()
+                },
+                ..ExploreConfig::default()
+            },
             ..ConsultConfig::default()
         };
         consult_with(
@@ -1437,11 +1391,17 @@ mod tests {
             .build();
         let dir = tempdir().unwrap();
         let cfg = ConsultConfig {
-            prompts: PromptOverrides {
-                consult: Some(CUSTOM.to_string()),
-                ..PromptOverrides::default()
+            explore: ExploreConfig {
+                phase: PhaseContext {
+                    prompts: PromptOverrides {
+                        consult: Some(CUSTOM.to_string()),
+                        ..PromptOverrides::default()
+                    },
+                    house_rules: Some(Arc::from(HOUSE)),
+                    ..PhaseContext::default()
+                },
+                ..ExploreConfig::default()
             },
-            house_rules: Some(Arc::from(HOUSE)),
             ..ConsultConfig::default()
         };
         consult_with(
@@ -1479,12 +1439,12 @@ mod tests {
             .on_model(MODEL, |_req| Ok(text_response("done")))
             .build();
         // Only the explorer key is set; the oneshot phase must ignore it.
-        let cfg = ConsultConfig {
+        let cfg = PhaseContext {
             prompts: PromptOverrides {
                 explorer: Some(CUSTOM_EXPLORER.to_string()),
                 ..PromptOverrides::default()
             },
-            ..ConsultConfig::default()
+            ..PhaseContext::default()
         };
         oneshot("q", &[], &arm(&client, MODEL), &cfg).await.unwrap();
 
@@ -1517,7 +1477,7 @@ mod tests {
             "just answer this",
             &[],
             &arm(&client, MODEL),
-            &ConsultConfig::default(),
+            &PhaseContext::default(),
         )
         .await
         .unwrap();
@@ -1574,7 +1534,7 @@ mod tests {
             "review these",
             &attachments,
             &arm(&client, MODEL),
-            &ConsultConfig::default(),
+            &PhaseContext::default(),
         )
         .await
         .unwrap();
@@ -1629,7 +1589,7 @@ mod tests {
             "just ask",
             &[],
             &arm(&client, MODEL),
-            &ConsultConfig::default(),
+            &PhaseContext::default(),
         )
         .await
         .unwrap();
@@ -1679,7 +1639,7 @@ mod tests {
             mime: "image/png",
             data_b64: "QUJD".into(),
         };
-        oneshot("", &[img], &arm(&client, MODEL), &ConsultConfig::default())
+        oneshot("", &[img], &arm(&client, MODEL), &PhaseContext::default())
             .await
             .unwrap();
         assert_eq!(
@@ -1840,7 +1800,7 @@ mod tests {
             .build();
 
         let dir = project_with_marker();
-        let cfg = ConsultConfig::default();
+        let cfg = ExploreConfig::default();
 
         let report = explore_with(
             "Where is target_marker defined?",
@@ -1900,9 +1860,12 @@ mod tests {
 
         let dir = project_with_marker();
         let sink = Arc::new(RecordingSink::default());
-        let cfg = ConsultConfig {
-            progress: sink.clone(),
-            ..ConsultConfig::default()
+        let cfg = ExploreConfig {
+            phase: PhaseContext {
+                progress: sink.clone(),
+                ..PhaseContext::default()
+            },
+            ..ExploreConfig::default()
         };
 
         explore_with(
@@ -1962,7 +1925,7 @@ mod tests {
             })
             .build();
 
-        let cfg = ConsultConfig::default();
+        let cfg = PhaseContext::default();
         let out = deliberate_direct(
             "Is the retry path safe?",
             "src/retry.rs:12 DOSSIER_MARKER fn retry()",
@@ -2034,7 +1997,13 @@ mod tests {
         let dir = project_with_marker();
         let sink = Arc::new(RecordingSink::default());
         let cfg = ConsultConfig {
-            progress: sink.clone(),
+            explore: ExploreConfig {
+                phase: PhaseContext {
+                    progress: sink.clone(),
+                    ..PhaseContext::default()
+                },
+                ..ExploreConfig::default()
+            },
             ..ConsultConfig::default()
         };
 
@@ -2085,7 +2054,7 @@ mod tests {
         );
     }
 
-    /// A stateless consult (default `ConsultConfig`) emits to the [`NullSink`] — no
+    /// A stateless consult (default `ConsultConfig`) emits to the `NullSink` — no
     /// panic, no observable effect. The opt-out path stays a true no-op.
     #[tokio::test]
     async fn the_default_sink_is_a_silent_no_op() {

--- a/src/consult/mod.rs
+++ b/src/consult/mod.rs
@@ -19,14 +19,16 @@
 //! Each tool gets its own fresh [`KaishWorker`] (a kernel rooted at the
 //! project), and so does every `explore′` delegation.
 
+mod config;
 mod engine;
 mod prompts;
 mod shaping;
 
+pub use config::{ConsultConfig, ExploreConfig, PhaseContext};
 pub(crate) use engine::explore_with;
 pub use engine::{
-    consult, deliberate_direct, oneshot, Arm, ConsultConfig, ConsultOutput, RunExplore,
-    RunExploreArgs, RunExploreError, Session,
+    consult, deliberate_direct, oneshot, Arm, ConsultOutput, RunExplore, RunExploreArgs,
+    RunExploreError, Session,
 };
 // `run_phase` is the offline-testable loop primitive; re-exported at crate scope so
 // `crate::consult::run_phase` (referenced in module docs) resolves. No in-crate `use`

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -29,7 +29,8 @@ use tracing::Instrument;
 
 use crate::config::{Backend, Cast, Config, Lane, ModelRole, ModelSlot};
 use crate::consult::{
-    consult, explore_with, oneshot, Arm, ConsultConfig, ModelCaps, PromptOverrides,
+    consult, explore_with, oneshot, Arm, ConsultConfig, ExploreConfig, ModelCaps, PhaseContext,
+    PromptOverrides,
 };
 use crate::explorer::format_output;
 use crate::jobs::{CancelOutcome, JobResult, JobState, JobStore};
@@ -1368,15 +1369,19 @@ impl KaiboHandler {
             &cast.name,
         )?;
         let cfg = ConsultConfig {
-            explorer_max_turns: input
-                .explorer_max_turns
-                .unwrap_or(defaults.explorer_max_turns),
+            explore: ExploreConfig {
+                phase: PhaseContext {
+                    progress: progress.clone(),
+                    house_rules: self.house_rules(&root)?,
+                    prompts: self.resolved_prompts(&cast),
+                    orientation: self.orientation(&root).await?,
+                },
+                explorer_max_turns: input
+                    .explorer_max_turns
+                    .unwrap_or(defaults.explorer_max_turns),
+                sandbox: self.config.sandbox.clone(),
+            },
             synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
-            sandbox: self.config.sandbox.clone(),
-            progress: progress.clone(),
-            house_rules: self.house_rules(&root)?,
-            prompts: self.resolved_prompts(&cast),
-            orientation: self.orientation(&root).await?,
             attachments,
         };
 
@@ -1483,15 +1488,19 @@ impl KaiboHandler {
         // clone of this exact handle, so what it reads is what the running phase emitted.
         let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
         let cfg = ConsultConfig {
-            explorer_max_turns: input
-                .explorer_max_turns
-                .unwrap_or(defaults.explorer_max_turns),
+            explore: ExploreConfig {
+                phase: PhaseContext {
+                    progress: progress_log.clone(),
+                    house_rules: self.house_rules(&root)?,
+                    prompts: self.resolved_prompts(&cast),
+                    orientation: self.orientation(&root).await?,
+                },
+                explorer_max_turns: input
+                    .explorer_max_turns
+                    .unwrap_or(defaults.explorer_max_turns),
+                sandbox: self.config.sandbox.clone(),
+            },
             synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
-            sandbox: self.config.sandbox.clone(),
-            progress: progress_log.clone(),
-            house_rules: self.house_rules(&root)?,
-            prompts: self.resolved_prompts(&cast),
-            orientation: self.orientation(&root).await?,
             attachments,
         };
 
@@ -1583,19 +1592,17 @@ impl KaiboHandler {
         let explorer = self.arm(&cast, ModelRole::Explorer)?;
         let progress = progress_sink(peer, &meta);
         let defaults = &self.config.defaults;
-        let cfg = ConsultConfig {
+        let cfg = ExploreConfig {
+            phase: PhaseContext {
+                progress: progress.clone(),
+                house_rules: self.house_rules(&root)?,
+                prompts: self.resolved_prompts(&cast),
+                orientation: self.orientation(&root).await?,
+            },
             explorer_max_turns: input
                 .explorer_max_turns
                 .unwrap_or(defaults.explorer_max_turns),
-            // Single-phase: no synth runs, so `synth_max_turns` is inert here.
-            synth_max_turns: defaults.synth_max_turns,
             sandbox: self.config.sandbox.clone(),
-            progress: progress.clone(),
-            house_rules: self.house_rules(&root)?,
-            prompts: self.resolved_prompts(&cast),
-            orientation: self.orientation(&root).await?,
-            // explore reads the repo itself — no caller attachments.
-            attachments: Vec::new(),
         };
 
         let span =
@@ -1660,20 +1667,17 @@ impl KaiboHandler {
         // spent. Only the deliberation (Stage 2) is handed off async.
         let progress = progress_sink(peer, &meta);
         let defaults = &self.config.defaults;
-        let cfg = ConsultConfig {
+        let cfg = ExploreConfig {
+            phase: PhaseContext {
+                progress: progress.clone(),
+                house_rules: self.house_rules(&root)?,
+                prompts: self.resolved_prompts(&cast),
+                orientation: self.orientation(&root).await?,
+            },
             explorer_max_turns: input
                 .explorer_max_turns
                 .unwrap_or(defaults.explorer_max_turns),
-            // The offline synth is a single turn (batch item / one direct completion), so
-            // synth_max_turns is inert — carried only to satisfy the shared config.
-            synth_max_turns: defaults.synth_max_turns,
             sandbox: self.config.sandbox.clone(),
-            progress: progress.clone(),
-            house_rules: self.house_rules(&root)?,
-            prompts: self.resolved_prompts(&cast),
-            orientation: self.orientation(&root).await?,
-            // deliberate reads the repo itself — no caller attachments.
-            attachments: Vec::new(),
         };
         let span = tracing::info_span!("deliberate.dossier", cast = %cast.name, explorer_model = %explorer_model);
         progress.emit(PhaseEvent::PhaseStarted {
@@ -1693,8 +1697,8 @@ impl KaiboHandler {
         // Stage 2 — hand the dossier to the offline synth. Its lane picks the mechanism
         // and the handle; both share the offline-synth preamble (`batch_system_prompt`,
         // overridable via `[prompts].batch` OR the synth slot's own `preamble` — the
-        // resolved `cfg.prompts` already layered both, same as the dossier phase above).
-        let system = crate::consult::batch_system_prompt(cfg.prompts.batch.as_deref());
+        // resolved `cfg.phase.prompts` already layered both, same as the dossier phase above).
+        let system = crate::consult::batch_system_prompt(cfg.phase.prompts.batch.as_deref());
         match lane {
             Lane::Batch => {
                 self.deliberate_batch(&cast, &explorer_model, &input.question, &dossier, &system)
@@ -1841,18 +1845,12 @@ impl KaiboHandler {
         // Gate image attachments on the model's vision capability (shared with batch).
         self.gate_image_attachments(arm.caps.vision, &attachments, &arm.model, &cast.name)?;
         let progress = progress_sink(peer, &meta);
-        let defaults = &self.config.defaults;
-        let cfg = ConsultConfig {
-            explorer_max_turns: defaults.explorer_max_turns,
-            synth_max_turns: defaults.synth_max_turns,
-            sandbox: self.config.sandbox.clone(),
+        let cfg = PhaseContext {
             progress: progress.clone(),
-            // oneshot reads no project: no house rules, no repo map, no shell — and no
-            // consult-style attachments (it inlines its `attach` files via `oneshot()`).
+            // oneshot reads no project: no house rules, no repo map, no shell.
             house_rules: None,
             prompts: self.resolved_prompts(&cast),
             orientation: None,
-            attachments: Vec::new(),
         };
 
         let span = tracing::info_span!("oneshot", cast = %cast.name, model = %arm.model);

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use kaibo::config::{default_models, Config, Defaults, ModelRole, ModelSlot};
 use kaibo::consult::{
     consult, consult_user_prompt, oneshot, request_params, thinking_params, Arm, ConsultConfig,
-    ModelCaps, ModelShape, ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
+    ModelCaps, ModelShape, PhaseContext, ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
 };
 use kaibo::credentials::{load, ProviderKind};
 use serde_json::{json, Value};
@@ -1262,7 +1262,7 @@ async fn secondary_local_cast_from_user_config_runs() {
          prevent?",
         &[],
         &arm,
-        &ConsultConfig::default(),
+        &PhaseContext::default(),
     )
     .await
     .expect("secondary-cast oneshot against Lemonade should succeed");
@@ -1323,7 +1323,7 @@ async fn oneshot_answers_from_pasted_context() {
          read-only sandbox?",
         &[],
         &arm,
-        &ConsultConfig::default(),
+        &PhaseContext::default(),
     )
     .await
     .expect("oneshot against local gemma should succeed");

--- a/tests/llm_timeout.rs
+++ b/tests/llm_timeout.rs
@@ -16,7 +16,7 @@
 use std::time::{Duration, Instant};
 
 use kaibo::config::{Config, ModelRole};
-use kaibo::consult::{oneshot, Arm, ConsultConfig};
+use kaibo::consult::{oneshot, Arm, PhaseContext};
 use tokio::net::TcpListener;
 
 /// Bind an ephemeral port and accept connections forever without ever replying —
@@ -66,7 +66,7 @@ async fn oneshot_aborts_when_the_provider_never_responds() {
             "What does the sandbox prevent?",
             &[],
             &arm,
-            &ConsultConfig::default(),
+            &PhaseContext::default(),
         ),
     )
     .await;


### PR DESCRIPTION
## Summary
- `ConsultConfig` carried every field any phase might need, so `oneshot` filled four fields it never read (`explorer_max_turns`/`synth_max_turns`/`sandbox`/`attachments`) and `explore`/`deliberate`'s dossier stage filled two (`synth_max_turns`/`attachments`) — both with comments admitting the fields were inert, riding along only because `ConsultConfig` was "the one bundle already threaded everywhere" (the last item of the module-splits health-review entry in `docs/issues.md`).
- New `src/consult/config.rs` splits it into a ladder mirroring the tool ladder it drives: `PhaseContext` (prompts/orientation/house_rules/progress — what the toolless `oneshot` needs) → `ExploreConfig` (+ `explorer_max_turns`/`sandbox` — what `explore` and `deliberate`'s dossier stage need) → `ConsultConfig` (+ `synth_max_turns`/`attachments` — the full two-phase `consult`), each embedding the tier below it.
- Every phase's signature now names its own config type, and every `server.rs` construction site builds exactly the fields it uses — `oneshot`'s site dropped from 8 fields (4 inert) to 4 (all real); `explore`/`deliberate`'s dropped from 8 (2 inert) to 6.
- Pure decomposition, no behavior change.

## Dependency — stacked on #51 and #52
This branch is built on a **local merge of `feat/split-consult` (#51) and `feat/split-server` (#52)**, since the split needs the directory-module structure both introduce. Both are still open, so this PR's diff currently includes their commits too. **Do not merge before #51 and #52 land.** Once they do (with a merge commit, so the commit SHAs are preserved), this PR's diff will collapse to just the config-split commit (`86db916`) with no further action needed.

## Review
Cross-family review via kaibo's own `consult` (DeepSeek, holistic read of `src/consult/{config,engine,mod}.rs` + `src/server/mod.rs`, no diff handed over): the three-tier split matches actual field usage exactly, no missed construction sites, no correctness bugs from the refactor. One trade-off flagged and accepted: nested access (`cfg.explore.phase.progress`) relocates verbosity from many construction sites into two internal functions (`consult_tools`/`consult_with`) — judged a good trade since it keeps "which tier owns this field" visible.

## Test plan
- [x] `cargo build --all-targets` clean
- [x] `cargo test --all` — 308 lib tests conserved, full integration suite green
- [x] `cargo clippy --all-targets` — clean on touched files (2 pre-existing warnings elsewhere, unrelated)
- [x] `rustfmt --check` clean on touched files (`--edition 2021`, per the no-repo-wide-fmt discipline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)