### PR TITLE
feat: first-class OpenRouter provider — one key, every family, reasoning on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,9 +280,23 @@ the git log. Each later release appends a new section at the top.
 - **OpenRouter as a first-class provider.** One `OPENROUTER_API_KEY` now reaches
   every major model family through the built-in `openrouter` backend and cast, with
   reasoning on by default (OpenRouter's unified `effort` param, forwarded verbatim so
-  a synth slot can reach past the usual `high` default into `xhigh`/`max`). The
-  built-in cast pins OpenRouter's `~author/family-latest` catalog aliases, so it stays
-  current as new models ship instead of rotting on a dated id.
+  a synth slot can reach past the usual `high` default into `xhigh`/`max` — measured
+  live: effort rides through the gateway and bills real reasoning tokens). Setting a
+  slot's `effort = "none"` sends OpenRouter's structural disable
+  (`{"reasoning": {"enabled": false}}`), so the opt-out doesn't depend on how the
+  gateway's effort ladder happens to read the string. The built-in cast pins
+  OpenRouter's `~author/family-latest` catalog aliases, so it stays current as new
+  models ship instead of rotting on a dated id. Every OpenRouter call carries an
+  explicit prompt-cache breakpoint, so Anthropic-family models behind the gateway
+  bill their (large, resident) system preamble at cache-read rates instead of full
+  input price every turn — providers whose caching is implicit simply ignore it.
+  **Data collection is denied by default**: one OpenRouter slug routes across
+  competing upstream hosts whose data policies differ, and kaibo's prompts carry
+  your source — so every request pins `provider.data_collection = "deny"` and a
+  model whose only hosts retain/train on prompts fails loudly instead of leaking
+  quietly. `data_collection = "allow"` on the backend is the explicit opt-in
+  (kaibo then emits no restriction; your account settings govern), and
+  `kaibo://config` renders the active policy so the posture is always visible.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,12 @@ the git log. Each later release appends a new section at the top.
   optional augmentation); the policy is documented in the README FAQ and `docs/config.md`.
 - **Single self-contained binary** per platform; Linux builds are fully static
   (musl). TLS is rustls + ring — no OpenSSL, no aws-lc, no C toolchain.
+- **OpenRouter as a first-class provider.** One `OPENROUTER_API_KEY` now reaches
+  every major model family through the built-in `openrouter` backend and cast, with
+  reasoning on by default (OpenRouter's unified `effort` param, forwarded verbatim so
+  a synth slot can reach past the usual `high` default into `xhigh`/`max`). The
+  built-in cast pins OpenRouter's `~author/family-latest` catalog aliases, so it stays
+  current as new models ship instead of rotting on a dated id.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ outside perspective into a code review, design session, or research: your agent 
 summary back.
 
 kaibo integrates as a stdio [MCP](https://modelcontextprotocol.io) server and supports
-Anthropic, Gemini, DeepSeek, and any OpenAI-compatible endpoint, including local
-services like llama.cpp. Each agent is set up to mix small models for exploration with
-larger models for synthesis, to help keep your API spend down.
+Anthropic, Gemini, DeepSeek, OpenRouter (one key reaching every major model family),
+and any OpenAI-compatible endpoint, including local services like llama.cpp. Each
+agent is set up to mix small models for exploration with larger models for synthesis,
+to help keep your API spend down.
 
 The agents reach your code through one tool: a [kaish](https://github.com/tobert/kaish)
 shell. kaish has all of its commands built in and mounts your project through a
@@ -124,8 +125,10 @@ not an error. `$XDG_CONFIG_HOME/kaibo/config.toml` lets you wire your own roster
 config has three concepts for configuring models:
 
 - **backend** — a *connection*: which wire protocol (`anthropic` | `deepseek` |
-  `gemini` | `openai`), base URL, and where its key comes from. Secrets never live in
-  the TOML — only the *name* of an env var or the path to a key file.
+  `gemini` | `openrouter` | `openai`), base URL, and where its key comes from. Secrets
+  never live in the TOML — only the *name* of an env var or the path to a key file.
+  `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every major
+  model family, reasoning on by default via its unified `effort` param.
 - **role** — a *job* a model does: `explorer` (fast sweeps) and `synth` (the voice that
   answers). A slot that reads images carries a `vision` pin (see [`docs/casts.md`](docs/casts.md)).
 - **cast** — a *composition*: a named team assigning models to roles. The `cast` call
@@ -162,6 +165,7 @@ merges over them by name. The built-ins are:
 | `anthropic` *(default)* | `claude-haiku-4-5` | `claude-sonnet-4-6` |
 | `deepseek` | `deepseek-v4-flash` | `deepseek-v4-pro` |
 | `gemini` | `gemini-flash-lite-latest` | `gemini-3.5-flash` |
+| `openrouter` | `~google/gemini-flash-latest` | `~anthropic/claude-sonnet-latest` |
 | `openai` | local Gemma (small) | local Gemma (large) |
 
 Per-call overrides, env vars, and CLI flags all layer over the file
@@ -279,7 +283,9 @@ the explorer sweep and the consult driver stop at a turn limit (100 and 200 by
 default), so a confused model can't loop forever burning tokens. All of these are
 configurable in `config.toml`.
 
-**What providers are supported?** Anthropic, DeepSeek, and Gemini natively, plus a
+**What providers are supported?** Anthropic, DeepSeek, and Gemini natively; OpenRouter
+as a keyed gateway that reaches every major model family through one key (`~author/
+family-latest` aliases keep the built-in cast current as new models ship); and a
 generic `openai` kind for any OpenAI-compatible endpoint (hosted GPT, a local
 llama.cpp / Ollama / Gemma server, …). See [Backends, Roles, and Casts](#backends-roles-and-casts).
 

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -52,9 +52,9 @@ composition, compositions choose connections.
 ## Config surface
 
 ```toml
-# --- backends: connections only. The four built-ins (anthropic, deepseek,
-#     gemini, openai-local) ship in code with today's key sources; a stanza here
-#     retargets one or adds a new one. ---
+# --- backends: connections only. The five built-ins (anthropic, deepseek,
+#     gemini, openrouter, openai-local) ship in code with today's key sources; a
+#     stanza here retargets one or adds a new one. ---
 
 # (No stanza needed for the local llama.cpp default: `gemma` is a built-in
 #  alias of the `openai-local` backend, which already points at localhost:13305.
@@ -98,8 +98,11 @@ Rules, in the loud-over-silent house style:
 - **`[profiles]` is deleted, not deprecated.** A config that still says
   `[profiles.x]` gets a load error pointing at this doc. Amy is the only
   user; git history is the record.
-- **Built-in equivalence:** four built-in backends + four same-named
-  single-backend casts. Today's profile aliases — `claude`→`anthropic`,
+- **Built-in equivalence:** five built-in backends + five same-named
+  single-backend casts (the `openrouter` kind added as a keyed gateway
+  alongside anthropic/deepseek/gemini — one key reaching every upstream model
+  family through a fixed endpoint, reasoning on by default via its unified
+  `effort` param). Today's profile aliases — `claude`→`anthropic`,
   `google`→`gemini`, `local`/`lemonade`/`gemma`/`gemma4`→`openai-local` — register
   at *both* levels (cast aliases so `cast = "claude"` resolves, backend
   aliases so a slot ref `claude/<id>` resolves), and user stanzas can declare

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -331,7 +331,9 @@ synth    = { backend = "claude", id = "claude-opus-4-8", effort = "max", max_tok
 #     it needs only slots. `~author/family-latest` aliases (see the built-in `openrouter`
 #     cast) track the newest release instead of rotting; `effort = "xhigh"` here pushes
 #     the synth slot past [defaults] synth_effort ("high") into a rung only OpenRouter's
-#     unified reasoning param reaches. ---
+#     unified reasoning param reaches. The same knob is the opt-out: reasoning is on by
+#     default for everything kaibo calls, and `effort = "none"` on a slot turns it off
+#     when the cost/latency isn't wanted (reasoning bills as output tokens). ---
 
 [casts.or-deep]
 explorer = "openrouter/~google/gemini-flash-latest"

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -227,10 +227,20 @@ api_key_file = "~/.gemini-api-key"
 # `{"reasoning":{"effort":…}}`, translated per upstream model and silently dropped
 # where a model has no such knob) — see [casts.or-deep] for pushing a slot past
 # [defaults] effort into OpenRouter's deeper `xhigh`/`max` rungs.
+#
+# One slug routes across COMPETING HOSTS whose data policies differ, and kaibo's
+# prompts carry your source — so every request pins no-collection routing
+# (`provider.data_collection = "deny"`) BY DEFAULT. A model whose only hosts
+# retain/train on prompts (most `:free` variants) then fails loudly instead of
+# leaking quietly. `data_collection = "allow"` is the explicit opt-in: kaibo
+# emits no restriction and your OpenRouter account settings govern. This knob
+# exists only on the openrouter kind — anywhere else it's a load error.
 [backends.openrouter]
 kind = "openrouter"
 api_key_env  = "OPENROUTER_API_KEY"
 api_key_file = "~/.openrouter-key"
+# kaibo always denies unless you uncomment this line:
+# data_collection = "allow"
 
 [backends.openai-local]                            # aliases: local, lemonade, gemma, gemma4
 kind = "openai"

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -4,10 +4,10 @@
 # or point at it with --config <path> / KAIBO_CONFIG.
 #
 # EVERYTHING here is optional. With no config file at all, kaibo runs exactly as it
-# does today: four built-in BACKENDS (connections: anthropic/deepseek/gemini/openai-local)
-# and six built-in CASTS (compositions: role → "backend/model-id") — four same-named
-# interactive ones plus two batch casts (anthropic-batch, gemini-batch) — ship in code;
-# this file only OVERRIDES fields or ADDS backends and casts.
+# does today: five built-in BACKENDS (connections: anthropic/deepseek/gemini/openrouter/
+# openai-local) and seven built-in CASTS (compositions: role → "backend/model-id") —
+# five same-named interactive ones plus two batch casts (anthropic-batch, gemini-batch)
+# — ship in code; this file only OVERRIDES fields or ADDS backends and casts.
 # `[profiles]` is gone — a config that still carries it is a load error pointing at
 # docs/casts.md.
 #
@@ -16,8 +16,8 @@
 #
 # Naming rule:  config key `foo_bar`  ⇄  env `KAIBO_FOO_BAR`  ⇄  CLI `--foo-bar`
 # Exceptions (kept native, on purpose): the provider key env vars
-# (ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY) and
-# OPENAI_BASE_URL. RUST_LOG is also kept as-is.
+# (ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY,
+# OPENAI_API_KEY) and OPENAI_BASE_URL. RUST_LOG is also kept as-is.
 
 # ---------------------------------------------------------------------------
 # Getting started — a fresh install has no key yet
@@ -26,7 +26,7 @@
 # the read-only shell needs no model. `consult` / `oneshot` need a
 # provider key on the default cast (`anthropic` out of the box). Give it one the
 # private way — kaibo reads the key at startup, so it never enters your chat:
-#   env:   export ANTHROPIC_API_KEY=sk-...     (or DEEPSEEK_/GEMINI_/OPENAI_…)
+#   env:   export ANTHROPIC_API_KEY=sk-...     (or DEEPSEEK_/GEMINI_/OPENROUTER_/OPENAI_…)
 #   file:  printf %s 'sk-...' > ~/.anthropic-key.txt   (env wins over file)
 # Don't paste the key to the model — set the env var or key file in your shell.
 # Then RECONNECT the kaibo MCP server so it re-reads the environment and this file
@@ -200,7 +200,7 @@ scratch_limit_bytes = 67108864
 # (rig fixes the keyed endpoints — a base_url there is a loud load error).
 # ---------------------------------------------------------------------------
 
-# --- The four built-ins, shown with their current defaults. You only need to
+# --- The five built-ins, shown with their current defaults. You only need to
 #     list a backend here to CHANGE something; these blocks are illustrative.
 #     Their alias names (claude, google, local, lemonade, gemma, gemma4) are
 #     reserved at both levels — naming a new backend or cast after one is a
@@ -220,6 +220,17 @@ api_key_file = "~/.deepseek-key"
 kind = "gemini"
 api_key_env  = "GEMINI_API_KEY"
 api_key_file = "~/.gemini-api-key"
+
+# OpenRouter: one key, every major model family, through a single gateway. Fixed
+# endpoint — rig owns it, so a base_url here is a loud load error, unlike the openai
+# kind below. Reasoning is on by default on every slot (OpenRouter's unified
+# `{"reasoning":{"effort":…}}`, translated per upstream model and silently dropped
+# where a model has no such knob) — see [casts.or-deep] for pushing a slot past
+# [defaults] effort into OpenRouter's deeper `xhigh`/`max` rungs.
+[backends.openrouter]
+kind = "openrouter"
+api_key_env  = "OPENROUTER_API_KEY"
+api_key_file = "~/.openrouter-key"
 
 [backends.openai-local]                            # aliases: local, lemonade, gemma, gemma4
 kind = "openai"
@@ -315,6 +326,16 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 aliases  = ["deep"]                          # casts (and backends) take aliases
 explorer = { backend = "deepseek", id = "deepseek-v4-flash", temperature = 0.0, thinking_budget = 4096, thinking_style = "auto" }
 synth    = { backend = "claude", id = "claude-opus-4-8", effort = "max", max_tokens = 32768 }
+
+# --- The built-in `openrouter` backend already has a key source, so a custom cast on
+#     it needs only slots. `~author/family-latest` aliases (see the built-in `openrouter`
+#     cast) track the newest release instead of rotting; `effort = "xhigh"` here pushes
+#     the synth slot past [defaults] synth_effort ("high") into a rung only OpenRouter's
+#     unified reasoning param reaches. ---
+
+[casts.or-deep]
+explorer = "openrouter/~google/gemini-flash-latest"
+synth    = { backend = "openrouter", id = "~anthropic/claude-sonnet-latest", effort = "xhigh" }
 
 # --- A per-model prompt: a local Gemma explorer wants different framing than a
 #     hosted Claude would. `preamble` lives on the slot, beside the tunables, and

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,7 +34,7 @@ full rationale is `docs/casts.md`.
 ## The model: backends, roles, casts
 
 ```
-ProviderKind = anthropic | deepseek | gemini | openai      (the wire protocol)
+ProviderKind = anthropic | deepseek | gemini | openrouter | openai   (the wire protocol)
 Backend      = { name, kind, base_url?, key source, request_timeout }
 Cast         = { name, role → ModelSlot }                  (freely spans backends)
 ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
@@ -82,6 +82,16 @@ Connection knobs only — models never live here:
   `false` otherwise. A key file that's *present but broken* (empty, unreadable) is
   a loud error even for a keyless backend — there-but-wrong is a mistake, not
   "keyless".
+- **`kind = "openrouter"`** is a keyed gateway, not a wire protocol of its own: one
+  `OPENROUTER_API_KEY` reaches every upstream model family through a fixed endpoint
+  (`base_url` there is the same loud load error as on the other keyed kinds).
+  Reasoning is **on by default on every slot** — OpenRouter's unified
+  `{"reasoning":{"effort":…}}` request field, which the gateway translates into
+  each upstream provider's native knob and drops silently where the pinned model
+  has none, so emitting it unconditionally never breaks a non-reasoning model. The
+  per-role `effort` (see [defaults] below) passes through verbatim, reaching
+  OpenRouter-only rungs (`xhigh`, `max`) deeper than the other kinds expose. No
+  `batch` lane.
 - **`request_timeout_secs`** (default from `[defaults]`, 900 = 15 min) is the
   wall-clock ceiling on a *single* completion call. rig's prompt loop is
   non-streaming and has no native timeout, so a provider that connects but never
@@ -180,11 +190,14 @@ The `[defaults]` knobs themselves:
   per slot, an out-of-range value is rejected at load, not clamped.
 - **`explorer_effort` / `synth_effort`** (`"high"` both): reasoning depth for the
   models that take an effort param — Anthropic's adaptive tier
-  (→ `output_config.effort`), DeepSeek (→ `reasoning_effort`), and the Gemini
-  3-line (→ `thinkingLevel`: the values align, `"high"`/`"low"`). A passthrough
-  string the provider validates (like a model id), so a new level lands without a
-  code change — set a synth slot's `effort = "max"`/`"xhigh"` for heavier runs.
-  Ignored by models with no effort sink (budget-tier Anthropic/Gemini, OpenAI).
+  (→ `output_config.effort`), DeepSeek (→ `reasoning_effort`), the Gemini
+  3-line (→ `thinkingLevel`: the values align, `"high"`/`"low"`), and OpenRouter
+  (→ its unified `{"reasoning":{"effort":…}}`, forwarded verbatim to whatever the
+  pinned model actually supports). A passthrough string the provider validates
+  (like a model id), so a new level lands without a code change — set a synth
+  slot's `effort = "max"`/`"xhigh"` for heavier runs; OpenRouter is where those
+  deeper rungs are actually reachable today. Ignored by models with no effort
+  sink (budget-tier Anthropic/Gemini, OpenAI).
 - **`thinking_style`** (`auto` | `adaptive` | `budget`, default `auto`) forces the
   Anthropic thinking shape instead of the built-in classifier. `auto` picks
   adaptive for Opus 4.6+/Sonnet 4.6/Fable 5 and enabled-budget for older models +
@@ -225,9 +238,15 @@ The `[defaults]` knobs themselves:
 
 ### Built-in registry (the defaults)
 
-Four backends and four same-named single-backend casts ship **in code** and
+Five backends and five same-named single-backend casts ship **in code** and
 reproduce kaibo's historical behavior exactly, so a **missing config file is not
-an error**. Two extra built-in casts ship for the offline batch lane —
+an error**. The `openrouter` built-in pins the drift-resistant `~author/family-latest`
+catalog aliases (explorer `~google/gemini-flash-latest`, synth
+`~anthropic/claude-sonnet-latest`) rather than a dated slug, and opts both slots into
+`vision` — the classifier defaults an `openrouter` slot to vision-off, since the
+gateway fronts blind and sighted models alike, but both default ids are
+multimodal-in per OpenRouter's own catalog. Two extra built-in casts ship for the
+offline batch lane —
 `gemini-batch` (synth Gemini Pro) and `anthropic-batch` (synth Claude Opus). Lane is
 a **per-slot** property, not a cast-level one: each carries a synth slot whose
 `lane = "batch"`, which staffs `batch_submit` *only*: the interactive tools
@@ -261,6 +280,7 @@ today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submi
 | `anthropic` | anthropic | — | `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` | `claude` |
 | `deepseek` | deepseek | — | `DEEPSEEK_API_KEY` / `~/.deepseek-key` | — |
 | `gemini` | gemini | — | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
+| `openrouter` | openrouter | — *(fixed)* | `OPENROUTER_API_KEY` / `~/.openrouter-key` | — |
 | `openai-local` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
 
 | cast | explorer | synth | synth lane |
@@ -268,6 +288,7 @@ today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submi
 | `anthropic` | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-4-6` | |
 | `deepseek` | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` | |
 | `gemini` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-3.5-flash` | |
+| `openrouter` | `openrouter/~google/gemini-flash-latest` | `openrouter/~anthropic/claude-sonnet-latest` | |
 | `openai-local` | `openai-local/Gemma-4-E4B-it-GGUF` | `openai-local/Gemma-4-26B-A4B-it-GGUF` | |
 | `gemini-batch` | — | `gemini/gemini-pro-latest` | `batch` |
 | `anthropic-batch` | — | `anthropic/claude-opus-4-8` | `batch` |
@@ -367,8 +388,9 @@ role the cast doesn't carry). The naming rule for everything else is mechanical:
 **Two deliberate exceptions to the rule:**
 
 - **Provider key vars stay native.** `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
-  `GEMINI_API_KEY`, `OPENAI_API_KEY` are *not* renamed to `KAIBO_*` — people and
-  CI expect those names. A backend points at one via `api_key_env`.
+  `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` are *not* renamed to
+  `KAIBO_*` — people and CI expect those names. A backend points at one via
+  `api_key_env`.
 - **`OPENAI_BASE_URL` is kept** as a back-compat override for any openai-kind
   backend that doesn't set an explicit `base_url` (it's what's wired today). New
   backends use the `base_url` config key instead.

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,7 +91,16 @@ Connection knobs only — models never live here:
   has none, so emitting it unconditionally never breaks a non-reasoning model. The
   per-role `effort` (see [defaults] below) passes through verbatim, reaching
   OpenRouter-only rungs (`xhigh`, `max`) deeper than the other kinds expose. No
-  `batch` lane.
+  `batch` lane. One slug routes across competing upstream *hosts* whose data
+  policies differ, so every request pins **no-collection routing by default**
+  (`provider.data_collection = "deny"` — kaibo's prompts carry your source, and
+  shipping it to a host that retains or trains on prompts must be a choice, never
+  a default). A model whose only hosts collect (most `:free` variants) fails
+  loudly instead of leaking quietly. `data_collection = "allow"` on the backend
+  is the explicit opt-in — kaibo then emits no restriction and your OpenRouter
+  account settings govern. The knob exists only on this kind (a load error
+  elsewhere), and `kaibo://config` renders the active policy per openrouter
+  backend so the posture is always visible.
 - **`request_timeout_secs`** (default from `[defaults]`, 900 = 15 min) is the
   wall-clock ceiling on a *single* completion call. rig's prompt loop is
   non-streaming and has no native timeout, so a provider that connects but never

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -462,6 +462,49 @@ tunables — if a provider caps output low, cap that slot, not the global, per t
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.
 
+### OpenRouter cost + shaping follow-ups (measured $4 GLM consult, 2026-07-03)
+First live `or-glm` consult (GLM-5 explorer / GLM-5.2 synth, 8 whole files attached):
+203 chat turns in 21 min, 18.2M cumulative input tokens (16.4M cache reads) for ~40K
+output. Pricing was honored; the driver **never delegated a single explore′ sweep** —
+every one of the 203 spans carried the consult-driver preamble (classified from the
+OTLP traces' `gen_ai.system_instructions`), so the synth opened all 8 attachments and
+every span itself, re-billing the growing prefix each turn at GLM's $0.18/M cache-read
+rate (50× DeepSeek-pro's $0.0036/M). The delegation failure is being addressed by the
+explorer-prompt/attachment work (in flight, separate session). Turn caps stay a
+*runaway backstop*, not a cost throttle — the synth may burn what the question needs;
+the cure for crawling is delegation.
+
+Shipped since (2026-07-03): **prompt caching on every OpenRouter arm**
+(`Arm::openrouter_completion_model` routes through rig's `with_prompt_caching`;
+unit-pinned in `engine.rs`, live round-trip green — Anthropic-upstream slots now get
+the `cache_control` breakpoint; implicit-caching upstreams accept and ignore it) and
+**measured reasoning accounting** (`tests/consult.rs::openrouter_reasoning_accounting_live`
+posts kaibo's exact shaped params with OpenRouter usage accounting on: effort=high
+billed 932 reasoning tokens, the structural `effort="none"` disable billed 0).
+Remaining OpenRouter-specific forks:
+- **Cache the transcript, not just the system prompt.** rig's breakpoint marks only
+  the system prompt, so an Anthropic-upstream slot's *growing transcript* still
+  re-bills at full input price every turn — the preamble is the only cached prefix.
+  Upstream rig gap; the fix wants a trailing-message breakpoint like rig's native
+  Anthropic path carries.
+- **Per-slot output ceilings vary by pinned slug** (`top_provider.max_completion_tokens`:
+  glm-5.2 32768, kimi-k2.7-code 16384, gpt-5.5 128000) and reasoning bills into the
+  same completion budget — the `[defaults]` 16384 starved a real GLM oneshot answer
+  mid-sentence. Per-slot `max_tokens` already exists; the gap is doctrine: set a synth
+  slot's ceiling from the catalog when pinning a slug, and watch 16384-capped reasoners
+  (kimi) for starvation.
+- **Provider routing variance — data policy shipped, the rest open.** One slug routes
+  to multiple upstream hosts differing in cache support, quantization, pricing, and
+  parameter fidelity. `provider.data_collection = "deny"` now rides every request by
+  default (backend `data_collection = "allow"` is the explicit opt-in; openrouter-kind
+  only, load error elsewhere). Still unexposed: `require_parameters` (a host that
+  silently drops the reasoning param defeats thinking-on-by-default), `order`/`only`/
+  `ignore`, and quantization filters. Belongs with the rig-OpenRouter exit-strategy
+  thinking.
+- **Spend visibility.** Traces already carry `gen_ai.usage.*` per turn (this incident
+  was diagnosed entirely from them); consider surfacing a per-call token/cost total in
+  the provenance footer or job result so the calling agent sees cost before the bill does.
+
 ### Explorer prose — residual probes (the report shape + reading strategy shipped)
 The structured report sections (`SummaryOfFindings`/`RelevantLocations`/
 `ExplorationTrace`), the curiosity + completeness behaviors, and the whole-first /

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -404,6 +404,31 @@ P1 entry):
   grounding (all of which the `gpal` MCP sibling drives directly). This is why "voice
   on Gemini" is parked with TTS. Track rig's gemini coverage; adopt its traits when
   they broaden rather than hand-rolling media modalities over raw HTTP.
+- **OpenRouter provider silently drops `max_tokens`.** rig 0.38.2's native
+  `providers::openrouter` request struct (`openrouter/completion.rs`,
+  `OpenrouterCompletionRequest`) has no `max_tokens` field and its `TryFrom` never
+  reads `CompletionRequest.max_tokens`, so `AgentBuilder::max_tokens()` — kaibo's
+  per-arm headroom mechanism — is a no-op there. Confirmed still present on rig
+  `main` (2026-07-03), untracked upstream. Collides with the `large-token-headroom`
+  doctrine (thinking eats the completion budget). Kaibo's workaround: inject
+  `max_completion_tokens` (OpenRouter's preferred name; their spec deprecates
+  `max_tokens`) via `additional_params`, guarded by a failing-first test. Watch
+  upstream; if it accretes — with rig's other thin spots and the missing universal
+  reasoning API (rig#951) — the exit is a **direct OpenRouter Rust SDK** for that
+  backend (per Amy, 2026-07-03: the kaijutsu precedent — break a provider out of
+  the framework when a good dedicated crate exists). Crate survey (2026-07-03):
+  **`openrouter-rs`** (realmorrisliu, MIT) is the pilot candidate — active (~weekly
+  releases), OpenAPI-drift CI against OpenRouter's spec, typed `ReasoningConfig` +
+  `reasoning_details` incl. the Anthropic `signature` field, streaming tool-call
+  accumulation, skips `: OPENROUTER PROCESSING` keepalives, `#[non_exhaustive]`
+  discipline; dep tree verified ring-only (no aws-lc/openssl), though TLS is
+  reqwest's default rather than a caller-pinned feature — our `src/tls.rs`
+  install-default covers that. Runner-up `openrouter_api` (staler, weaker error
+  typing, but caller-selectable TLS feature + MCP client). Switch triggers: rig
+  lags a feature we need (reasoning-details pass-through, provider routing),
+  openrouter-rs hits 1.0 / gains a second maintainer, or OpenRouter quirks get
+  awkward to special-case through rig's abstractions. Adapter cost: it's a direct
+  client, not a rig `CompletionModel` — the arm would hand-roll that seam.
 
 ### Per-model request shaping (`ModelShape`): remaining knobs
 `ModelShape` (`consult.rs`) resolves request params per (kind, model), fit per
@@ -424,6 +449,15 @@ tunables — if a provider caps output low, cap that slot, not the global, per t
   4.6+/Sonnet 4.6/Fable 5 to adaptive (the rest stay enabled-budget). Add ids as models
   ship, or set `thinking_style` on the slot to override; confirm a new id with the
   `#[ignore]`d Opus-4.8 probe rather than guessing.
+- **`openai`-kind emits no thinking at all** — `ProviderKind::Openai ⇒
+  ThinkingStyle::None` (`shaping.rs`), so a reasoning-capable model behind an
+  OpenAI-compatible endpoint (OpenRouter fronting Claude/Gemini/DeepSeek, a hosted
+  GPT, a local Qwen/GLM reasoner) is silently called with reasoning *off*. That
+  inverts our doctrine (per Amy, 2026-07-03): **anything kaibo calls should have
+  thinking maximized by default**, opt-*out* per slot, never silently absent. The
+  fix wants model-aware shaping on the openai wire — e.g. emit `reasoning_effort`
+  for OpenAI-compatible reasoners, OpenRouter's unified `reasoning` param when the
+  backend is OpenRouter — landing with the first-class OpenRouter work.
 
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -458,6 +458,11 @@ tunables — if a provider caps output low, cap that slot, not the global, per t
   fix wants model-aware shaping on the openai wire — e.g. emit `reasoning_effort`
   for OpenAI-compatible reasoners, OpenRouter's unified `reasoning` param when the
   backend is OpenRouter — landing with the first-class OpenRouter work.
+- **`thinking_style` is missing from the `inert_tunables` render** (GLM review,
+  2026-07-03): `kaibo://config` flags an inert `thinking_budget`/`effort`/
+  `temperature` per slot (`config_resource.rs`), but a `thinking_style` set on a
+  slot whose kind ignores the override (anything non-Anthropic) renders as if
+  effective. Display accuracy only; add it to the inert check alongside the others.
 
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1126,6 +1126,7 @@ pub fn supported_kinds_list() -> String {
         ProviderKind::Anthropic,
         ProviderKind::DeepSeek,
         ProviderKind::Gemini,
+        ProviderKind::OpenRouter,
         ProviderKind::Openai,
     ]
     .into_iter()
@@ -2083,8 +2084,13 @@ mod tests {
         assert!(batch_supported(ProviderKind::Anthropic));
         assert!(batch_supported(ProviderKind::Gemini));
         assert!(!batch_supported(ProviderKind::DeepSeek));
+        assert!(!batch_supported(ProviderKind::OpenRouter));
         assert!(!batch_supported(ProviderKind::Openai));
-        for kind in [ProviderKind::DeepSeek, ProviderKind::Openai] {
+        for kind in [
+            ProviderKind::DeepSeek,
+            ProviderKind::OpenRouter,
+            ProviderKind::Openai,
+        ] {
             let mut b = anthropic_backend();
             b.kind = kind;
             b.name = format!("{kind:?}").to_lowercase();

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1386,6 +1386,7 @@ mod tests {
             api_key_file: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1424,13 +1424,14 @@ fn backend_template(kind: ProviderKind, defaults: &Defaults) -> Backend {
     }
 }
 
-/// The four built-in backends, named after their kind.
+/// The built-in backends, named after their kind.
 fn builtin_backends(defaults: &Defaults) -> BTreeMap<String, Backend> {
     let mut m = BTreeMap::new();
     for kind in [
         ProviderKind::Anthropic,
         ProviderKind::DeepSeek,
         ProviderKind::Gemini,
+        ProviderKind::OpenRouter,
         ProviderKind::Openai,
     ] {
         let mut b = backend_template(kind, defaults);
@@ -1449,15 +1450,27 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
         ProviderKind::Anthropic,
         ProviderKind::DeepSeek,
         ProviderKind::Gemini,
+        ProviderKind::OpenRouter,
         ProviderKind::Openai,
     ] {
         let name = kind.builtin_name().to_string();
         let (explorer, synth) = default_models(kind);
+        // OpenRouter's vision classifier defaults false (the gateway fronts blind and
+        // sighted models alike — it's a property of the pinned model, not the wire), so
+        // the built-in cast opts its slots in: both default ids (`~google/gemini-flash-latest`,
+        // `~anthropic/claude-sonnet-latest`) advertise `image` in `architecture.input_modalities`
+        // in OpenRouter's catalog (verified 2026-07-03). Every other built-in kind is
+        // classified correctly by default, so it needs no pin.
+        let vision = matches!(kind, ProviderKind::OpenRouter).then_some(true);
+        let slot = |id| ModelSlot {
+            vision,
+            ..ModelSlot::bare(&name, id)
+        };
         // Both agent roles are seeded. A cast may omit one in config — absent means
         // the capability is absent, and nothing downstream errors on that.
         let slots = BTreeMap::from([
-            (ModelRole::Explorer, ModelSlot::bare(&name, explorer)),
-            (ModelRole::Synth, ModelSlot::bare(&name, synth)),
+            (ModelRole::Explorer, slot(explorer)),
+            (ModelRole::Synth, slot(synth)),
         ]);
         m.insert(name.clone(), Cast { name, slots });
     }
@@ -1516,6 +1529,12 @@ pub fn default_models(kind: ProviderKind) -> (&'static str, &'static str) {
         ProviderKind::Anthropic => ("claude-haiku-4-5", "claude-sonnet-4-6"),
         ProviderKind::DeepSeek => ("deepseek-v4-flash", "deepseek-v4-pro"),
         ProviderKind::Gemini => ("gemini-flash-lite-latest", "gemini-3.5-flash"),
+        // OpenRouter serves `~author/family-latest` aliases as real catalog entries
+        // that track the newest family member, so these don't rot as ids retire.
+        ProviderKind::OpenRouter => (
+            "~google/gemini-flash-latest",
+            "~anthropic/claude-sonnet-latest",
+        ),
         ProviderKind::Openai => ("Gemma-4-E4B-it-GGUF", "Gemma-4-26B-A4B-it-GGUF"),
     }
 }
@@ -2712,12 +2731,18 @@ mod tests {
         assert!(!b.key_optional);
     }
 
-    /// All four interactive built-in casts exist, each single-backend with
+    /// Every interactive built-in cast exists, each single-backend with
     /// explorer+synth, and none has a synth on an offline lane.
     #[test]
-    fn all_four_builtin_casts_resolve() {
+    fn all_interactive_builtin_casts_resolve() {
         let cfg = Config::builtin();
-        for name in ["anthropic", "deepseek", "gemini", "openai-local"] {
+        for name in [
+            "anthropic",
+            "deepseek",
+            "gemini",
+            "openrouter",
+            "openai-local",
+        ] {
             let cast = cfg.resolve_cast(name).unwrap();
             assert_eq!(
                 cast.synth_lane(),
@@ -2729,6 +2754,58 @@ mod tests {
                 assert_eq!(slot.backend, name, "built-in casts are single-backend");
             }
         }
+    }
+
+    /// The OpenRouter built-in: a keyed backend (OPENROUTER_API_KEY, no configurable
+    /// base URL) and a cast pinning the drift-resistant `~author/family-latest` aliases,
+    /// with `vision` opted in on both slots (OpenRouter's classifier defaults false, but
+    /// both default models are multimodal — see the cast comment). Pins the whole
+    /// built-in so a bad default fails here, not mid-call.
+    #[test]
+    fn builtin_openrouter_cast_and_backend() {
+        let cfg = Config::builtin();
+        let (explorer, synth) = default_models(ProviderKind::OpenRouter);
+        assert_eq!(explorer, "~google/gemini-flash-latest");
+        assert_eq!(synth, "~anthropic/claude-sonnet-latest");
+
+        let cast = cfg.resolve_cast("openrouter").unwrap();
+        let e = cast.require_slot(ModelRole::Explorer).unwrap();
+        let s = cast.require_slot(ModelRole::Synth).unwrap();
+        assert_eq!(
+            (e.backend.as_str(), e.id.as_str()),
+            ("openrouter", explorer)
+        );
+        assert_eq!((s.backend.as_str(), s.id.as_str()), ("openrouter", synth));
+        assert_eq!(e.vision, Some(true), "explorer model is multimodal-in");
+        assert_eq!(s.vision, Some(true), "synth model is multimodal-in");
+
+        let b = cfg.resolve_backend("openrouter").unwrap();
+        assert_eq!(b.kind, ProviderKind::OpenRouter);
+        assert_eq!(b.api_key_env.as_deref(), Some("OPENROUTER_API_KEY"));
+        assert!(!b.key_optional, "OpenRouter is a keyed gateway");
+        assert!(
+            b.base_url.is_none(),
+            "OpenRouter's endpoint is fixed by rig — no configurable base URL"
+        );
+    }
+
+    /// A base_url on the keyed OpenRouter kind is a config mistake (its endpoint is
+    /// pinned), rejected loudly at load like the other keyed kinds — not silently
+    /// ignored into a wrong endpoint.
+    #[test]
+    fn openrouter_backend_rejects_a_base_url() {
+        let err = Config::from_toml_str(
+            r#"
+            [backends.myrouter]
+            kind = "openrouter"
+            base_url = "https://example.com/v1"
+            "#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("base_url"),
+            "a base_url on a keyed kind must be refused: {err}"
+        );
     }
 
     /// The built-in batch casts' synth slots positively declare `lane = Batch`, carry

--- a/src/config.rs
+++ b/src/config.rs
@@ -369,6 +369,37 @@ pub fn parse_slot_ref(s: &str) -> Result<(String, String)> {
 
 // --- Backends ---------------------------------------------------------------
 
+/// OpenRouter upstream-host data policy: whether requests may route to hosts
+/// that retain or train on prompts. kaibo ships source code in its prompts, so
+/// the default is [`DataCollection::Deny`] — OpenRouter then routes only to
+/// hosts whose policy is no-collection, and a model with no compliant host
+/// fails loudly instead of leaking quietly. `Allow` is the explicit opt-in:
+/// kaibo omits the restriction and the caller's OpenRouter account settings
+/// govern. Config: `data_collection = "deny" | "allow"` on an openrouter-kind
+/// backend (anywhere else is a load error).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DataCollection {
+    /// Route only to upstream hosts that don't retain/train on prompts (default).
+    #[default]
+    Deny,
+    /// No routing restriction — the account's own OpenRouter settings apply.
+    Allow,
+}
+
+impl std::str::FromStr for DataCollection {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "deny" => Ok(Self::Deny),
+            "allow" => Ok(Self::Allow),
+            other => bail!(
+                "data_collection {other:?} is not a policy — use \"deny\" (route only \
+                 to no-collection hosts, the default) or \"allow\" (explicit opt-in)"
+            ),
+        }
+    }
+}
+
 /// A connection: how kaibo reaches one provider endpoint. The `kind` is the wire
 /// protocol (the closed [`ProviderKind`] enum — the one place "provider" still
 /// means something); everything else describes the wire: endpoint, key source,
@@ -397,6 +428,10 @@ pub struct Backend {
     /// the 2026-06-06 stall (see `consult.rs` / `docs/issues.md`). Seeded from
     /// [`Defaults::request_timeout`], overridable per backend.
     pub request_timeout: Duration,
+    /// OpenRouter only: upstream-host data policy (see [`DataCollection`]).
+    /// Deny by default on every kind; only an openrouter-kind backend may set it,
+    /// and only the openrouter arm reads it.
+    pub data_collection: DataCollection,
 }
 
 impl Backend {
@@ -1421,6 +1456,9 @@ fn backend_template(kind: ProviderKind, defaults: &Defaults) -> Backend {
         api_key_file: Some(format!("~/{}", kind.key_file_name())),
         key_optional: kind.key_optional(),
         request_timeout: defaults.request_timeout,
+        // Deny is the only safe default: kaibo's prompts carry source code, and
+        // routing them to a data-collecting host must be an explicit choice.
+        data_collection: DataCollection::Deny,
     }
 }
 
@@ -1729,6 +1767,7 @@ struct RawBackend {
     api_key_file: Option<String>,
     key_optional: Option<bool>,
     request_timeout_secs: Option<u64>,
+    data_collection: Option<String>,
 }
 
 impl RawBackend {
@@ -1763,6 +1802,23 @@ impl RawBackend {
         }
         if let Some(v) = self.request_timeout_secs {
             b.request_timeout = Duration::from_secs(v);
+        }
+        if let Some(v) = &self.data_collection {
+            // The policy only exists on the OpenRouter wire; naming it anywhere
+            // else is a config mistake worth a loud error, not a silent no-op the
+            // user believes is protecting them.
+            if b.kind != ProviderKind::OpenRouter {
+                bail!(
+                    "backend {:?} (kind {:?}) sets data_collection, but only the \
+                     `openrouter` kind routes across upstream hosts with differing \
+                     data policies",
+                    b.name,
+                    b.kind
+                );
+            }
+            b.data_collection = v.parse().with_context(|| {
+                format!("backend {:?} data_collection", b.name)
+            })?;
         }
         Ok(())
     }
@@ -2808,6 +2864,69 @@ mod tests {
         );
     }
 
+    /// The data policy defaults to deny on every backend and takes only the two
+    /// explicit values — the privacy default must hold with an empty config, and
+    /// an opt-in must be spelled exactly, never inferred.
+    #[test]
+    fn data_collection_defaults_deny_and_parses_explicit_allow() {
+        let cfg = Config::builtin();
+        let b = cfg.resolve_backend("openrouter").unwrap();
+        assert_eq!(
+            b.data_collection,
+            DataCollection::Deny,
+            "the built-in openrouter backend must deny data collection out of the box"
+        );
+
+        let cfg = Config::from_toml_str(
+            r#"
+            [backends.openrouter]
+            data_collection = "allow"
+            "#,
+        )
+        .unwrap();
+        let b = cfg.resolve_backend("openrouter").unwrap();
+        assert_eq!(
+            b.data_collection,
+            DataCollection::Allow,
+            "the explicit opt-in must parse and stick"
+        );
+    }
+
+    /// A value outside the two-policy vocabulary is a loud load error naming both
+    /// legal spellings — a typo'd "denied" silently defaulting would betray the
+    /// user's intent in the worst direction.
+    #[test]
+    fn data_collection_rejects_an_unknown_value() {
+        let err = Config::from_toml_str(
+            r#"
+            [backends.openrouter]
+            data_collection = "denied"
+            "#,
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("deny") && msg.contains("allow"), "got: {msg}");
+    }
+
+    /// The policy only exists on the OpenRouter wire; setting it elsewhere is a
+    /// config mistake refused at load — not a silent no-op the user believes is
+    /// protecting them.
+    #[test]
+    fn data_collection_is_openrouter_only() {
+        let err = Config::from_toml_str(
+            r#"
+            [backends.anthropic]
+            data_collection = "deny"
+            "#,
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("data_collection") && msg.contains("openrouter"),
+            "got: {msg}"
+        );
+    }
+
     /// The built-in batch casts' synth slots positively declare `lane = Batch`, carry
     /// **synth only** (batch is a toolless oneshot — an explorer slot would be dead
     /// weight), and synth a batch-capable backend. Pins the lane's shape so an
@@ -3037,6 +3156,8 @@ mod tests {
         api_key_file = "/nonexistent-kaibo-test/deepseek"
         [backends.gemini]
         api_key_file = "/nonexistent-kaibo-test/gemini"
+        [backends.openrouter]
+        api_key_file = "/nonexistent-kaibo-test/openrouter"
         [backends.openai-local]
         api_key_file = "/nonexistent-kaibo-test/openai"
     "#;

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -2937,6 +2937,88 @@ mod tests {
         );
     }
 
+    /// The explicit `data_collection = "allow"` opt-in threads all the way to the
+    /// arm: the provider pin must be *absent* (kaibo steps aside for the account's
+    /// own settings — it never emits a restriction it was told to drop, and never
+    /// pushes toward collection with an explicit "allow"). Arm-level on purpose
+    /// (GLM review, 2026-07-03): a flipped condition in `inject_provider_prefs`
+    /// would slip past the function-level test alone.
+    #[test]
+    fn openrouter_arm_allow_omits_the_provider_pin() {
+        let defaults = crate::config::Defaults::default();
+        let dir = tempfile::tempdir().unwrap();
+        let key_file = dir.path().join("openrouter-key");
+        std::fs::write(&key_file, "sk-or-test").unwrap();
+        let backend = crate::config::Backend {
+            name: "openrouter".into(),
+            kind: ProviderKind::OpenRouter,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: Some(key_file.to_str().unwrap().to_string()),
+            key_optional: false,
+            request_timeout: Duration::from_secs(30),
+            data_collection: crate::config::DataCollection::Allow,
+        };
+        let slot = ModelSlot::bare("openrouter", "~anthropic/claude-sonnet-latest");
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyed openrouter arm builds from a key file");
+        let params = arm.params.expect("the openrouter arm always sends params");
+        assert!(
+            params.get("provider").is_none(),
+            "the opt-in must reach the arm as an *absent* pin, got: {params}"
+        );
+        assert_eq!(
+            params["reasoning"]["effort"],
+            defaults.synth_effort.as_str(),
+            "everything else in the blob is unchanged by the opt-in"
+        );
+    }
+
+    /// `effort = "none"` on a slot threads to the arm as the structural reasoning
+    /// disable, coexisting with the budget workaround and the privacy pin — the
+    /// full injection chain, not just the `to_params` step it's pinned at in
+    /// shaping.rs (GLM review, 2026-07-03).
+    #[test]
+    fn openrouter_arm_effort_none_carries_the_structural_disable() {
+        let defaults = crate::config::Defaults::default();
+        let dir = tempfile::tempdir().unwrap();
+        let key_file = dir.path().join("openrouter-key");
+        std::fs::write(&key_file, "sk-or-test").unwrap();
+        let backend = crate::config::Backend {
+            name: "openrouter".into(),
+            kind: ProviderKind::OpenRouter,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: Some(key_file.to_str().unwrap().to_string()),
+            key_optional: false,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+        };
+        let slot = ModelSlot {
+            effort: Some("none".into()),
+            ..ModelSlot::bare("openrouter", "z-ai/glm-5.2")
+        };
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyed openrouter arm builds from a key file");
+        let params = arm.params.expect("the openrouter arm always sends params");
+        assert_eq!(
+            params["reasoning"]["enabled"], false,
+            "the opt-out must arrive structurally, not as a passthrough string"
+        );
+        assert!(
+            params["reasoning"].get("effort").is_none(),
+            "no effort string rides beside the disable, got: {params}"
+        );
+        assert_eq!(
+            params["max_completion_tokens"], defaults.max_tokens,
+            "the budget workaround coexists with the disable"
+        );
+        assert_eq!(
+            params["provider"]["data_collection"], "deny",
+            "the privacy pin coexists with the disable"
+        );
+    }
+
     /// The OpenRouter arm rides with rig's explicit prompt caching ON: Anthropic-
     /// upstream slugs need `cache_control` breakpoints to bill cache-read rates
     /// (2026-07-03: a consult re-billed its full growing prefix every turn without

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -16,7 +16,7 @@ use rig_core::completion::message::{
     UserContent,
 };
 use rig_core::completion::{CompletionModel, Message, Prompt, PromptError, ToolDefinition};
-use rig_core::providers::{anthropic, deepseek, gemini, openai};
+use rig_core::providers::{anthropic, deepseek, gemini, openai, openrouter};
 use rig_core::tool::{Tool, ToolDyn};
 use rig_core::OneOrMany;
 use serde::Deserialize;
@@ -202,6 +202,10 @@ impl Arm {
             Some(t.top_p),
             &t.effort,
         );
+        // OpenRouter drops rig's native `max_tokens` (see `inject_output_budget`), so
+        // the budget must ride `additional_params` as `max_completion_tokens`. A no-op
+        // for every other kind, whose `max_tokens` rig sends itself.
+        let params = super::shaping::inject_output_budget(backend.kind, params, t.max_tokens);
         let caps = ModelCaps::resolve(backend.kind, &slot.id, slot.vision);
 
         // One HTTP backend carrying the per-request deadline, built by the shared
@@ -236,6 +240,20 @@ impl Arm {
                     .http_client(http)
                     .build()
                     .map_err(|e| anyhow!("gemini client init: {e}"))?;
+                Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
+            }
+            ProviderKind::OpenRouter => {
+                // A keyed gateway with a *fixed* endpoint (rig pins the base URL), so —
+                // unlike the openai kind — there is no base_url to resolve. `with_app_identity`
+                // stamps the X-OpenRouter-Title / HTTP-Referer headers so kaibo's traffic is
+                // identifiable in the OpenRouter dashboard.
+                let key = backend.resolve_key()?;
+                let client = openrouter::Client::builder()
+                    .api_key(&key)
+                    .http_client(http)
+                    .with_app_identity("kaibo", "https://github.com/tobert/kaibo")
+                    .build()
+                    .map_err(|e| anyhow!("openrouter client init: {e}"))?;
                 Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
             }
             ProviderKind::Openai => {

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -2847,6 +2847,47 @@ mod tests {
         );
     }
 
+    /// The OpenRouter arm's full params assembly — `to_params` chained through
+    /// `inject_output_budget` at the single live construction point. The reasoning
+    /// object (thinking on by default), the rig-defect budget workaround, and the
+    /// slot's sampling must coexist in the one blob the arm sends; any of them
+    /// silently missing starves or blinds the call. Keyed via a key file so the
+    /// test never touches process env.
+    #[test]
+    fn openrouter_arm_carries_reasoning_budget_and_sampling_together() {
+        let defaults = crate::config::Defaults::default();
+        let dir = tempfile::tempdir().unwrap();
+        let key_file = dir.path().join("openrouter-key");
+        std::fs::write(&key_file, "sk-or-test").unwrap();
+        let backend = crate::config::Backend {
+            name: "openrouter".into(),
+            kind: ProviderKind::OpenRouter,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: Some(key_file.to_str().unwrap().to_string()),
+            key_optional: false,
+            request_timeout: Duration::from_secs(30),
+        };
+        let slot = ModelSlot {
+            temperature: Some(0.3),
+            ..ModelSlot::bare("openrouter", "~anthropic/claude-sonnet-latest")
+        };
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyed openrouter arm builds from a key file");
+        assert_eq!(arm.model, "~anthropic/claude-sonnet-latest");
+        let params = arm.params.expect("the openrouter arm always sends params");
+        assert_eq!(
+            params["reasoning"]["effort"],
+            defaults.synth_effort.as_str(),
+            "reasoning rides on by default at the synth-role effort"
+        );
+        assert_eq!(
+            params["max_completion_tokens"], defaults.max_tokens,
+            "the output budget must reach the body rig won't carry natively"
+        );
+        assert_eq!(params["temperature"], 0.3, "slot sampling coexists");
+    }
+
     /// `Arm::from_slot` is the single live construction point, and per-call
     /// overrides build slots that never saw config load's budget validation —
     /// so the thinking_budget < max_tokens rule must hold here too, as the same

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use rig_core::agent::{HookAction, PromptHook};
+use rig_core::agent::{AgentBuilder, HookAction, PromptHook};
 use rig_core::client::CompletionClient;
 use rig_core::completion::message::{
     AssistantContent, Image, ImageMediaType, MimeType, ToolChoice, ToolResult, ToolResultContent,
@@ -44,13 +44,13 @@ use super::shaping::{ModelCaps, ModelShape};
 /// loop, again for the turn-cap finalize turn — see [`run_phase`]).
 type ToolFactory<'a> = &'a (dyn Fn() -> Result<Vec<Box<dyn ToolDyn>>> + Send + Sync);
 
-/// The object-safe seam one [`Arm`] runs its loops through: a (client, model)
-/// pair erased behind a vtable. rig's provider clients are distinct concrete
-/// types; monomorphizing every phase combination would be a kinds² macro product
-/// (the decided plumbing fork, `docs/casts.md`) — the calls are network-bound,
-/// so dynamic dispatch here is free. The one implementation, [`ClientArm`],
-/// forwards to the generic [`run_phase`], which stays the offline-testable
-/// primitive.
+/// The object-safe seam one [`Arm`] runs its loops through: a pre-built
+/// completion model erased behind a vtable. rig's provider models are distinct
+/// concrete types; monomorphizing every phase combination would be a kinds² macro
+/// product (the decided plumbing fork, `docs/casts.md`) — the calls are
+/// network-bound, so dynamic dispatch here is free. The one implementation,
+/// [`ModelArm`], forwards to the generic [`run_phase`], which stays the
+/// offline-testable primitive.
 trait PhaseRunner: Send + Sync {
     #[allow(clippy::too_many_arguments)] // mirrors run_phase's loop inputs
     fn run_phase<'a>(
@@ -66,16 +66,21 @@ trait PhaseRunner: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>>;
 }
 
-/// The concrete (client, model) pair behind the [`PhaseRunner`] vtable.
-struct ClientArm<C> {
-    client: C,
-    model: String,
+/// The concrete pre-built completion model behind the [`PhaseRunner`] vtable.
+/// Holding the *model* (not a client + id) lets a provider-specific constructor
+/// ride along — the OpenRouter arm's explicit prompt caching is set once here and
+/// every loop turn inherits it.
+struct ModelArm<M> {
+    model: M,
+    /// The model id, for the `run_phase` span — the vtable erases the type, and
+    /// the telemetry must keep naming which model ran (it's how spend and
+    /// behavior get attributed per model when reading traces).
+    name: String,
 }
 
-impl<C> PhaseRunner for ClientArm<C>
+impl<M> PhaseRunner for ModelArm<M>
 where
-    C: CompletionClient + Clone + Send + Sync + 'static,
-    C::CompletionModel: 'static,
+    M: CompletionModel + 'static,
 {
     fn run_phase<'a>(
         &'a self,
@@ -89,8 +94,8 @@ where
         break_on_view_image: bool,
     ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
         Box::pin(run_phase(
-            &self.client,
             &self.model,
+            &self.name,
             preamble,
             max_tokens,
             initial_prompt,
@@ -153,10 +158,32 @@ impl Arm {
         C::CompletionModel: 'static,
     {
         let model = model.into();
+        Self::from_model(
+            client.completion_model(&model),
+            model,
+            max_tokens,
+            params,
+            caps,
+        )
+    }
+
+    /// Wrap a pre-built completion model as an arm — the seam a provider-specific
+    /// model constructor (OpenRouter's prompt-caching flag) enters through.
+    fn from_model<M>(
+        model_impl: M,
+        model: impl Into<String>,
+        max_tokens: u64,
+        params: Option<Value>,
+        caps: ModelCaps,
+    ) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        let model = model.into();
         Self {
-            runner: Arc::new(ClientArm {
-                client,
-                model: model.clone(),
+            runner: Arc::new(ModelArm {
+                model: model_impl,
+                name: model.clone(),
             }),
             model,
             max_tokens,
@@ -206,6 +233,11 @@ impl Arm {
         // the budget must ride `additional_params` as `max_completion_tokens`. A no-op
         // for every other kind, whose `max_tokens` rig sends itself.
         let params = super::shaping::inject_output_budget(backend.kind, params, t.max_tokens);
+        // OpenRouter routing honors the backend's data policy — deny by default, so
+        // source never reaches a data-collecting upstream host without an explicit
+        // config opt-in. A no-op for every other kind.
+        let params =
+            super::shaping::inject_provider_prefs(backend.kind, params, backend.data_collection);
         let caps = ModelCaps::resolve(backend.kind, &slot.id, slot.vision);
 
         // One HTTP backend carrying the per-request deadline, built by the shared
@@ -254,7 +286,8 @@ impl Arm {
                     .with_app_identity("kaibo", "https://github.com/tobert/kaibo")
                     .build()
                     .map_err(|e| anyhow!("openrouter client init: {e}"))?;
-                Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
+                let model = Self::openrouter_completion_model(&client, &slot.id);
+                Ok(Self::from_model(model, &slot.id, t.max_tokens, params, caps))
             }
             ProviderKind::Openai => {
                 // Any OpenAI-compatible endpoint, addressed by the backend's base
@@ -271,6 +304,22 @@ impl Arm {
                 Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
             }
         }
+    }
+
+    /// Build the OpenRouter arm's completion model: explicit prompt caching ON.
+    /// rig marks the system prompt with a `cache_control: ephemeral` breakpoint,
+    /// so Anthropic-upstream slugs bill the resident preamble at cache-read rates
+    /// instead of full input price every turn; implicit-caching upstreams
+    /// (DeepSeek/GLM/Kimi/Gemini/OpenAI) ignore the marker. The growing
+    /// transcript is not marked — an upstream rig limitation, tracked in
+    /// docs/issues.md. Kept as a named seam so the construction is unit-testable:
+    /// rig exposes the caching flag as a public field, and `from_slot` must
+    /// route through here.
+    fn openrouter_completion_model(
+        client: &openrouter::Client,
+        id: &str,
+    ) -> openrouter::CompletionModel {
+        client.completion_model(id).with_prompt_caching()
     }
 
     /// Does a `view_image` on this arm need the user-turn rewrite? True exactly when
@@ -579,10 +628,10 @@ fn split_for_resume(mut history: Vec<Message>) -> (Vec<Message>, Message) {
 // span and nests under this one, so a phase's whole model loop (every `chat` turn,
 // every `tool` call) hangs off one `run_phase` span carrying the model. Inert
 // unless an exporter is attached (telemetry off → no subscriber records it).
-#[tracing::instrument(name = "run_phase", skip_all, fields(model = %model, max_turns = max_turns))]
-pub(crate) async fn run_phase<C, F>(
-    client: &C,
-    model: &str,
+#[tracing::instrument(name = "run_phase", skip_all, fields(model = %model_name, max_turns = max_turns))]
+pub(crate) async fn run_phase<M, F>(
+    model: &M,
+    model_name: &str,
     preamble: &str,
     max_tokens: u64,
     initial_prompt: Message,
@@ -593,8 +642,7 @@ pub(crate) async fn run_phase<C, F>(
     break_on_view_image: bool,
 ) -> Result<String>
 where
-    C: CompletionClient,
-    C::CompletionModel: 'static,
+    M: CompletionModel + 'static,
     F: Fn() -> Result<Vec<Box<dyn ToolDyn>>>,
 {
     // Loop state across view_image-break resumes. The caller hands us the *assembled*
@@ -618,7 +666,6 @@ where
             let mut full = history;
             full.push(prompt);
             return finalize_after_max_turns(
-                client,
                 model,
                 preamble,
                 max_tokens,
@@ -630,8 +677,7 @@ where
             .await;
         }
 
-        let mut builder = client
-            .agent(model)
+        let mut builder = AgentBuilder::new(model.clone())
             .preamble(preamble)
             .max_tokens(max_tokens);
         // Thinking on (both phases) where the provider takes a request-time toggle.
@@ -658,7 +704,6 @@ where
                 // tell the caller, so a watching client sees "wrapping up" not silence.
                 progress.emit(PhaseEvent::TurnCapReached);
                 return finalize_after_max_turns(
-                    client,
                     model,
                     preamble,
                     max_tokens,
@@ -691,9 +736,8 @@ where
 /// history validates) but [`ToolChoice::None`] forbidding any further call. See
 /// [`run_phase`]'s recovery note and [`finalize_prompt`].
 #[allow(clippy::too_many_arguments)] // mirrors run_phase's loop inputs
-async fn finalize_after_max_turns<C>(
-    client: &C,
-    model: &str,
+async fn finalize_after_max_turns<M>(
+    model: &M,
     preamble: &str,
     max_tokens: u64,
     thinking: Option<&Value>,
@@ -702,12 +746,10 @@ async fn finalize_after_max_turns<C>(
     max_turns: usize,
 ) -> Result<String>
 where
-    C: CompletionClient,
-    C::CompletionModel: 'static,
+    M: CompletionModel + 'static,
 {
     let (history, prompt) = finalize_prompt(chat_history);
-    let mut builder = client
-        .agent(model)
+    let mut builder = AgentBuilder::new(model.clone())
         .preamble(preamble)
         .max_tokens(max_tokens)
         .tool_choice(ToolChoice::None);
@@ -2815,6 +2857,7 @@ mod tests {
             api_key_file: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
         };
         let slot = ModelSlot {
             vision: Some(true),
@@ -2867,6 +2910,7 @@ mod tests {
             api_key_file: Some(key_file.to_str().unwrap().to_string()),
             key_optional: false,
             request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
         };
         let slot = ModelSlot {
             temperature: Some(0.3),
@@ -2886,6 +2930,41 @@ mod tests {
             "the output budget must reach the body rig won't carry natively"
         );
         assert_eq!(params["temperature"], 0.3, "slot sampling coexists");
+        assert_eq!(
+            params["provider"]["data_collection"], "deny",
+            "no-collection routing rides every OpenRouter arm by default — source \
+             must not reach a data-collecting upstream host without an explicit opt-in"
+        );
+    }
+
+    /// The OpenRouter arm rides with rig's explicit prompt caching ON: Anthropic-
+    /// upstream slugs need `cache_control` breakpoints to bill cache-read rates
+    /// (2026-07-03: a consult re-billed its full growing prefix every turn without
+    /// them), and implicit-caching upstreams ignore the marker. rig exposes the
+    /// flag as a public field, and `from_slot` routes through this constructor —
+    /// so this pins the wiring, not an internal default.
+    #[test]
+    fn openrouter_arm_enables_prompt_caching() {
+        // Built through kaibo's one TLS client-build site (ring installed there) —
+        // a bare reqwest builder panics under `rustls-no-provider` unless another
+        // test happened to install the provider first.
+        let http = crate::tls::https_client(Duration::from_secs(30)).unwrap();
+        let client = openrouter::Client::builder()
+            .api_key("sk-or-test")
+            .http_client(http)
+            .build()
+            .expect("offline openrouter client construction");
+        let plain = client.completion_model("~anthropic/claude-sonnet-latest");
+        assert!(
+            !plain.prompt_caching,
+            "rig defaults the flag off — the arm constructor below is load-bearing"
+        );
+        let armed =
+            Arm::openrouter_completion_model(&client, "~anthropic/claude-sonnet-latest");
+        assert!(
+            armed.prompt_caching,
+            "the OpenRouter arm must build its model with prompt caching enabled"
+        );
     }
 
     /// `Arm::from_slot` is the single live construction point, and per-call
@@ -2908,6 +2987,7 @@ mod tests {
             api_key_file: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
         };
         let slot = ModelSlot::bare("anthropic", "claude-haiku-4-5");
         let err = Arm::from_slot(&backend, &slot, ModelRole::Explorer, &defaults)

--- a/src/consult/mod.rs
+++ b/src/consult/mod.rs
@@ -41,6 +41,6 @@ pub use prompts::{
     ConsultAttachment, Phase, PromptOverrides,
 };
 pub use shaping::{
-    request_params, thinking_params, ModelCaps, ModelShape, ThinkingStyleOverride, DEFAULT_EFFORT,
-    THINKING_BUDGET,
+    inject_provider_prefs, request_params, thinking_params, ModelCaps, ModelShape,
+    ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
 };

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -551,4 +551,30 @@ mod tests {
             "non-OpenRouter params pass through untouched — no max_completion_tokens added"
         );
     }
+
+    /// Canary tying `inject_output_budget` to the rig 0.38 pin. The workaround
+    /// exists because rig's `OpenrouterCompletionRequest` has no `max_tokens`
+    /// field; the day a rig bump adds one, `AgentBuilder::max_tokens` starts
+    /// arriving natively and the injected `max_completion_tokens` rides alongside
+    /// it — redundant at best, a provider 400 at worst, and silent either way.
+    /// This failing test is the tripwire: on a rig bump, re-read rig's
+    /// `openrouter/completion.rs`, retire (or deliberately keep) the injection,
+    /// then advance the version prefix here.
+    #[test]
+    fn rig_bump_reaudits_the_openrouter_budget_workaround() {
+        let lock = include_str!("../../Cargo.lock");
+        let entry = lock
+            .find("name = \"rig-core\"")
+            .expect("rig-core pinned in Cargo.lock");
+        let version = lock[entry..]
+            .lines()
+            .nth(1)
+            .expect("version line follows the name line");
+        assert!(
+            version.contains("version = \"0.38."),
+            "rig-core moved past 0.38 ({version}): re-audit the \
+             OpenrouterCompletionRequest max_tokens defect before shipping — \
+             see inject_output_budget"
+        );
+    }
 }

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -96,6 +96,14 @@ fn transport_supports_tool_result_images(kind: ProviderKind) -> bool {
     match kind {
         ProviderKind::Anthropic | ProviderKind::Gemini => true,
         ProviderKind::Openai => false,
+        // OpenRouter speaks the OpenAI wire but is *more* dangerous than a 400: rig's
+        // converter silently rewrites a tool-result image to the placeholder text
+        // "[Image content not supported in tool results]" (openrouter/completion.rs,
+        // the `ToolResultContent::Image(_)` arm of the `role:tool` conversion) — a
+        // quiet drop, the exact silent loss kaibo refuses. `false` routes a seen image
+        // onto the user-turn channel (the break-rewrite-resume path) *before* it can
+        // reach that converter, so the bytes actually arrive.
+        ProviderKind::OpenRouter => false,
         // Vision-blind on the wire; the value is unreached (no view_image attaches),
         // but "no tool-result image channel" is the honest answer.
         ProviderKind::DeepSeek => false,
@@ -119,6 +127,11 @@ fn is_vision_capable(kind: ProviderKind, _model: &str) -> bool {
         // per slot (`vision = true` in the role table) rather than guessed from an
         // arbitrary id.
         ProviderKind::Openai => false,
+        // OpenRouter fronts every model — vision-capable and text-only alike — so the
+        // capability is a property of the pinned *model*, not the gateway. Opt in per
+        // slot (`vision = true`), like the generic OpenAI kind; the built-in openrouter
+        // cast pins it on both its (multimodal) default models.
+        ProviderKind::OpenRouter => false,
     }
 }
 
@@ -135,6 +148,11 @@ enum ThinkingStyle {
     GeminiBudget,
     /// DeepSeek V4 hybrids: `{thinking:{type:"enabled"}, reasoning_effort:<role>}`.
     DeepSeekEffort,
+    /// OpenRouter's unified reasoning param: `{reasoning:{effort:<role>}}`. The gateway
+    /// translates it per upstream provider (Anthropic budget, OpenAI effort, Gemini
+    /// thinkingLevel) and silently drops it for a model that has no reasoning knob, so
+    /// emitting it unconditionally is safe.
+    OpenRouterEffort,
     /// No request-time toggle (the generic OpenAI path).
     None,
 }
@@ -215,12 +233,17 @@ impl ModelShape {
                 }
             }
             ProviderKind::DeepSeek => ThinkingStyle::DeepSeekEffort,
+            ProviderKind::OpenRouter => ThinkingStyle::OpenRouterEffort,
             ProviderKind::Openai => ThinkingStyle::None,
         };
         let (sampling_under_thinking, sampling_placement) = match kind {
             ProviderKind::Anthropic => (false, SamplingPlacement::TopLevel),
             ProviderKind::Gemini => (true, SamplingPlacement::GeminiGenerationConfig),
-            ProviderKind::DeepSeek | ProviderKind::Openai => (true, SamplingPlacement::TopLevel),
+            // OpenRouter takes OpenAI-shaped sampling top-level and, being tolerant of
+            // unsupported params (dropped per-model), keeps it under reasoning.
+            ProviderKind::DeepSeek | ProviderKind::OpenRouter | ProviderKind::Openai => {
+                (true, SamplingPlacement::TopLevel)
+            }
         };
         Self {
             thinking,
@@ -251,6 +274,7 @@ impl ModelShape {
             ThinkingStyle::AnthropicAdaptive
                 | ThinkingStyle::GeminiLevel
                 | ThinkingStyle::DeepSeekEffort
+                | ThinkingStyle::OpenRouterEffort
         )
     }
 
@@ -364,6 +388,15 @@ impl ModelShape {
                 obj.insert("thinking".into(), json!({ "type": "enabled" }));
                 obj.insert("reasoning_effort".into(), json!(effort));
             }
+            ThinkingStyle::OpenRouterEffort => {
+                // The unified reasoning knob. `effort` is the per-role depth lever, a
+                // passthrough string OpenRouter validates against its ladder
+                // (none|minimal|low|medium|high|xhigh|max) — so the default "high" maps
+                // to "high", and a slot's `effort = "xhigh"` reaches the deeper rungs
+                // without a code change. The gateway maps it onto each upstream model's
+                // native reasoning field, or drops it for a model that has none.
+                obj.insert("reasoning".into(), json!({ "effort": effort }));
+            }
             ThinkingStyle::None => {}
         }
     }
@@ -396,6 +429,32 @@ pub fn request_params(
     )
 }
 
+/// Fold this arm's output-token budget into `params` where the provider needs it
+/// carried out-of-band. **OpenRouter only, and it's a rig-defect workaround**: rig
+/// 0.38's `OpenrouterCompletionRequest` (openrouter/completion.rs) has no `max_tokens`
+/// field and its `TryFrom` never reads `CompletionRequest.max_tokens`, so
+/// `AgentBuilder::max_tokens()` is silently a no-op for that provider — the answer
+/// would run on OpenRouter's own default budget, starving a thinking-on completion.
+/// `additional_params` *is* `#[serde(flatten)]`-merged into the body, so we inject the
+/// budget there under `max_completion_tokens` (OpenRouter's preferred spelling; the
+/// spec deprecates `max_tokens`). A no-op for every other kind — rig sends their
+/// `max_tokens` natively, so a second copy here would be redundant at best.
+pub fn inject_output_budget(
+    kind: ProviderKind,
+    params: Option<Value>,
+    max_tokens: u64,
+) -> Option<Value> {
+    if kind != ProviderKind::OpenRouter {
+        return params;
+    }
+    let mut obj = match params {
+        Some(Value::Object(m)) => m,
+        _ => serde_json::Map::new(),
+    };
+    obj.insert("max_completion_tokens".into(), json!(max_tokens));
+    Some(Value::Object(obj))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -421,6 +480,75 @@ mod tests {
         assert_eq!(
             params["generationConfig"]["thinkingConfig"]["thinkingLevel"],
             "high"
+        );
+    }
+
+    /// OpenRouter's unified reasoning knob: the per-role effort must land as
+    /// `{reasoning:{effort:<role>}}` — thinking-on by default, and a slot's `effort`
+    /// (including OpenRouter's deeper `xhigh`/`max` rungs, which pass through as any
+    /// other string) reaching the gateway, not silently dropped.
+    #[test]
+    fn openrouter_reasoning_carries_the_per_role_effort() {
+        let shape = ModelShape::resolve(
+            ProviderKind::OpenRouter,
+            "~anthropic/claude-sonnet-latest",
+            ThinkingStyleOverride::Auto,
+        );
+        let params = shape.to_params(8192, None, None, DEFAULT_EFFORT).unwrap();
+        assert_eq!(
+            params["reasoning"]["effort"], "high",
+            "the default effort rides the unified reasoning param"
+        );
+        // A deeper rung passes through verbatim — xhigh/max are reachable via slot config.
+        let params = shape.to_params(8192, None, None, "xhigh").unwrap();
+        assert_eq!(params["reasoning"]["effort"], "xhigh");
+        // Sampling stays top-level and survives alongside reasoning (OpenRouter drops
+        // it per-model if unsupported, so kaibo emits it).
+        let params = shape
+            .to_params(8192, Some(0.5), None, DEFAULT_EFFORT)
+            .unwrap();
+        assert_eq!(params["temperature"], 0.5);
+    }
+
+    /// OpenRouter drops rig's native `max_tokens`, so the budget must ride
+    /// `additional_params` as `max_completion_tokens` — the rig-defect workaround. The
+    /// value must actually land in the blob the arm sends; and it must be a no-op for
+    /// every other kind (rig sends their `max_tokens` natively).
+    #[test]
+    fn openrouter_output_budget_rides_max_completion_tokens() {
+        // Merges into an existing reasoning blob without clobbering it.
+        let params = ModelShape::resolve(
+            ProviderKind::OpenRouter,
+            "~google/gemini-flash-latest",
+            ThinkingStyleOverride::Auto,
+        )
+        .to_params(8192, None, None, DEFAULT_EFFORT);
+        let out = inject_output_budget(ProviderKind::OpenRouter, params, 16384).unwrap();
+        assert_eq!(
+            out["max_completion_tokens"], 16384,
+            "the output budget must reach the request body OpenRouter reads"
+        );
+        assert_eq!(
+            out["reasoning"]["effort"], "high",
+            "the injection preserves the reasoning param"
+        );
+
+        // Even with no other params (None), the budget still lands.
+        let out = inject_output_budget(ProviderKind::OpenRouter, None, 4096).unwrap();
+        assert_eq!(out["max_completion_tokens"], 4096);
+
+        // A no-op for every other kind — rig sends their max_tokens itself.
+        assert!(inject_output_budget(ProviderKind::Anthropic, None, 4096).is_none());
+        let anthropic = ModelShape::resolve(
+            ProviderKind::Anthropic,
+            "claude-sonnet-4-6",
+            ThinkingStyleOverride::Auto,
+        )
+        .to_params(8192, None, None, DEFAULT_EFFORT);
+        let passthrough = inject_output_budget(ProviderKind::Anthropic, anthropic.clone(), 16384);
+        assert_eq!(
+            passthrough, anthropic,
+            "non-OpenRouter params pass through untouched — no max_completion_tokens added"
         );
     }
 }

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -3,6 +3,7 @@
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 
+use crate::config::DataCollection;
 use crate::credentials::ProviderKind;
 
 /// Token budget for model "thinking"/reasoning, for the providers that expose a
@@ -391,11 +392,19 @@ impl ModelShape {
             ThinkingStyle::OpenRouterEffort => {
                 // The unified reasoning knob. `effort` is the per-role depth lever, a
                 // passthrough string OpenRouter validates against its ladder
-                // (none|minimal|low|medium|high|xhigh|max) — so the default "high" maps
+                // (minimal|low|medium|high|xhigh|max) — so the default "high" maps
                 // to "high", and a slot's `effort = "xhigh"` reaches the deeper rungs
                 // without a code change. The gateway maps it onto each upstream model's
                 // native reasoning field, or drops it for a model that has none.
-                obj.insert("reasoning".into(), json!({ "effort": effort }));
+                // `"none"` is the opt-out and gets the *structural* disable — the
+                // gateway's documented off-switch — rather than trusting the effort
+                // ladder to treat the literal string as off (a drift there would
+                // silently re-enable reasoning, billed as output tokens).
+                if effort == "none" {
+                    obj.insert("reasoning".into(), json!({ "enabled": false }));
+                } else {
+                    obj.insert("reasoning".into(), json!({ "effort": effort }));
+                }
             }
             ThinkingStyle::None => {}
         }
@@ -455,6 +464,30 @@ pub fn inject_output_budget(
     Some(Value::Object(obj))
 }
 
+/// Fold the backend's upstream-host data policy into `params`. **OpenRouter only**:
+/// one slug routes across competing hosts whose data policies differ, and kaibo's
+/// prompts carry source code — so under [`DataCollection::Deny`] (the default) every
+/// request pins `provider: {"data_collection": "deny"}` and OpenRouter routes only
+/// to no-collection hosts (a model with no compliant host fails loudly, which is
+/// the point). The explicit `Allow` opt-in emits nothing: kaibo never pushes
+/// *toward* collection, it just steps aside and lets the operator's own OpenRouter
+/// account settings govern. A no-op for every other kind.
+pub fn inject_provider_prefs(
+    kind: ProviderKind,
+    params: Option<Value>,
+    data_collection: DataCollection,
+) -> Option<Value> {
+    if kind != ProviderKind::OpenRouter || data_collection == DataCollection::Allow {
+        return params;
+    }
+    let mut obj = match params {
+        Some(Value::Object(m)) => m,
+        _ => serde_json::Map::new(),
+    };
+    obj.insert("provider".into(), json!({ "data_collection": "deny" }));
+    Some(Value::Object(obj))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -508,6 +541,74 @@ mod tests {
             .to_params(8192, Some(0.5), None, DEFAULT_EFFORT)
             .unwrap();
         assert_eq!(params["temperature"], 0.5);
+    }
+
+    /// `effort = "none"` is the documented reasoning opt-out, and it must be the
+    /// *structural* disable (`{"reasoning": {"enabled": false}}`), not a passthrough
+    /// effort string — OpenRouter's explicit off-switch, independent of how the
+    /// gateway's effort ladder treats the literal "none" today. Any other rung
+    /// keeps riding as effort (pinned above).
+    #[test]
+    fn openrouter_effort_none_disables_reasoning_structurally() {
+        let shape = ModelShape::resolve(
+            ProviderKind::OpenRouter,
+            "~anthropic/claude-sonnet-latest",
+            ThinkingStyleOverride::Auto,
+        );
+        let params = shape.to_params(8192, None, None, "none").unwrap();
+        assert_eq!(
+            params["reasoning"]["enabled"], false,
+            "none must emit the explicit disable, not rely on ladder semantics"
+        );
+        assert!(
+            params["reasoning"].get("effort").is_none(),
+            "no effort string rides alongside the disable"
+        );
+    }
+
+    /// Kaibo's prompts carry source code, and one OpenRouter slug routes across
+    /// hosts with differing data policies — so every OpenRouter request must pin
+    /// `provider.data_collection = "deny"` unless the backend explicitly opted in.
+    /// The deny must merge into the existing params blob (reasoning, budget,
+    /// sampling) without clobbering it, and the Allow opt-in must emit *nothing* —
+    /// kaibo steps aside for the account's own settings, it never pushes toward
+    /// collection. Other kinds are untouched either way.
+    #[test]
+    fn openrouter_denies_data_collection_by_default() {
+        let params = ModelShape::resolve(
+            ProviderKind::OpenRouter,
+            "z-ai/glm-5.2",
+            ThinkingStyleOverride::Auto,
+        )
+        .to_params(8192, None, None, DEFAULT_EFFORT);
+        let out = inject_provider_prefs(ProviderKind::OpenRouter, params, DataCollection::Deny)
+            .expect("openrouter always sends params");
+        assert_eq!(
+            out["provider"]["data_collection"], "deny",
+            "the default must pin no-collection routing on every request"
+        );
+        assert_eq!(
+            out["reasoning"]["effort"], "high",
+            "the deny merges beside the reasoning blob, not over it"
+        );
+
+        // The explicit opt-in: no provider object at all.
+        let params = ModelShape::resolve(
+            ProviderKind::OpenRouter,
+            "z-ai/glm-5.2",
+            ThinkingStyleOverride::Auto,
+        )
+        .to_params(8192, None, None, DEFAULT_EFFORT);
+        let out = inject_provider_prefs(ProviderKind::OpenRouter, params, DataCollection::Allow)
+            .expect("openrouter always sends params");
+        assert!(
+            out.get("provider").is_none(),
+            "allow emits nothing — the account's own policy governs"
+        );
+
+        // Any other kind: passthrough both ways, including a None params.
+        let out = inject_provider_prefs(ProviderKind::Anthropic, None, DataCollection::Deny);
+        assert!(out.is_none(), "non-openrouter kinds are untouched");
     }
 
     /// OpenRouter drops rig's native `max_tokens`, so the budget must ride

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -4,9 +4,10 @@
 //! source of truth is a per-provider dotfile in `$HOME`; if the matching env var
 //! is set it wins (handy for CI / one-off overrides).
 //!
-//! - Anthropic: `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt`
-//! - DeepSeek:  `DEEPSEEK_API_KEY`  / `~/.deepseek-key`
-//! - Gemini:    `GEMINI_API_KEY`    / `~/.gemini-api-key`
+//! - Anthropic:  `ANTHROPIC_API_KEY`  / `~/.anthropic-key.txt`
+//! - DeepSeek:   `DEEPSEEK_API_KEY`   / `~/.deepseek-key`
+//! - Gemini:     `GEMINI_API_KEY`     / `~/.gemini-api-key`
+//! - OpenRouter: `OPENROUTER_API_KEY` / `~/.openrouter-key`
 //!
 //! [`ProviderKind::Openai`] is the general case: any endpoint speaking the OpenAI
 //! wire protocol, addressed by [`openai_base_url`] (`OPENAI_BASE_URL`, default a
@@ -26,15 +27,20 @@ use anyhow::{anyhow, Context, Result};
 /// `OPENAI_BASE_URL` env var (see [`openai_base_url`]).
 pub const DEFAULT_OPENAI_BASE_URL: &str = "http://localhost:13305/api/v1";
 
-/// A model provider. The keyed providers (Anthropic/DeepSeek/Gemini) each speak
-/// their own wire protocol and require an API key. [`ProviderKind::Openai`] is the
-/// generic OpenAI-compatible endpoint: any base URL speaking that protocol, with
+/// A model provider. The keyed providers (Anthropic/DeepSeek/Gemini/OpenRouter) each
+/// speak their own wire protocol and require an API key. [`ProviderKind::Openai`] is
+/// the generic OpenAI-compatible endpoint: any base URL speaking that protocol, with
 /// an *optional* key — keyless by default, since the default endpoint is local.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderKind {
     Anthropic,
     DeepSeek,
     Gemini,
+    /// OpenRouter's unified gateway: one keyed endpoint (`OPENROUTER_API_KEY`, fixed
+    /// base URL) fronting every upstream model. It speaks the OpenAI wire but is a
+    /// *keyed* kind with a pinned endpoint (not a configurable base URL), and it
+    /// translates a unified `reasoning` param per underlying provider.
+    OpenRouter,
     /// Any OpenAI-compatible endpoint, addressed by base URL; key optional.
     /// Defaults to a local keyless server (Gemma via an OpenAI-compatible host).
     Openai,
@@ -59,6 +65,7 @@ impl ProviderKind {
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::DeepSeek => "deepseek",
             ProviderKind::Gemini => "gemini",
+            ProviderKind::OpenRouter => "openrouter",
             ProviderKind::Openai => "openai",
         }
     }
@@ -83,6 +90,7 @@ impl ProviderKind {
             ProviderKind::Anthropic => "ANTHROPIC_API_KEY",
             ProviderKind::DeepSeek => "DEEPSEEK_API_KEY",
             ProviderKind::Gemini => "GEMINI_API_KEY",
+            ProviderKind::OpenRouter => "OPENROUTER_API_KEY",
             ProviderKind::Openai => "OPENAI_API_KEY",
         }
     }
@@ -95,6 +103,7 @@ impl ProviderKind {
             ProviderKind::Anthropic => ".anthropic-key.txt",
             ProviderKind::DeepSeek => ".deepseek-key",
             ProviderKind::Gemini => ".gemini-api-key",
+            ProviderKind::OpenRouter => ".openrouter-key",
             ProviderKind::Openai => ".openai-key",
         }
     }
@@ -113,11 +122,12 @@ impl std::str::FromStr for ProviderKind {
             "anthropic" | "claude" => Ok(ProviderKind::Anthropic),
             "deepseek" => Ok(ProviderKind::DeepSeek),
             "gemini" | "google" => Ok(ProviderKind::Gemini),
+            "openrouter" => Ok(ProviderKind::OpenRouter),
             // The OpenAI-compatible endpoint. Also accept the names people reach
             // for when it points at the local keyless default (Gemma via Lemonade).
             "openai" | "local" | "lemonade" | "gemma" | "gemma4" => Ok(ProviderKind::Openai),
             other => Err(anyhow!(
-                "unknown provider {other:?} (expected anthropic, deepseek, gemini, or openai)"
+                "unknown provider {other:?} (expected anthropic, deepseek, gemini, openrouter, or openai)"
             )),
         }
     }

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -119,7 +119,7 @@ pub fn topics() -> Vec<(&'static str, &'static str)> {
 /// truncating host (Claude Code's 2048-char cap) would cut.
 fn kaibo_lead() -> &'static str {
     "kaibo (解剖) — grounded, cited answers about a codebase from a model outside \
-     your own family. DeepSeek, Gemini, Anthropic, or a local model reads the \
+     your own family. DeepSeek, Gemini, Anthropic, OpenRouter, or a local model reads the \
      project READ-ONLY and answers with file:line citations. Say in prose what you \
      did or want to know — kaibo finds and reads the current code itself; no \
      pasted files or diffs needed. `consult` is the front door. `explore` \
@@ -172,8 +172,8 @@ fn setup_section(config: &Config) -> String {
          can't reach a model. `run_kaish` works now (read-only shell, no model) to \
          browse the code meanwhile.\n\n\
          Give the cast a key via an **environment variable** or **key file** — kaibo \
-         reads either at startup, kept out of the chat (set it in your shell, not \
-         pasted to the model):\n\
+         reads either at startup, kept out of the chat (set in your shell, never \
+         pasted here):\n\
          {backends}\n\n\
          Then **reconnect the kaibo MCP server** so it re-reads the environment \
          (Claude Code: `/mcp`; other hosts: their own reload). Prefer another \

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,9 @@ struct Args {
     no_follow_worktrees: bool,
 
     /// Default cast when a call omits it (a built-in name or a cast defined in
-    /// config.toml). Built-ins: anthropic | deepseek | gemini | openai-local
-    /// (plus aliases: claude, google, local, …) and the batch casts gemini-batch
-    /// | anthropic-batch. Replaces the old --provider flag
+    /// config.toml). Built-ins: anthropic | deepseek | gemini | openrouter |
+    /// openai-local (plus aliases: claude, google, local, …) and the batch casts
+    /// gemini-batch | anthropic-batch. Replaces the old --provider flag
     /// (clap rejects the unknown flag loudly).
     #[arg(long)]
     cast: Option<String>,

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -182,6 +182,12 @@ pub(super) fn render_config_resource(
         /// True when a missing key falls back to a placeholder (keyless endpoint).
         key_optional: bool,
         request_timeout_secs: u64,
+        /// OpenRouter only: the upstream-host data policy this backend requests
+        /// (`"deny"` routes only to no-collection hosts — the default; `"allow"`
+        /// is the explicit opt-in). Rendered so the privacy posture is visible,
+        /// absent on every other kind.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        data_collection: Option<&'static str>,
     }
 
     /// One cast slot: the `"backend/id"` ref plus its *resolved* capabilities
@@ -236,6 +242,7 @@ pub(super) fn render_config_resource(
                 api_key_file,
                 key_optional,
                 request_timeout,
+                data_collection,
             } = b;
             let rendered_base_url = if *kind == crate::credentials::ProviderKind::Openai {
                 Some(b.resolved_base_url())
@@ -250,6 +257,11 @@ pub(super) fn render_config_resource(
                 api_key_file: api_key_file.clone(),
                 key_optional: *key_optional,
                 request_timeout_secs: request_timeout.as_secs(),
+                data_collection: (*kind == crate::credentials::ProviderKind::OpenRouter)
+                    .then(|| match data_collection {
+                        crate::config::DataCollection::Deny => "deny",
+                        crate::config::DataCollection::Allow => "allow",
+                    }),
             };
             (name.clone(), doc)
         })

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1468,7 +1468,7 @@ impl KaiboHandler {
         description = "Ask a model outside your own family about a codebase — code review, \
             debugging, architecture, \"what does this change break\" — and get a grounded \
             answer with `file:line` citations. A capable model (DeepSeek, Gemini, \
-            Anthropic, or local — pick with `cast`) drives a READ-ONLY shell over the \
+            Anthropic, OpenRouter, or local — pick with `cast`) drives a READ-ONLY shell over the \
             project: it reads the real, current source, delegates broad sweeps to a fast \
             explorer, and answers with evidence, never modifying anything. Describe your \
             intent in prose; kaibo locates the code itself, so you don't paste files or \

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2806,19 +2806,30 @@ Work through these steps:
    • `kaibo://config` — the resolved live state: the casts and backends that exist now, \
 and where each key is sourced from.
 2. Ask me which providers I can actually reach before writing anything: which of \
-Anthropic / DeepSeek / Gemini I hold API keys for, and whether I run any \
+Anthropic / DeepSeek / Gemini / OpenRouter I hold API keys for, and whether I run any \
 OpenAI-compatible local servers (llama.cpp, Ollama, an image server) and at what base \
-URLs. Let me tell you my providers rather than guessing them.
+URLs. Let me tell you my providers rather than guessing them. OpenRouter is worth \
+naming on its own — one key there reaches every major model family through a single \
+gateway.
 3. Propose a roster built on a provider I actually named in step 2, then write it to \
 `$XDG_CONFIG_HOME/kaibo/config.toml` (default `~/.config/kaibo/config.toml`). The \
-default shape is a single outside family — DeepSeek, Gemini, Anthropic, or a local pair \
-— with explorer and synth both within it. That one family is already the whole win: it \
-augments my own lineage with a different house's eyes (a cheap, fast explorer and a \
-stronger synth, same family). kaibo's built-in casts are already within-family pairs, \
-so often this is just giving one of them a key rather than writing a new cast. Mixing \
-families across roles (a 'chimera' — say a DeepSeek explorer with a Claude synth) is an \
-advanced move for someone who holds several keys and asks for it; don't reach for it by \
-default.
+default shape is a single outside family — DeepSeek, Gemini, Anthropic, OpenRouter, or \
+a local pair — with explorer and synth both within it. That one family is already the \
+whole win: it augments my own lineage with a different house's eyes (a cheap, fast \
+explorer and a stronger synth, same family). kaibo's built-in casts are already \
+within-family pairs, so often this is just giving one of them a key rather than writing \
+a new cast. Mixing families across roles (a 'chimera' — say a DeepSeek explorer with a \
+Claude synth) is an advanced move for someone who holds several keys and asks for it; \
+don't reach for it by default. If OpenRouter is the family, ground the model picks in \
+its live catalog instead of guessing ids: `GET https://openrouter.ai/api/v1/models` is \
+public, no auth, and filters to what matters — \
+`?supported_parameters=tools&category=programming&sort=intelligence-high-to-low` finds \
+tool-capable coding models (a consult cast needs `tools` support); `q=` / `context=` / \
+`max_price=` narrow further; each entry carries live pricing, context length, and a \
+`reasoning` capability block. Favor the drift-proof `~author/family-latest` aliases \
+(e.g. `~anthropic/claude-sonnet-latest`) over a pinned slug, and know that `:free` / \
+`:nitro` / `:floor` suffixes pick a free, fastest, or cheapest variant of a concrete \
+slug where offered.
 4. Keep secrets in the environment or a key file. A backend names an env var \
 (`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
 the secret stays outside it. Tell me which env vars to set or files to write, and let \

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1181,6 +1181,7 @@ fn local_backend(api_key_file: Option<String>, key_optional: bool) -> Backend {
         api_key_file,
         key_optional,
         request_timeout: Duration::from_secs(900),
+        data_collection: Default::default(),
     }
 }
 
@@ -1217,6 +1218,7 @@ fn required_key_with_no_source_is_an_error() {
         api_key_file: None,
         key_optional: false,
         request_timeout: Duration::from_secs(900),
+        data_collection: Default::default(),
     };
     let err = b.resolve_key().unwrap_err();
     assert!(

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -1508,6 +1508,101 @@ async fn openrouter_consult_round_trips() {
     );
 }
 
+/// One minimal OpenRouter completion carrying kaibo's shaped params, with the
+/// gateway's usage accounting on. Returns the parsed response JSON.
+#[cfg(test)]
+async fn openrouter_probe_completion(key: &str, model: &str, params: &Value) -> Value {
+    let mut body = json!({
+        "model": model,
+        "messages": [{
+            "role": "user",
+            "content": "How many prime numbers are there between 10 and 50? \
+                        Work it out carefully, then answer with just the count.",
+        }],
+        "max_completion_tokens": 8192,
+        "usage": {"include": true},
+    });
+    for (k, v) in params.as_object().expect("shaped params are an object") {
+        body[k] = v.clone();
+    }
+    let http = kaibo::tls::https_client(std::time::Duration::from_secs(120)).unwrap();
+    let resp = http
+        .post("https://openrouter.ai/api/v1/chat/completions")
+        .bearer_auth(key)
+        .json(&body)
+        .send()
+        .await
+        .expect("openrouter request");
+    let status = resp.status();
+    let json: Value = resp.json().await.expect("openrouter response json");
+    assert!(
+        status.is_success(),
+        "openrouter rejected kaibo's shaped params ({status}): {json}"
+    );
+    json
+}
+
+#[tokio::test]
+#[ignore = "hits the OpenRouter API (keyed gateway); run with --ignored and OPENROUTER_API_KEY"]
+async fn openrouter_reasoning_accounting_live() {
+    // "Reasoning on by default" is doctrine, so it gets *measured*, not assumed
+    // (2026-07-03: a live consult averaged ~150 output tokens per turn — thin
+    // enough to question whether effort was landing). This posts kaibo's exact
+    // shaped params — `ModelShape::to_params`, the seam every OpenRouter arm
+    // rides — with OpenRouter's usage accounting on, and reads what the gateway
+    // actually billed: effort-on must show reasoning tokens, and the structural
+    // disable (`effort = "none"` ⇒ `{"reasoning":{"enabled":false}}`) must not.
+    let key = match load(ProviderKind::OpenRouter) {
+        Ok(k) => k,
+        Err(e) => panic!("no OpenRouter credential for live test: {e}"),
+    };
+    // The built-in cast's explorer alias — the slot the doctrine most needs to
+    // hold on, since the explorer runs the most turns.
+    let model = "~google/gemini-flash-latest";
+    let shape = ModelShape::resolve(
+        ProviderKind::OpenRouter,
+        model,
+        ThinkingStyleOverride::Auto,
+    );
+
+    // Default posture: effort = high ⇒ the gateway bills reasoning tokens. The
+    // no-collection routing pin rides along exactly as every live arm sends it —
+    // so this also proves deny-routing still reaches the built-in cast's models.
+    let params = shape.to_params(THINKING_BUDGET, None, None, DEFAULT_EFFORT);
+    let params = kaibo::consult::inject_provider_prefs(
+        ProviderKind::OpenRouter,
+        params,
+        kaibo::config::DataCollection::Deny,
+    )
+    .expect("openrouter always sends params");
+    let resp = openrouter_probe_completion(&key, model, &params).await;
+    let reasoning = resp["usage"]["completion_tokens_details"]["reasoning_tokens"]
+        .as_u64()
+        .unwrap_or(0);
+    eprintln!("=== effort={DEFAULT_EFFORT} usage: {}", resp["usage"]);
+    assert!(
+        reasoning > 0,
+        "effort={DEFAULT_EFFORT} must bill reasoning tokens — thinking-on-by-default \
+         isn't landing, got usage: {}",
+        resp["usage"]
+    );
+
+    // The opt-out: the structural disable really turns reasoning off.
+    let params = shape
+        .to_params(THINKING_BUDGET, None, None, "none")
+        .expect("openrouter always sends params");
+    let resp = openrouter_probe_completion(&key, model, &params).await;
+    let reasoning = resp["usage"]["completion_tokens_details"]["reasoning_tokens"]
+        .as_u64()
+        .unwrap_or(0);
+    eprintln!("=== effort=none usage: {}", resp["usage"]);
+    assert_eq!(
+        reasoning, 0,
+        "effort=none must not bill reasoning tokens, got usage: {}",
+        resp["usage"]
+    );
+}
+
 #[tokio::test]
 #[ignore = "hits the Anthropic API on Opus 4.8 (adaptive-only tier); run with --ignored and a key"]
 async fn adaptive_only_anthropic_model_round_trips() {

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -1424,6 +1424,60 @@ async fn two_phase_consult_answers_from_the_real_tree() {
 }
 
 #[tokio::test]
+#[ignore = "hits the OpenRouter API (keyed gateway); run with --ignored and OPENROUTER_API_KEY"]
+async fn openrouter_consult_round_trips() {
+    // The live proof of the OpenRouter arm: the unified `{reasoning:{effort}}` param,
+    // the `max_completion_tokens` workaround (rig drops native max_tokens for this
+    // provider — without the injection a thinking-on answer would starve), and the
+    // `with_app_identity` headers all have to be accepted end-to-end. Runs the built-in
+    // openrouter cast (the `~author/family-latest` aliases) so a regression in any of
+    // those surfaces as a live failure here, not in production.
+    if let Err(e) = load(ProviderKind::OpenRouter) {
+        panic!("no OpenRouter credential for live test: {e}");
+    }
+
+    let cfg = Config::builtin();
+    let backend = cfg
+        .resolve_backend("openrouter")
+        .expect("openrouter backend");
+    let explorer_slot = cfg
+        .resolve_cast("openrouter")
+        .unwrap()
+        .require_slot(ModelRole::Explorer)
+        .unwrap()
+        .clone();
+    let synth_slot = cfg
+        .resolve_cast("openrouter")
+        .unwrap()
+        .require_slot(ModelRole::Synth)
+        .unwrap()
+        .clone();
+    let explorer = Arm::from_slot(backend, &explorer_slot, ModelRole::Explorer, &cfg.defaults)
+        .expect("explorer arm on openrouter");
+    let synth = Arm::from_slot(backend, &synth_slot, ModelRole::Synth, &cfg.defaults)
+        .expect("synth arm on openrouter");
+
+    let out = consult(
+        "How does kaibo stop the explorer from deleting real files? Name the mechanism and the file.",
+        None,
+        env!("CARGO_MANIFEST_DIR"),
+        &explorer,
+        &synth,
+        &ConsultConfig::default(),
+        None,
+    )
+    .await
+    .expect("openrouter consult should succeed (reasoning + max_completion_tokens accepted)");
+
+    let lower = out.answer.to_lowercase();
+    assert!(
+        lower.contains("sandbox") || lower.contains("read-only") || lower.contains("read only"),
+        "answer should explain the read-only sandbox mechanism, got: {}",
+        out.answer
+    );
+}
+
+#[tokio::test]
 #[ignore = "hits the Anthropic API on Opus 4.8 (adaptive-only tier); run with --ignored and a key"]
 async fn adaptive_only_anthropic_model_round_trips() {
     // The real proof of the "fix anthropic" work: Opus 4.8 *rejects* the old

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -549,6 +549,25 @@ fn model_caps_classify_per_kind_and_honor_the_override() {
     // per slot rather than guessed from an arbitrary id.
     assert!(!ModelCaps::resolve(ProviderKind::Openai, "Gemma-4-E4B-it-GGUF", None).vision);
     assert!(ModelCaps::resolve(ProviderKind::Openai, "Gemma-4-E4B-it-GGUF", Some(true)).vision);
+    // OpenRouter is the same shape: the gateway fronts blind and sighted models
+    // alike, so vision is the pinned model's property — opt-in per slot (the
+    // built-in cast pins it on its multimodal defaults).
+    assert!(
+        !ModelCaps::resolve(
+            ProviderKind::OpenRouter,
+            "~anthropic/claude-sonnet-latest",
+            None
+        )
+        .vision
+    );
+    assert!(
+        ModelCaps::resolve(
+            ProviderKind::OpenRouter,
+            "~anthropic/claude-sonnet-latest",
+            Some(true)
+        )
+        .vision
+    );
     // The override pins in both directions.
     assert!(!ModelCaps::resolve(ProviderKind::Anthropic, "claude-sonnet-4-6", Some(false)).vision);
 
@@ -567,6 +586,18 @@ fn model_caps_classify_per_kind_and_honor_the_override() {
     );
     // The vision override never flips the transport channel — it's the wire's property.
     assert!(!ModelCaps::resolve(ProviderKind::Openai, "anything", Some(true)).tool_result_images);
+    // OpenRouter's transport is *worse* than a 400: rig's converter silently rewrites
+    // a tool-result image to placeholder text, so the channel must stay closed — a
+    // seeing OpenRouter model gets its image on the user turn instead.
+    assert!(
+        !ModelCaps::resolve(
+            ProviderKind::OpenRouter,
+            "~google/gemini-flash-latest",
+            Some(true)
+        )
+        .tool_result_images,
+        "an OpenRouter VLM sees, but rig's tool-result converter would drop the bytes"
+    );
 }
 
 #[test]

--- a/tests/credentials.rs
+++ b/tests/credentials.rs
@@ -76,6 +76,49 @@ fn only_openai_tolerates_a_missing_key() {
     assert!(!ProviderKind::Anthropic.key_optional());
     assert!(!ProviderKind::DeepSeek.key_optional());
     assert!(!ProviderKind::Gemini.key_optional());
+    // OpenRouter is a *keyed* gateway — a missing key is a hard error, not tolerated.
+    assert!(!ProviderKind::OpenRouter.key_optional());
+}
+
+// --- OpenRouter: a keyed gateway (one key, fixed endpoint) fronting every model.
+
+#[test]
+fn openrouter_parses_and_carries_its_key_source() {
+    assert_eq!(
+        ProviderKind::from_str("openrouter").unwrap(),
+        ProviderKind::OpenRouter
+    );
+    assert_eq!(
+        ProviderKind::from_str("  OpenRouter ").unwrap(),
+        ProviderKind::OpenRouter
+    );
+    assert_eq!(ProviderKind::OpenRouter.canonical_name(), "openrouter");
+    assert_eq!(ProviderKind::OpenRouter.builtin_name(), "openrouter");
+    assert_eq!(ProviderKind::OpenRouter.env_var(), "OPENROUTER_API_KEY");
+    assert_eq!(
+        ProviderKind::OpenRouter.key_file(std::path::Path::new("/home/amy")),
+        std::path::Path::new("/home/amy/.openrouter-key")
+    );
+}
+
+#[test]
+fn openrouter_key_resolves_from_env_then_file() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join(ProviderKind::OpenRouter.key_file_name());
+    fs::write(&file, "sk-or-from-file\n").unwrap();
+    // Env wins...
+    assert_eq!(resolve(Some("sk-or-env"), &file).unwrap(), "sk-or-env");
+    // ...and the file is the fallback.
+    assert_eq!(resolve(None, &file).unwrap(), "sk-or-from-file");
+}
+
+#[test]
+fn unknown_provider_error_lists_openrouter() {
+    let err = ProviderKind::from_str("nope").unwrap_err();
+    assert!(
+        err.to_string().contains("openrouter"),
+        "the error should list openrouter among the expected kinds: {err}"
+    );
 }
 
 #[test]
@@ -101,5 +144,9 @@ fn provider_paths_match_amys_dotfiles() {
     );
     assert_eq!(ProviderKind::DeepSeek.key_file(home), home.join(".deepseek-key"));
     assert_eq!(ProviderKind::Gemini.key_file(home), home.join(".gemini-api-key"));
+    assert_eq!(
+        ProviderKind::OpenRouter.key_file(home),
+        home.join(".openrouter-key")
+    );
     assert_eq!(ProviderKind::Openai.key_file(home), home.join(".openai-key"));
 }


### PR DESCRIPTION
## What

A new keyed `ProviderKind::OpenRouter` on rig 0.38.2's native openrouter client: a user with an [OpenRouter account](https://openrouter.ai/docs/quickstart) sets `OPENROUTER_API_KEY` (or `~/.openrouter-key`) and the built-in `openrouter` backend + cast light up — one key reaching every major model family. The `configure` prompt now walks a setting-up agent through OpenRouter, including using the **public model catalog** (`GET /api/v1/models`, filterable by tools support, category, price) to propose cast models with live data.

## Decisions (from the research arc with Amy, 2026-07-03)

- **Native rig provider over the generic openai wire.** rig's openrouter module round-trips structured `reasoning_details` — including Anthropic's signed thinking blocks — across tool-call turns, which the generic path cannot preserve. For kaibo's multi-turn consult loop with thinking on, that's correctness, not polish.
- **Reasoning maximized by default, opt-out per slot.** Doctrine: anything kaibo calls has thinking on unless the user says otherwise. The new `ThinkingStyle::OpenRouterEffort` emits OpenRouter's unified `{reasoning:{effort:<role>}}`, which the gateway translates per upstream provider and silently drops where unsupported — so unconditional emission is safe. Effort passes through verbatim: slot `effort = "xhigh"`/`"max"` reaches OpenRouter's deeper rungs, `effort = "none"` is the documented opt-out.
- **rig 0.38 defect worked around, with a tripwire.** rig's `OpenrouterCompletionRequest` silently drops `max_tokens` (confirmed still broken on rig `main`) — a thinking-on answer would starve on the gateway's default budget. The budget rides the flattened `additional_params` as `max_completion_tokens`; a canary test fails on any rig bump past 0.38 and names the re-audit, so the fix upstream can't silently double-send. Exit strategy if rig gaps accrete is logged in `docs/issues.md` (direct-SDK breakout; `openrouter-rs` surveyed as pilot candidate).
- **Tool-result images stay off this transport.** rig's converter rewrites a tool-result image to placeholder text — silent data loss — so the arm routes seen images through the existing user-turn rewrite path instead.
- **Drift-proof built-in cast.** Explorer `~google/gemini-flash-latest`, synth `~anthropic/claude-sonnet-latest` — OpenRouter's live `~author/family-latest` catalog aliases track the newest family member instead of rotting like hardcoded ids. Both are multimodal-in per the catalog, so vision is pinned on both slots.
- **Loud edges:** keyed kind, fixed endpoint (`base_url` in config is a load error), no batch lane (honest refusal naming the batch-capable kinds).

## Review

Cross-family per house discipline, no diff handed over: **Gemini Pro** (batch lane, twelve whole files attached) and **DeepSeek** (agentic consult over the worktree). Both judged the design sound; their three real findings are closed in the final commit (ModelCaps test coverage for the new kind, an arm-level params-assembly integration test, the rig-bump canary) plus the `effort = "none"` opt-out documentation. One DeepSeek finding (missing CHANGELOG entry) was a false positive.

## Verification

- Offline suite green: 319 lib tests + all integration suites, 0 failures; instructions budget tests pass (the resident-text additions were paid for by compression).
- `cargo tree -i aws-lc-rs` / `aws-lc-sys` / `openssl-sys` all empty — TLS invariant holds.
- The `#[ignore]`d live probe (`tests/consult.rs`, gated on `OPENROUTER_API_KEY`) has **not** been run — no key on this machine. Worth one live round-trip before this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)