### PR TITLE
fix(attach): bound every raw read so a stat-then-read swap can't OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,13 @@ the git log. Each later release appends a new section at the top.
   The VFS refuses to follow a symlink out of the allowed tree at read time, so a path
   swapped for an out-of-tree symlink *after* the check is rejected structurally rather
   than by racing a re-check — the boundary holds regardless of timing.
+- **A raced file-swap can't OOM the reader.** Every attachment/image read now carries a
+  byte ceiling into the read itself (via the VFS `read_range`, honoured with a real
+  `File::take` — no whole-file slurp), sized one byte past the caller's budget. A file
+  swapped to something enormous between kaibo's size check and the read stops at that
+  ceiling and is refused or demoted by length, where before an unbounded read could pull
+  the swapped file whole into memory. Closes the size-swap sibling of the symlink-swap
+  above — the timing window is bounded, not raced.
 - **Attachment wrappers can't be confused by their own contents.** Neither an attached
   file's *body* nor its *name* can forge the `<file>` wrapper boundary anymore. A body
   holding a `<file>`-tag lookalike — a `</file>` close, a stray opening `<file …>`, or a

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -482,14 +482,31 @@ mod tests {
             .strip_prefix("<file path=\"evil.md\">\n")
             .and_then(|s| s.strip_suffix("\n</file>"))
             .expect("wrapper brackets the body");
-        let tag = Regex::new(r"(?i)<\s*/?\s*file\b[^>]*>").unwrap();
+        // Teeth for the escape itself, one assertion per dimension: each injected
+        // lookalike must appear in the body in its *escaped* form (`<` → `<\`). We assert
+        // the escaped literal is *present* rather than that the impl's own regex no
+        // longer matches `inner` — the latter is a tautology, and two cross-family
+        // reviews (2026-07-03 and 2026-07-04) flagged the earlier `!tag.is_match(inner)`
+        // for exactly that: `replace_all` removes every match by construction, so a regex
+        // that stopped catching `< / FILE >` would leave it unescaped *and* fail to match
+        // it, and the assertion would pass blind. Checking the escaped literal fails loud
+        // if any dimension regresses — the close form, the *opening* form, and the
+        // whitespace+case variant that proves the `(?i)` and `\s*` handling.
         assert!(
-            !tag.is_match(inner),
-            "no bare <file>-tag lookalike survives in the body: {inner}"
+            inner.contains(r"<\/file>"),
+            "the bare close lookalike is escaped: {inner}"
         );
-        // Independent of the escape regex (so this isn't circular with the impl): on
-        // the FULL wrapped output, the only literal open/close tags are the wrapper's
-        // own — exactly one each (Gemini cross-family review, 2026-07-03).
+        assert!(
+            inner.contains(r#"<\file path="x">"#),
+            "the opening lookalike is escaped: {inner}"
+        );
+        assert!(
+            inner.contains(r"<\ / FILE >"),
+            "the whitespace+case variant is escaped (proves (?i) and \\s* tolerance): {inner}"
+        );
+        // And on the FULL wrapped output, the only literal open/close tags left are the
+        // wrapper's own — exactly one each. A bare delimiter that slipped the escape
+        // would push a count to 2.
         assert_eq!(
             wrapped.matches("<file path=").count(),
             1,

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -116,6 +116,16 @@ pub fn check_attachment_bounds(
 /// `if x < y` reads truer than `if x &lt; y`. The backslash form leaves the body legible
 /// while removing the tag (`<\/file>` is no longer matched as a tag), so the only bare
 /// `<file>`/`</file>` left in the wrapper is kaibo's own.
+///
+/// A note to the next reviewer, because a cross-family pass mis-flagged this as a
+/// *critical* breakout: the wrapper's own delimiters (in [`Attachment::wrapped_text`])
+/// are the **bare** `<file …>` / `</file>` — there is no backslash in them. The
+/// backslash form `<\/file>` is *only ever this function's neutralized output*. So a
+/// body already containing a literal `<\/file>` is not a breakout — it is byte-identical
+/// to what we'd emit for a defanged tag, i.e. already safe, and the regex rightly leaves
+/// it alone. Breaking out would require a *bare* `</file>` to survive into the body; that
+/// is exactly what the regex rewrites, and what the wrapper-count assertions in
+/// `file_tag_lookalikes_in_body_are_all_escaped` verify with a literal (non-regex) scan.
 fn escape_file_body(body: &str) -> String {
     static FILE_TAG: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)<\s*/?\s*file\b[^>]*>").expect("static file-tag regex compiles")

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -43,7 +43,7 @@ use kaish_kernel::interpreter::ExecResult;
 use kaish_kernel::tools::{Tool, ToolArgs, ToolCtx, ToolRegistry, ToolSchema};
 use kaish_kernel::vfs::{ByteBudget, Filesystem, LocalFs, MemoryFs, VfsRouter};
 use kaish_kernel::{
-    IgnoreConfig, Kernel, KernelBackend, KernelConfig, LocalBackend, OutputLimitConfig,
+    IgnoreConfig, Kernel, KernelBackend, KernelConfig, LocalBackend, OutputLimitConfig, ReadRange,
 };
 
 /// Wraps a real builtin, preserving its identity and schema but refusing to run.
@@ -208,11 +208,13 @@ pub fn build_readonly_kernel_with(
 /// That router is the *only* handle that reads a file's bytes directly: under
 /// `Kernel::with_backend` the kernel's own [`Kernel::vfs`] is just its internal
 /// `/v/*` scratch — our project mounts live on the backend's router, reachable only
-/// through execution (capped, text) or this handle. [`KaishWorker::read_file`]
-/// (for `view_image`) needs the raw bytes uncapped, so the worker keeps this router
-/// and reads through it. It's the *same* router execution uses, so a read stays
-/// governed by the read-only project mount and the `/` scratch — containment and
-/// read-only stay structural, identical to `run_kaish`.
+/// through execution (capped, text) or this handle. [`KaishWorker::read_file_capped`]
+/// (for `view_image` and attachments) needs the raw bytes *outside* the script-output
+/// cap — but not unbounded: it reads through this router with its own per-call byte
+/// ceiling (`read_range`'s `File::take`), so a stat-then-read swap can't slurp to OOM.
+/// It's the *same* router execution uses, so a read stays governed by the read-only
+/// project mount and the `/` scratch — containment and read-only stay structural,
+/// identical to `run_kaish`.
 fn build_readonly_kernel_and_vfs(
     root: impl Into<PathBuf>,
     sandbox: &SandboxConfig,
@@ -383,14 +385,21 @@ enum Job {
         script: String,
         reply: tokio::sync::oneshot::Sender<KaishOutput>,
     },
-    /// Read a file's bytes through the kernel's VFS, *bypassing* the script-output
-    /// cap (an image is megabytes; `cat | base64` through `run`'s capped stdout
-    /// would truncate it). Same VFS as every read, so containment and read-only stay
-    /// structural — an out-of-mount path routes to the empty `/` scratch and 404s.
-    /// Reply carries the bytes or a rendered error string (`io::Error` is not `Send`
-    /// across the boundary cleanly, and the caller only needs the message).
+    /// Read at most `limit` bytes of a file through the kernel's VFS, *bypassing* the
+    /// script-output cap (an image is megabytes; `cat | base64` through `run`'s capped
+    /// stdout would truncate it) but never unbounded: `limit` is a hard ceiling on the
+    /// bytes pulled into memory, so a file swapped between the caller's `stat` and this
+    /// read cannot slurp a giant file and OOM the process — the read stops at `limit`
+    /// and the caller detects the overflow by length (see [`KaishWorker::read_file`]).
+    /// It rides through `read_range`, which `LocalFs` honours with `File::take(limit)`
+    /// (no whole-file slurp-then-slice), so the ceiling is real, not cosmetic. Same VFS
+    /// as every read, so containment and read-only stay structural — an out-of-mount
+    /// path routes to the empty `/` scratch and 404s. Reply carries the bytes or a
+    /// rendered error string (`io::Error` is not `Send` across the boundary cleanly,
+    /// and the caller only needs the message).
     Read {
         path: PathBuf,
+        limit: u64,
         reply: tokio::sync::oneshot::Sender<std::result::Result<Vec<u8>, String>>,
     },
 }
@@ -455,16 +464,25 @@ impl KaishWorker {
                                 // Receiver gone (caller cancelled) is fine — drop it.
                                 let _ = reply.send(out);
                             }
-                            Job::Read { path, reply } => {
+                            Job::Read { path, limit, reply } => {
                                 // Read straight through the *project* VFS router on
                                 // this thread. The read-only mount governs what
                                 // resolves: under `root` → real bytes; anywhere else →
-                                // the empty `/` scratch → NotFound. No output cap
-                                // applies — that's a script-execution guard, not a VFS
-                                // one. (The kernel's own `vfs()` carries only its
-                                // internal `/v/*` scratch under `with_backend`, not
-                                // these mounts — hence the retained handle.)
-                                let out = project_vfs.read(&path).await.map_err(|e| format!("{e}"));
+                                // the empty `/` scratch → NotFound. The script-output
+                                // cap doesn't apply here (that's a run-execution guard),
+                                // so this path carries its OWN ceiling: a byte-ranged
+                                // read of `[0, limit)`. `LocalFs::read_range` honours it
+                                // with `File::take(limit)`, so a raced swap to a huge
+                                // file stops at `limit` instead of slurping to OOM — the
+                                // caller sizes `limit` one byte past its budget and
+                                // detects the overflow by the returned length. (The
+                                // kernel's own `vfs()` carries only its internal `/v/*`
+                                // scratch under `with_backend`, not these mounts — hence
+                                // the retained handle.)
+                                let out = project_vfs
+                                    .read_range(&path, Some(ReadRange::bytes(0, limit)))
+                                    .await
+                                    .map_err(|e| format!("{e}"));
                                 let _ = reply.send(out);
                             }
                         }
@@ -493,22 +511,41 @@ impl KaishWorker {
             .map_err(|_| anyhow::anyhow!("kaish worker dropped the reply"))
     }
 
-    /// Read a file's raw bytes through the kernel's VFS. The returned future is
-    /// `Send`. This is the read path for binary content (`view_image`): it bypasses
+    /// Read up to `max_bytes` of a file's raw bytes through the kernel's VFS — never
+    /// more, even if the file is larger. The returned future is `Send`. This is the
+    /// read path for binary/whole-file content (`view_image`, attachments): it bypasses
     /// the script-output cap (which exists to keep a wide `cat` from flooding the
     /// model's context, not to bound a deliberate single-file read) while keeping the
     /// *same* read-only mount as every other read — so containment and read-only stay
     /// structural. A path that resolves outside the project mount lands in the empty
     /// `/` scratch and comes back `NotFound`.
     ///
+    /// **Why the cap is a parameter, not "read it all".** Every caller stats the file
+    /// first and reads only what fits its budget, but stat-then-read is a TOCTOU: a
+    /// file swapped to something enormous in that window would otherwise be slurped
+    /// whole into memory (OOM) before the caller's post-read size check could refuse
+    /// it. Passing the ceiling *down into the read* closes that window — the read stops
+    /// at `max_bytes`, never the swapped size. There is deliberately no uncapped read
+    /// method: an unbounded read of caller-swappable bytes is a footgun with no user.
+    ///
+    /// The convention every caller shares: pass `budget + 1` as `max_bytes`, then treat
+    /// a returned length `> budget` as "the file overflowed my budget" — refuse or
+    /// demote it. A returned length `<= budget` is the whole file, read intact. (The
+    /// `+ 1` is what distinguishes a file exactly at the budget from one past it.)
+    ///
     /// `path` should be absolute and already inside the workspace; the caller
-    /// (`view_image`) canonicalizes and boundary-checks host-side first so it can
-    /// give an actionable out-of-workspace error before ever reaching here.
-    pub async fn read_file(&self, path: impl Into<PathBuf>) -> Result<Vec<u8>> {
+    /// canonicalizes and boundary-checks host-side first so it can give an actionable
+    /// out-of-workspace error before ever reaching here.
+    pub async fn read_file_capped(
+        &self,
+        path: impl Into<PathBuf>,
+        max_bytes: u64,
+    ) -> Result<Vec<u8>> {
         let (reply, rx) = tokio::sync::oneshot::channel();
         self.jobs
             .send(Job::Read {
                 path: path.into(),
+                limit: max_bytes,
                 reply,
             })
             .map_err(|_| anyhow::anyhow!("kaish worker thread is gone"))?;

--- a/src/server/containment.rs
+++ b/src/server/containment.rs
@@ -202,12 +202,22 @@ impl super::KaiboHandler {
                     })?;
                 workers.insert(tree.clone(), worker);
             }
-            let bytes = workers[&tree].read_file(canon.clone()).await.map_err(|e| {
-                McpError::invalid_params(
-                    format!("attachment {} could not be read: {e:#}", canon.display()),
-                    None,
-                )
-            })?;
+            // Cap the read one byte past the largest a single file may legally be — the
+            // greater of the two per-encoding caps `classify` enforces. The stat above
+            // fed the *batch* budget; this bounds the *per-file* read so a stat-then-read
+            // swap can't slurp a raced-huge file into memory. An over-cap file comes back
+            // truncated at cap+1 and `classify` refuses it loudly by length, exactly as it
+            // would refuse an honest over-cap file — same outcome, no OOM window.
+            let read_cap = DEFAULT_MAX_TEXT_BYTES.max(DEFAULT_MAX_IMAGE_BYTES) as u64 + 1;
+            let bytes = workers[&tree]
+                .read_file_capped(canon.clone(), read_cap)
+                .await
+                .map_err(|e| {
+                    McpError::invalid_params(
+                        format!("attachment {} could not be read: {e:#}", canon.display()),
+                        None,
+                    )
+                })?;
             // Label the attachment with the caller's path (what they typed), not the
             // canonical one — it's their reference and it's what the model should see.
             out.push(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1037,10 +1037,18 @@ impl KaiboHandler {
                     )?,
                 );
             }
+            // Read at most one byte past `remaining`. The `meta.len()` gate above is a
+            // stat, and stat-then-read is a TOCTOU: a file swapped to something enormous
+            // in that window would slurp whole into memory if the read were unbounded.
+            // Capping the read at `remaining + 1` bounds that window — a raced-huge file
+            // comes back as `remaining + 1` bytes, which the length check below reads as
+            // "over budget" and demotes to `TextOversize` (the model then `cat`s it
+            // itself), never an OOM. So the demotion path does double duty: it catches
+            // both an honest over-budget file and a raced swap, from the one length test.
             let bytes = worker
                 .as_ref()
                 .expect("worker was just spawned")
-                .read_file(canon.clone())
+                .read_file_capped(canon.clone(), remaining + 1)
                 .await
                 .map_err(|e| {
                     McpError::invalid_params(
@@ -1048,8 +1056,8 @@ impl KaiboHandler {
                         None,
                     )
                 })?;
-            // Re-sniff from the full bytes — authoritative for anything inlined. A file
-            // that grew past the remaining budget between stat and read demotes instead.
+            // Re-sniff from the (capped) bytes — authoritative for anything inlined; a
+            // magic number lives in the first few bytes, so the cap never blinds it.
             if crate::view_image::sniff_mime(&bytes).is_some() {
                 out.push(crate::consult::ConsultAttachment::Image { path: display_path });
                 continue;
@@ -3608,8 +3616,7 @@ mod tests {
         )
         .await
         .expect("all three resolve");
-        let prompt =
-            crate::consult::consult_user_prompt("Assess it.", None, &[], &attachments);
+        let prompt = crate::consult::consult_user_prompt("Assess it.", None, &[], &attachments);
 
         assert!(
             prompt.contains("<file path=\"src/small.rs\">"),

--- a/src/view_image.rs
+++ b/src/view_image.rs
@@ -130,12 +130,20 @@ impl ViewImage {
     /// parser needs.
     async fn view(&self, path_arg: &str) -> Result<Value, ViewImageError> {
         let canon = self.resolve_in_workspace(path_arg)?;
-        let bytes = self.worker.read_file(&canon).await.map_err(|e| {
-            ViewImageError(format!(
-                "view_image: failed to read {}: {e}",
-                canon.display()
-            ))
-        })?;
+        // Read at most one byte past the limit: a file swapped to something enormous
+        // between the caller's view and this read stops at the cap instead of slurping
+        // to OOM, and a returned length past `max_bytes` is exactly the over-limit
+        // signal the size-check below refuses on.
+        let bytes = self
+            .worker
+            .read_file_capped(&canon, self.max_bytes as u64 + 1)
+            .await
+            .map_err(|e| {
+                ViewImageError(format!(
+                    "view_image: failed to read {}: {e}",
+                    canon.display()
+                ))
+            })?;
 
         if bytes.len() > self.max_bytes {
             return Err(ViewImageError(format!(

--- a/tests/worker.rs
+++ b/tests/worker.rs
@@ -70,6 +70,60 @@ async fn worker_refuses_to_lossy_decode_binary_output() {
     );
 }
 
+/// The read path carries its own byte ceiling so a file swapped to something enormous
+/// between a caller's `stat` and the read can't be slurped whole into memory (OOM).
+/// Teeth: the file is 10× the cap, so an unbounded read (the old `project_vfs.read`)
+/// would return all 4096 bytes and fail the `== cap` assertion — only a real
+/// `read_range`/`File::take` ceiling returns exactly `cap`. The over-cap read must still
+/// stop at the ceiling *and* signal overflow: the caller convention is `budget + 1`, and
+/// a returned length past `budget` is the refuse/demote trigger.
+#[tokio::test]
+async fn read_file_capped_bounds_the_bytes_pulled() {
+    let dir = tempdir().unwrap();
+    let cap: u64 = 400;
+    fs::write(dir.path().join("big.bin"), vec![0xABu8; 4096]).unwrap();
+
+    let worker = KaishWorker::spawn(dir.path()).unwrap();
+    let big = dir.path().join("big.bin");
+
+    // A file far larger than the cap comes back truncated *at* the cap — never the
+    // whole 4096 bytes. This is the OOM guard: the read stops at `cap`.
+    let bytes = worker.read_file_capped(&big, cap).await.unwrap();
+    assert_eq!(
+        bytes.len() as u64,
+        cap,
+        "an over-cap file must read exactly `cap` bytes, not the whole file"
+    );
+
+    // The `budget + 1` convention: reading `budget + 1` past a `budget`-sized budget
+    // yields `budget + 1` bytes for an over-budget file, and the caller reads
+    // `len > budget` as overflow.
+    let budget: u64 = 400;
+    let probed = worker.read_file_capped(&big, budget + 1).await.unwrap();
+    assert!(
+        probed.len() as u64 > budget,
+        "a file past the budget must return more than `budget` bytes so the caller can refuse it"
+    );
+}
+
+/// A file at or under the cap reads whole — the ceiling only ever bounds an oversize
+/// read, it never truncates a legitimate one. Guards against a cap that clips honest
+/// files (the everyday attachment/image case).
+#[tokio::test]
+async fn read_file_capped_reads_small_files_whole() {
+    let dir = tempdir().unwrap();
+    let body = b"kai the crab\n";
+    fs::write(dir.path().join("small.txt"), body).unwrap();
+
+    let worker = KaishWorker::spawn(dir.path()).unwrap();
+    // Cap far larger than the file: the whole file comes back, byte for byte.
+    let bytes = worker
+        .read_file_capped(dir.path().join("small.txt"), 1 << 20)
+        .await
+        .unwrap();
+    assert_eq!(bytes, body, "an under-cap file must read whole and intact");
+}
+
 #[tokio::test]
 async fn worker_denies_writes_to_real_files() {
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Why

A Gemini Pro batch review of the attach-inline work (2026-07-03) flagged an **OOM vector** on the file-read path: callers `stat` a file, check it against a budget, then read it — and the read (`KaishWorker::read_file`) was **unbounded**. A file swapped to something enormous in the stat→read window would slurp whole into memory before the post-read size check could refuse it. Verified real (the VFS `Job::Read` handler called `project_vfs.read`, no ceiling).

The same review's *critical* finding — a `<file>` wrapper breakout — was a **false positive** (it read the backslash escape *output* `<\/file>` as the wrapper's delimiter, but the wrapper's own tags are the bare `<file>`/`</file>`). Both this branch's cross-family reviewers independently confirmed the escape is sound.

## What

- **Bound the read at the read itself.** `read_file` → `read_file_capped(path, max_bytes)`, carried through `Job::Read` as a `limit` honoured by the VFS `read_range` (`ReadRange::bytes(0, limit)` → `LocalFs`'s `File::take` — a real ceiling, no whole-file slurp). The unbounded read method is **removed** — an uncapped read of caller-swappable bytes is a footgun with no user.
- **Every caller passes `budget + 1`**, so the *existing* post-read size check becomes the overflow detector — no new branching. consult demotes to `TextOversize`, view_image refuses, oneshot/batch let `classify` refuse by length. Honest-file behaviour is byte-for-byte unchanged; only a raced swap now stops at the ceiling.
- **Commentary at every touched site** spells out the TOCTOU and how the cap closes it, and a note in `escape_file_body` pre-empts re-raising the false-positive breakout.
- **Test teeth**, proven by removing the guard and watching the test fail:
  - `read_file_capped_bounds_the_bytes_pulled` — an over-cap read returns exactly `cap` bytes (flip the handler to the unbounded read → 4096 vs 400).
  - `file_tag_lookalikes_in_body_are_all_escaped` rewritten to assert each injected variant survives in its *escaped* form (drop `(?i)` → the whitespace/case-variant assertion fails). This closes a tautology the reviews caught — see comments.

## Review

Cross-family, no diff shown to either — a Gemini Pro batch (whole files) and a live DeepSeek agent on the worktree. Both returned a clean bill on correctness and security. The detailed findings, the one defect fixed, and the harmless-by-design items we're *not* acting on are in the PR comments.

## Changelog

Security bullet added — the size-swap sibling of the existing symlink-swap defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
