### PR TITLE
fix(job_wait): park-and-coalesce so `level:"info"` stops poll-storming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,16 +128,20 @@ the git log. Each later release appends a new section at the top.
   file, or a binary that isn't a known image is refused with a clear error.
 - **`job_wait`** — block briefly and productively for your async work instead of
   blind-polling `job_get`. Fire off consults and batches, do your other work, then `job_wait`
-  when you're ready to spend a minute on kaibo: it blocks up to `timeout_secs` (you
-  choose — no clamp; interruptible) and returns as soon as something lands, or on a clean
-  timeout. By default it hands back what kaibo flags as worth your attention (a job
-  finished/failed, a research-limit) plus which consult jobs are still running; pass
-  `level: "info"` to also pull the watchable narrative — each kaish command, sweep, and
-  milestone the agents ran — into your context. Name batch handles in `handles` to fold a
-  one-shot poll of them in too. Nothing wakes you (you choose when to block) and it isn't
-  the source of truth — `job_get`/`job_list` are; a clean empty return just means nothing new yet.
-  This pairs with launching work in parallel: submit several, do everything else, then
-  `job_wait` to merge the outputs.
+  when you're ready to spend a minute on kaibo: it parks up to `timeout_secs` (you
+  choose — no clamp; interruptible) and returns early only when a job finishes or fails (a
+  real event), else on a clean timeout — narrative alone never cuts the park short, so a
+  single `job_wait` watches a long job without turning into a poll storm. On return it hands
+  back a sample of what happened plus which consult jobs are still running. `level` sizes
+  that sample, not the timing: the default (`warn`) is the flagged milestones; `level:
+  "info"` folds in the watchable narrative too — each kaish command, sweep, and milestone
+  the agents ran, coalesced to the most recent `limit` — so a richer level fills the tail
+  without ever making the call return sooner (to check in more often, pass a shorter
+  `timeout_secs`). Name batch handles in `handles` to fold a one-shot poll of them in too.
+  Nothing wakes you (you choose when to block) and it isn't the source of truth —
+  `job_get`/`job_list` are; a clean empty return just means nothing new yet. This pairs with
+  launching work in parallel: submit several, do everything else, then `job_wait` to merge
+  the outputs.
 - **Async consults are watchable again.** A `consult_submit` job now streams its liveness
   (each kaish command, sweep, and milestone) onto kaibo's logging channel — the live
   "watch it work" view a synchronous `consult` always had, restored for the async path.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,43 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-07-04 — `job_wait` parks-and-coalesces instead of returning on the first line
+
+Running the kaish 0.11.0 pre-release review as one background consult, Amy parked with
+`job_wait(timeout_secs=300, level="info")` and watched ~130 back-to-back calls return in
+*seconds* each — never near the 300s window. The tell: if it actually blocked to timeout,
+130×5min is absurd; being able to fire 130 in quick succession meant it was returning on
+the first event, not the window.
+
+Contributing factor, found in the code: `level` was doing two jobs. `wait_level_floor`
+became `wait_drain_with`'s `return_floor`, and the drain loop returned the moment it
+collected *any* record at that floor. At `level:"info"` that's the first `running kaish: …`
+line — so observability ("watch the narrative") and "park until something real happens"
+were mutually exclusive: `warn` blocked nicely but returned no story, `info` told the story
+but degenerated into a poll storm. The tool description already promised the *right*
+behavior ("returns as soon as a job finishes or fails, or on a clean timeout") — the code
+was what had drifted.
+
+Amy's call (two forks, both settled before code): **reinterpret `level`** as the
+observability sample floor only — never the return trigger — and **wake on any Warn+**
+(a job finished/failed *or* a real mid-flight warning; narrative below Warn never cuts the
+park short). So `wait_drain_with` grew a third floor: `drain` (what to consume + stream to
+the human), `sample` (what rides back in the tail), and `wake` (what ends the block early,
+always Warn). The returned sample also went from first-`limit` (head) to a sliding
+last-`limit` **tail**, capped at Warn so the terminal ping is always present even if a
+caller asks for a higher floor. The default (`warn`) is unchanged — only sub-warn levels
+stop poll-storming. This matters because the live progress stream reaches the *human* only
+(see `[[mcp-notification-channels]]`): the returned tail is the model's sole window into
+the narrative, so coalesce-and-return-the-tail is the actual mechanism, not a nicety.
+
+TDD, with teeth proven by reverting the loop to the old behavior and watching two of the
+three new `mcp_log` tests fail: `sub_wake_…parks_to_timeout` (wake decoupled from sample)
+and `over_limit_…newest_tail` (tail, not head); `a_warn_wakes_…` is a behavior lock that
+passes both ways. Model-facing text re-read holistically: the `level` schema doc (was
+literally "Lowest level to return"), the tool description, and the `kaibo://tools` resource
+all now say *`level` sizes the sample, never the timing — for more frequent check-ins, pass
+a shorter `timeout_secs`*.
+
 ## 2026-07-03 — attach means the model sees the bytes (inline + sweep directives)
 
 Amy asked how attachments reach explorers, and the honest answer — "they don't" —

--- a/src/mcp_log.rs
+++ b/src/mcp_log.rs
@@ -213,54 +213,72 @@ impl NotificationBuffer {
         floor: u8,
         limit: usize,
     ) -> Vec<LogRecord> {
-        // The simple form: drain and return at one floor, no side-channel.
-        self.wait_drain_with(timeout, floor, floor, limit, |_| {})
+        // The simple form: one floor is drain, sample, *and* wake — return as soon as a
+        // record at `floor` lands, sampling exactly those, no side-channel.
+        self.wait_drain_with(timeout, floor, floor, floor, limit, |_| {})
             .await
     }
 
-    /// The streaming core behind [`wait_drain`]: drain every record at or above
-    /// `drain_floor`, hand each to `on_drained` (the `job_wait` tool streams the Info-level
-    /// narrative to the client's progress channel here), and *return* those at or above
-    /// `return_floor` (capped at `limit`). It blocks until a returnable record lands or
-    /// the deadline passes — so a default `job_wait` streams the narrative the whole time and
-    /// returns only when something the model should act on (a completion) arrives.
+    /// The streaming core behind [`wait_drain`], with three independent floors so
+    /// observability and "park until something real happens" stop fighting each other:
     ///
-    /// `drain_floor` ≤ `return_floor`: the caller drains *down to* what it streams (Info)
-    /// while returning only the salient (Warn+). A drained-but-not-returned record is
-    /// consumed — it was delivered via `on_drained` — so the narrative isn't left to pile
-    /// up once it's been streamed.
+    /// - `drain_floor` — what to *consume* from the ring. Each drained record is handed to
+    ///   `on_drained` (the `job_wait` tool streams the Info-level narrative to the client's
+    ///   progress channel here).
+    /// - `sample_floor` — what to *include in the returned tail*. Records at or above it
+    ///   accumulate into a sliding last-`limit` window, so the caller gets the *newest*
+    ///   activity, not the first `limit` records then silence.
+    /// - `wake_floor` — what *ends the block early*. Only a record at or above it (Warn+ for
+    ///   `job_wait`: a job finished/failed, or a real mid-flight warning) returns before the
+    ///   deadline. Narrative below it never cuts the park short — it just rides along in the
+    ///   sample. Otherwise the call parks the whole window, then returns the coalesced tail.
+    ///
+    /// So `drain_floor` ≤ `sample_floor` ≤ `wake_floor` in the usual shape (drain Info,
+    /// sample Info, wake Warn). A drained-but-not-sampled record is still consumed — it was
+    /// delivered via `on_drained` — so streamed narrative isn't left to pile up.
     pub async fn wait_drain_with<F: FnMut(&LogRecord)>(
         &self,
         timeout: std::time::Duration,
         drain_floor: u8,
-        return_floor: u8,
+        sample_floor: u8,
+        wake_floor: u8,
         limit: usize,
         mut on_drained: F,
     ) -> Vec<LogRecord> {
-        let deadline = tokio::time::Instant::now() + timeout;
-        let mut collected: Vec<LogRecord> = Vec::new();
-        loop {
-            for rec in self.drain(drain_floor, usize::MAX) {
+        // Drain, stream, sample into the sliding tail, and report whether anything crossed
+        // the wake bar. Shared by the main loop and the final post-deadline sweep.
+        let mut absorb = |drained: Vec<LogRecord>,
+                          tail: &mut std::collections::VecDeque<LogRecord>|
+         -> bool {
+            let mut woke = false;
+            for rec in drained {
                 on_drained(&rec);
-                if rank(rec.level) >= return_floor && collected.len() < limit {
-                    collected.push(rec);
+                if rank(rec.level) >= wake_floor {
+                    woke = true;
+                }
+                if rank(rec.level) >= sample_floor {
+                    tail.push_back(rec);
+                    while tail.len() > limit {
+                        tail.pop_front();
+                    }
                 }
             }
-            if !collected.is_empty() {
-                return collected;
+            woke
+        };
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut tail: std::collections::VecDeque<LogRecord> = std::collections::VecDeque::new();
+        loop {
+            if absorb(self.drain(drain_floor, usize::MAX), &mut tail) {
+                return tail.into_iter().collect();
             }
             // Register the wake future *before* re-checking, so a push between the drain
             // above and the await below leaves a permit rather than being missed.
             let notified = self.notify.notified();
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
-                for rec in self.drain(drain_floor, usize::MAX) {
-                    on_drained(&rec);
-                    if rank(rec.level) >= return_floor && collected.len() < limit {
-                        collected.push(rec);
-                    }
-                }
-                return collected;
+                absorb(self.drain(drain_floor, usize::MAX), &mut tail);
+                return tail.into_iter().collect();
             }
             tokio::select! {
                 _ = notified => {}
@@ -504,8 +522,9 @@ mod tests {
         let returned = buf
             .wait_drain_with(
                 std::time::Duration::from_secs(5),
-                rank(LoggingLevel::Info), // drain down to Info (to stream)
-                rank(LoggingLevel::Warning), // return only the Warn-bar records
+                rank(LoggingLevel::Info),    // drain down to Info (to stream)
+                rank(LoggingLevel::Warning), // sample only the Warn-bar records
+                rank(LoggingLevel::Warning), // wake on the Warn-bar records
                 20,
                 |r| streamed.push(r.message.clone()),
             )
@@ -518,6 +537,97 @@ mod tests {
         assert_eq!(returned[0].message, "job done");
         // Everything drained is consumed — the streamed narrative isn't left to pile up.
         assert!(buf.is_empty());
+    }
+
+    /// The park-and-coalesce contract: below the wake bar, narrative alone must NOT end the
+    /// block. An info-only stream parks the *whole* window and hands back the coalesced
+    /// tail — instead of returning on "kaish a" (the busy-poll the old return-on-first-record
+    /// behavior caused when a caller asked for `level:"info"`). A short real timeout keeps
+    /// the test fast without tokio's test-util time control (as elsewhere in this module).
+    #[tokio::test]
+    async fn sub_wake_narrative_parks_to_timeout_then_returns_the_tail() {
+        let buf = NotificationBuffer::new(16);
+        buf.push(rec(LoggingLevel::Info, "kaish a"));
+        buf.push(rec(LoggingLevel::Info, "kaish b"));
+        buf.push(rec(LoggingLevel::Info, "kaish c"));
+
+        let start = std::time::Instant::now();
+        let returned = buf
+            .wait_drain_with(
+                std::time::Duration::from_millis(150),
+                rank(LoggingLevel::Info),    // drain the narrative
+                rank(LoggingLevel::Info),    // sample it into the tail
+                rank(LoggingLevel::Warning), // but only Warn+ wakes the park
+                20,
+                |_| {},
+            )
+            .await;
+
+        // No Warn+ ever arrived, so it parked to the deadline instead of returning at ~0ms
+        // on "kaish a" (the old bug). 100ms of the 150ms window is a comfortable floor.
+        assert!(
+            start.elapsed() >= std::time::Duration::from_millis(100),
+            "info narrative must not wake the park"
+        );
+        // …and handed back the coalesced narrative tail, oldest activity first.
+        let msgs: Vec<_> = returned.iter().map(|r| r.message.clone()).collect();
+        assert_eq!(msgs, vec!["kaish a", "kaish b", "kaish c"]);
+    }
+
+    /// A Warn+ record wakes the park at once, and the returned tail carries the info
+    /// narrative that preceded it — the model gets both "something happened" and the story.
+    /// The generous timeout would dominate the runtime if the wake didn't fire.
+    #[tokio::test]
+    async fn a_warn_wakes_the_park_and_the_tail_carries_the_narrative() {
+        let buf = NotificationBuffer::new(16);
+        buf.push(rec(LoggingLevel::Info, "kaish a"));
+        buf.push(rec(LoggingLevel::Info, "kaish b"));
+        buf.push(rec(LoggingLevel::Warning, "job done"));
+
+        let start = std::time::Instant::now();
+        let returned = buf
+            .wait_drain_with(
+                std::time::Duration::from_secs(300),
+                rank(LoggingLevel::Info),
+                rank(LoggingLevel::Info),
+                rank(LoggingLevel::Warning),
+                20,
+                |_| {},
+            )
+            .await;
+
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "a Warn+ record ends the park at once, nowhere near the 300s window"
+        );
+        let msgs: Vec<_> = returned.iter().map(|r| r.message.clone()).collect();
+        assert_eq!(msgs, vec!["kaish a", "kaish b", "job done"]);
+    }
+
+    /// Over `limit`, the returned sample is the *tail* (newest activity), not the head — a
+    /// long narrative hands back its most recent lines, and the terminal ping rides along.
+    #[tokio::test]
+    async fn over_limit_returns_the_newest_tail_including_the_wake() {
+        let buf = NotificationBuffer::new(64);
+        for i in 0..6 {
+            buf.push(rec(LoggingLevel::Info, &format!("n{i}")));
+        }
+        buf.push(rec(LoggingLevel::Warning, "done"));
+
+        let returned = buf
+            .wait_drain_with(
+                std::time::Duration::from_secs(5),
+                rank(LoggingLevel::Info),
+                rank(LoggingLevel::Info),
+                rank(LoggingLevel::Warning),
+                3,
+                |_| {},
+            )
+            .await;
+
+        // Six info lines + a warn = seven sampled; a limit of 3 keeps the last three.
+        let msgs: Vec<_> = returned.iter().map(|r| r.message.clone()).collect();
+        assert_eq!(msgs, vec!["n4", "n5", "done"]);
     }
 
     /// A finished job's completion ping (carrying `job=<id>`) is retired when that job is

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2526,7 +2526,7 @@ impl KaiboHandler {
                 limit,
                 |rec| {
                     // Stream Info+ to the human's progress channel; the model's return is the
-                    // separate `return_floor` collection inside `wait_drain_with`.
+                    // separate `sample_floor` tail collected inside `wait_drain_with`.
                     if let Some(token) = &token {
                         if crate::mcp_log::rank(rec.level) >= info_floor {
                             let param = ProgressNotificationParam {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -440,13 +440,17 @@ pub struct WaitInput {
     #[serde(default)]
     pub timeout_secs: Option<u64>,
 
-    /// Max records to return (default 20, newest activity last).
+    /// Max records to sample into the result (default 20, newest activity last — when more
+    /// happened than this, you get the most recent tail).
     #[serde(default)]
     pub limit: Option<usize>,
 
-    /// Lowest level to return: `warn` (default — what kaibo flags for you: a job finished
-    /// or failed), `info` (also the watchable narrative — each kaish command, sweep,
-    /// milestone), `error`, or `debug`. A salience bar, not severity.
+    /// How much narrative rides back in the result — *not* when the call returns. It always
+    /// parks up to `timeout_secs` and returns early only when a job finishes or fails (a
+    /// real event), then hands back a sample of what happened. `warn` (default) is just the
+    /// flagged milestones; `info` folds in the watchable narrative (each kaish command,
+    /// sweep, milestone) so you can follow along; `debug` is everything; `error` trims to
+    /// failures. A richer level never makes the call return sooner — it only fills the tail.
     #[serde(default)]
     pub level: Option<String>,
 
@@ -2460,10 +2464,11 @@ impl KaiboHandler {
     }
 
     #[tool(description = "Park for async work to make progress: blocks up to \
-            `timeout_secs` and returns as soon as a job finishes or fails, or on a \
+            `timeout_secs`, returning early only when a job finishes or fails, else on a \
             clean timeout — the productive alternative to polling `job_get`. \
-            `level:\"info\"` adds the live narrative (each shell command, sweep, \
-            milestone); name batch `handles` to fold their status in.")]
+            `level:\"info\"` folds the live narrative (each shell command, sweep, \
+            milestone) into the result without changing when it returns; name batch \
+            `handles` to fold their status in.")]
     async fn job_wait(
         &self,
         Parameters(input): Parameters<WaitInput>,
@@ -2485,51 +2490,65 @@ impl KaiboHandler {
                 ));
             }
         }
-        let return_floor = wait_level_floor(input.level.as_deref())?;
+        // `level` sizes the *observability sample* — how much narrative rides back in the
+        // result — never *when* the call returns. Wake is always the Warn bar (a job
+        // finished/failed, or a real mid-flight warning); narrative below it rides along in
+        // the tail but never cuts the park short, so `level:"info"` parks-and-coalesces
+        // instead of returning on the first `running kaish: …` line. Cap the sample floor at
+        // Warn so the terminal ping is always in the tail even if a caller asks higher.
+        let wake_floor = crate::mcp_log::rank(LoggingLevel::Warning);
+        let sample_floor = wait_level_floor(input.level.as_deref())?.min(wake_floor);
         let limit = input.limit.unwrap_or(20);
         let timeout = std::time::Duration::from_secs(input.timeout_secs.unwrap_or(60));
 
         // The live view for the *human*: while this call is open, stream the Info-level
         // narrative (each kaish command, sweep, milestone) as `notifications/progress` on
         // this call's token, so the client renders it in real time — the channel sync
-        // `consult` used, reopened on demand. Independent of what we *return* to the model
-        // (Warn+ by default): the human watches the show, the model gets the salient bits.
+        // `consult` used, reopened on demand. Independent of what we *return* to the model:
+        // the human watches the show live, the model gets the coalesced tail at wake/timeout.
         let info_floor = crate::mcp_log::rank(LoggingLevel::Info);
         let token = progress_token(&meta);
         // Drain down to whichever is lower — Info (to stream) when a token is present,
-        // else just the return floor (don't consume narrative no one is watching).
+        // else just the sample floor (don't consume narrative no one is watching).
         let drain_floor = if token.is_some() {
-            info_floor.min(return_floor)
+            info_floor.min(sample_floor)
         } else {
-            return_floor
+            sample_floor
         };
         let seq = AtomicU64::new(0);
         let records = self
             .notifications
-            .wait_drain_with(timeout, drain_floor, return_floor, limit, |rec| {
-                // Stream Info+ to the human's progress channel; the model's return is the
-                // separate `return_floor` collection inside `wait_drain_with`.
-                if let Some(token) = &token {
-                    if crate::mcp_log::rank(rec.level) >= info_floor {
-                        let param = ProgressNotificationParam {
-                            progress_token: token.clone(),
-                            progress: seq.fetch_add(1, Ordering::Relaxed) as f64,
-                            total: None,
-                            message: Some(format!(
-                                "[{}] {}",
-                                wait_level_label(rec.level),
-                                rec.message
-                            )),
-                        };
-                        let peer = peer.clone();
-                        // Fire-and-forget, like `ProgressReporter`: don't make the drain
-                        // loop await a notification it doesn't depend on.
-                        tokio::spawn(async move {
-                            let _ = peer.notify_progress(param).await;
-                        });
+            .wait_drain_with(
+                timeout,
+                drain_floor,
+                sample_floor,
+                wake_floor,
+                limit,
+                |rec| {
+                    // Stream Info+ to the human's progress channel; the model's return is the
+                    // separate `return_floor` collection inside `wait_drain_with`.
+                    if let Some(token) = &token {
+                        if crate::mcp_log::rank(rec.level) >= info_floor {
+                            let param = ProgressNotificationParam {
+                                progress_token: token.clone(),
+                                progress: seq.fetch_add(1, Ordering::Relaxed) as f64,
+                                total: None,
+                                message: Some(format!(
+                                    "[{}] {}",
+                                    wait_level_label(rec.level),
+                                    rec.message
+                                )),
+                            };
+                            let peer = peer.clone();
+                            // Fire-and-forget, like `ProgressReporter`: don't make the drain
+                            // loop await a notification it doesn't depend on.
+                            tokio::spawn(async move {
+                                let _ = peer.notify_progress(param).await;
+                            });
+                        }
                     }
-                }
-            })
+                },
+            )
             .await;
 
         // Gentle batch poll: a batch is provider-side with no push, so fold in a one-shot
@@ -3090,11 +3109,13 @@ One small surface drives both kinds:
   batches section shows the last 24h (anything older is done and still collectible by its
   handle); pass `all: true` for the full history.
 - **`job_wait`** is how you *productively park*: submit your async work, do your other
-  work, then call `job_wait` to block briefly (up to `timeout_secs` — your choice, to a
-  3600s ceiling) and return as soon
-  as something lands — or on a clean timeout. By default it hands back what kaibo flagged
-  for you (a job finished or failed); pass `level: \"info\"` to also pull in the watchable
-  narrative — each kaish command, sweep, and milestone the agents ran.
+  work, then call `job_wait` to block (up to `timeout_secs` — your choice, to a 3600s
+  ceiling). It parks the whole window and returns early only when a job finishes or fails
+  (a real event) — narrative alone never cuts it short — then hands back a sample of what
+  happened. By default that sample is what kaibo flagged for you (the milestones); pass
+  `level: \"info\"` to fold in the watchable narrative too — each kaish command, sweep, and
+  milestone the agents ran. `level` sizes the sample, never the timing; to check in more
+  often, pass a shorter `timeout_secs`, not a higher level.
 
 This is a fire-and-forget lane. Submit, then go do other work — don't sit in a tight
 poll/sleep loop holding your turn open. `job_wait` when you're ready to spend a minute;


### PR DESCRIPTION
## The problem

Running the kaish 0.11.0 pre-release review as one background consult, Amy parked with `job_wait(timeout_secs=300, level="info")` and watched **~130 back-to-back calls return in seconds each** — never near the 300s window. A live A/B on the *same* running job confirmed the split: flipped back to default `level:"warn" timeout_secs=600`, it parked the full 600s ("Nothing new in 600s") and returned only on the clean timeout.

**Root cause (contributing factors):** `level` was doing two jobs at once. `wait_level_floor` became `wait_drain_with`'s `return_floor`, and the drain loop returned the moment it collected *any* record at that floor. At `level:"info"` that's the first `running kaish: …` line. Default `warn` only parked nicely because the sole Warn records are the completion/failure pings — so observability ("watch the narrative") and "park until something real happens" were **structurally mutually exclusive**. The tool *description* already promised the right behavior ("returns as soon as a job finishes or fails, or on a clean timeout") — the code had drifted from it.

## The fix

Two forks settled with Amy before writing code:

1. **Reinterpret `level`** as the observability *sample floor* only — never the return trigger.
2. **Wake on any Warn+** — a job finished/failed, or a real mid-flight warning. Narrative below Warn rides along in the tail but never cuts the park short.

`wait_drain_with` grew a third floor, so the three concerns stop fighting:
- `drain_floor` — what to consume (and stream to the human's progress channel).
- `sample_floor` — what rides back in the returned tail.
- `wake_floor` — what ends the block early (Warn+, always).

The returned sample also went from first-`limit` (**head**, then silence) to a sliding last-`limit` **tail** (newest activity), capped at Warn so the terminal ping is always present even if a caller asks for a higher floor. **The default (`warn`) behavior is unchanged** — only sub-warn levels stop poll-storming.

Why this matters beyond the poll storm: the live progress stream reaches the **human only** (nothing on the MCP channel wakes the calling agent), so the returned tail is the model's *sole* window into the narrative. Coalesce-and-return-the-tail is the actual mechanism by which a watching model sees anything, not a nicety.

## Verification

- **TDD, teeth proven** by reverting the loop to the old behavior and watching two of three new `mcp_log` tests fail:
  - `sub_wake_narrative_parks_to_timeout_then_returns_the_tail` — wake decoupled from sample (the poll-storm fix).
  - `over_limit_returns_the_newest_tail_including_the_wake` — tail, not head.
  - `a_warn_wakes_the_park_and_the_tail_carries_the_narrative` — behavior lock (passes both ways).
- 341 lib + all integration suites green; clippy clean on touched files.
- Model-facing text re-read holistically (per *Writing for models*): the `level` schema doc (was literally "Lowest level to return"), the `job_wait` tool description, and the `kaibo://tools` resource all now say *`level` sizes the sample, never the timing — pass a shorter `timeout_secs` to check in more often*.
- CHANGELOG `job_wait` bullet refined (unreleased 0.2.0 — this corrects an unreleased feature, not a shipped one) + a devlog entry.

## Open design note for review

Wake = **any Warn+**, so a genuine mid-flight `warn!` (rate-limit/retry) also cuts the park short — matching how the default already treats the Warn bar. The original observation phrased it as "terminal event (job finished/failed)"; in practice those *are* the Warn records. If we'd rather a mid-flight warn *not* wake the park (strictly job-tagged pings only), it's a one-line change to the wake predicate — flagging for the reviewers' judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)