### PR TITLE
chore(deps): upgrade kaish-kernel 0.10.0 → 0.11.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,10 +249,19 @@ even for a one-line doc fix.
   `v*` tag. Before tagging: confirm the `kaish-kernel` pin is current (next bullet),
   re-run `docs/sandbox-probes.md` and stamp its "Last run" line, and verify
   `cargo tree -i aws-lc-rs` is empty and the musl binary is `not a dynamic executable`.
-- **kaish pin.** Currently `kaish-kernel = "0.10.0"`. The bump from `0.9.0` was
-  API-compatible — no kaibo call sites changed, identical builtin/tool set; under the
-  hood kaish gained bignum arithmetic (`num-bigint`) and a new regex engine
-  (`regex-bites`). Offline suite green (462 tests), boundary tests still have teeth.
-  The prior `0.8.4 → 0.9.0` step had renamed the `mcp()` config constructors
-  (`IgnoreConfig`/`OutputLimitConfig`/`KernelConfig`) to `agent()` in `sandbox.rs`.
-  Keep this current per the **Working here** kaish-bump discipline before cutting.
+- **kaish pin.** Currently `kaish-kernel = "0.11.0"`. The `0.10.0 → 0.11.0` bump was
+  API-compatible — **zero** kaibo call sites changed. It looks scary in the kaish
+  changelog (four **BREAKING** entries) but none reach kaibo: the new `ToolSchema.raw_argv`
+  and `ExecResult.latch` fields are additive (kaibo builds both via constructors, never
+  struct literals), the `kaish-help` `Fragment` `rank` field only bites code that
+  constructs `Fragment` literals (kaibo doesn't), the latched-`--json` envelope change
+  never fires (kaibo is read-only, so no destructive op ever latches), and the
+  scatter/gather + sed-BRE changes are runtime behavior kaibo has no hand-rolled docs for.
+  The whole agent-facing surface (native collections, `keys`/`values`/`typeof`, the `test`
+  builtin, `help regex`/`help collections`, JSON/JSONL bridges, importance-ranked
+  onboarding) flows in *for free* because kaibo single-sources it from `kaish_kernel::help`
+  — the bump updates the sourced text, no kaibo edits. Under the hood chumsky migrated
+  `1.0.0-alpha.8 → 0.13` (two stale regex crates dropped). Offline suite green (525 tests),
+  boundary tests still have teeth. Precedent that a bump *can* move call sites: `0.8.4 →
+  0.9.0` renamed the `mcp()` config constructors to `agent()` in `sandbox.rs`. Keep this
+  current per the **Working here** kaish-bump discipline before cutting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,19 @@ the git log. Each later release appends a new section at the top.
 
 ### Changed
 
+- **The read-only shell under `consult` / `explore` / `run_kaish` speaks kaish 0.11.**
+  Native collections land in the toolbox the models drive: list/record literals
+  (`xs=[a b c]`, `{port: 8080}`), typed subscripts and slices (`${xs[0]}`, `${r[key]}`,
+  `${xs[0:2]}`), `keys` / `values` / `typeof` and `[[ -list ]]` / `[[ -record ]]` shape
+  guards, and typed membership (`[[ 443 in ${servers[web]} ]]`). A real `test` builtin
+  evaluates POSIX conditions *through the VFS* — where kaibo's no-subprocess sandbox
+  used to leave the old `/usr/bin/test` shell-out dead, `test -f path` now works.
+  `fromjson` / `tojson` / `fromjsonl` / `tojsonl` bridge JSON and JSONL, `jq -s` is real
+  slurp, and redirects work inside `$(...)`. The always-on onboarding now leads with its
+  most critical rules and points enumeration at `$(keys …)` / `$(values …)`; `help regex`
+  and `help collections` are new one-screen references. All of it arrives through kaibo's
+  single-sourced kaish guidance — no new resident cost.
+
 - **Models read files WHOLE by default, and a truncated giant stages into targeted
   reads.** The explorer, the `consult` driver, and the shared kaish cheatsheet all
   lead with whole-file reads: `cat -n FILE` is the stated first move on any file that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata 0.4.14",
+ "regex-automata",
  "serde",
 ]
 
@@ -250,12 +250,12 @@ dependencies = [
 
 [[package]]
 name = "chumsky"
-version = "1.0.0-alpha.8"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e82d74e6c83060ec269fe9e0d408d6de4a1645d525f9a0bbbb841ba4efd91ac"
+checksum = "e0d2bfadce76f963d776feff99db6dc33783829539258314776383b33e2a00f8"
 dependencies = [
  "hashbrown 0.15.5",
- "regex-automata 0.3.9",
+ "regex-automata",
  "serde",
  "stacker",
  "unicode-ident",
@@ -776,8 +776,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -798,8 +798,8 @@ dependencies = [
  "bstr",
  "grep-matcher",
  "log",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1131,7 +1131,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.14",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1372,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004c2b35ef382d73a3848cf99d91b3dd802b4297742f08ba17aa4ee98ff6d25"
+checksum = "655c4b3b21dac667a9ff9f05b789afca823ea3f605a8e5c3f3cff6c3f6fd22fc"
 dependencies = [
  "async-trait",
  "ignore",
@@ -1384,18 +1384,18 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e909e59dd3ceeb52fca039e5bdaf3de3daabbc54a2222a6101bc216b33dece6a"
+checksum = "2624c843b339bb68a9f0054b3b216b10dc5f39c4cba5ad1919bab4ce92601975"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7159e8c95950d54e5fa45a31abaedbfaaab61a01129326392e3719ac7ff60bb6"
+checksum = "94c62d1a6bb137ca549b0b78e974ade3375dc1fafe7e6d9014635993c7ffa9c0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5224be7bfee3db6c3190375accbcf1a809d9b6dc866517156b4459568159bd9e"
+checksum = "9ceb8635bef7f7773147e8786ab1ca4a4bb4fdfafa872189c85e3969c8cc07c2"
 dependencies = [
  "async-trait",
  "clap",
@@ -1450,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9198f9f6098e84ba99656feb9fe02401eeaa3edee7fc8085408b31fa4d597ec3"
+checksum = "aba70d0b299dad64558f713fddf464f57e46cba572f0d292f35bc77f4efc48d5"
 dependencies = [
  "base64",
  "serde",
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f35edc501e437e760765b4a50d4d3fb4e8a58dd4793112ff797695dfbd85ca"
+checksum = "6a906cdfc75143ffb1fe644bb0aeb6f1fe39963da4c6cf1a9b3b0e1d19761c7d"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -1533,8 +1533,8 @@ dependencies = [
  "fnv",
  "proc-macro2",
  "quote",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
+ "regex-automata",
+ "regex-syntax",
  "syn",
 ]
 
@@ -1562,7 +1562,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.14",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2106,19 +2106,8 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.7.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2129,7 +2118,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2137,12 +2126,6 @@ name = "regex-bites"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -3054,7 +3037,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.14",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # `os-integration` (trash) OFF — so those builtins are never compiled in. kaibo's
 # read-only safety is thus structural (the dangerous surface doesn't exist),
 # backed by the runtime read-only mount; see src/sandbox.rs.
-kaish-kernel = { version = "0.10.0", default-features = false, features = ["localfs"] }
+kaish-kernel = { version = "0.11.0", default-features = false, features = ["localfs"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
 async-trait = "0.1"
 anyhow = "1"

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -34,9 +34,9 @@ use crate::config::{CastUsability, Config, Lane, ModelRole};
 pub const KAISH_SANDBOX_ADDENDUM: &str = "\
 In kaibo this shell runs over a READ-ONLY snapshot of one project, offline: writes, \
 `git`, `touch`, and external commands are refused, so just read — files WHOLE by \
-default, `cat -n FILE`. Two grep notes: alternation takes `-E` \
-(`grep -rnE 'foo|bar' .`), and `-r` wants a directory (for one file, \
-`grep -n PATTERN FILE`). Each call starts at the project root; \
+default, `cat -n FILE`. One grep note: `-r` wants a directory \
+(`grep -rn PATTERN src`); on a single file it silently finds nothing — use \
+`grep -n PATTERN FILE`. Each call starts at the project root; \
 there is no persistent cwd. Read the exit code: 0 is success; 3 means the output \
 was too large and came back as a head+tail sample (not a failure); 124 means the \
 script was killed for running past its time budget; 126 means blocked by the \
@@ -340,7 +340,6 @@ pub fn kaibo_sandbox_doc() -> String {
          whole:\n\
          - `cat -n FILE` — the whole file, numbered; the default move on any file that matters\n\
          - `grep -rn PATTERN [PATH]` — find which files matter, then open them whole\n\
-         - `grep -rnE 'foo|bar' .` — alternation (the `-E` is what enables `|`)\n\
          - `grep -rn -B3 -A6 PATTERN .` — preview matches in context across files\n\
          - `grep -rl PATTERN src` — just the file names that match\n\
          - `cat -n FILE | sed -n '1200,2400p'` — a targeted wide span of a truncated giant (`grep -n SYMBOL FILE` pins where to aim)\n\n\

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3106,8 +3106,7 @@ by waiting — the handles keep.
 `run_kaish` runs a kaish (sh-like) script against the project and returns exit code +
 stdout + stderr. Lead with the idioms that produce accurate `file:line`s: `cat -n FILE`
 to read a file WHOLE (the default move — nearly every file fits one look),
-`grep -rn PATTERN .` to find which files matter (alternation takes `-E`:
-`grep -rnE 'foo|bar' .`). A whole read that truncates (exit 3) hands back the head and
+`grep -rn PATTERN .` to find which files matter. A whole read that truncates (exit 3) hands back the head and
 tail; stage the rest as targeted wide spans (`grep -n SYMBOL FILE`, then
 `cat -n FILE | sed -n '1200,2400p'`). Compose builtins with pipes
 (`grep`/`jq`/`awk`/`find`/…). Each call starts fresh at the project root.


### PR DESCRIPTION
## What

Bumps the embedded `kaish-kernel` dependency `0.10.0 → 0.11.0` (just released), and — capitalizing on it — trims shell coaching kaibo no longer needs to pay tokens for. **Zero kaibo *code* changes for the bump itself** — verified by a clean build and the full offline suite (525 tests green).

## Why the bump is safe despite four BREAKING entries

kaish 0.11's changelog carries four **BREAKING** items; we checked each against kaibo's real code (a cross-family `deepseek` review agreed, citing file:line — see the review comment below):

| kaish 0.11 BREAKING | Reaches kaibo? | Why |
|---|---|---|
| `ToolSchema.raw_argv` field added | No | kaibo builds `ToolSchema` only via `::new()`, never a struct literal; reads only `.name` |
| `ExecResult.latch` typed field; latched `--json` nonce moves out of `.data` | No | kaibo builds `ExecResult` via `::failure()` and reads only `code`/`err`/`out_bytes()`/`text_out()`. And it's **read-only** — no destructive op ever latches a nonce to relocate |
| `kaish-help` `Fragment` gains required `rank: u8` | No | kaibo never names `Fragment`; it composes help via `Recipe` / `SchemaContent` / `get_help` |
| scatter/gather `--format`/`--first` removed; `sed` `\|`/`\(…\)`/`\{n,m\}` → ERE | No | kaibo hand-rolls no docs pinning those flags or relying on `sed \|` erroring (its `sed` examples are line-range only) |

## What agents *gain* — for free

kaibo single-sources its kaish guidance from `kaish_kernel::help`, so the whole new agent-facing surface flows in on the bump with **no new resident cost**:

- native collections (`xs=[a b c]`, `{port: 8080}`), typed subscripts/slices, `keys`/`values`/`typeof` + `[[ -list ]]`/`[[ -record ]]` shape guards, typed membership
- a real `test` builtin evaluating POSIX conditions **through the VFS** — where kaibo's no-subprocess sandbox left the old `/usr/bin/test` shell-out dead, `test -f path` now works
- `fromjson`/`tojson`/`fromjsonl`/`tojsonl` bridges, real `jq -s` slurp, redirects inside `$(...)`
- importance-ranked onboarding (leads with the load-bearing rules, steers enumeration at `$(keys …)`/`$(values …)`); new `help regex` / `help collections` references

Functionally confirmed the new surface renders through kaibo's own path (`render_topic("collections")`, `help regex`, and `$(keys …)`/`$(values …)` now resident in the composed foundations).

## Also here: trimming obsolete shell coaching

0.11 makes BRE `\|` (and `\(…\)`, `\{n,m\}`) native operators **and** kaish now teaches it in its own error message — so kaibo's three hand-rolled "alternation takes `-E`" notes (a 0.10 workaround from #56) are dead weight. Dropped them from `KAISH_SANDBOX_ADDENDUM`, the cheatsheet, and the `run_kaish` instructions; models type `\|` / `-E 'a|b'` naturally and both work now. This is the "let models do what's natural, stop paying to instruct where the tool self-corrects" principle.

Kept — and sharpened — the `-r`-wants-a-directory note, which guards a **different, still-live** gotcha: `grep -r PATTERN FILE` (a file operand, not a dir) silently finds nothing on 0.11. Filed upstream as **tobert/kaish#105**; the fix there retires this last note too.

## Under the hood / invariants

- chumsky migrated `1.0.0-alpha.8 → 0.13`; two stale transitive regex crates dropped from the tree.
- **TLS invariant intact** — `cargo tree -i aws-lc-rs` is empty; no aws-lc / openssl pulled in.
- Docs updated: `AGENTS.md` kaish-pin note and a user-facing `CHANGELOG.md` entry.

_Cross-family review notes and follow-ups are in the comments below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
