### PR TITLE
ci: reproducible archives + prebuilt zigbuild + precise C claim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,10 @@ jobs:
           cp "$bin" "$dist"/
           # Fix mtimes before zipping so the archive is byte-stable for this commit —
           # including the directory itself (7z stores the dir entry's mtime too).
+          # Entry ORDER is the other determinism axis: 7z enumerates the filesystem
+          # (no --sort=name equivalent), which is only guaranteed stable here because
+          # the archive holds a single file. If this zip ever gains more files, feed
+          # 7z an explicitly sorted list.
           touch -d "@$SOURCE_DATE_EPOCH" "$dist" "$dist"/*
           7z a "$dist.zip" "$dist" >/dev/null
           sha256sum "$dist.zip" > "$dist.zip.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,17 @@ jobs:
 
       # cargo-zigbuild + zig only for the musl cross-builds; native targets use plain
       # cargo (no zig needed) so we don't pay for it on macOS/Windows.
-      - name: Install cargo-zigbuild + zig
+      - name: Install zig
         if: endsWith(matrix.target, '-linux-musl')
-        run: |
-          pip install ziglang
-          cargo install --locked cargo-zigbuild
+        run: python3 -m pip install ziglang
+
+      # Prebuilt binary, not `cargo install` from source — that compiled from scratch
+      # on every run and made the arm64 leg's cold start painfully slow.
+      - name: Install cargo-zigbuild
+        if: endsWith(matrix.target, '-linux-musl')
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        with:
+          tool: cargo-zigbuild
 
       - name: Build (musl, static)
         if: endsWith(matrix.target, '-linux-musl')
@@ -104,21 +110,28 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
           bin="target/${{ matrix.target }}/release/kaibo"
           dist="kaibo-${GITHUB_REF_NAME//\//-}-${{ matrix.target }}" # slashes in a branch ref break mkdir/tar
           mkdir "$dist"
           cp "$bin" README.md LICENSE "$dist"/ 2>/dev/null || cp "$bin" "$dist"/
-          tar czf "$dist.tar.gz" "$dist"
+          # macOS's bundled tar is bsdtar, which lacks --sort/--mtime; GitHub's macOS
+          # runners also ship GNU tar as `gtar`, so prefer that for a byte-stable archive.
+          tar=$(command -v gtar || command -v tar)
+          "$tar" --sort=name --owner=0 --group=0 --numeric-owner --mtime="@$SOURCE_DATE_EPOCH" -cf - "$dist" | gzip -n > "$dist.tar.gz"
           sha256sum "$dist.tar.gz" > "$dist.tar.gz.sha256"
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
           bin="target/${{ matrix.target }}/release/kaibo.exe"
           dist="kaibo-${GITHUB_REF_NAME//\//-}-${{ matrix.target }}" # slashes in a branch ref break mkdir/tar
           mkdir "$dist"
           cp "$bin" "$dist"/
+          # Fix mtimes before zipping so the archive is byte-stable for this commit.
+          touch -d "@$SOURCE_DATE_EPOCH" "$dist"/*
           7z a "$dist.zip" "$dist" >/dev/null
           sha256sum "$dist.zip" > "$dist.zip.sha256"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,9 @@ jobs:
           dist="kaibo-${GITHUB_REF_NAME//\//-}-${{ matrix.target }}" # slashes in a branch ref break mkdir/tar
           mkdir "$dist"
           cp "$bin" "$dist"/
-          # Fix mtimes before zipping so the archive is byte-stable for this commit.
-          touch -d "@$SOURCE_DATE_EPOCH" "$dist"/*
+          # Fix mtimes before zipping so the archive is byte-stable for this commit —
+          # including the directory itself (7z stores the dir entry's mtime too).
+          touch -d "@$SOURCE_DATE_EPOCH" "$dist" "$dist"/*
           7z a "$dist.zip" "$dist" >/dev/null
           sha256sum "$dist.zip" > "$dist.zip.sha256"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,9 @@ project and cannot run external commands.
 
 kaibo ships as a single static-ish binary per platform, built by
 `.github/workflows/release.yml` on a `v*` tag (also `workflow_dispatch` to smoke the
-matrix). This is feasible *because* the TLS invariant above keeps the tree C-free:
-no aws-lc, no OpenSSL.
+matrix). This is feasible *because* the TLS invariant above keeps the tree free of
+cmake/autotools C (no aws-lc, no OpenSSL) — ring's small C/asm compiles with zig or
+the platform cc alone.
 
 - **Linux → fully static** via `x86_64`/`aarch64-unknown-linux-musl`, built with
   `cargo zigbuild` (zig is the cross C compiler/linker for ring's small C/asm). The


### PR DESCRIPTION
Bootstrapping the release build — dial-in slice (c), the last of the PR-2 hardening from `docs/releases.md`:

- **Reproducible archives.** `SOURCE_DATE_EPOCH` comes from the commit date; the tarball is built with sorted entries/zeroed ownership/clamped mtimes through `gzip -n` (gtar selected on macOS — bsdtar lacks the determinism flags); the zip gets its mtimes pinned, directory entry included. Teeth-tested locally: two runs at different times produce byte-identical tarballs.
- **Prebuilt `cargo-zigbuild`** via SHA-pinned `taiki-e/install-action` v2.82.9 (pin verified against the GitHub API; its manifest ships aarch64-linux) instead of compiling it from source every release; `pip` → `python3 -m pip` while touching the line. Arm leg 4m22s → 3m40s (cache warmth confounds; the structural win is not building a tool at release time).
- **Precise C claim** in AGENTS.md Build & release: the tree is free of *cmake/autotools* C (no aws-lc, no OpenSSL) — ring's small C/asm still compiles, via zig or the platform cc.

**Cross-family review (DeepSeek, via kaibo):** five HIGH-confidence confirmations (`command -v` under `set -e`, shallow-clone `git log -1`, `tar|gzip` under `pipefail` fails correctly, taiki-e arm64 + checksum posture, AGENTS.md wording) and **one actionable finding, closed in a review commit**: 7z has no `--sort=name`, so zip entry order rests on filesystem enumeration — deterministic today only because the archive holds a single file; the boundary is now stated at the site so a second file triggers the sorted-list fix.

Validation dispatches: https://github.com/tobert/kaibo/actions/runs/28746908084 (all five legs green, prebuilt zigbuild proven on amd64+arm64) and https://github.com/tobert/kaibo/actions/runs/28747039327 (tip, comment-only delta, running at PR time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)