### PR TITLE
chore: v0.2.0-rc.1 — smoke tag for the never-run publish leg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,3 +165,6 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
+          # A semver prerelease tag (v0.2.0-rc.1) is a GitHub prerelease — the
+          # Releases page must not present an rc as the latest stable.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.1.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "解剖 — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.1.0"
+version = "0.2.0-rc.1"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
Bootstrapping the release build: the publish job (download-artifact v8, gh-release v3) has never executed — every run so far was tag-gated out. Per the plan discussion, an rc smoke tag proves that leg end-to-end before signing (plan PR 3) lands, so the real v0.2.0 is born signed.

This PR: version → `0.2.0-rc.1` (Cargo.toml + lock; the binary reports what it is), and the publish job marks semver-prerelease tags as GitHub prereleases. After merge: tag `v0.2.0-rc.1` on main, watch the first-ever publish run, verify the release artifacts, then delete or keep the rc as you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)