### PR TITLE
ci: first CI workflow — offline suite, clippy -D warnings, TLS tripwire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# The offline test suite, clippy as errors, and the rustls+ring TLS-invariant guard —
+# the fast correctness gate that runs on every pull request and every push to main.
+# release.yml is the cross-platform build/smoke story (tagged releases); this is quick
+# feedback on every change so nothing lands with a red suite, a new lint, or a C
+# crypto/TLS dependency that snuck back into the tree.
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable branch, pinned 2026-07-05
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      # TLS is rustls + ring, never a C crypto/TLS stack (see AGENTS.md's TLS
+      # invariant / src/tls.rs) — that's what lets the release builds link fully
+      # static. A stray reqwest/rig feature flag (or a dependency bump) can silently
+      # re-pull aws-lc or OpenSSL; this step is the tripwire. `cargo tree -i` on a
+      # package that isn't in the tree doesn't reliably exit non-zero, so the
+      # assertion is on the error text itself — "did not match any packages" IS the
+      # passing case here, not a failure to shrug off with `|| true`.
+      - name: TLS invariant (no C crypto/TLS in the tree)
+        shell: bash
+        run: |
+          for pkg in aws-lc-rs aws-lc-sys openssl-sys native-tls; do
+            out=$(cargo tree -i "$pkg" 2>&1 || true)
+            if ! grep -q "did not match any packages" <<<"$out"; then
+              echo "TLS invariant violated: $pkg is present in the dependency tree"
+              echo "$out"
+              exit 1
+            fi
+          done

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -258,7 +258,7 @@ pub(super) fn render_config_resource(
                 key_optional: *key_optional,
                 request_timeout_secs: request_timeout.as_secs(),
                 data_collection: (*kind == crate::credentials::ProviderKind::OpenRouter)
-                    .then(|| match data_collection {
+                    .then_some(match data_collection {
                         crate::config::DataCollection::Deny => "deny",
                         crate::config::DataCollection::Allow => "allow",
                     }),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -54,6 +54,10 @@ impl OtelGuard {
     }
 }
 
+/// The boxed tracing layer paired with the guard that flushes it on shutdown —
+/// what [`init`] returns once telemetry is enabled.
+type OtelLayer<S> = (Box<dyn Layer<S> + Send + Sync>, OtelGuard);
+
 /// Build the OTLP exporter and the tracing layer that feeds it, from config.
 ///
 /// Returns `Ok(None)` when telemetry is disabled — the caller adds nothing to the
@@ -61,9 +65,7 @@ impl OtelGuard {
 /// an [`OtelGuard`] the caller must hold until after the server loop and then
 /// [`shutdown`](OtelGuard::shutdown). Generic over the subscriber so the layer can
 /// be boxed against `main`'s concrete registry type.
-pub fn init<S>(
-    cfg: &TelemetryConfig,
-) -> Result<Option<(Box<dyn Layer<S> + Send + Sync>, OtelGuard)>>
+pub fn init<S>(cfg: &TelemetryConfig) -> Result<Option<OtelLayer<S>>>
 where
     S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {

--- a/tests/no_write_path.rs
+++ b/tests/no_write_path.rs
@@ -9,9 +9,9 @@
 //! This is the teeth behind "read-only is unconditional" in AGENTS.md. It *would* fire
 //! on the old `generate_image` capability (its `write_artifact` did `std::fs::create_dir_all`
 //! + `std::fs::write` to the out-dir) — that whole write path is gone. If kaibo ever
-//! grows a deliberate, individually-mediated *capability tool* that records an artifact,
-//! that's a conscious exception: this test is updated in the same change that adds it and
-//! its review, never silently.
+//!   grows a deliberate, individually-mediated *capability tool* that records an artifact,
+//!   that's a conscious exception: this test is updated in the same change that adds it and
+//!   its review, never silently.
 //!
 //! Scope: the *production* half of each `src/**.rs` — everything before the file's first
 //! `#[cfg(test)]` (test modules legitimately write fixtures). Line comments are stripped so

--- a/tests/no_write_path.rs
+++ b/tests/no_write_path.rs
@@ -7,11 +7,11 @@
 //! the source: production code in `src/` must contain no filesystem-mutating call.
 //!
 //! This is the teeth behind "read-only is unconditional" in AGENTS.md. It *would* fire
-//! on the old `generate_image` capability (its `write_artifact` did `std::fs::create_dir_all`
-//! + `std::fs::write` to the out-dir) — that whole write path is gone. If kaibo ever
-//!   grows a deliberate, individually-mediated *capability tool* that records an artifact,
-//!   that's a conscious exception: this test is updated in the same change that adds it and
-//!   its review, never silently.
+//! on the old `generate_image` capability (its `write_artifact` did `std::fs::create_dir_all` +
+//! `std::fs::write` to the out-dir) — that whole write path is gone. If kaibo ever
+//! grows a deliberate, individually-mediated *capability tool* that records an artifact,
+//! that's a conscious exception: this test is updated in the same change that adds it and
+//! its review, never silently.
 //!
 //! Scope: the *production* half of each `src/**.rs` — everything before the file's first
 //! `#[cfg(test)]` (test modules legitimately write fixtures). Line comments are stripped so


### PR DESCRIPTION
Bootstrapping the build: until now the 528-test suite ran only on our machines and the rustls+ring TLS invariant had no automated teeth — release.yml was the repo's only workflow. Every PR and push to main now runs the offline suite, clippy with `-D warnings`, and a `cargo tree` tripwire that fails if aws-lc/openssl/native-tls ever re-enter the dependency tree (asserted on the error text — `cargo tree -i`'s exit code is not reliable for an absent package; teeth proven locally by pointing the guard at `ring`, which is in the tree, and watching it fail).

Rides with the five outstanding clippy lints fixed so `-D warnings` holds from the first run (plus a review commit rewording a doc line instead of indenting mid-sentence prose into an accidental rustdoc bullet). Same SHA pins as release.yml, reused verbatim. This PR's own checks are the live validation of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)