### PR TITLE
feat(context): steer citations to shell reads; opt-in cat -n numbering for house rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,17 @@ the git log. Each later release appends a new section at the top.
   against the canonical names kaibo advertises. The default is now resolved before
   comparison, so the right cast is flagged however you named it.
 
+- **Models are steered away from inventing line numbers for the house-rules
+  context.** Observed live (2026-07-05): a local explorer answered by quoting the
+  inlined `AGENTS.md` verbatim under made-up line numbers — an answer that *looked*
+  grounded but wasn't checkable. The house-rules framing now tells the model to
+  ground every `file:line` it cites in a file it read through the shell, including
+  a guidance file it wants to cite precisely. For operators whose context files
+  *are* the kind a consult should cite directly, a new `[context] numbered = true`
+  knob inlines the sections with `cat -n`-style line numbers (the same form
+  attachments take); the default stays plain prose — house rules are guidance,
+  not source.
+
 ### Security
 
 - **Read-only is structural, not best-effort.** kaibo compiles in only kaish's

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -424,10 +424,14 @@ synth    = { backend = "gemma", id = "Big-Local-70B-GGUF", lane = "direct" }
 #     error). Read in trusted server-side Rust; only the CONTENTS reach the model,
 #     never the path, so the read-only shell's scope is not widened. Env
 #     KAIBO_USER_FILES / CLI --user-context-file.
+#   numbered — inline the sections with cat -n-style line numbers (default false:
+#     house rules are guidance, not source, and a model that needs to cite one
+#     precisely re-reads it through the shell). File-only knob, like [prompts].
 #
 # [context]
 # project_files = ["AGENTS.md"]
 # user_files    = ["~/.claude/CLAUDE.md"]
+# numbered      = false
 
 # ---------------------------------------------------------------------------
 # [prompts] — per-PHASE system-prompt overrides. Where [context] ADDS project

--- a/docs/config.md
+++ b/docs/config.md
@@ -510,6 +510,13 @@ project_files = ["AGENTS.md", "docs/CONVENTIONS.md"]
 # Absolute/tilde paths, read UNCONDITIONALLY (a missing one is a startup-visible
 # error — you declared it, so kaibo won't silently drop it). Default: none.
 user_files = ["~/.claude/CLAUDE.md"]
+
+# Inline the sections with cat -n-style line numbers (the form attachments take).
+# Default false: house rules are guidance, not source — the preamble tells the
+# model to re-read a guidance file through the shell if it needs to cite one
+# precisely, so the numbers would be clutter on prose. Opt in when your context
+# files are the kind a consult should cite by file:line directly.
+numbered = false
 ```
 
 Two lists, two deliberately different failure semantics:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -271,6 +271,18 @@ real config before adding the knob. Project-local `.kaibo.toml` layering (alread
 noted under "File location") would let a repo ship its own `[context]` without a
 global edit.
 
+### Provenance footer credits the explorer even when no sweep ran
+`consult`'s footer names both arms from cast *composition* (`server/mod.rs` —
+`("explorer", &explorer.model)` unconditionally at the `with_provenance` call), not
+from what answered: a narrow zorak consult (2026-07-05) delegated zero sweeps yet
+footed `explorer gemma4-e4b`, and the $4 or-glm consult (203 driver turns, zero
+sweeps) likewise. The handler already holds the evidence — `out.report` empty ⇒ no
+delegation (`include_report`'s own doc says so) — so name the explorer only when a
+sweep contributed. Cross-model studies read the footer as "which models answered
+this"; keep it honest. Delegation itself is not broken: a broad job-lane survey
+(same cast, same day) delegated an e4b sweep 15 s into the loop — a narrow question
+handled by the driver reading directly is the designed behavior, not a failure.
+
 ### Multi-turn session history is unbounded per session
 `SessionStore` (`session.rs`) caps the number of *sessions* (LRU, `session_capacity`)
 but keeps every `(question, answer)` pair in a session forever — matching dpal, which

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -167,8 +167,9 @@ pub(crate) fn escape_attr_value(s: &str) -> String {
 /// then the line verbatim (a final newline numbers no phantom tail). Inlined text rides
 /// every prompt in this form so a model can cite an attachment by `file:line` exactly as
 /// accurately as a span it read with `cat -n` in the shell — accurate citations are the
-/// product, and un-numbered bytes invite guessed line numbers.
-fn number_lines(body: &str) -> String {
+/// product, and un-numbered bytes invite guessed line numbers. The one source of truth
+/// for the form: `context.rs` numbers its `[context]` house-rules sections with it too.
+pub(crate) fn number_lines(body: &str) -> String {
     let mut out = String::with_capacity(body.len() + (body.len() >> 4));
     for (i, line) in body.split_inclusive('\n').enumerate() {
         out.push_str(&format!("{:>6}\t{line}", i + 1));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1672,6 +1672,11 @@ struct RawContext {
     /// Absolute/tilde files read unconditionally (missing = error). Env:
     /// `KAIBO_USER_FILES` (colon-separated). Default: empty.
     user_files: Option<Vec<String>>,
+    /// Inline the sections with `cat -n`-style line numbers. Default: false —
+    /// house rules are guidance, not source; a model that needs to cite one
+    /// precisely re-reads it through the shell. File-only knob (no env/CLI),
+    /// like `[prompts]`.
+    numbered: Option<bool>,
 }
 
 /// The `[prompts]` stanza — per-phase system-prompt (preamble) overrides. Each
@@ -1816,9 +1821,9 @@ impl RawBackend {
                     b.kind
                 );
             }
-            b.data_collection = v.parse().with_context(|| {
-                format!("backend {:?} data_collection", b.name)
-            })?;
+            b.data_collection = v
+                .parse()
+                .with_context(|| format!("backend {:?} data_collection", b.name))?;
         }
         Ok(())
     }
@@ -2047,6 +2052,7 @@ fn merge_context(raw: RawContext) -> anyhow::Result<ContextConfig> {
             .iter()
             .map(|s| expand_path(s))
             .collect::<anyhow::Result<Vec<_>>>()?,
+        numbered: raw.numbered.unwrap_or(false),
     })
 }
 
@@ -2492,7 +2498,11 @@ fn expand_env_vars(s: &str) -> anyhow::Result<String> {
                     // give — and so both reference forms agree on what a name is. (The
                     // braced form *is* an explicit expansion request, so a bad name is an
                     // error here, unlike a bare `$1` which is simply not a reference.)
-                    let ok = if name.is_empty() { is_start(nc) } else { is_continue(nc) };
+                    let ok = if name.is_empty() {
+                        is_start(nc)
+                    } else {
+                        is_continue(nc)
+                    };
                     if !ok {
                         bail!(
                             "path {s:?} has an invalid character {nc:?} in a ${{...}} \
@@ -2605,19 +2615,19 @@ mod tests {
         );
 
         for bad in [
-            format!("${unset}"),       // bare form, undefined
-            format!("${{{unset}}}"),   // braced form, undefined
+            format!("${unset}"),     // bare form, undefined
+            format!("${{{unset}}}"), // braced form, undefined
             "${UNTERMINATED".to_string(),
             "${}".to_string(),
             // The braced form is an explicit expansion request, so an invalid name is a
             // loud parse error (not the misleading "not set" the env lookup would give).
-            "${1bad}".to_string(),     // can't start with a digit
-            "${A/B}".to_string(),      // `/` is not a name char
+            "${1bad}".to_string(), // can't start with a digit
+            "${A/B}".to_string(),  // `/` is not a name char
             // A stray `$` that begins no reference is a typo in a boundary path, refused
             // rather than kept as a silent literal. Write `$$` for a real literal `$`.
-            "/a/$ b".to_string(),      // `$` followed by a space
-            "/cost/$100".to_string(),  // `$` followed by a digit
-            "trailing$".to_string(),   // `$` at end of string
+            "/a/$ b".to_string(),     // `$` followed by a space
+            "/cost/$100".to_string(), // `$` followed by a digit
+            "trailing$".to_string(),  // `$` at end of string
         ] {
             assert!(
                 expand_env_vars(&bad).is_err(),

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -27,7 +27,9 @@ fn with_house_rules(base: String, house_rules: Option<&str>) -> String {
              conventions and working preferences for this repository. Treat it as \
              trusted standing context: honor it as you investigate and when you write \
              your answer. It's background about how this codebase works, not the \
-             question you're answering.\n\n{rules}"
+             question you're answering. Ground every `file:line` you cite in a file \
+             you read with the shell — including a guidance file, if the answer needs \
+             to cite one precisely.\n\n{rules}"
         ),
     }
 }
@@ -893,8 +895,12 @@ mod tests {
                 text_attach("notes.md", "note body"),
             ],
         );
-        let inline_at = prompt.find("<file path=\"notes.md\">").expect("text inlines");
-        let oversize_at = prompt.find("- src/big.rs (500000 bytes)").expect("oversize listed");
+        let inline_at = prompt
+            .find("<file path=\"notes.md\">")
+            .expect("text inlines");
+        let oversize_at = prompt
+            .find("- src/big.rs (500000 bytes)")
+            .expect("oversize listed");
         let image_at = prompt.find("- docs/shot.png").expect("image listed");
         let question_at = prompt.find("Assess the change.").expect("question present");
         assert!(
@@ -914,10 +920,7 @@ mod tests {
             "q",
             None,
             &[],
-            &[
-                oversize_attach(evil, 42),
-                image_attach("img\nfake.png"),
-            ],
+            &[oversize_attach(evil, 42), image_attach("img\nfake.png")],
         );
         assert!(
             !prompt.contains("\n- /etc/shadow"),

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,6 +41,13 @@ pub struct ContextConfig {
     /// Absolute files (`$VAR`/`~` already expanded) read unconditionally — a missing
     /// one is an error, since the operator declared it. Default empty.
     pub user_files: Vec<PathBuf>,
+    /// Inline the sections with `cat -n`-style line numbers (default **false**).
+    /// House rules are *guidance*, so by default they splice as plain prose — the
+    /// numbers would be citation bait on content that isn't source, and a model
+    /// that needs to cite a guidance file precisely re-reads it through the shell
+    /// (the preamble framing says so). Opt in when your context files are the kind
+    /// a consult should cite by `file:line` directly.
+    pub numbered: bool,
 }
 
 impl ContextConfig {
@@ -83,7 +90,7 @@ impl ContextConfig {
                 }
                 let body = std::fs::read_to_string(&canon)
                     .with_context(|| format!("reading project context file {}", canon.display()))?;
-                sections.push(section(&format!("project: {name}"), &body));
+                sections.push(section(&format!("project: {name}"), &body, self.numbered));
             }
         }
 
@@ -98,7 +105,11 @@ impl ContextConfig {
                     path.display()
                 )
             })?;
-            sections.push(section(&format!("user: {}", path.display()), &body));
+            sections.push(section(
+                &format!("user: {}", path.display()),
+                &body,
+                self.numbered,
+            ));
         }
 
         if sections.is_empty() {
@@ -110,9 +121,21 @@ impl ContextConfig {
 }
 
 /// One provenance-headed section. Trailing whitespace trimmed so concatenation
-/// stays tidy; the header names where the bytes came from.
-fn section(provenance: &str, body: &str) -> String {
-    format!("### {provenance}\n\n{}", body.trim_end())
+/// stays tidy; the header names where the bytes came from. With `numbered`, the
+/// body carries `cat -n`-style line numbers ([`crate::attach::number_lines`], the
+/// same form attachments are inlined in) — trimming only drops trailing
+/// whitespace, never interior newlines, so the numbers keep matching the on-disk
+/// file. Plain (the default) splices the prose verbatim; the preamble framing
+/// steers a model that wants to cite a guidance file to re-read it through the
+/// shell (a local explorer once quoted an inlined AGENTS.md under invented line
+/// numbers, 2026-07-05).
+fn section(provenance: &str, body: &str, numbered: bool) -> String {
+    let body = body.trim_end();
+    if numbered {
+        format!("### {provenance}\n\n{}", crate::attach::number_lines(body))
+    } else {
+        format!("### {provenance}\n\n{body}")
+    }
 }
 
 #[cfg(test)]
@@ -137,6 +160,7 @@ mod tests {
         let ctx = ContextConfig {
             project_files: vec!["AGENTS.md".into()],
             user_files: vec![],
+            numbered: false,
         };
         let out = ctx.assemble(dir.path()).unwrap().expect("some context");
         assert!(
@@ -153,6 +177,7 @@ mod tests {
         let ctx = ContextConfig {
             project_files: vec!["AGENTS.md".into()],
             user_files: vec![],
+            numbered: false,
         };
         // No AGENTS.md on disk: assembles cleanly to None.
         assert_eq!(ctx.assemble(dir.path()).unwrap(), None);
@@ -166,6 +191,7 @@ mod tests {
         let ctx = ContextConfig {
             project_files: vec![],
             user_files: vec![dir.path().join("nope-not-here.md")],
+            numbered: false,
         };
         let err = ctx.assemble(dir.path()).unwrap_err();
         let msg = format!("{err:#}");
@@ -181,6 +207,7 @@ mod tests {
         let ctx = ContextConfig {
             project_files: vec![],
             user_files: vec![user.clone()],
+            numbered: false,
         };
         let out = ctx.assemble(dir.path()).unwrap().expect("some context");
         assert!(out.contains("### user:"), "header missing: {out}");
@@ -201,6 +228,7 @@ mod tests {
         let ctx = ContextConfig {
             project_files: vec!["../secret.md".into()],
             user_files: vec![],
+            numbered: false,
         };
         let err = ctx.assemble(&root).unwrap_err();
         let msg = format!("{err:#}");
@@ -209,6 +237,55 @@ mod tests {
             "wrong error: {msg}"
         );
         assert!(!msg.contains("exfiltrate me"), "leaked the body: {msg}");
+    }
+
+    /// By default the sections splice as plain prose — house rules are guidance,
+    /// not source, and line numbers on them would be citation bait (a model that
+    /// needs to cite a guidance file precisely re-reads it through the shell).
+    #[test]
+    fn sections_are_plain_prose_by_default() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("AGENTS.md"), "first rule\nsecond rule\n").unwrap();
+        let ctx = ContextConfig {
+            project_files: vec!["AGENTS.md".into()],
+            user_files: vec![],
+            numbered: false,
+        };
+        let out = ctx.assemble(dir.path()).unwrap().expect("some context");
+        assert!(
+            out.contains("first rule\nsecond rule"),
+            "body should be verbatim prose: {out}"
+        );
+        assert!(
+            !out.contains('\t'),
+            "no cat -n gutter unless `numbered` opts in: {out}"
+        );
+    }
+
+    /// `numbered = true` opts the sections into `cat -n`-style line numbers — for
+    /// operators whose context files are the kind a consult cites by `file:line`.
+    /// Observed live 2026-07-05 (why the knob exists at all): a local explorer
+    /// quoted the un-numbered inlined AGENTS.md verbatim under invented numbers.
+    #[test]
+    fn numbered_opts_sections_into_cat_n_style() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("AGENTS.md"), "first rule\nsecond rule\n").unwrap();
+        let user = dir.path().join("user.md");
+        fs::write(&user, "user rule\n").unwrap();
+        let ctx = ContextConfig {
+            project_files: vec!["AGENTS.md".into()],
+            user_files: vec![user],
+            numbered: true,
+        };
+        let out = ctx.assemble(dir.path()).unwrap().expect("some context");
+        assert!(
+            out.contains("     1\tfirst rule") && out.contains("     2\tsecond rule"),
+            "project section lines not numbered cat -n style: {out}"
+        );
+        assert!(
+            out.contains("     1\tuser rule"),
+            "user section lines not numbered cat -n style: {out}"
+        );
     }
 
     /// Project then user, in configured order, both present — sections concatenate
@@ -222,6 +299,7 @@ mod tests {
         let ctx = ContextConfig {
             project_files: vec!["AGENTS.md".into()],
             user_files: vec![user],
+            numbered: false,
         };
         let out = ctx.assemble(dir.path()).unwrap().unwrap();
         let proj = out.find("project rule").unwrap();

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1444,12 +1444,28 @@ fn a_non_numeric_telemetry_timeout_is_a_loud_error() {
 // --- [context] house-rules files ----------------------------------------------
 
 /// With no `[context]` table, kaibo reads `AGENTS.md` by default (vendor-neutral,
-/// opt-out) and no user files — the behavior an operator gets for free.
+/// opt-out) and no user files — the behavior an operator gets for free. Sections
+/// splice as plain prose by default (house rules are guidance, not source).
 #[test]
 fn context_defaults_to_agents_md_only() {
     let c = Config::builtin();
     assert_eq!(c.context.project_files, vec!["AGENTS.md".to_string()]);
     assert!(c.context.user_files.is_empty());
+    assert!(!c.context.numbered, "numbering is opt-in");
+}
+
+/// `numbered = true` opts the spliced sections into `cat -n`-style line numbers,
+/// for operators whose context files are the kind a consult cites by `file:line`.
+#[test]
+fn context_numbered_is_an_opt_in_knob() {
+    let c = Config::from_toml_str(
+        r#"
+        [context]
+        numbered = true
+        "#,
+    )
+    .unwrap();
+    assert!(c.context.numbered);
 }
 
 /// An explicit `[context]` table replaces both lists — including the canonical
@@ -1679,4 +1695,3 @@ fn a_zero_orientation_ceiling_is_a_loud_error() {
         "names the knob: {err:#}"
     );
 }
-


### PR DESCRIPTION
## Why

The first all-local `explore` (zorak cast, 2026-07-05) surfaced a citation-honesty hole: the gemma4-e4b explorer answered in one completion, zero tool calls, by quoting the `[context]`-inlined `AGENTS.md` verbatim — under **invented line numbers** (`AGENTS.md:153-164`; real text, wrong lines). The inlined house-rules block looks citable, but it carried no line numbers, so any `file:line` against it was a guess dressed as evidence.

## Decisions

- **House rules are guidance, not source** (Amy's call). Asking a model to quote `AGENTS.md` accurately by line is unfair, and `cat -n` gutters on prose directives are clutter. The **default stays plain prose**; the house-rules framing carries the fix instead — it now tells the model to ground every `file:line` it cites in a file it read through the shell, including a guidance file if the answer needs to cite one precisely. In practice that re-read should be rare for kaibo.
- **`[context] numbered = true`** is the opt-in for operators whose context files *are* the kind a consult should cite directly. It reuses `attach.rs::number_lines` (now `pub(crate)`) so the numbered form has one source of truth with attachment inlining.
- Files the sibling finding from the same probe (provenance footer credits the explorer even when zero sweeps ran) as an open `docs/issues.md` entry — separate fix.

## Tests

- `context.rs`: default-plain and opt-in-numbered assertions (the numbered one was written failing-first against the un-numbered `section()`); all existing literals updated for the new field.
- `tests/config.rs`: `numbered` parses and defaults off.
- Full offline suite green (21 binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)