### PR TITLE
feat: token usage on the provenance footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,9 +308,11 @@ the git log. Each later release appends a new section at the top.
   loop *and* every delegated explorer sweep; the cache-read / cache-write / reasoning
   splits ride along only when a provider reports them, so the common line stays lean.
   When a backend reports no usage at all the line is simply omitted rather than
-  printing a misleading `0 in · 0 out`. (Counts are exact on the normal path; the rare
-  turn-cap and image-resume paths undercount, since the underlying loop yields no usage
-  on those exits — noted in `docs/issues.md`.)
+  printing a misleading `0 in · 0 out`. The batch `deliberate` lane, whose synth cost
+  lands later on the provider's result, notes the synchronous dossier-build cost in its
+  submit acknowledgement. (Counts are exact on the normal path; the rare turn-cap and
+  image-resume paths undercount, since the underlying loop yields no usage on those
+  exits — noted in `docs/issues.md`.)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,16 @@ the git log. Each later release appends a new section at the top.
   quietly. `data_collection = "allow"` on the backend is the explicit opt-in
   (kaibo then emits no restriction; your account settings govern), and
   `kaibo://config` renders the active policy so the posture is always visible.
+- **Token usage on the provenance footer.** Every `consult`, `explore`, `oneshot`,
+  and direct `deliberate` answer now ends its footer with a `tokens · … in · … out`
+  line — the token counts the provider reported for the call, so "what did this cost
+  me?" is answered in-band without turning on telemetry. A `consult` sums the synth
+  loop *and* every delegated explorer sweep; the cache-read / cache-write / reasoning
+  splits ride along only when a provider reports them, so the common line stays lean.
+  When a backend reports no usage at all the line is simply omitted rather than
+  printing a misleading `0 in · 0 out`. (Counts are exact on the normal path; the rare
+  turn-cap and image-resume paths undercount, since the underlying loop yields no usage
+  on those exits — noted in `docs/issues.md`.)
 
 ### Changed
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -506,9 +506,22 @@ Remaining OpenRouter-specific forks:
   silently drops the reasoning param defeats thinking-on-by-default), `order`/`only`/
   `ignore`, and quantization filters. Belongs with the rig-OpenRouter exit-strategy
   thinking.
-- **Spend visibility.** Traces already carry `gen_ai.usage.*` per turn (this incident
-  was diagnosed entirely from them); consider surfacing a per-call token/cost total in
-  the provenance footer or job result so the calling agent sees cost before the bill does.
+- **Spend visibility — token total shipped, two residuals.** The provenance footer
+  now carries a `tokens · … in · … out` line (cache/reasoning splits when reported):
+  `consult` sums the synth loop plus every delegated explorer sweep, drawn from rig's
+  `PromptResponse.usage` via `.extended_details()` (see `render::fmt_usage`,
+  `engine::run_phase`). Still open:
+  - **Undercount on the exceptional exits.** rig hands back no usage on
+    `MaxTurnsError` / `PromptCancelled`, so a phase that hits its turn cap or breaks for
+    an image-resume (`run_phase`'s view_image path) loses the tokens of the capped/broken
+    run — only the finalize/resumed run's usage survives. The normal path is exact.
+    Recovering it means summing per-completion through a `PromptHook` rather than reading
+    the run's aggregate; deferred as low-value (both are rare paths) but real.
+  - **Dollars, not just tokens.** rig's normalized `Usage` carries token counts only —
+    even OpenRouter's response `usage.cost` is dropped in normalization. A per-call
+    *cost* needs a kaibo-side price table keyed by model (input/output/cache-read rates),
+    which drifts with the catalog (`provider-model-ids`). Tokens are the honest product;
+    price them caller-side, or add the table when the demand is real.
 
 ### Explorer prose — residual probes (the report shape + reading strategy shipped)
 The structured report sections (`SummaryOfFindings`/`RelevantLocations`/

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -15,7 +15,7 @@ use rig_core::completion::message::{
     AssistantContent, Image, ImageMediaType, MimeType, ToolChoice, ToolResult, ToolResultContent,
     UserContent,
 };
-use rig_core::completion::{CompletionModel, Message, Prompt, PromptError, ToolDefinition};
+use rig_core::completion::{CompletionModel, Message, Prompt, PromptError, ToolDefinition, Usage};
 use rig_core::providers::{anthropic, deepseek, gemini, openai, openrouter};
 use rig_core::tool::{Tool, ToolDyn};
 use rig_core::OneOrMany;
@@ -44,6 +44,12 @@ use super::shaping::{ModelCaps, ModelShape};
 /// loop, again for the turn-cap finalize turn — see [`run_phase`]).
 type ToolFactory<'a> = &'a (dyn Fn() -> Result<Vec<Box<dyn ToolDyn>>> + Send + Sync);
 
+/// The eventual `(answer, usage)` a phase loop yields, boxed `Send` for the
+/// [`PhaseRunner`] vtable: the model's answer paired with the token [`Usage`] the
+/// provider reported for the phase (zero-valued when unreported). A named alias so
+/// the vtable signature stays readable — and under clippy's `type_complexity` bar.
+type PhaseFuture<'a> = Pin<Box<dyn Future<Output = Result<(String, Usage)>> + Send + 'a>>;
+
 /// The object-safe seam one [`Arm`] runs its loops through: a pre-built
 /// completion model erased behind a vtable. rig's provider models are distinct
 /// concrete types; monomorphizing every phase combination would be a kinds² macro
@@ -63,7 +69,7 @@ trait PhaseRunner: Send + Sync {
         progress: &'a dyn ProgressSink,
         make_tools: ToolFactory<'a>,
         break_on_view_image: bool,
-    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>>;
+    ) -> PhaseFuture<'a>;
 }
 
 /// The concrete pre-built completion model behind the [`PhaseRunner`] vtable.
@@ -92,7 +98,7 @@ where
         progress: &'a dyn ProgressSink,
         make_tools: ToolFactory<'a>,
         break_on_view_image: bool,
-    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+    ) -> PhaseFuture<'a> {
         Box::pin(run_phase(
             &self.model,
             &self.name,
@@ -331,7 +337,10 @@ impl Arm {
     }
 
     /// Run one bounded tool loop on this arm: its client, model, params, and
-    /// `max_tokens`, with the caller's preamble/prompt/turn-cap/toolset.
+    /// `max_tokens`, with the caller's preamble/prompt/turn-cap/toolset. Returns the
+    /// model's answer paired with the token [`Usage`] the provider reported for this
+    /// phase (zero-valued when the provider reported none, or on the undercounted
+    /// exceptional paths — see [`run_phase`]).
     pub(crate) async fn run(
         &self,
         preamble: &str,
@@ -339,7 +348,7 @@ impl Arm {
         max_turns: usize,
         progress: &dyn ProgressSink,
         make_tools: ToolFactory<'_>,
-    ) -> Result<String> {
+    ) -> Result<(String, Usage)> {
         self.runner
             .run_phase(
                 preamble,
@@ -355,12 +364,17 @@ impl Arm {
     }
 }
 
-/// The result of a consult: the final answer plus the explorer's report (kept so
-/// callers can inspect/debug the hand-off, and for future session storage).
+/// The result of a consult: the final answer, the explorer's report (kept so
+/// callers can inspect/debug the hand-off, and for future session storage), and the
+/// token [`Usage`] the whole consult reported — the synth loop plus every delegated
+/// `explore′` sweep, summed. Zero-valued when no provider reported usage (the
+/// existing "unknown" sentinel), so a footer can tell "cost this much" from "the
+/// backend told us nothing".
 #[derive(Debug, Clone)]
 pub struct ConsultOutput {
     pub answer: String,
     pub report: String,
+    pub usage: Usage,
 }
 
 /// The forced-finish instruction we append when a phase exhausts its turn cap.
@@ -640,7 +654,7 @@ pub(crate) async fn run_phase<M, F>(
     progress: &dyn ProgressSink,
     make_tools: F,
     break_on_view_image: bool,
-) -> Result<String>
+) -> Result<(String, Usage)>
 where
     M: CompletionModel + 'static,
     F: Fn() -> Result<Vec<Box<dyn ToolDyn>>>,
@@ -690,15 +704,25 @@ where
         // must be scoped to *this* turn. Hoisting it out of the loop (or reusing the
         // agent across resumes) would carry a stale flag — breaking on the first
         // completion call of a resume that ran no view_image. Keep it built here.
+        // `.extended_details()` swaps rig's plain-`String` result for a
+        // `PromptResponse` carrying the token `usage` the provider reported, summed
+        // across every turn of *this* run (rig aggregates `usage += resp.usage` per
+        // completion). The clean `Ok` path is the common case — one run, the full
+        // count. The two exceptional exits below (turn cap, view_image break) undercount:
+        // rig hands back no usage on `MaxTurnsError`/`PromptCancelled`, so the turns
+        // spent in a capped or broken run are lost and only the finalize/resumed run's
+        // usage survives. Deliberate — recovering it would mean summing per-completion
+        // through a hook; documented as a known undercount rather than silently exact.
         let result = agent
             .prompt(prompt.clone())
             .with_history(history.clone())
             .with_hook(ViewImageBreakHook::new(break_on_view_image))
             .max_turns(remaining)
+            .extended_details()
             .await;
 
         match result {
-            Ok(answer) => return Ok(answer),
+            Ok(resp) => return Ok((resp.output, resp.usage)),
             Err(PromptError::MaxTurnsError { chat_history, .. }) => {
                 // The loop hit its cap and is about to write a forced final answer —
                 // tell the caller, so a watching client sees "wrapping up" not silence.
@@ -744,7 +768,7 @@ async fn finalize_after_max_turns<M>(
     tools: Vec<Box<dyn ToolDyn>>,
     chat_history: Vec<Message>,
     max_turns: usize,
-) -> Result<String>
+) -> Result<(String, Usage)>
 where
     M: CompletionModel + 'static,
 {
@@ -764,7 +788,9 @@ where
         .prompt(prompt)
         .with_history(history)
         .max_turns(1)
+        .extended_details()
         .await
+        .map(|resp| (resp.output, resp.usage))
         .map_err(|e| {
             anyhow!(
                 "model used all {max_turns} turns, and the forced final-answer turn \
@@ -795,7 +821,7 @@ pub(crate) async fn run_explore_phase(
     sandbox: &SandboxConfig,
     max_turns: usize,
     progress: &Arc<dyn ProgressSink>,
-) -> Result<String> {
+) -> Result<(String, Usage)> {
     arm.run(
         preamble,
         Message::user(question.to_string()),
@@ -833,6 +859,11 @@ pub struct RunExplore {
     /// sweeps found (the recomposed `consult`'s `report`) and a test can observe
     /// that a delegation actually happened.
     reports: Arc<Mutex<Vec<String>>>,
+    /// Every sweep's token usage sums in here. The explorer runs *inside* the synth's
+    /// tool loop, so its tokens never reach the synth's own `PromptResponse.usage` —
+    /// this shared cell is how `consult_with` recovers them to fold into the consult
+    /// total. Parallel to `reports`: one sink, many sweeps.
+    usage_sink: Arc<Mutex<Usage>>,
     /// Liveness for the sweep: brackets each delegation with start/finish, and is
     /// handed to the nested kernel's `run_kaish` so the sub-agent's own reads show
     /// through too (a delegated sweep is where a long consult spends its silence).
@@ -852,6 +883,7 @@ impl RunExplore {
         root: impl Into<PathBuf>,
         sandbox: SandboxConfig,
         reports: Arc<Mutex<Vec<String>>>,
+        usage_sink: Arc<Mutex<Usage>>,
         progress: Arc<dyn ProgressSink>,
         preamble: Arc<str>,
     ) -> Self {
@@ -861,6 +893,7 @@ impl RunExplore {
             root: root.into(),
             sandbox,
             reports,
+            usage_sink,
             progress,
             preamble,
         }
@@ -934,8 +967,14 @@ impl Tool for RunExplore {
         )
         .await;
         self.progress.emit(PhaseEvent::SweepFinished);
-        let report = result.map_err(|e| RunExploreError(format!("{e:#}")))?;
+        let (report, usage) = result.map_err(|e| RunExploreError(format!("{e:#}")))?;
+        // Fold this sweep's tokens into the shared consult total before returning the
+        // report to the driver — the synth's own `PromptResponse` will never see them.
         // Lock poisoning means another delegation panicked — surface it, don't mask.
+        *self
+            .usage_sink
+            .lock()
+            .expect("explore usage sink poisoned") += usage;
         self.reports
             .lock()
             .expect("explore report sink poisoned")
@@ -969,7 +1008,7 @@ pub async fn oneshot(
     attachments: &[Attachment],
     arm: &Arm,
     cfg: &PhaseContext,
-) -> Result<String> {
+) -> Result<(String, Usage)> {
     let user_prompt = crate::attach::with_text_context(attachments, prompt);
     let image_parts: Vec<UserContent> = attachments
         .iter()
@@ -1020,11 +1059,13 @@ pub async fn oneshot(
 /// Build the recomposed `consult` toolset: `{run_kaish, explore′}`. Factored out so
 /// the wiring (both tools present, explore′ pointed at the explorer arm) is
 /// unit-testable without a live model. `reports` collects each `explore′` sweep.
+#[allow(clippy::too_many_arguments)] // the sinks and flags are each a distinct wiring input
 fn consult_tools(
     explorer: &Arm,
     root: &Path,
     cfg: &ConsultConfig,
     reports: Arc<Mutex<Vec<String>>>,
+    explore_usage: Arc<Mutex<Usage>>,
     synth_vision: bool,
 ) -> Result<Vec<Box<dyn ToolDyn>>> {
     // run_kaish for precise reads by the consult model itself — carries the sink so
@@ -1057,6 +1098,7 @@ fn consult_tools(
         root,
         cfg.explore.sandbox.clone(),
         reports,
+        explore_usage,
         cfg.explore.phase.progress.clone(),
         explorer_preamble,
     );
@@ -1091,7 +1133,7 @@ pub(crate) async fn explore_with(
     explorer: &Arm,
     cfg: &ExploreConfig,
     attached: &[super::prompts::ConsultAttachment],
-) -> Result<String> {
+) -> Result<(String, Usage)> {
     let mut preamble = resolve_phase_preamble(
         Phase::Explorer,
         &cfg.phase.prompts,
@@ -1169,7 +1211,7 @@ pub async fn deliberate_direct(
     system: &str,
     deadline: Duration,
     progress: &Arc<dyn ProgressSink>,
-) -> Result<String> {
+) -> Result<(String, Usage)> {
     with_call_deadline(
         deadline,
         "deliberate",
@@ -1200,8 +1242,12 @@ pub(crate) async fn consult_with(
     cfg: &ConsultConfig,
 ) -> Result<ConsultOutput> {
     let reports = Arc::new(Mutex::new(Vec::<String>::new()));
+    // The delegated sweeps' tokens land here (they run inside the synth loop, so the
+    // synth's own `PromptResponse.usage` never counts them); summed with the synth's
+    // usage below into the consult total.
+    let explore_usage = Arc::new(Mutex::new(Usage::new()));
 
-    let answer = with_call_deadline(
+    let (answer, synth_usage) = with_call_deadline(
         cfg.explore.phase.call_deadline,
         "consult",
         synth.run(
@@ -1215,9 +1261,18 @@ pub(crate) async fn consult_with(
             cfg.synth_max_turns,
             cfg.explore.phase.progress.as_ref(),
             // Rebuilt per call (main loop, and again if run_phase forces a final
-            // turn); every build shares the one `reports` sink so all explore′
-            // sweeps aggregate.
-            &|| consult_tools(explorer, root, cfg, reports.clone(), synth.caps.vision),
+            // turn); every build shares the one `reports` + `explore_usage` sink so
+            // all explore′ sweeps aggregate.
+            &|| {
+                consult_tools(
+                    explorer,
+                    root,
+                    cfg,
+                    reports.clone(),
+                    explore_usage.clone(),
+                    synth.caps.vision,
+                )
+            },
         ),
     )
     .await
@@ -1227,7 +1282,13 @@ pub(crate) async fn consult_with(
         .lock()
         .expect("explore report sink poisoned")
         .join("\n\n---\n\n");
-    Ok(ConsultOutput { answer, report })
+    // Consult total: the synth's own loop plus every delegated sweep.
+    let usage = synth_usage + *explore_usage.lock().expect("explore usage sink poisoned");
+    Ok(ConsultOutput {
+        answer,
+        report,
+        usage,
+    })
 }
 
 /// A consult turn's session binding: the store and the session id. `None` is a
@@ -1296,7 +1357,7 @@ mod tests {
     use crate::session::SessionStore;
     use crate::test_support::{
         has_tool, is_finalize_turn, provider_error, text_response, tool_call_response,
-        transcript_text, RecordingSink, ScriptedClient,
+        transcript_text, usage, with_usage, RecordingSink, ScriptedClient,
     };
     use std::fs;
     use std::num::NonZeroUsize;
@@ -1779,6 +1840,24 @@ mod tests {
         );
     }
 
+    /// oneshot carries the provider's reported token usage back out — the thin
+    /// single-turn seam threads `PromptResponse.usage` the same as the loop does.
+    #[tokio::test]
+    async fn oneshot_returns_reported_usage() {
+        const MODEL: &str = "synth";
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, |_req| {
+                Ok(with_usage(text_response("done"), usage(321, 21)))
+            })
+            .build();
+        let (answer, reported) = oneshot("q", &[], &arm(&client, MODEL), &PhaseContext::default())
+            .await
+            .unwrap();
+        assert_eq!(answer, "done");
+        assert_eq!(reported.input_tokens, 321);
+        assert_eq!(reported.output_tokens, 21);
+    }
+
     /// The load-bearing e2e: a scripted consult that delegates a sweep to `explore′`,
     /// reads a span itself, and answers — driving the *real* loop end to end with no
     /// network. This proves what the offline wiring test below cannot: the driver's
@@ -1895,6 +1974,75 @@ mod tests {
         );
     }
 
+    /// A consult's reported `usage` must be the synth loop's tokens **plus** every
+    /// delegated `explore′` sweep's — the nested explorer runs inside the synth's tool
+    /// loop, so its tokens never reach the synth's own `PromptResponse.usage` and a
+    /// naive implementation would drop them. Each scripted completion "reports" a fixed
+    /// per-call usage; rig sums `usage += resp.usage` across a run, so the expected
+    /// total is (synth completions × synth-usage) + (explorer completions × explorer-usage),
+    /// computed from the request log so it can't drift with the loop's turn count. The
+    /// teeth: forget to fold the explorer sink in and the total comes back short by the
+    /// explorer's share, and this fails.
+    #[tokio::test]
+    async fn consult_usage_sums_synth_and_delegated_explorer_tokens() {
+        const SYNTH: &str = "capable-synth";
+        const EXPLORER: &str = "cheap-explorer";
+        const REPORT: &str = "EXPLORER_REPORT: src/foo.rs:1";
+        // Distinct per-call footprints so a missing addend is obvious in the total.
+        let synth_each = usage(100, 10);
+        let explorer_each = usage(50, 5);
+
+        let client = ScriptedClient::builder()
+            .on_model(SYNTH, move |req| {
+                let resp = if transcript_text(req).contains("EXPLORER_REPORT") {
+                    text_response("ANSWER: done.")
+                } else {
+                    tool_call_response("t-explore", "explore", json!({ "question": "sweep" }))
+                };
+                Ok(with_usage(resp, synth_each))
+            })
+            .on_model(EXPLORER, move |_req| {
+                Ok(with_usage(text_response(REPORT), explorer_each))
+            })
+            .build();
+
+        let dir = project_with_marker();
+        let cfg = ConsultConfig::default();
+
+        let out = consult_with(
+            "Where is target_marker defined?",
+            dir.path(),
+            &arm(&client, EXPLORER),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect("scripted consult should succeed");
+
+        // Expected = per-call usage × how many completions each model actually made.
+        let ns = client.requests_for(SYNTH).len() as u64;
+        let ne = client.requests_for(EXPLORER).len() as u64;
+        assert!(ns >= 2, "driver should delegate then answer (≥2 turns), got {ns}");
+        assert!(ne >= 1, "explorer should have been delegated at least one sweep");
+
+        assert_eq!(
+            out.usage.input_tokens,
+            ns * 100 + ne * 50,
+            "input tokens must sum synth + explorer completions"
+        );
+        assert_eq!(
+            out.usage.output_tokens,
+            ns * 10 + ne * 5,
+            "output tokens must sum synth + explorer completions"
+        );
+        // And the explorer's share is genuinely included — the total strictly exceeds
+        // the synth's own tokens, so dropping the nested sink would fail here.
+        assert!(
+            out.usage.input_tokens > ns * 100,
+            "the delegated explorer's tokens must be folded into the consult total"
+        );
+    }
+
     /// Attachments reach the delegated sweep: a consult carrying attachments must
     /// hand every `explore′` sub-agent the read-them-WHOLE directive in its
     /// preamble — the sweep is a fresh agent that never saw the driver prompt, so
@@ -2002,7 +2150,7 @@ mod tests {
         let dir = project_with_marker();
         let cfg = ExploreConfig::default();
 
-        let report = explore_with(
+        let (report, _usage) = explore_with(
             "Where is target_marker defined?",
             dir.path().to_path_buf(),
             &arm(&client, EXPLORER),
@@ -2164,7 +2312,7 @@ mod tests {
             .build();
 
         let cfg = PhaseContext::default();
-        let out = deliberate_direct(
+        let (out, _usage) = deliberate_direct(
             "Is the retry path safe?",
             "src/retry.rs:12 DOSSIER_MARKER fn retry()",
             &arm(&client, SYNTH),
@@ -3302,6 +3450,7 @@ mod tests {
             dir.path(),
             &cfg,
             reports,
+            Arc::new(Mutex::new(Usage::new())),
             false, // synth is not vision-capable
         )
         .expect("building the consult toolset should succeed");
@@ -3336,6 +3485,7 @@ mod tests {
             dir.path(),
             &cfg,
             reports,
+            Arc::new(Mutex::new(Usage::new())),
             true, // synth IS vision-capable
         )
         .expect("building the consult toolset should succeed");
@@ -3360,8 +3510,16 @@ mod tests {
         let explorer = arm(&client, "m");
         let reports = Arc::new(Mutex::new(Vec::<String>::new()));
 
-        let blind = consult_tools(&explorer, dir.path(), &cfg, reports.clone(), false)
-            .expect("blind toolset builds");
+        let usage_sink = Arc::new(Mutex::new(Usage::new()));
+        let blind = consult_tools(
+            &explorer,
+            dir.path(),
+            &cfg,
+            reports.clone(),
+            usage_sink.clone(),
+            false,
+        )
+        .expect("blind toolset builds");
         let blind_names: Vec<String> = blind.iter().map(|t| t.name()).collect();
         assert!(blind_names.iter().any(|n| n == "run_kaish"));
         assert!(blind_names.iter().any(|n| n == "explore"));
@@ -3370,7 +3528,7 @@ mod tests {
             "no view_image without vision, got {blind_names:?}"
         );
 
-        let seeing = consult_tools(&explorer, dir.path(), &cfg, reports, true)
+        let seeing = consult_tools(&explorer, dir.path(), &cfg, reports, usage_sink, true)
             .expect("vision toolset builds");
         let seeing_names: Vec<String> = seeing.iter().map(|t| t.name()).collect();
         assert!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,9 +50,9 @@ mod render;
 use config_resource::render_config_resource;
 use render::{
     batch_poll_brief, batch_within_window, consult_result, consultation_failed,
-    consultation_failure_text, is_batch_handle, now_epoch_secs, parse_batch_handle, render_job,
-    render_jobs_section, render_wait, wait_level_floor, wait_level_label, with_provenance,
-    BATCH_RECENCY_WINDOW_SECS,
+    consultation_failure_text, fmt_usage, is_batch_handle, now_epoch_secs, parse_batch_handle,
+    render_job, render_jobs_section, render_wait, wait_level_floor, wait_level_label,
+    with_provenance, BATCH_RECENCY_WINDOW_SECS,
 };
 
 /// kaibo's resource URI namespace. Everything kaish-related hangs off `kaibo://kaish/`.
@@ -1894,8 +1894,15 @@ impl KaiboHandler {
         let system = crate::consult::batch_system_prompt(cfg.phase.prompts.batch.as_deref());
         match lane {
             Lane::Batch => {
-                self.deliberate_batch(&cast, &explorer_model, &input.question, &dossier, &system)
-                    .await
+                self.deliberate_batch(
+                    &cast,
+                    &explorer_model,
+                    &input.question,
+                    &dossier,
+                    &system,
+                    dossier_usage,
+                )
+                .await
             }
             Lane::Direct => self.deliberate_direct_job(
                 &cast,
@@ -1921,6 +1928,11 @@ impl KaiboHandler {
         question: &str,
         dossier: &str,
         system: &str,
+        // The dossier stage's explorer tokens — real synchronous spend kaibo already
+        // paid to build the dossier. The offline synth's own cost lands later on the
+        // provider's batch result (not rendered here), but the caller should still see
+        // what the build cost rather than have it silently dropped on this lane.
+        dossier_usage: Usage,
     ) -> Result<CallToolResult, McpError> {
         let (slot, backend, _caps) = self.batch_synth(cast)?;
         let backend_name = backend.name.clone();
@@ -1940,11 +1952,16 @@ impl KaiboHandler {
             .await
             .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
         let handle = format!("{backend_name}/{provider_id}");
+        // Fold the dossier build's real cost into the ack — the synth's own tokens land
+        // later on the provider's batch result, but the build spend is knowable now.
+        let dossier_cost = fmt_usage(&dossier_usage)
+            .map(|t| format!(", {t}"))
+            .unwrap_or_default();
         let msg = format!(
-            "Dossier built (explorer `{explorer_model}`) and handed to the batch lane as \
-             `{handle}` — cast `{}`, synth `{model}` at max thinking. It deliberates offline; \
-             collect it with `job_get {handle}` (durable — survives restart), or stop it with \
-             `job_cancel {handle}`. Nothing to wait on now.",
+            "Dossier built (explorer `{explorer_model}`{dossier_cost}) and handed to the batch \
+             lane as `{handle}` — cast `{}`, synth `{model}` at max thinking. It deliberates \
+             offline; collect it with `job_get {handle}` (durable — survives restart), or stop it \
+             with `job_cancel {handle}`. Nothing to wait on now.",
             cast.name
         );
         Ok(CallToolResult::success(vec![Content::text(msg)]))
@@ -4301,6 +4318,14 @@ mod tests {
         ));
         let cast = h.config.resolve_cast("mydeliberate").unwrap().clone();
 
+        // The dossier build's real explorer spend — the batch lane must surface it in
+        // the ack rather than drop it (its synth cost lands later on the batch result).
+        let dossier_usage = Usage {
+            input_tokens: 200,
+            output_tokens: 20,
+            total_tokens: 220,
+            ..Usage::new()
+        };
         let out = h
             .deliberate_batch(
                 &cast,
@@ -4308,13 +4333,19 @@ mod tests {
                 "Is the retry safe?",
                 "DOSSIER: src/x.rs:1 fn retry",
                 "offline-synth-system",
+                dossier_usage,
             )
             .await
             .expect("scripted deliberate_batch succeeds");
 
+        let ack = result_text(out);
         assert!(
-            result_text(out).contains("gem/msgbatch_d"),
+            ack.contains("gem/msgbatch_d"),
             "the reply carries the durable batch handle"
+        );
+        assert!(
+            ack.contains("tokens · 200 in · 20 out"),
+            "the ack surfaces the synchronous dossier-build cost: {ack}"
         );
         let submits = scripted.submits();
         assert_eq!(submits.len(), 1, "the dossier is one batch");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use kaish_kernel::tools::ToolSchema;
+use rig_core::completion::Usage;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
@@ -1600,6 +1601,7 @@ impl KaiboHandler {
             out.answer,
             &cast.name,
             &[("explorer", &explorer.model), ("synth", &synth.model)],
+            &out.usage,
         );
         Ok(consult_result(answer, out.report, input.include_report))
     }
@@ -1717,6 +1719,7 @@ impl KaiboHandler {
                             ("explorer", explorer_model.as_str()),
                             ("synth", synth_model.as_str()),
                         ],
+                        &out.usage,
                     );
                     Ok(JobResult {
                         answer,
@@ -1791,11 +1794,11 @@ impl KaiboHandler {
         let span =
             tracing::info_span!("explore", cast = %cast.name, explorer_model = %explorer.model);
         progress.emit(PhaseEvent::PhaseStarted { phase: "explore" });
-        let report = match explore_with(&input.question, root, &explorer, &cfg, &attachments)
+        let (report, usage) = match explore_with(&input.question, root, &explorer, &cfg, &attachments)
             .instrument(span)
             .await
         {
-            Ok(report) => report,
+            Ok(out) => out,
             // A provider/model-loop failure is a clean tool-result error, same as `consult`.
             Err(e) => return Ok(consultation_failed("explore", &cast.name, e)),
         };
@@ -1803,7 +1806,7 @@ impl KaiboHandler {
 
         // The report IS the text (no structured_content). Provenance names the one arm
         // that produced it, so a cross-model study sees which explorer surveyed.
-        let report = with_provenance(report, &cast.name, &[("explorer", &explorer.model)]);
+        let report = with_provenance(report, &cast.name, &[("explorer", &explorer.model)], &usage);
         Ok(CallToolResult::success(vec![Content::text(report)]))
     }
 
@@ -1872,13 +1875,14 @@ impl KaiboHandler {
         progress.emit(PhaseEvent::PhaseStarted {
             phase: "deliberate.dossier",
         });
-        let dossier = match explore_with(&input.question, root, &explorer, &cfg, &attachments)
-            .instrument(span)
-            .await
-        {
-            Ok(d) => d,
-            Err(e) => return Ok(consultation_failed("deliberate", &cast.name, e)),
-        };
+        let (dossier, dossier_usage) =
+            match explore_with(&input.question, root, &explorer, &cfg, &attachments)
+                .instrument(span)
+                .await
+            {
+                Ok(out) => out,
+                Err(e) => return Ok(consultation_failed("deliberate", &cast.name, e)),
+            };
         progress.emit(PhaseEvent::PhaseFinished {
             phase: "deliberate.dossier",
         });
@@ -1899,6 +1903,7 @@ impl KaiboHandler {
                 &input.question,
                 &dossier,
                 &system,
+                dossier_usage,
             ),
         }
     }
@@ -1957,6 +1962,9 @@ impl KaiboHandler {
         question: &str,
         dossier: &str,
         system: &str,
+        // The dossier stage's explorer tokens, summed into the final footer with the
+        // synth's — the footer names both roles, so it counts both.
+        dossier_usage: Usage,
     ) -> Result<CallToolResult, McpError> {
         let synth = self.arm(cast, ModelRole::Synth)?;
         let synth_model = synth.model.clone();
@@ -1993,7 +2001,7 @@ impl KaiboHandler {
             )
             .await
             {
-                Ok(answer) => Ok(JobResult {
+                Ok((answer, synth_usage)) => Ok(JobResult {
                     answer: with_provenance(
                         answer,
                         &cast_name,
@@ -2001,6 +2009,7 @@ impl KaiboHandler {
                             ("explorer", explorer_model.as_str()),
                             ("synth", synth_model.as_str()),
                         ],
+                        &(dossier_usage + synth_usage),
                     ),
                     report: None,
                 }),
@@ -2062,17 +2071,17 @@ impl KaiboHandler {
 
         let span = tracing::info_span!("oneshot", cast = %cast.name, model = %arm.model);
         progress.emit(PhaseEvent::PhaseStarted { phase: "oneshot" });
-        let answer = match oneshot(&input.prompt, &attachments, &arm, &cfg)
+        let (answer, usage) = match oneshot(&input.prompt, &attachments, &arm, &cfg)
             .instrument(span)
             .await
         {
-            Ok(answer) => answer,
+            Ok(out) => out,
             // A provider failure is a clean tool-result error, same as `consult`.
             Err(e) => return Ok(consultation_failed("oneshot", &cast.name, e)),
         };
         progress.emit(PhaseEvent::PhaseFinished { phase: "oneshot" });
 
-        let answer = with_provenance(answer, &cast.name, &[("model", &arm.model)]);
+        let answer = with_provenance(answer, &cast.name, &[("model", &arm.model)], &usage);
         Ok(CallToolResult::success(vec![Content::text(answer)]))
     }
 

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -380,8 +380,10 @@ pub(super) fn with_provenance(
 /// field can't quietly slip past this guard. We distinguish "cost this much" from
 /// "the backend told us nothing" rather than printing a misleading `0 in · 0 out`.
 /// Input and output always show; the cache splits and reasoning ride along only when
-/// non-zero, so the common (uncached, no-thinking-report) line stays lean.
-fn fmt_usage(usage: &Usage) -> Option<String> {
+/// non-zero, so the common (uncached, no-thinking-report) line stays lean. Shared by
+/// the answer footer ([`with_provenance`]) and the deliberate batch ack, which folds
+/// the synchronous dossier-build cost into its message.
+pub(super) fn fmt_usage(usage: &Usage) -> Option<String> {
     if *usage == Usage::new() {
         return None;
     }

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -3,6 +3,7 @@
 //! consult answers and their provenance footer, failure classification, and the
 //! job / batch / wait status views.
 
+use rig_core::completion::Usage;
 use rmcp::model::{CallToolResult, Content, LoggingLevel};
 use rmcp::ErrorData as McpError;
 use serde_json::json;
@@ -354,13 +355,50 @@ pub(super) fn parse_batch_handle(handle: &str) -> Result<(&str, &str), McpError>
         })
 }
 
-pub(super) fn with_provenance(answer: String, cast: &str, roles: &[(&str, &str)]) -> String {
+pub(super) fn with_provenance(
+    answer: String,
+    cast: &str,
+    roles: &[(&str, &str)],
+    usage: &Usage,
+) -> String {
     let models = roles
         .iter()
         .map(|(label, model)| format!("{label} `{model}`"))
         .collect::<Vec<_>>()
         .join(" · ");
-    format!("{answer}\n\n———\nkaibo · cast `{cast}` · {models}")
+    let footer = format!("{answer}\n\n———\nkaibo · cast `{cast}` · {models}");
+    match fmt_usage(usage) {
+        Some(tokens) => format!("{footer}\n{tokens}"),
+        None => footer,
+    }
+}
+
+/// Render the reported token usage as one compact footer line, or `None` when the
+/// provider reported nothing. rig zeroes every field of [`Usage`] when a provider
+/// omits usage metrics, and uses that all-zero value as its own "unknown" sentinel
+/// (`reported_usage`); we mirror it exactly with `== Usage::new()`, so a new rig
+/// field can't quietly slip past this guard. We distinguish "cost this much" from
+/// "the backend told us nothing" rather than printing a misleading `0 in · 0 out`.
+/// Input and output always show; the cache splits and reasoning ride along only when
+/// non-zero, so the common (uncached, no-thinking-report) line stays lean.
+fn fmt_usage(usage: &Usage) -> Option<String> {
+    if *usage == Usage::new() {
+        return None;
+    }
+    let mut line = format!(
+        "tokens · {} in · {} out",
+        usage.input_tokens, usage.output_tokens
+    );
+    if usage.reasoning_tokens > 0 {
+        line.push_str(&format!(" · {} reasoning", usage.reasoning_tokens));
+    }
+    if usage.cached_input_tokens > 0 {
+        line.push_str(&format!(" · {} cached", usage.cached_input_tokens));
+    }
+    if usage.cache_creation_input_tokens > 0 {
+        line.push_str(&format!(" · {} cache-write", usage.cache_creation_input_tokens));
+    }
+    Some(line)
 }
 
 #[cfg(test)]
@@ -641,6 +679,7 @@ mod tests {
                 ("explorer", "gemini-flash-lite-latest"),
                 ("synth", "gemini-3.5-flash"),
             ],
+            &Usage::new(),
         );
         assert!(
             out.starts_with("the answer"),
@@ -655,12 +694,65 @@ mod tests {
             out.contains("synth `gemini-3.5-flash`"),
             "names the synth model: {out}"
         );
+        // An all-zero usage (no provider reported any) adds no tokens line — the
+        // footer never claims a misleading `0 in · 0 out`.
+        assert!(
+            !out.contains("tokens"),
+            "unreported usage stays silent: {out}"
+        );
 
         // The oneshot shape: a single labelled model.
-        let one = with_provenance("x".into(), "deepseek", &[("model", "deepseek-v4-pro")]);
+        let one = with_provenance(
+            "x".into(),
+            "deepseek",
+            &[("model", "deepseek-v4-pro")],
+            &Usage::new(),
+        );
         assert!(
             one.contains("cast `deepseek` · model `deepseek-v4-pro`"),
             "{one}"
+        );
+    }
+
+    /// The tokens line: reported usage renders in-band, cache/reasoning splits show
+    /// only when non-zero, and an unreported (all-zero) usage renders nothing.
+    #[test]
+    fn usage_footer_renders_reported_tokens_and_stays_silent_when_unreported() {
+        // Unreported → no line at all (rig's all-zero sentinel).
+        assert_eq!(fmt_usage(&Usage::new()), None);
+
+        // A plain report: input + output, no cache/reasoning noise.
+        let plain = Usage {
+            input_tokens: 48170,
+            output_tokens: 3102,
+            ..Usage::new()
+        };
+        assert_eq!(
+            fmt_usage(&plain).unwrap(),
+            "tokens · 48170 in · 3102 out",
+            "plain report shows only in/out"
+        );
+
+        // Everything present: reasoning + cache read + cache write ride along.
+        let rich = Usage {
+            input_tokens: 1000,
+            output_tokens: 200,
+            reasoning_tokens: 150,
+            cached_input_tokens: 800,
+            cache_creation_input_tokens: 64,
+            ..Usage::new()
+        };
+        let line = fmt_usage(&rich).unwrap();
+        assert!(line.contains("1000 in · 200 out"), "{line}");
+        assert!(line.contains("150 reasoning"), "{line}");
+        assert!(line.contains("800 cached"), "{line}");
+        assert!(line.contains("64 cache-write"), "{line}");
+
+        // And it reaches the footer through with_provenance.
+        let out = with_provenance("A".into(), "deepseek", &[("model", "m")], &plain);
+        assert!(
+            out.contains("tokens · 48170 in · 3102 out"),
+            "footer carries the tokens line: {out}"
         );
     }
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -282,6 +282,28 @@ fn response(choice: OneOrMany<AssistantContent>) -> CompletionResponse<()> {
     }
 }
 
+/// A [`Usage`] a scripted provider "reports" for one completion, `input`/`output`
+/// tokens (with `total` filled to match, the way a real provider does). Lets a test
+/// prove kaibo threads and sums the token counts rig hands back — rig aggregates
+/// `usage += resp.usage` across a run, so this is the real accounting path, not a
+/// mocked-out one. Zero on both is indistinguishable from "provider reported nothing"
+/// (rig's sentinel), so pass a non-zero count when a test means to observe usage.
+pub fn usage(input: u64, output: u64) -> Usage {
+    Usage {
+        input_tokens: input,
+        output_tokens: output,
+        total_tokens: input + output,
+        ..Usage::new()
+    }
+}
+
+/// Stamp a reported [`usage`] onto a scripted response. `text_response`/`tool_call_response`
+/// default to `Usage::new()` (nothing reported); wrap them here to drive the accounting.
+pub fn with_usage(mut resp: CompletionResponse<()>, usage: Usage) -> CompletionResponse<()> {
+    resp.usage = usage;
+    resp
+}
+
 /// A provider-side error — drives `run_phase`'s failure arm (the model loop fails
 /// before it concludes). Return `Err(provider_error(..))` from a responder.
 pub fn provider_error(msg: impl Into<String>) -> CompletionError {

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -1287,7 +1287,7 @@ async fn secondary_local_cast_from_user_config_runs() {
     let secondary = ModelSlot::bare(glm_synth.backend.clone(), "Gemma-4-E4B-it-GGUF");
     let arm = Arm::from_slot(backend, &secondary, ModelRole::Synth, &cfg.defaults)
         .expect("secondary arm builds");
-    let answer = oneshot(
+    let (answer, _usage) = oneshot(
         "Context: src/sandbox.rs builds a read-only kernel; writes and external \
          commands are refused.\n\nIn one sentence, what does kaibo's read-only sandbox \
          prevent?",
@@ -1348,7 +1348,7 @@ async fn recomposed_consult_runs_against_local_gemma() {
 async fn oneshot_answers_from_pasted_context() {
     let arm = builtin_arm("openai-local", ModelRole::Synth);
 
-    let answer = oneshot(
+    let (answer, _usage) = oneshot(
         "Context: src/sandbox.rs builds a read-only kernel; the LocalFs read-only \
          mount refuses every write.\n\nIn one sentence, which file enforces kaibo's \
          read-only sandbox?",


### PR DESCRIPTION
## What

Surface the token counts providers already report, **in-band** on the answer footer. Every `consult`, `explore`, `oneshot`, and direct `deliberate` answer now ends with a line like:

```
———
kaibo · cast `deepseek` · explorer `deepseek-v4-flash` · synth `deepseek-v4-pro`
tokens · 48170 in · 3102 out · 12000 cached
```

This answers *"what did this cost me?"* without turning on OTLP telemetry. Resolves the "Spend visibility" item in `docs/issues.md`.

## Why these decisions

- **rig's own accounting, not a re-count.** `run_phase` awaited the `Standard` `PromptRequest` (bare `String`, usage discarded). It now uses `.extended_details()` → `PromptResponse.usage`, the aggregate rig already sums across every turn of a run (`usage += resp.usage`). The number is the provider's, threaded — not estimated. A `(String, Usage)` return flows through the phase seams (`run_phase`, `finalize_after_max_turns`, `PhaseRunner`/`ModelArm`, `Arm::run`, `run_explore_phase`, `oneshot`, `explore_with`, `deliberate_direct`).

- **A `consult` sums two places.** The synth loop's usage is its own `PromptResponse`. The delegated explorer runs *inside* that loop as the `explore` tool, so its tokens never reach the synth's aggregate — `RunExplore` folds each sweep into a shared `Arc<Mutex<Usage>>` sink (parallel to the existing `reports` sink) that `consult_with` adds to the synth total, exposed as a new `ConsultOutput.usage`.

- **Unreported stays silent.** rig zeroes all fields when a provider omits usage and treats all-zero as its "unknown" sentinel. `fmt_usage` mirrors that (`== Usage::new()`) and omits the line rather than print a misleading `0 in · 0 out`. Cache-read / cache-write / reasoning splits ride along only when non-zero, so the common line stays lean.

- **Tokens, not dollars.** rig's normalized `Usage` carries token counts only — even OpenRouter's response cost is dropped in normalization — so pricing would need a drift-prone per-model table. Tokens are the honest product; price them caller-side. Left as a residual in `docs/issues.md`.

- **Batch `deliberate`** (second commit, from review): its synth cost lands later on the provider's result, but the synchronous dossier build is real spend — now surfaced in the submit acknowledgement instead of dropped.

## Known limitation (documented)

Counts are **exact on the normal path**. rig hands back no usage on `MaxTurnsError` / `PromptCancelled`, so the rare **turn-cap** and **image-resume** exits count only the finalize/resumed run, not the capped/broken one. Recovering it means summing per-completion through a `PromptHook`; deferred as low-value (both are rare) but noted in `docs/issues.md`.

## Tests (TDD — proven to fail)

- `consult_usage_sums_synth_and_delegated_explorer_tokens` — drives the real consult loop with a scripted client that reports per-call usage; asserts the total = (synth completions × synth-usage) + (explorer completions × explorer-usage), computed from the request log so it can't drift with turn count. Verified it **fails** when the explorer-sink fold is removed.
- `oneshot_returns_reported_usage`, `usage_footer_renders_reported_tokens_and_stays_silent_when_unreported`, and a batch-ack dossier-cost assertion.
- Full offline suite green (all 21 binaries); `clippy --all-targets` clean.

## Review

Cross-family holistic review by **DeepSeek** (via kaibo's own `consult`, no diff) confirmed the aggregation is correct with no double-count and validated the undercount reasoning; it surfaced the batch-lane dossier-cost gap, fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)