### PR TITLE
feat(release): born-signed releases — cosign keyless + SLSA provenance + SPDX SBOM (plan PR 3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@
 # Actions are pinned by commit SHA, not tag — a tag can be moved, a digest can't
 # (supply-chain). Each pin carries a `# vX.Y.Z` comment naming the release it points
 # at, for humans and Dependabot.
+#
+# Releases are born signed: the publish job cosign-signs an aggregated
+# checksums.txt (keyless — the identity IS this workflow at this tag), attaches
+# SLSA build provenance per artifact (`gh attestation verify`), and ships an SPDX
+# SBOM from Cargo.lock. Verification commands live in the README.
 name: release
 
 on:
@@ -148,6 +153,8 @@ jobs:
             kaibo-*.tar.gz*
             kaibo-*.zip*
 
+  # Signing, provenance, and the SBOM all live here in the tag-gated publish job —
+  # a `workflow_dispatch` smoke run never mints an OIDC identity or a signature.
   release:
     name: publish release
     needs: build
@@ -155,11 +162,70 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release and upload assets
+      id-token: write # mint the OIDC identity cosign + provenance sign with
+      attestations: write # store the build-provenance attestations
     steps:
+      # Checkout is here only for Cargo.lock: the SBOM catalogs the locked
+      # dependency tree, which covers every target (the lockfile is a superset
+      # including each platform's conditional deps). The binaries themselves
+      # carry no dependency metadata for syft to read — that would take
+      # cargo-auditable, tracked as a follow-up in docs/issues.md.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
+
+      - name: SBOM (syft over Cargo.lock)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: Cargo.lock
+          format: spdx-json
+          output-file: dist/kaibo-${{ github.ref_name }}-sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      # One aggregated manifest so the signature below covers every artifact
+      # transitively: verify checksums.txt once, then `sha256sum -c` whichever
+      # file you downloaded. The per-artifact .sha256 sidecars stay — the
+      # README's download one-liner uses them.
+      - name: Aggregate checksums
+        working-directory: dist
+        run: sha256sum kaibo-*.tar.gz kaibo-*.zip kaibo-*-sbom.spdx.json > checksums.txt
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless: the signature binds to this workflow run's OIDC identity (repo,
+      # workflow path, tag ref) via a short-lived Fulcio certificate, recorded in
+      # the Rekor transparency log — no long-lived key anywhere. Verification
+      # REQUIRES the identity flags (a bare verify-blob cannot work for keyless);
+      # the exact invocation lives in the README's "Verify a download" section.
+      # Both signature shapes ship: .sig/.pem verifies on cosign v2 and v3, and
+      # the .sigstore.json protobuf bundle is self-contained (cert + signature +
+      # Rekor entry) for a v3 `verify-blob --bundle` that works offline.
+      - name: Sign checksums.txt (cosign keyless)
+        working-directory: dist
+        run: |
+          cosign sign-blob --yes \
+            --output-signature checksums.txt.sig \
+            --output-certificate checksums.txt.pem \
+            --bundle checksums.txt.sigstore.json \
+            checksums.txt
+
+      # SLSA build provenance per artifact, stored in GitHub's attestation store
+      # (adds no release assets): `gh attestation verify <file> -R tobert/kaibo`
+      # is the one-command per-file verification path.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/kaibo-*.tar.gz
+            dist/kaibo-*.zip
+            dist/kaibo-*-sbom.spdx.json
+            dist/checksums.txt
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,10 @@ even for a one-line doc fix.
   `v*` tag. Before tagging: confirm the `kaish-kernel` pin is current (next bullet),
   re-run `docs/sandbox-probes.md` and stamp its "Last run" line, and verify
   `cargo tree -i aws-lc-rs` is empty and the musl binary is `not a dynamic executable`.
+  After the release publishes: run the README "Verify a download" commands against a
+  fresh asset (`gh attestation verify`, `cosign verify-blob` with the new tag's
+  identity) — the tag-gated publish job signs releases, and signing an operator can't
+  verify is theater, so prove it the way a user would.
 - **kaish pin.** Currently `kaish-kernel = "0.12.0"`. The `0.11.0 → 0.12.0` bump was
   again API-compatible — **zero** call-site changes, `cargo build`/`clippy`/`cargo tree -i
   aws-lc-rs` all clean. The changelog's **BREAKING (embedders)** entries all land on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,16 @@ the git log. Each later release appends a new section at the top.
 
 ### Security
 
+- **Releases are born signed, and you can check.** Every release now carries three
+  independently verifiable trust artifacts, produced in public CI with no maintainer
+  key to steal: a **cosign keyless signature** over an aggregated `checksums.txt`
+  (verify it once and it covers every file it lists — the signing identity is the
+  release workflow at that exact tag, witnessed by the Sigstore transparency log),
+  **SLSA build provenance** per artifact (`gh attestation verify <file> -R
+  tobert/kaibo`, one command), and an **SPDX SBOM** cataloging the exact locked
+  dependency tree the binaries were built from. The README's "Verify a download"
+  section has the copy-paste invocations, including the identity flags keyless
+  verification requires.
 - **Read-only is structural, not best-effort.** kaibo compiles in only kaish's
   `localfs` axis — `subprocess` / `git` / `host` / `os-integration` are off, so
   `exec` / `spawn` / `git` / `ps` don't exist in the binary — and mounts the project

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "解剖 — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ every file it lists. Grab `checksums.txt`, `checksums.txt.sig`, and
 cosign verify-blob \
   --certificate checksums.txt.pem \
   --signature checksums.txt.sig \
-  --certificate-identity "https://github.com/tobert/kaibo/.github/workflows/release.yml@refs/tags/v0.2.0" \
+  --certificate-identity "https://github.com/tobert/kaibo/.github/workflows/release.yml@refs/tags/vX.Y.Z" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   checksums.txt
 sha256sum -c --ignore-missing checksums.txt

--- a/README.md
+++ b/README.md
@@ -97,6 +97,41 @@ install -m 0755 kaibo ~/.local/bin/    # anywhere on your PATH
 Prefer building from source? `git clone https://github.com/tobert/kaibo` and
 `cargo install --path kaibo` with a Rust toolchain ≥ 1.85 produces the same binary.
 
+### Verify a download
+
+Every release is born signed in public CI: the signing identity *is* the release
+workflow at that tag, witnessed by the Sigstore transparency log — no maintainer
+key to steal or trust. Two independent checks; either one is sufficient.
+
+With the [`gh` CLI](https://cli.github.com/), SLSA build provenance is one command
+against any file from the release:
+
+```sh
+gh attestation verify kaibo-v0.2.0-x86_64-unknown-linux-musl.tar.gz -R tobert/kaibo
+```
+
+With [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) (no
+GitHub tooling needed), verify the signed checksum manifest once and it covers
+every file it lists. Grab `checksums.txt`, `checksums.txt.sig`, and
+`checksums.txt.pem` from the release, substituting the tag you downloaded:
+
+```sh
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity "https://github.com/tobert/kaibo/.github/workflows/release.yml@refs/tags/v0.2.0" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
+sha256sum -c --ignore-missing checksums.txt
+```
+
+(cosign ≥ 3 can take the release's `checksums.txt.sigstore.json` instead of the
+`.pem`/`.sig` pair — pass `--bundle checksums.txt.sigstore.json` with the same two
+identity flags; the bundle is self-contained, so that verify works offline.)
+
+Each release also carries an SPDX SBOM (`kaibo-<tag>-sbom.spdx.json`) cataloging
+the exact locked dependency tree the binaries were built from.
+
 Then register it with your agent. kaibo is a standard stdio MCP server, so any
 MCP-capable client works — Claude Code, Codex CLI, Cline, OpenCode, whatever you
 run. The stanza goes in your client's MCP config; in Claude Code that's `.mcp.json`

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -231,9 +231,19 @@ sandbox) — with a companion **`/reconfigure`** host-agent prompt to tame the d
 devcontainer `mcp add` config friction (kaibo advises via `kaibo://config`, the host agent
 edits — kaibo can't write configs or run docker). **Going wide is gated on install ease**
 (engineering PRs and even tags land first — `v0.2.0-rc.1` already proved the tag→release
-leg). Sequenced PRs (1 plan doc, 2 harden matrix — both realized 2026-07-05 → **next: 3
-signing/provenance/SBOM** → 4 ghcr image + container UX → 5 channels, gated on demand) in
-the doc; delete this entry when the pipeline ships.
+leg). Sequenced PRs (1 plan doc, 2 harden matrix — realized 2026-07-05; 3 signing/
+provenance/SBOM — realized 2026-07-13 → **next: 4 ghcr image + container UX** → 5
+channels, gated on demand) in the doc; delete this entry when the pipeline ships.
+
+### `cargo-auditable` — per-binary SBOMs
+The release SBOM is generated from `Cargo.lock` (one SPDX document covering all
+targets — a bare Rust binary carries no dependency metadata for syft to read).
+Building with `cargo auditable` would embed the dep tree in each binary, letting
+syft/`cargo audit` catalog *the artifact itself* rather than trusting the lockfile
+rode along honestly. Deliberately deferred from the signing PR (2026-07-13, w/ Amy):
+it changes the build invocation on all five legs (including through `cargo zigbuild`
+— compatibility unverified) and deserves its own validation dispatches. Do it when
+the audit story matters more than the extra moving part.
 
 ### `KaishWorker::read_file` is unbounded — stat-then-read growth race
 `sandbox.rs` `Job::Read` slurps the whole file through the VFS with no size cap.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -52,7 +52,27 @@ a `cargo tree` TLS-invariant tripwire) and **`v0.2.0-rc.1`, the first-ever relea
 (#63 + tag): the publish job ran for the first time, produced a correctly-**prerelease**
 GitHub release with all 10 assets, and the end-to-end user path verified — download,
 checksum OK, fully static, binary reports `kaibo 0.2.0-rc.1`. The rc exists to prove the
-tag→release leg *before* PR 3, so the real v0.2.0 is born signed. **Next: PR 3.**
+tag→release leg *before* PR 3, so the real v0.2.0 is born signed.
+
+**PR 3 realized — 2026-07-13.** Signing/provenance/SBOM live entirely in the tag-gated
+publish job, so a `workflow_dispatch` smoke run never mints an OIDC identity (build legs
+keep `contents: read`; the publish job adds `id-token: write` + `attestations: write`).
+The layout, decided with Amy: **one signed aggregate `checksums.txt`** (cosign keyless —
+verify once, `sha256sum -c` covers any file it lists; ships both signature shapes,
+`.sig`/`.pem` for cosign v2+v3 and a self-contained `.sigstore.json` bundle for an
+offline v3 `verify-blob --bundle`; the per-artifact `.sha256` sidecars stay for the
+README's download one-liner),
+**per-artifact SLSA provenance** via `actions/attest-build-provenance` (stored in
+GitHub's attestation store — `gh attestation verify <file> -R tobert/kaibo`, zero extra
+assets), and **one SPDX SBOM from `Cargo.lock`** (a bare Rust binary carries nothing for
+syft to read; `cargo-auditable` per-binary SBOMs are a tracked follow-up in
+`docs/issues.md`). README gained a "Verify a download" section with the exact
+invocations — including the identity flags keyless verification requires and
+`--ignore-missing` so a single-file download checks clean. New pins
+(`cosign-installer`, `attest-build-provenance`, `sbom-action`) digest-verified through
+two independent paths. Validation: an rc tag exercising the signing path end-to-end,
+verified with the README's own commands. **Next: PR 4 (ghcr image), and the real
+v0.2.0 — born signed.**
 
 This doc is the *pipeline* side only. The operator-side checklist for actually cutting
 a release (CHANGELOG retitle, kaish-kernel pin check, `docs/sandbox-probes.md` re-run,
@@ -216,7 +236,8 @@ No framework, no ABI change — sharpen what's already there.
 - Cross-family review (release surface — a real look).
 
 ### PR 3 — keyless signing + SLSA provenance + SBOM (GitHub-native)
-The transparency payoff; all free, no middleman.
+The transparency payoff; all free, no middleman. **Realized 2026-07-13 — details and
+the decided layout in "Where we are now" above.**
 - `cosign` **keyless** signing (`cosign-installer`) over the archives + checksums.
 - **SLSA build provenance** via `actions/attest-build-provenance`; add `id-token: write`
   + `attestations: write`.


### PR DESCRIPTION
## Why

Plan PR 3 of [`docs/releases.md`](docs/releases.md): the transparency payoff. v0.2.0-rc.1 proved the tag→release leg precisely so the real v0.2.0 could be **born signed** — this PR is that signing layer, all GitHub-native, no middleman, no long-lived key anywhere.

## What

Everything lands in the **tag-gated publish job** — a `workflow_dispatch` smoke run never mints an OIDC identity or a signature. Build legs keep `contents: read`; the publish job adds `id-token: write` + `attestations: write`.

Layout (decided with Amy 2026-07-13):

- **One signed aggregate `checksums.txt`** (cosign keyless): verify the manifest once and `sha256sum -c` covers any file it lists. Ships **both signature shapes** — `.sig`/`.pem` (works on cosign v2 and v3) and a self-contained `.sigstore.json` protobuf bundle (offline `verify-blob --bundle` on v3). The per-artifact `.sha256` sidecars stay; the README download one-liner uses them.
- **Per-artifact SLSA build provenance** via `actions/attest-build-provenance`, stored in GitHub's attestation store — `gh attestation verify <file> -R tobert/kaibo` is the one-command path, zero extra release assets.
- **One SPDX SBOM from `Cargo.lock`** — a bare Rust binary carries no dependency metadata for syft to read; `cargo-auditable` per-binary SBOMs are a tracked follow-up in `docs/issues.md` (touches all five build legs incl. zigbuild, deserves its own validation).
- **README "Verify a download"** with the exact invocations — including the identity flags keyless verification *requires* (Gemini's plan-review finding: a bare `verify-blob` cannot work for keyless; signing nobody can verify is theater) and `--ignore-missing` so a single-file download checks clean.
- AGENTS.md cutting-a-release checklist gains the post-publish step: run the README's own verification commands against a fresh asset.

## Diligence

- New action pins (`cosign-installer` v4.1.2, `attest-build-provenance` v4.1.1, `sbom-action` v0.24.0) digest-verified through **two independent paths** (GH API + `git ls-remote` peeled tags); input names verified against each `action.yml` at the pinned SHA.
- cosign-installer defaults to **cosign v3.0.6**, which changed sign-blob defaults to the new bundle format — confirmed against `sign_blob.go` at that tag that `--output-signature`/`--output-certificate` still write files alongside `--bundle`, so the legacy pair and the bundle coexist in one invocation.
- `actionlint` clean, YAML parses.

## Validation plan

The signing steps only run on a tag, so a branch dispatch can't exercise them. Plan: tag an rc (e.g. `v0.2.0-rc.2`) to fire the signing path end-to-end, then verify the assets **with the README's own commands**, the way a user would — before the real v0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)