### PR TITLE
fix(release): bundle-only blob signature — cosign v3 ignores the legacy pair (rc.2 kink)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,17 +202,14 @@ jobs:
       # the Rekor transparency log — no long-lived key anywhere. Verification
       # REQUIRES the identity flags (a bare verify-blob cannot work for keyless);
       # the exact invocation lives in the README's "Verify a download" section.
-      # Both signature shapes ship: .sig/.pem verifies on cosign v2 and v3, and
-      # the .sigstore.json protobuf bundle is self-contained (cert + signature +
-      # Rekor entry) for a v3 `verify-blob --bundle` that works offline.
+      # One signature shape: the .sigstore.json protobuf bundle, self-contained
+      # (cert + signature + Rekor entry), so `verify-blob --bundle` works offline.
+      # cosign v3 IGNORES the legacy --output-signature/--output-certificate pair
+      # in bundle mode (v0.2.0-rc.2 proved it: warned, wrote nothing) — an operator
+      # without cosign verifies through `gh attestation verify` instead.
       - name: Sign checksums.txt (cosign keyless)
         working-directory: dist
-        run: |
-          cosign sign-blob --yes \
-            --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem \
-            --bundle checksums.txt.sigstore.json \
-            checksums.txt
+        run: cosign sign-blob --yes --bundle checksums.txt.sigstore.json checksums.txt
 
       # SLSA build provenance per artifact, stored in GitHub's attestation store
       # (adds no release assets): `gh attestation verify <file> -R tobert/kaibo`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "解剖 — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -110,24 +110,22 @@ against any file from the release:
 gh attestation verify kaibo-v0.2.0-x86_64-unknown-linux-musl.tar.gz -R tobert/kaibo
 ```
 
-With [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) (no
-GitHub tooling needed), verify the signed checksum manifest once and it covers
-every file it lists. Grab `checksums.txt`, `checksums.txt.sig`, and
-`checksums.txt.pem` from the release, substituting the tag you downloaded:
+With [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) ≥ 3
+(no GitHub tooling needed), verify the signed checksum manifest once and it
+covers every file it lists. Grab `checksums.txt` and `checksums.txt.sigstore.json`
+from the release, substituting the tag you downloaded in the identity:
 
 ```sh
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity "https://github.com/tobert/kaibo/.github/workflows/release.yml@refs/tags/vX.Y.Z" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   checksums.txt
 sha256sum -c --ignore-missing checksums.txt
 ```
 
-(cosign ≥ 3 can take the release's `checksums.txt.sigstore.json` instead of the
-`.pem`/`.sig` pair — pass `--bundle checksums.txt.sigstore.json` with the same two
-identity flags; the bundle is self-contained, so that verify works offline.)
+The bundle is self-contained — certificate, signature, and transparency-log
+entry in one file — so that verify works offline.
 
 Each release also carries an SPDX SBOM (`kaibo-<tag>-sbom.spdx.json`) cataloging
 the exact locked dependency tree the binaries were built from.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -58,10 +58,9 @@ tag→release leg *before* PR 3, so the real v0.2.0 is born signed.
 publish job, so a `workflow_dispatch` smoke run never mints an OIDC identity (build legs
 keep `contents: read`; the publish job adds `id-token: write` + `attestations: write`).
 The layout, decided with Amy: **one signed aggregate `checksums.txt`** (cosign keyless —
-verify once, `sha256sum -c` covers any file it lists; ships both signature shapes,
-`.sig`/`.pem` for cosign v2+v3 and a self-contained `.sigstore.json` bundle for an
-offline v3 `verify-blob --bundle`; the per-artifact `.sha256` sidecars stay for the
-README's download one-liner),
+verify once, `sha256sum -c` covers any file it lists; one signature shape, the
+self-contained `.sigstore.json` bundle, which verifies offline with cosign ≥ 3; the
+per-artifact `.sha256` sidecars stay for the README's download one-liner),
 **per-artifact SLSA provenance** via `actions/attest-build-provenance` (stored in
 GitHub's attestation store — `gh attestation verify <file> -R tobert/kaibo`, zero extra
 assets), and **one SPDX SBOM from `Cargo.lock`** (a bare Rust binary carries nothing for
@@ -70,9 +69,16 @@ syft to read; `cargo-auditable` per-binary SBOMs are a tracked follow-up in
 invocations — including the identity flags keyless verification requires and
 `--ignore-missing` so a single-file download checks clean. New pins
 (`cosign-installer`, `attest-build-provenance`, `sbom-action`) digest-verified through
-two independent paths. Validation: an rc tag exercising the signing path end-to-end,
-verified with the README's own commands. **Next: PR 4 (ghcr image), and the real
-v0.2.0 — born signed.**
+two independent paths. Validated live by **`v0.2.0-rc.2`** (fired the whole path first
+try — SBOM → checksums → sign → attest → release, publish job 14s) with all three
+README verification commands proven against its real assets: `gh attestation verify`
+exit 0, `cosign verify-blob --bundle` Verified OK under the tag identity,
+`sha256sum -c --ignore-missing` OK. The rc earned its keep by catching the one kink:
+cosign v3 *ignores* the legacy `--output-signature`/`--output-certificate` flags in
+bundle mode (warned, wrote nothing — the planned `.sig`/`.pem` pair never shipped), so
+the bundle became the only signature shape rather than pinning cosign back to v2 for a
+format it deprecates; `v0.2.0-rc.3` validates the bundle-only invocation. **Next: PR 4
+(ghcr image), and the real v0.2.0 — born signed.**
 
 This doc is the *pipeline* side only. The operator-side checklist for actually cutting
 a release (CHANGELOG retitle, kaish-kernel pin check, `docs/sandbox-probes.md` re-run,


### PR DESCRIPTION
## What rc.2 taught us

`v0.2.0-rc.2` fired the full signing path green first try, and **everything that shipped verifies**: `gh attestation verify` exit 0, `cosign verify-blob --bundle` Verified OK under the tag identity, `sha256sum -c --ignore-missing` OK — all run against the real assets, the way a user would.

The one kink: cosign v3 in new-bundle-format mode **warns that `--output-signature`/`--output-certificate` are deprecated and ignores them** — the planned `.sig`/`.pem` pair never shipped (the `sign_blob.go` write path we source-checked does write them; a CLI-layer guard nils the flags first in bundle mode — the [run log](https://github.com/tobert/kaibo/actions/runs/29284271510) has the receipts).

## The fix

Embrace bundle-only rather than pin cosign back to v2 for a shape it deprecates:

- Sign step emits just `checksums.txt.sigstore.json` — self-contained (cert + signature + Rekor entry), verifies **offline** with cosign ≥ 3.
- README's cosign section documents the bundle invocation as *the* command — the exact flow already proven against rc.2. Operators without cosign keep `gh attestation verify` as the no-cosign path.
- `docs/releases.md` records the rc.2 validation + kink story.
- Version → `0.2.0-rc.3`, which validates the bundle-only invocation end-to-end.

actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)