### PR TITLE
feat(release): ghcr container image — multiarch distroless, born signed, built to be COPY'd (plan PR 4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@
 # Releases are born signed: the publish job cosign-signs an aggregated
 # checksums.txt (keyless — the identity IS this workflow at this tag), attaches
 # SLSA build provenance per artifact (`gh attestation verify`), and ships an SPDX
-# SBOM from Cargo.lock. Verification commands live in the README.
+# SBOM from Cargo.lock. The image job ships the same binaries as a multiarch
+# ghcr.io/tobert/kaibo image (distroless, non-root), signed and attested by the
+# same machinery. Verification commands live in the README.
 name: release
 
 on:
@@ -231,3 +233,100 @@ jobs:
           # A semver prerelease tag (v0.2.0-rc.1) is a GitHub prerelease — the
           # Releases page must not present an rc as the latest stable.
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # ghcr multiarch image (amd64 + arm64): the fully-static musl binaries dropped
+  # into distroless/static:nonroot — see the Dockerfile for the image contract
+  # (COPY source for devcontainers, /work mount, stdio ENTRYPOINT). The job runs
+  # its build + smoke on a workflow_dispatch too, so a branch dispatch validates
+  # the Dockerfile and manifest assembly; pushing, signing, and attesting stay
+  # tag-gated like the release job, so no dispatch ever publishes or signs.
+  image:
+    name: publish ghcr image
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the image to ghcr (tag runs only)
+      id-token: write # mint the OIDC identity cosign + provenance sign with
+      attestations: write # store the image provenance attestation
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: kaibo-*-unknown-linux-musl
+          path: dist
+          merge-multiple: true
+
+      # The Dockerfile COPYs binaries/<TARGETARCH>/kaibo, so unpack each musl
+      # archive to the docker arch name its target maps to.
+      - name: Stage per-arch binaries
+        run: |
+          stage() { # <rust-target> <docker-arch>
+            mkdir -p "binaries/$2"
+            tar xzf dist/kaibo-*-"$1".tar.gz
+            mv kaibo-*-"$1"/kaibo "binaries/$2/kaibo"
+          }
+          stage x86_64-unknown-linux-musl amd64
+          stage aarch64-unknown-linux-musl arm64
+
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Linking isn't running holds for images too: boot the amd64 image and make
+      # the binary speak before anything is pushed. (The arm64 binary already
+      # smoke-ran natively in its build leg.)
+      - name: Smoke (run the image)
+        run: |
+          docker buildx build --load --platform linux/amd64 -t kaibo-smoke .
+          docker run --rm kaibo-smoke --version
+
+      - name: Login to ghcr
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tag policy: the full semver always (0.2.0-rc.4, 0.2.0); major.minor and
+      # `latest` only for a stable release (metadata-action skips prereleases for
+      # both — an rc must never become somebody's `latest`). The sha tag exists so
+      # a dispatch run has a well-formed (never-pushed) reference.
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/tobert/kaibo
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build (and push on a tag)
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Same keyless machinery as the blob signing above, aimed at the manifest
+      # digest — the signature covers every tag pointing at it.
+      - name: Sign image (cosign keyless)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: cosign sign --yes ghcr.io/tobert/kaibo@${{ steps.build.outputs.digest }}
+
+      - name: Attest image provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/tobert/kaibo
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,9 +290,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Tag policy: the full semver always (0.2.0-rc.4, 0.2.0); major.minor and
-      # `latest` only for a stable release (metadata-action skips prereleases for
-      # both — an rc must never become somebody's `latest`). The sha tag exists so
-      # a dispatch run has a well-formed (never-pushed) reference.
+      # `latest` only for a stable release. Verified in metadata-action's source at
+      # the pinned SHA (meta.ts procSemver): a prerelease DEGRADES every semver
+      # pattern to {{version}} and holds `latest` false — so an rc never becomes
+      # somebody's `latest` or `0.2`. The sha tag exists so a dispatch run has a
+      # well-formed (never-pushed) reference.
       - name: Image metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,16 @@ the git log. Each later release appends a new section at the top.
   submit acknowledgement. (Counts are exact on the normal path; the rare turn-cap and
   image-resume paths undercount, since the underlying loop yields no usage on those
   exits — noted in `docs/issues.md`.)
+- **A container image, built to be COPY'd.** Every release now ships
+  `ghcr.io/tobert/kaibo` — multiarch (amd64/arm64), the fully-static binary in a
+  distroless, shell-less, **non-root** base, signed and attested by the same
+  machinery as the archives. Because the binary links against nothing, the image
+  doubles as a one-line install for devcontainers and custom images
+  (`COPY --from=ghcr.io/tobert/kaibo:latest /usr/local/bin/kaibo /usr/local/bin/kaibo`),
+  and running it directly is one documented mount: your project read-only at
+  `/work`. The README's container section has the docker/podman recipes — including
+  the two footguns (`-i` is load-bearing for a stdio server; UID mapping for the
+  read-only mount).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "解剖 — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# kaibo container image — the fully-static musl binary in a distroless, shell-less base.
+#
+# Because the binary links against nothing (see AGENTS.md "Build & release"), this
+# image doubles as a COPY source: pull kaibo into any other image — a devcontainer
+# especially — with one line, no libc or package concerns, FROM scratch to Ubuntu:
+#
+#   COPY --from=ghcr.io/tobert/kaibo:latest /usr/local/bin/kaibo /usr/local/bin/kaibo
+#
+# Built multiarch (amd64 + arm64) by .github/workflows/release.yml from the per-arch
+# musl release binaries staged under binaries/<arch>/ — pure COPY, no RUN, so neither
+# platform needs emulation to build.
+#
+# distroless/static:nonroot: no shell, no package manager, runs as nonroot (uid
+# 65532), and ships CA certificates at /etc/ssl/certs — which rustls-native-certs
+# finds for kaibo's outbound provider calls. Pinned by manifest-list digest, same
+# discipline as the workflow's action pins.
+FROM gcr.io/distroless/static:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478
+
+# Links the ghcr package to the repo (README, visibility inheritance) even for a
+# manual build; the workflow's metadata-action adds the full OCI label set on top.
+LABEL org.opencontainers.image.source="https://github.com/tobert/kaibo" \
+      org.opencontainers.image.description="grounded, cited, read-only codebase consultation from a model outside your agent's family — stdio MCP server" \
+      org.opencontainers.image.licenses="MIT"
+
+ARG TARGETARCH
+COPY binaries/${TARGETARCH}/kaibo /usr/local/bin/kaibo
+
+# /work is the canonical project mount: kaibo scopes its read-only access to the
+# cwd when --root isn't given, so `-v "$PWD:/work:ro"` is the whole setup. The
+# container runs kaibo as an MCP server over stdio — `-i` is load-bearing (without
+# it stdin is closed immediately and the server exits at once, silently).
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/kaibo"]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,50 @@ entry in one file — so that verify works offline.
 Each release also carries an SPDX SBOM (`kaibo-<tag>-sbom.spdx.json`) cataloging
 the exact locked dependency tree the binaries were built from.
 
+### Container image (ghcr)
+
+The same release ships as a multiarch (amd64/arm64) container image,
+[`ghcr.io/tobert/kaibo`](https://github.com/tobert/kaibo/pkgs/container/kaibo) — the fully-static binary
+in a distroless, shell-less, non-root base.
+
+Because the binary links against nothing, the image doubles as a **COPY
+source** — the easiest way to put kaibo into a devcontainer (or any image),
+with zero libc or package-manager concerns:
+
+```dockerfile
+COPY --from=ghcr.io/tobert/kaibo:latest /usr/local/bin/kaibo /usr/local/bin/kaibo
+```
+
+That's the whole install: inside a devcontainer your workspace mount is already
+declared, so kaibo registers as a plain local MCP server from there.
+
+To run the image itself as the MCP server, mount your project read-only at
+`/work` (the image's working directory — kaibo scopes its read access to it)
+and keep stdin open:
+
+```sh
+claude mcp add kaibo -- docker run --rm -i \
+  -u "$(id -u):$(id -g)" \
+  -v "$PWD:/work:ro" \
+  -e DEEPSEEK_API_KEY \
+  ghcr.io/tobert/kaibo:latest
+```
+
+- **`-i` is load-bearing.** kaibo is a stdio MCP server: without `-i`, stdin
+  closes immediately and the container exits 0 in silence — and distroless has
+  no shell to debug into.
+- `-u` runs the container as you so the mount's file permissions line up;
+  podman users want `--userns=keep-id` in its place.
+- Pass provider keys by name (`-e DEEPSEEK_API_KEY`) — the value rides your
+  shell environment, never your MCP config.
+- The `:ro` mount is an OS-enforced belt under kaibo's own read-only sandbox:
+  kaibo never writes either way, this just makes the kernel agree.
+
+The image is signed and attested by the same machinery as the archives — verify
+with `gh attestation verify oci://ghcr.io/tobert/kaibo:<tag> -R tobert/kaibo`,
+or `cosign verify ghcr.io/tobert/kaibo:<tag>` with the same two identity flags
+shown above.
+
 Then register it with your agent. kaibo is a standard stdio MCP server, so any
 MCP-capable client works — Claude Code, Codex CLI, Cline, OpenCode, whatever you
 run. The stanza goes in your client's MCP config; in Claude Code that's `.mcp.json`

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ claude mcp add kaibo -- docker run --rm -i \
 - The `:ro` mount is an OS-enforced belt under kaibo's own read-only sandbox:
   kaibo never writes either way, this just makes the kernel agree.
 
+The package is public — pulling (and `COPY --from`) needs no registry login.
 The image is signed and attested by the same machinery as the archives — verify
 with `gh attestation verify oci://ghcr.io/tobert/kaibo:<tag> -R tobert/kaibo`,
 or `cosign verify ghcr.io/tobert/kaibo:<tag>` with the same two identity flags

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -232,8 +232,19 @@ devcontainer `mcp add` config friction (kaibo advises via `kaibo://config`, the 
 edits — kaibo can't write configs or run docker). **Going wide is gated on install ease**
 (engineering PRs and even tags land first — `v0.2.0-rc.1` already proved the tag→release
 leg). Sequenced PRs (1 plan doc, 2 harden matrix — realized 2026-07-05; 3 signing/
-provenance/SBOM — realized 2026-07-13 → **next: 4 ghcr image + container UX** → 5
-channels, gated on demand) in the doc; delete this entry when the pipeline ships.
+provenance/SBOM and 4 ghcr image — realized 2026-07-13 → **next: 5 channels, gated on
+demand**; the `/reconfigure` container-UX workstream rides alongside) in the doc;
+delete this entry when the pipeline ships.
+
+### Graceful no-stdin error for the container case
+`docker run` without `-i` hands kaibo a closed stdin: the MCP server sees immediate
+EOF and exits 0 in silence — the hardest failure to debug in a distroless image with
+no shell (the entrypoint IS the binary, so this is a kaibo code change, deferred out
+of pipeline PR 4; the README documents the footgun loudly meanwhile). Fix shape: when
+stdin reaches EOF before *any* MCP traffic arrived, say so on stderr ("stdin closed
+before the MCP handshake — in a container, did you forget `-i`?") and exit non-zero;
+after real traffic, EOF stays a normal shutdown. Stderr is the right channel (a host
+that captures it shows the operator; nothing breaks for hosts that don't).
 
 ### `cargo-auditable` — per-binary SBOMs
 The release SBOM is generated from `Cargo.lock` (one SPDX document covering all

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -77,8 +77,30 @@ exit 0, `cosign verify-blob --bundle` Verified OK under the tag identity,
 cosign v3 *ignores* the legacy `--output-signature`/`--output-certificate` flags in
 bundle mode (warned, wrote nothing — the planned `.sig`/`.pem` pair never shipped), so
 the bundle became the only signature shape rather than pinning cosign back to v2 for a
-format it deprecates; `v0.2.0-rc.3` validates the bundle-only invocation. **Next: PR 4
-(ghcr image), and the real v0.2.0 — born signed.**
+format it deprecates; `v0.2.0-rc.3` validated the bundle-only invocation end-to-end
+(all verification commands green against real assets, negative tests refused loudly,
+SBOM real — 370 packages, ring present, aws-lc absent: the TLS invariant is now
+visible in every release).
+
+**PR 4 realized — 2026-07-13, same day** (pulled forward by Amy). The ghcr image ships
+from a new tag-gated-publish `image` job: multiarch amd64+arm64 assembled from the
+per-arch musl release binaries (pure `COPY`, no emulation), `FROM
+gcr.io/distroless/static:nonroot` **pinned by manifest digest**, non-root, CA certs
+present for the outbound provider calls. The image is **born signed** — `cosign sign`
+on the manifest digest plus `attest-build-provenance` pushed to the registry, the PR-3
+machinery aimed at OCI. The Dockerfile is written as a **COPY-source contract**
+(`COPY --from=ghcr.io/tobert/kaibo:latest /usr/local/bin/kaibo …` — the fully-static
+binary is what makes this a one-liner into any devcontainer or image), `WORKDIR /work`
+as the canonical read-only project mount. The job build+smokes on a branch dispatch
+(boots the amd64 image, `--version`) with push/sign/attest tag-gated, so dispatch never
+publishes. README gained the container section: the COPY recipe, the
+`docker run --rm -i -u … -v "$PWD:/work:ro"` MCP registration, podman
+`--userns=keep-id`, and the `-i`-is-load-bearing warning. One-time operator step after
+the first push: flip the ghcr package visibility to **public** (packages created by a
+workflow default private). `v0.2.0-rc.4` validates the image path end-to-end, including
+a live consult *through the pulled image* (which exercises the distroless TLS-cert
+question for real). **Next: PR 5 (channels, gated on demand), and the real v0.2.0 —
+born signed.**
 
 This doc is the *pipeline* side only. The operator-side checklist for actually cutting
 a release (CHANGELOG retitle, kaish-kernel pin check, `docs/sandbox-probes.md` re-run,
@@ -254,7 +276,10 @@ the decided layout in "Where we are now" above.**
 
 ### PR 4 — ghcr distroless image (multiarch, non-root) — a first-class distribution path
 Lands *after* signing so the image is **born signed** — we don't ship an unsigned primary
-artifact.
+artifact. **Realized 2026-07-13 — see "Where we are now"; the graceful no-stdin error
+moved to `docs/issues.md`** (it's a kaibo code change — the entrypoint *is* the binary in
+a shell-less image — not pipeline YAML; the README documents the `-i` footgun loudly in
+the meantime).
 - **Multiarch `amd64`+`arm64`** manifest `FROM gcr.io/distroless/static:nonroot`, copying
   the static musl binaries already built per-arch; `USER nonroot`. Push to
   `ghcr.io/tobert/kaibo` (+`latest`); `cosign` signs the image with the PR 3 machinery.


### PR DESCRIPTION
## Why

Plan PR 4 of [`docs/releases.md`](docs/releases.md), pulled forward: the ghcr image as a first-class distribution path, landing *after* signing so it's **born signed**. The headline design goal (Amy): the fully-static binary makes the image a **COPY source** — `COPY --from=ghcr.io/tobert/kaibo:latest /usr/local/bin/kaibo /usr/local/bin/kaibo` is a one-line kaibo install into any devcontainer or image, zero libc/package concerns.

## What

- **`Dockerfile`** — the image contract: `FROM gcr.io/distroless/static:nonroot` **pinned by manifest digest** (same discipline as action pins), `ARG TARGETARCH` COPY of the per-arch musl binary, `WORKDIR /work` as the canonical read-only project mount, exec-form stdio ENTRYPOINT, OCI source/description/license labels.
- **New `image` job** in release.yml: multiarch amd64+arm64 from the already-built musl artifacts (pure COPY — no QEMU), smoke-boots the amd64 image (`--version`) *before* any push, then tag-gated: ghcr login, metadata-action tags (full semver always; `major.minor` + `latest` only for stable — an rc never becomes someone's `latest`), push, `cosign sign` on the manifest digest, `attest-build-provenance` with `push-to-registry`. The job's build+smoke also runs on `workflow_dispatch`, so this branch's dispatch validates it; **no dispatch ever publishes or signs**.
- **README container section**: COPY recipe first, then the `docker run --rm -i -u … -v "$PWD:/work:ro"` MCP registration with the two documented footguns — `-i` is load-bearing for a stdio server (silent EOF-exit otherwise, and distroless has no shell to debug into), and UID mapping (`-u` / podman `--userns=keep-id`). Keys passed by name. Image verification via `gh attestation verify oci://…` or `cosign verify`.
- CHANGELOG (Added), releases.md PR-4 realization, issues.md: pipeline pointer advanced + a new **graceful no-stdin error** entry (it's a kaibo *code* change — in a shell-less image the entrypoint IS the binary — deferred out of pipeline YAML with a concrete fix shape).
- Version → **0.2.0-rc.4** (Amy: another rc validates the containers).

## Proven locally before CI

- podman build + run: `kaibo 0.2.0-rc.3`, uid 65532, `/work`, correct entrypoint.
- **COPY contract**: `COPY --from` into `ubuntu:24.04` → binary runs.
- **MCP flow**: `initialize` handshake through the container with `--userns=keep-id` + `:ro` mount answers correctly (honest "Setup needed" instructions with no key passed).

## Diligence

Four docker action pins digest-verified via two independent paths (GH API + `git ls-remote`); distroless digest fetched from gcr.io directly. actionlint clean. Branch `workflow_dispatch` validation in flight; rc.4 validates the publish path end-to-end after merge, including a live consult **through the pulled image** (the distroless TLS-cert proof).

**One-time operator step after the first push (Amy):** flip `ghcr.io/tobert/kaibo` package visibility to **public** (workflow-created packages default private) — anonymous `docker pull` and the COPY recipe need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)