### PR TITLE
feat(release): per-tag get+verify block on every release page

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,0 +1,46 @@
+<!--
+Rendered onto every release page by release.yml, prepended above GitHub's
+auto-generated notes. envsubst fills TAG (the git tag, v-prefixed) and VERSION
+(the same without the v — how the image is tagged). This is the one surface
+where every placeholder is concrete — the commands below carry the exact tag,
+ready to copy — so keep it that way: no angle-bracket stand-ins. HTML comments
+don't render on GitHub, so this block ships invisibly (envsubst reaches inside
+it, which is why it names the variables in prose).
+-->
+## Get it
+
+Grab your platform's archive below ([install + MCP registration](https://github.com/tobert/kaibo#installation)) — or take the [container image](https://github.com/tobert/kaibo/pkgs/container/kaibo):
+
+```sh
+docker pull ghcr.io/tobert/kaibo:${VERSION}
+```
+
+```dockerfile
+# one-line install into a devcontainer or any image — the binary is fully static
+COPY --from=ghcr.io/tobert/kaibo:${VERSION} /usr/local/bin/kaibo /usr/local/bin/kaibo
+```
+
+(Pull version tags like `${VERSION}` — the `sha256-*` tags on the package page are
+cosign signature/attestation artifacts riding alongside the image, not images.)
+
+## Verify it
+
+Every artifact carries SLSA build provenance — any downloaded file, one command:
+
+```sh
+gh attestation verify kaibo-${TAG}-x86_64-unknown-linux-musl.tar.gz -R tobert/kaibo
+gh attestation verify oci://ghcr.io/tobert/kaibo:${VERSION} -R tobert/kaibo
+```
+
+Or keyless-verify the signed checksum manifest with cosign ≥ 3 (covers every file it lists, works offline):
+
+```sh
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity "https://github.com/tobert/kaibo/.github/workflows/release.yml@refs/tags/${TAG}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
+sha256sum -c --ignore-missing checksums.txt
+```
+
+---

--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -25,7 +25,8 @@ cosign signature/attestation artifacts riding alongside the image, not images.)
 
 ## Verify it
 
-Every artifact carries SLSA build provenance — any downloaded file, one command:
+Run these from the folder holding your downloads. Every artifact carries SLSA
+build provenance — any downloaded file, one command:
 
 ```sh
 gh attestation verify kaibo-${TAG}-x86_64-unknown-linux-musl.tar.gz -R tobert/kaibo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,8 +303,9 @@ jobs:
       # `latest` only for a stable release. Verified in metadata-action's source at
       # the pinned SHA (meta.ts procSemver): a prerelease DEGRADES every semver
       # pattern to {{version}} and holds `latest` false — so an rc never becomes
-      # somebody's `latest` or `0.2`. The sha tag exists so a dispatch run has a
-      # well-formed (never-pushed) reference.
+      # somebody's `latest` or `0.2`. The sha tag gives a dispatch run a well-formed
+      # (never-pushed) reference; it's disabled on tag runs so a release publishes
+      # version tags only.
       - name: Image metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -313,24 +314,30 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=sha,enable=${{ github.ref_type != 'tag' }}
 
-      - name: Build (and push on a tag)
+      # Tag runs push BY DIGEST here and apply the version tags in the last step
+      # below, after signing. Order matters for the package page: GitHub's install
+      # box advertises the most recently published version, and cosign/provenance
+      # land as sha256-* tagged artifacts in the same package — publish the version
+      # tags last and "Latest" is always a pullable image, never a signature
+      # bundle. (v0.2.0-rc.4 shipped image→sign order and the package page's
+      # copy-paste box offered the signature tag; podman refused it, confusingly.)
+      - name: Build (and push by digest on a tag)
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=ghcr.io/tobert/kaibo,name-canonical=true,push-by-digest=true,push=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/v')
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # Same keyless machinery as the blob signing above, aimed at the manifest
-      # digest — the signature covers every tag pointing at it.
+      # digest — the signature covers every tag later pointed at it.
       - name: Sign image (cosign keyless)
         if: startsWith(github.ref, 'refs/tags/v')
         run: cosign sign --yes ghcr.io/tobert/kaibo@${{ steps.build.outputs.digest }}
@@ -342,3 +349,17 @@ jobs:
           subject-name: ghcr.io/tobert/kaibo
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+      # The finale, deliberately: point the version tags at the signed manifest
+      # list. imagetools create copies the existing list under each tag — no
+      # rebuild, no layer movement — and because this is the package's newest
+      # publish, the install box shows a real, pullable version.
+      - name: Publish version tags (last, so "Latest" is pullable)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          args=()
+          while IFS= read -r t; do [ -n "$t" ] && args+=(-t "$t"); done <<< "$TAGS"
+          docker buildx imagetools create "${args[@]}" "ghcr.io/tobert/kaibo@$DIGEST"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,9 +225,19 @@ jobs:
             dist/kaibo-*-sbom.spdx.json
             dist/checksums.txt
 
+      # The release page leads with per-tag get + verify commands rendered from
+      # .github/release-body.md — the one surface where every placeholder is
+      # concrete (the README must say vX.Y.Z; this page never should). softprops
+      # prepends the body above GitHub's auto-generated notes.
+      - name: Render release body
+        run: |
+          TAG="${GITHUB_REF_NAME}" VERSION="${GITHUB_REF_NAME#v}" \
+            envsubst '${TAG} ${VERSION}' < .github/release-body.md > release-body.md
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
+          body_path: release-body.md
           files: dist/*
           generate_release_notes: true
           # A semver prerelease tag (v0.2.0-rc.1) is a GitHub prerelease — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,13 @@ the git log. Each later release appends a new section at the top.
   `/work`. The README's container section has the docker/podman recipes — including
   the two footguns (`-i` is load-bearing for a stdio server; UID mapping for the
   read-only mount).
+- **Release pages you can copy-paste from.** Every release now opens with its own
+  get-and-verify block: the container pull and `COPY --from` lines, both
+  `gh attestation verify` one-liners, and the cosign bundle verification — all
+  carrying that release's exact tag, so nothing needs substituting (the README keeps
+  the generic `vX.Y.Z` form). It also points out that the `sha256-*` tags on the
+  package page are signature artifacts riding alongside the image, not something to
+  pull.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,7 +329,10 @@ the git log. Each later release appends a new section at the top.
   carrying that release's exact tag, so nothing needs substituting (the README keeps
   the generic `vX.Y.Z` form). It also points out that the `sha256-*` tags on the
   package page are signature artifacts riding alongside the image, not something to
-  pull.
+  pull — and the publish order now applies the version tags *last*, so the package
+  page's install box always advertises a pullable version tag instead of the
+  signature bundle that lands after the image (copy-pasting it got a confusing
+  mediaType refusal).
 
 ### Changed
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -107,7 +107,15 @@ rendered from `.github/release-body.md` (envsubst on TAG/VERSION, prepended abov
 auto-generated notes) — a package link, the pull + `COPY --from` lines, both
 attestation one-liners, and the cosign bundle verify, all carrying the exact tag so
 nothing needs substituting; it also warns that the package page's `sha256-*` tags are
-cosign signature artifacts, not pullable images (Amy hit exactly that). **Next: PR 5 (channels, gated on demand), and the real v0.2.0 —
+cosign signature artifacts, not pullable images (Amy hit exactly that — worse, the
+package page's own install box *offered* that tag, because GitHub advertises the most
+recently published version and the signature lands after the image). The structural
+fix rode the same slice: tag runs now push the image **by digest**, sign and attest
+the digest, then apply the version tags as the job's final act (`buildx imagetools
+create` — a tag-only copy of the signed manifest list), so the newest published
+version — the one the install box shows — is always pullable; the metadata `sha` tag
+is also disabled on tag runs (dispatch-only), keeping a release's tag set to versions
+only. Validated by the next tag. **Next: PR 5 (channels, gated on demand), and the real v0.2.0 —
 born signed.**
 
 This doc is the *pipeline* side only. The operator-side checklist for actually cutting

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -97,9 +97,17 @@ publishes. README gained the container section: the COPY recipe, the
 `docker run --rm -i -u … -v "$PWD:/work:ro"` MCP registration, podman
 `--userns=keep-id`, and the `-i`-is-load-bearing warning. One-time operator step after
 the first push: flip the ghcr package visibility to **public** (packages created by a
-workflow default private). `v0.2.0-rc.4` validates the image path end-to-end, including
-a live consult *through the pulled image* (which exercises the distroless TLS-cert
-question for real). **Next: PR 5 (channels, gated on demand), and the real v0.2.0 —
+workflow default private). `v0.2.0-rc.4` validated the image path end-to-end — first
+ghcr push/sign/attest all green, image pulled and multiarch-confirmed, cosign +
+`gh attestation verify oci://` both pass under the tag identity, and a **live consult
+through the pulled container** answered with its provenance footer (the distroless
+TLS-cert question, settled for real). Follow-on slice, prompted by Amy reading the
+package page: **the release page now leads with per-tag get + verify commands**
+rendered from `.github/release-body.md` (envsubst on TAG/VERSION, prepended above the
+auto-generated notes) — a package link, the pull + `COPY --from` lines, both
+attestation one-liners, and the cosign bundle verify, all carrying the exact tag so
+nothing needs substituting; it also warns that the package page's `sha256-*` tags are
+cosign signature artifacts, not pullable images (Amy hit exactly that). **Next: PR 5 (channels, gated on demand), and the real v0.2.0 —
 born signed.**
 
 This doc is the *pipeline* side only. The operator-side checklist for actually cutting


### PR DESCRIPTION
## Why

Two field reports from Amy reading the rc.4 release + package pages: the release page should link the ghcr package, and her first pull attempt grabbed a `sha256-*` tag — which is a **cosign signature artifact**, not an image (podman refused it with the sigstore-bundle mediaType error). Both are education-at-the-right-surface problems; the release page is the surface.

## What

- **`.github/release-body.md`** — a template the publish job renders with `envsubst` (TAG = `v0.2.0`, VERSION = `0.2.0`) and passes to softprops as `body_path`; softprops documents that a body **prepends** above `generate_release_notes`. The block: package link, `docker pull` + `COPY --from` lines, both `gh attestation verify` one-liners (file and `oci://`), the cosign bundle verify + `sha256sum -c` — **every command carrying that release's exact tag**, ready to copy (the README must keep `vX.Y.Z`; the release page never should). Plus the warning that `sha256-*` package tags are signatures riding alongside the image.
- CHANGELOG (Added), releases.md realization note.

## Validation

- Rendered locally with rc.4 values: zero unexpanded variables, actionlint clean.
- **The rendered block is live on [rc.4's release page](https://github.com/tobert/kaibo/releases/tag/v0.2.0-rc.4) right now** (via `gh release edit`) — real markdown on a real page, exactly what the workflow will produce. The workflow path itself gets exercised by the next tag (rc.5 or v0.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)