### PR TITLE
chore: bump to 0.2.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "解剖 — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
Version bump for the rc that validates #72 against the live registry: the publish-order reorder (version tags last → package-page install box always pullable) and the in-workflow release-body render. Glance-scale change — the build proves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)