### PR TITLE
feat(openrouter): default the built-in cast to Qwen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,9 +288,13 @@ the git log. Each later release appends a new section at the top.
   live: effort rides through the gateway and bills real reasoning tokens). Setting a
   slot's `effort = "none"` sends OpenRouter's structural disable
   (`{"reasoning": {"enabled": false}}`), so the opt-out doesn't depend on how the
-  gateway's effort ladder happens to read the string. The built-in cast pins
-  OpenRouter's `~author/family-latest` catalog aliases, so it stays current as new
-  models ship instead of rotting on a dated id. Every OpenRouter call carries an
+  gateway's effort ladder happens to read the string. The built-in cast defaults to
+  **Qwen** (explorer `qwen/qwen3.6-flash`, synth `qwen/qwen3.7-max`) — a family kaibo
+  can't reach directly, so the gateway earns its keep with a distinct lineage for a
+  genuine cross-family read, rather than re-serving the Gemini/Claude you already have
+  keyed. OpenRouter serves no `~qwen/*-latest` router alias, so the cast pins the
+  undated family ids — the most rot-resistant Qwen ids available (each tracks the
+  newest point-release until the next `.x`). Every OpenRouter call carries an
   explicit prompt-cache breakpoint, so Anthropic-family models behind the gateway
   bill their (large, resident) system preamble at cache-read rates instead of full
   input price every turn — providers whose caching is implicit simply ignore it.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ merges over them by name. The built-ins are:
 | `anthropic` *(default)* | `claude-haiku-4-5` | `claude-sonnet-4-6` |
 | `deepseek` | `deepseek-v4-flash` | `deepseek-v4-pro` |
 | `gemini` | `gemini-flash-lite-latest` | `gemini-3.5-flash` |
-| `openrouter` | `~google/gemini-flash-latest` | `~anthropic/claude-sonnet-latest` |
+| `openrouter` | `qwen/qwen3.6-flash` | `qwen/qwen3.7-max` |
 | `openai-local` | local Gemma (small) | local Gemma (large) |
 | `anthropic-batch` | — | `claude-opus-4-8` (batch lane) |
 | `gemini-batch` | — | `gemini-pro-latest` (batch lane) |

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -338,8 +338,9 @@ explorer = { backend = "deepseek", id = "deepseek-v4-flash", temperature = 0.0, 
 synth    = { backend = "claude", id = "claude-opus-4-8", effort = "max", max_tokens = 32768 }
 
 # --- The built-in `openrouter` backend already has a key source, so a custom cast on
-#     it needs only slots. `~author/family-latest` aliases (see the built-in `openrouter`
-#     cast) track the newest release instead of rotting; `effort = "xhigh"` here pushes
+#     it needs only slots. `~author/family-latest` aliases (OpenRouter serves them for
+#     anthropic/google/openai/x-ai/moonshotai — not every family) track the newest
+#     release instead of rotting; `effort = "xhigh"` here pushes
 #     the synth slot past [defaults] synth_effort ("high") into a rung only OpenRouter's
 #     unified reasoning param reaches. The same knob is the opt-out: reasoning is on by
 #     default for everything kaibo calls, and `effort = "none"` on a slot turns it off

--- a/docs/config.md
+++ b/docs/config.md
@@ -249,12 +249,20 @@ The `[defaults]` knobs themselves:
 
 Five backends and five same-named single-backend casts ship **in code** and
 reproduce kaibo's historical behavior exactly, so a **missing config file is not
-an error**. The `openrouter` built-in pins the drift-resistant `~author/family-latest`
-catalog aliases (explorer `~google/gemini-flash-latest`, synth
-`~anthropic/claude-sonnet-latest`) rather than a dated slug, and opts both slots into
-`vision` — the classifier defaults an `openrouter` slot to vision-off, since the
-gateway fronts blind and sighted models alike, but both default ids are
-multimodal-in per OpenRouter's own catalog. Two extra built-in casts ship for the
+an error**. The `openrouter` built-in defaults to **Qwen** — a family kaibo can't
+reach directly (DeepSeek, Gemini, and Anthropic each have their own keyed backend),
+so the gateway earns its keep with a distinct lineage for a genuine cross-family
+read. OpenRouter serves no `~qwen/*-latest` router alias (only anthropic / google /
+moonshotai / openai / x-ai get those), so the built-in pins the **undated** family
+ids — the most rot-resistant Qwen ids available, each tracking the newest
+point-release until the next `.x` bump. Explorer is the cheap multimodal
+`qwen/qwen3.6-flash`, with `vision` pinned on (the classifier defaults an
+`openrouter` slot to vision-off, since the gateway fronts blind and sighted models
+alike, but the flash is multimodal-in per OpenRouter's own catalog); synth is the
+flagship reasoner `qwen/qwen3.7-max`, which is **text-only**, so its slot takes no
+vision pin. (To keep vision on the synth, swap in the multimodal plus tier
+`qwen/qwen3.7-plus` and pin its vision on — a weaker reasoner, ~4.5× cheaper.) Two
+extra built-in casts ship for the
 offline batch lane —
 `gemini-batch` (synth Gemini Pro) and `anthropic-batch` (synth Claude Opus). Lane is
 a **per-slot** property, not a cast-level one: each carries a synth slot whose
@@ -297,7 +305,7 @@ today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submi
 | `anthropic` | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-4-6` | |
 | `deepseek` | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` | |
 | `gemini` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-3.5-flash` | |
-| `openrouter` | `openrouter/~google/gemini-flash-latest` | `openrouter/~anthropic/claude-sonnet-latest` | |
+| `openrouter` | `openrouter/qwen/qwen3.6-flash` | `openrouter/qwen/qwen3.7-max` | |
 | `openai-local` | `openai-local/Gemma-4-E4B-it-GGUF` | `openai-local/Gemma-4-26B-A4B-it-GGUF` | |
 | `gemini-batch` | — | `gemini/gemini-pro-latest` | `batch` |
 | `anthropic-batch` | — | `anthropic/claude-opus-4-8` | `batch` |

--- a/src/config.rs
+++ b/src/config.rs
@@ -1495,20 +1495,21 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
         let (explorer, synth) = default_models(kind);
         // OpenRouter's vision classifier defaults false (the gateway fronts blind and
         // sighted models alike — it's a property of the pinned model, not the wire), so
-        // the built-in cast opts its slots in: both default ids (`~google/gemini-flash-latest`,
-        // `~anthropic/claude-sonnet-latest`) advertise `image` in `architecture.input_modalities`
-        // in OpenRouter's catalog (verified 2026-07-03). Every other built-in kind is
-        // classified correctly by default, so it needs no pin.
-        let vision = matches!(kind, ProviderKind::OpenRouter).then_some(true);
-        let slot = |id| ModelSlot {
+        // a multimodal default id must opt its slot in. The Qwen default splits by role:
+        // explorer `qwen/qwen3.6-flash` advertises `image` in `architecture.input_modalities`
+        // (verified 2026-07-15) so it pins vision on, while synth `qwen/qwen3.7-max` is
+        // text-only — its slot leaves `vision: None`, letting the classifier's `false`
+        // stand. Every other built-in kind is classified correctly by default, needing no pin.
+        let slot = |id, vision| ModelSlot {
             vision,
             ..ModelSlot::bare(&name, id)
         };
+        let or = matches!(kind, ProviderKind::OpenRouter);
         // Both agent roles are seeded. A cast may omit one in config — absent means
         // the capability is absent, and nothing downstream errors on that.
         let slots = BTreeMap::from([
-            (ModelRole::Explorer, slot(explorer)),
-            (ModelRole::Synth, slot(synth)),
+            (ModelRole::Explorer, slot(explorer, or.then_some(true))),
+            (ModelRole::Synth, slot(synth, None)),
         ]);
         m.insert(name.clone(), Cast { name, slots });
     }
@@ -1567,12 +1568,18 @@ pub fn default_models(kind: ProviderKind) -> (&'static str, &'static str) {
         ProviderKind::Anthropic => ("claude-haiku-4-5", "claude-sonnet-4-6"),
         ProviderKind::DeepSeek => ("deepseek-v4-flash", "deepseek-v4-pro"),
         ProviderKind::Gemini => ("gemini-flash-lite-latest", "gemini-3.5-flash"),
-        // OpenRouter serves `~author/family-latest` aliases as real catalog entries
-        // that track the newest family member, so these don't rot as ids retire.
-        ProviderKind::OpenRouter => (
-            "~google/gemini-flash-latest",
-            "~anthropic/claude-sonnet-latest",
-        ),
+        // OpenRouter's job here is a family we *can't* reach directly (we key
+        // DeepSeek, Gemini, and Anthropic on their own backends), so the gateway
+        // default is Qwen — a distinct lineage for a genuine cross-family read.
+        // OpenRouter serves no `~qwen/*-latest` router alias (only anthropic /
+        // google / moonshotai / openai / x-ai get those), so we pin the *undated*
+        // family ids, which are the most rot-resistant Qwen ids available — each
+        // tracks the newest point-release until the next `.x` bump. Explorer is the
+        // cheap multimodal flash; synth is the flagship reasoner `qwen3.7-max`,
+        // which is text-only (hence the synth slot takes no vision pin below). If
+        // you'd rather keep vision on the synth, swap in the multimodal plus tier
+        // `qwen/qwen3.7-plus` (weaker reasoner, ~4.5× cheaper) and pin its vision on.
+        ProviderKind::OpenRouter => ("qwen/qwen3.6-flash", "qwen/qwen3.7-max"),
         ProviderKind::Openai => ("Gemma-4-E4B-it-GGUF", "Gemma-4-26B-A4B-it-GGUF"),
     }
 }
@@ -2813,16 +2820,16 @@ mod tests {
     }
 
     /// The OpenRouter built-in: a keyed backend (OPENROUTER_API_KEY, no configurable
-    /// base URL) and a cast pinning the drift-resistant `~author/family-latest` aliases,
-    /// with `vision` opted in on both slots (OpenRouter's classifier defaults false, but
-    /// both default models are multimodal — see the cast comment). Pins the whole
-    /// built-in so a bad default fails here, not mid-call.
+    /// base URL) and a Qwen cast — a family we can't reach directly. Explorer is the
+    /// multimodal flash (vision pinned on, since OpenRouter's classifier defaults false),
+    /// synth is the text-only flagship `qwen3.7-max` (no vision pin — classifier's false
+    /// stands). Pins the whole built-in so a bad default fails here, not mid-call.
     #[test]
     fn builtin_openrouter_cast_and_backend() {
         let cfg = Config::builtin();
         let (explorer, synth) = default_models(ProviderKind::OpenRouter);
-        assert_eq!(explorer, "~google/gemini-flash-latest");
-        assert_eq!(synth, "~anthropic/claude-sonnet-latest");
+        assert_eq!(explorer, "qwen/qwen3.6-flash");
+        assert_eq!(synth, "qwen/qwen3.7-max");
 
         let cast = cfg.resolve_cast("openrouter").unwrap();
         let e = cast.require_slot(ModelRole::Explorer).unwrap();
@@ -2832,8 +2839,8 @@ mod tests {
             ("openrouter", explorer)
         );
         assert_eq!((s.backend.as_str(), s.id.as_str()), ("openrouter", synth));
-        assert_eq!(e.vision, Some(true), "explorer model is multimodal-in");
-        assert_eq!(s.vision, Some(true), "synth model is multimodal-in");
+        assert_eq!(e.vision, Some(true), "explorer flash is multimodal-in");
+        assert_eq!(s.vision, None, "text-only synth leaves the classifier's false to stand");
 
         let b = cfg.resolve_backend("openrouter").unwrap();
         assert_eq!(b.kind, ProviderKind::OpenRouter);

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -130,8 +130,10 @@ fn is_vision_capable(kind: ProviderKind, _model: &str) -> bool {
         ProviderKind::Openai => false,
         // OpenRouter fronts every model — vision-capable and text-only alike — so the
         // capability is a property of the pinned *model*, not the gateway. Opt in per
-        // slot (`vision = true`), like the generic OpenAI kind; the built-in openrouter
-        // cast pins it on both its (multimodal) default models.
+        // slot (`vision = true`), like the generic OpenAI kind. The built-in openrouter
+        // cast splits by role: its explorer default (multimodal `qwen3.6-flash`) pins
+        // vision on, while its synth default (text-only `qwen3.7-max`) leaves the slot
+        // `None` and lets this false stand.
         ProviderKind::OpenRouter => false,
     }
 }

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -550,8 +550,10 @@ fn model_caps_classify_per_kind_and_honor_the_override() {
     assert!(!ModelCaps::resolve(ProviderKind::Openai, "Gemma-4-E4B-it-GGUF", None).vision);
     assert!(ModelCaps::resolve(ProviderKind::Openai, "Gemma-4-E4B-it-GGUF", Some(true)).vision);
     // OpenRouter is the same shape: the gateway fronts blind and sighted models
-    // alike, so vision is the pinned model's property — opt-in per slot (the
-    // built-in cast pins it on its multimodal defaults).
+    // alike, so vision is the pinned model's property — opt-in per slot. The
+    // built-in cast splits by role: its explorer default is multimodal and pins
+    // vision on; its text-only synth default leaves the slot None. The literal id
+    // below is arbitrary — the OpenRouter classifier ignores it, keying on the kind.
     assert!(
         !ModelCaps::resolve(
             ProviderKind::OpenRouter,


### PR DESCRIPTION
The built-in `openrouter` cast defaulted to OpenRouter's `~google/gemini-flash-latest` + `~anthropic/claude-sonnet-latest` aliases — but kaibo already reaches Gemini and Anthropic through their own keyed backends, so the gateway was re-serving families we can hit directly. OpenRouter's value is a family we *can't* reach directly, so default it to Qwen: a distinct lineage for a genuine cross-family read.

OpenRouter serves no `~qwen/*-latest` router alias (only anthropic / google / moonshotai / openai / x-ai get those), so pin the undated family ids — the most rot-resistant Qwen ids available, each tracking the newest point-release until the next `.x` bump. Explorer is the cheap multimodal `qwen/qwen3.6-flash` (vision pinned on, since the OpenRouter classifier defaults a slot vision-off); synth is the flagship reasoner `qwen/qwen3.7-max`, which is text-only — so its slot leaves vision=None and lets the classifier's false stand. The multimodal alternative (`qwen/qwen3.7-plus`) is noted in the code/docs for anyone who'd rather keep vision on the synth.

Verified against OpenRouter's live catalog (2026-07-15): both ids exist, qwen3.6-flash advertises image input and qwen3.7-max does not, and no `~qwen/*-latest` alias is served.