### PR TITLE
feat(cli): a CLI front door — kaibo consult / kaibo config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,20 @@ the git log. Each later release appends a new section at the top.
   `KAIBO_STATE_DB` / `[persistence] path`. If the store can't open, kaibo **fails to start
   loudly** naming that escape hatch rather than silently losing your sessions. The db is a
   convenience layer, safe to delete. See `docs/config.md`.
+- **A CLI front door: `kaibo consult` and `kaibo config`.** kaibo now answers without
+  an MCP client: `kaibo consult "question" [--cast … --attach … --session … --json]`
+  runs the same read-only investigation from the command line — for agents that shell
+  out instead of speaking MCP (pi, scripts, CI) and for humans. The answer (with the
+  usual provenance footer) goes to **stdout**; progress and logs go to **stderr**, so
+  piping stays clean; `--json` emits a structured `{answer, cast, models, usage}`
+  envelope for script callers. Exit codes tell the truth: `0` answer, `2` usage/config
+  error, `3` containment/setup rejection, `4` consultation failure. `--session NAME`
+  rides the persistent store, so a thread started over MCP continues on the CLI and
+  vice versa; a stateless consult never touches the db. `kaibo config` prints the
+  resolved configuration (what `kaibo://config` shows). Bare `kaibo` still runs the
+  MCP server exactly as before — existing client configs are untouched (`kaibo serve`
+  is the explicit spelling). More subcommands (`oneshot`, `explore`, `kaish`, batch)
+  follow.
 
 ### Changed
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,702 @@
+//! The CLI front door — `kaibo consult …`, `kaibo config`, and (from `main`) the
+//! implicit/`serve` MCP server.
+//!
+//! kaibo is an MCP server first; the CLI is the *same* read-only codebase
+//! consultation, reachable without an MCP client (CLI-first agents, scripts, CI, a
+//! human at a terminal). It runs the identical resolution glue the server does —
+//! the shared [`Resolver`](crate::server::Resolver) — so a `--session` started over
+//! MCP continues on the CLI and back. Two contracts a script can rely on:
+//!
+//! - **stdout is the answer, stderr is everything else.** The answer (with the same
+//!   provenance footer the MCP tool returns) goes to stdout; progress beats and logs
+//!   go to stderr (via [`TerminalSink`](crate::progress::TerminalSink)). `--json`
+//!   swaps stdout for a structured envelope (answer + provenance + usage).
+//! - **exit codes have teeth.** `0` = an answer; `2` = a usage/config error; `3` = a
+//!   containment or setup rejection (bad path/cast/attachment/key); `4` = the
+//!   consultation itself failed (provider/model-loop). So an agent branches on the
+//!   code without parsing prose.
+//!
+//! `--help` is model-facing text: an agent reads it the way an MCP client reads a
+//! tool description, so the top-level `about` front-loads what kaibo is and every
+//! flag doc earns its line (the "Writing for models" discipline).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::{Args, Parser, Subcommand};
+use rmcp::ErrorData as McpError;
+
+use crate::config::{Config, ModelRole, ToolDisables};
+use crate::consult::{consult, ConsultConfig, ConsultOutput, ExploreConfig, PhaseContext};
+use crate::progress::TerminalSink;
+use crate::server::{consultation_failure_text, render_config_resource, with_provenance, Resolver};
+use crate::session::{SessionStore as MemSessionStore, Sessions};
+
+/// Exit codes, distinct so an agent caller branches without parsing prose.
+pub const EXIT_OK: i32 = 0;
+/// A usage or config-load error (also clap's own arg-error code).
+pub const EXIT_USAGE: i32 = 2;
+/// A containment or setup rejection: bad `--path`/`--root`, unknown cast, an
+/// attachment outside the boundary, a missing provider key.
+pub const EXIT_SETUP: i32 = 3;
+/// The consultation ran but failed (provider overload, model-loop error, timeout).
+pub const EXIT_CONSULT_FAILURE: i32 = 4;
+
+/// kaibo (解剖) — read-only codebase consultation from a model outside your own
+/// family. Ask a question; a capable model (DeepSeek, Gemini, Anthropic, OpenRouter,
+/// or local — pick with `--cast`) reads the project READ-ONLY and answers with
+/// `file:line` citations, never modifying anything. Bare `kaibo` is the MCP server
+/// (stdio); `kaibo consult` is the one-shot CLI; `kaibo config` prints the resolved
+/// configuration.
+#[derive(Parser, Debug)]
+#[command(name = "kaibo", version)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
+    /// The implicit `serve` flags: a bare `kaibo` (no subcommand) runs the MCP
+    /// server, so every existing client config keeps working unchanged.
+    #[command(flatten)]
+    pub serve: ServeArgs,
+}
+
+#[derive(Subcommand, Debug)]
+// The parsed CLI lives for one `main` dispatch, so the size gap between the arg
+// variants is irrelevant — and clap's derive can't parse a `Box<Args>` variant.
+#[allow(clippy::large_enum_variant)]
+pub enum Command {
+    /// Run the MCP server on stdio (the explicit form of a bare `kaibo`).
+    Serve(ServeArgs),
+    /// Ask one read-only consultation question; the cited answer prints to stdout.
+    Consult(ConsultArgs),
+    /// Print the resolved runtime configuration (the `kaibo://config` document).
+    Config(CommonArgs),
+}
+
+/// Flags shared by every front door: config discovery, the containment boundary, the
+/// default cast, house-rules files, and the persistence store.
+#[derive(Args, Debug, Clone)]
+pub struct CommonArgs {
+    /// Path to config.toml. Overrides $KAIBO_CONFIG; default is
+    /// $XDG_CONFIG_HOME/kaibo/config.toml (absent → built-in defaults).
+    #[arg(long, value_name = "FILE", global = true)]
+    pub config: Option<PathBuf>,
+
+    /// Default project root, and an allowed tree. A per-call `--path` must resolve to
+    /// at-or-under `--root` or an `--allow-path` tree. With neither, the allowed set
+    /// (and inferred default root) is the invocation cwd — so run kaibo from the
+    /// workspace and you configure nothing.
+    #[arg(long, value_name = "DIR", global = true)]
+    pub root: Option<PathBuf>,
+
+    /// Additional allowed path tree. Repeatable. Use `--allow-path /` to lift all
+    /// limits. Also settable via KAIBO_ALLOW_PATHS (colon-separated) or
+    /// [server] allow_paths; a non-empty set of flags replaces that layer.
+    #[arg(long = "allow-path", value_name = "DIR", action = clap::ArgAction::Append, global = true)]
+    pub allow_path: Vec<PathBuf>,
+
+    /// Don't follow git worktrees of an allowed repo (by default a sibling worktree is
+    /// reachable without an --allow-path). Also KAIBO_NO_FOLLOW_WORKTREES.
+    #[arg(long, global = true)]
+    pub no_follow_worktrees: bool,
+
+    /// Default cast (model team) when a call omits it: a built-in (anthropic |
+    /// deepseek | gemini | openrouter | openai-local, plus aliases) or one from
+    /// config.toml. `kaibo config` lists every cast.
+    #[arg(long, global = true)]
+    pub cast: Option<String>,
+
+    /// Project house-rules file spliced into the consult preamble, resolved relative
+    /// to the root and read only if present. Repeatable; defaults to AGENTS.md.
+    #[arg(long = "project-context-file", value_name = "FILE", action = clap::ArgAction::Append, global = true)]
+    pub project_context_file: Vec<String>,
+
+    /// User house-rules file (e.g. ~/.claude/CLAUDE.md) spliced into the preamble;
+    /// read unconditionally (missing is an error). Repeatable.
+    #[arg(long = "user-context-file", value_name = "FILE", action = clap::ArgAction::Append, global = true)]
+    pub user_context_file: Vec<PathBuf>,
+
+    /// Don't persist sessions or batch handles — run fully in-memory. By default kaibo
+    /// keeps a small state db so a `--session` survives a restart and is shared across
+    /// front doors. Also KAIBO_NO_PERSISTENCE.
+    #[arg(long, global = true)]
+    pub no_persistence: bool,
+
+    /// Path to the persistence state db. Overrides KAIBO_STATE_DB / [persistence] path
+    /// / the default ($XDG_STATE_HOME/kaibo/state.db).
+    #[arg(long = "state-db", value_name = "FILE", global = true)]
+    pub state_db: Option<PathBuf>,
+}
+
+/// The MCP server flags: the shared set plus the per-tool `--no-<tool>` gates (which
+/// only make sense for the long-lived server).
+#[derive(Args, Debug, Clone)]
+pub struct ServeArgs {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
+    /// Don't advertise the `consult` tool.
+    #[arg(long)]
+    pub no_consult: bool,
+    /// Don't advertise the `explore` tool.
+    #[arg(long)]
+    pub no_explore: bool,
+    /// Don't advertise the `deliberate` tool.
+    #[arg(long)]
+    pub no_deliberate: bool,
+    /// Don't advertise the `oneshot` tool.
+    #[arg(long)]
+    pub no_oneshot: bool,
+    /// Don't advertise the `run_kaish` tool.
+    #[arg(long)]
+    pub no_run_kaish: bool,
+    /// Don't advertise `batch_submit`. The shared job verbs stay while `consult` is on.
+    #[arg(long)]
+    pub no_batch: bool,
+}
+
+impl ServeArgs {
+    /// The `--no-<tool>` flags as a [`ToolDisables`].
+    pub fn tool_disables(&self) -> ToolDisables {
+        ToolDisables {
+            consult: self.no_consult,
+            explore: self.no_explore,
+            deliberate: self.no_deliberate,
+            oneshot: self.no_oneshot,
+            run_kaish: self.no_run_kaish,
+            batch: self.no_batch,
+        }
+    }
+}
+
+/// `kaibo consult` — one read-only consultation.
+#[derive(Args, Debug)]
+pub struct ConsultArgs {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
+    /// The question to investigate. Say in prose what you did or want to know — kaibo
+    /// locates and reads the real, current code itself, so your intent beats a diff.
+    pub question: String,
+
+    /// Project to explore. Optional — defaults to the root/allowed cwd; must resolve
+    /// to at-or-under an allowed tree.
+    #[arg(long, value_name = "DIR")]
+    pub path: Option<String>,
+
+    /// Workspace file to put in front of the investigation (inlined if small, else read
+    /// whole by the model; an image needs a vision-capable cast). Repeatable.
+    #[arg(long, value_name = "FILE", action = clap::ArgAction::Append)]
+    pub attach: Vec<String>,
+
+    /// Multi-turn session name: kaibo replays this session's prior turns and records
+    /// this one. Shared with the MCP server through the persistent store, so a session
+    /// started there continues here. Omit for a stateless one-shot.
+    #[arg(long, value_name = "NAME")]
+    pub session: Option<String>,
+
+    /// Optional starting evidence — a change/diff summary or pasted source kaibo can't
+    /// reach. Trusted: kaibo extends it rather than re-deriving cited spans.
+    #[arg(long)]
+    pub context: Option<String>,
+
+    /// Override the explorer (investigation) model id (verbatim; pair with
+    /// --explorer-backend to also retarget).
+    #[arg(long, value_name = "ID")]
+    pub explorer_model: Option<String>,
+    /// Run the explorer override on this backend (name or alias). Requires --explorer-model.
+    #[arg(long, value_name = "BACKEND")]
+    pub explorer_backend: Option<String>,
+    /// Override the synth (final-answer) model id (pair with --synth-backend to retarget).
+    #[arg(long, value_name = "ID")]
+    pub synth_model: Option<String>,
+    /// Run the synth override on this backend (name or alias). Requires --synth-model.
+    #[arg(long, value_name = "BACKEND")]
+    pub synth_backend: Option<String>,
+
+    /// Max tool-loop turns per delegated explorer sweep (default 100).
+    #[arg(long, value_name = "N")]
+    pub explorer_max_turns: Option<usize>,
+    /// Max tool-loop turns for the consult driver loop (default 200).
+    #[arg(long, value_name = "N")]
+    pub synth_max_turns: Option<usize>,
+
+    /// Also print the explorer's aggregated report (under `report` in --json; appended
+    /// on a rule below otherwise). Empty when the consult delegated no sweep.
+    #[arg(long)]
+    pub include_report: bool,
+
+    /// Emit a JSON envelope on stdout (answer + provenance + usage) instead of prose,
+    /// for a script caller.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Load config for a CLI subcommand and overlay the shared CLI flags. Tool gating
+/// stays default-on (the `--no-<tool>` gates are a serve-only concern), so a
+/// disabled-tool config never blocks a CLI consult.
+fn load_config(common: &CommonArgs) -> anyhow::Result<Config> {
+    let config_path = common
+        .config
+        .clone()
+        .or_else(|| std::env::var_os("KAIBO_CONFIG").map(PathBuf::from));
+    let mut config = Config::load(config_path)?;
+    config.apply_cli(
+        common.root.clone(),
+        common.cast.clone(),
+        ToolDisables::default(),
+        common.allow_path.clone(),
+        common.no_follow_worktrees,
+        common.project_context_file.clone(),
+        common.user_context_file.clone(),
+        common.no_persistence,
+        common.state_db.clone(),
+    );
+    Ok(config)
+}
+
+/// A quiet-by-default stderr tracing subscriber for the CLI: RUST_LOG still wins, but
+/// the CLI's own liveness is the [`TerminalSink`] progress channel, so the log floor
+/// defaults to `warn` and stays out of the answer stream. Best-effort — a second
+/// init (only possible if a caller wired one already) is ignored.
+fn init_cli_logging() {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::registry()
+        .with(
+            fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_filter(filter),
+        )
+        .try_init();
+}
+
+/// Print `err` to stderr and return `code` — the shared shape for a setup/usage
+/// rejection (before the model runs). With `--json`, the message rides a structured
+/// envelope on stdout so a script parses it uniformly with a success envelope.
+fn fail_setup(json: bool, kind: &str, message: String, code: i32) -> i32 {
+    if json {
+        println!("{}", error_envelope(kind, &message));
+    } else {
+        eprintln!("kaibo: {message}");
+    }
+    code
+}
+
+/// Run `kaibo consult`. Returns the process exit code (never panics on an expected
+/// failure — a bad cast, a provider outage, and a clean answer all return through
+/// here with their own code).
+pub async fn run_consult(args: ConsultArgs) -> i32 {
+    init_cli_logging();
+
+    let config = match load_config(&args.common) {
+        Ok(c) => c,
+        Err(e) => {
+            return fail_setup(
+                args.json,
+                "config",
+                format!("config error: {e:#}"),
+                EXIT_USAGE,
+            )
+        }
+    };
+    // The shared resolver computes the allowed set + inferred default root exactly as
+    // the server does, so this invocation's cwd joins the boundary the same way.
+    let persistence = config.persistence.clone();
+    let session_capacity = config.defaults.session_capacity;
+    let inline_budget = config.defaults.inline_attach_budget;
+    let call_deadline = config.defaults.call_deadline;
+    let default_explorer_turns = config.defaults.explorer_max_turns;
+    let default_synth_turns = config.defaults.synth_max_turns;
+    let sandbox = config.sandbox.clone();
+    let resolver = match Resolver::from_config(Arc::new(config)) {
+        Ok(r) => r,
+        Err(e) => {
+            return fail_setup(args.json, "setup", format!("{e:#}"), EXIT_SETUP);
+        }
+    };
+
+    // Resolution stage — every refusable thing (bad path/cast/key/attachment) is an
+    // EXIT_SETUP rejection, distinct from a consultation that ran and failed.
+    let outcome = resolve_and_run(
+        &args,
+        &resolver,
+        inline_budget,
+        call_deadline,
+        default_explorer_turns,
+        default_synth_turns,
+        &sandbox,
+        &persistence,
+        session_capacity,
+    )
+    .await;
+    match outcome {
+        Ok(code) => code,
+        Err(SetupError {
+            kind,
+            message,
+            code,
+        }) => fail_setup(args.json, kind, message, code),
+    }
+}
+
+/// A setup-stage rejection carrying the exit code it maps to.
+struct SetupError {
+    kind: &'static str,
+    message: String,
+    code: i32,
+}
+
+impl From<McpError> for SetupError {
+    fn from(e: McpError) -> Self {
+        SetupError {
+            kind: "setup",
+            message: e.message.to_string(),
+            code: EXIT_SETUP,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn resolve_and_run(
+    args: &ConsultArgs,
+    resolver: &Resolver,
+    inline_budget: usize,
+    call_deadline: std::time::Duration,
+    default_explorer_turns: usize,
+    default_synth_turns: usize,
+    sandbox: &crate::sandbox::SandboxConfig,
+    persistence: &crate::config::PersistenceConfig,
+    session_capacity: std::num::NonZeroUsize,
+) -> Result<i32, SetupError> {
+    let root = resolver.resolve_root(args.path.clone())?;
+    let mut cast = resolver.resolve_cast(args.common.cast.clone())?;
+    resolver.reject_offline_cast(&cast, "consult")?;
+    resolver.apply_model_override(
+        &mut cast,
+        ModelRole::Explorer,
+        args.explorer_model.as_deref(),
+        args.explorer_backend.as_deref(),
+        "explorer_model",
+        "explorer_backend",
+    )?;
+    resolver.apply_model_override(
+        &mut cast,
+        ModelRole::Synth,
+        args.synth_model.as_deref(),
+        args.synth_backend.as_deref(),
+        "synth_model",
+        "synth_backend",
+    )?;
+    let explorer = resolver.arm(&cast, ModelRole::Explorer)?;
+    let synth = resolver.arm(&cast, ModelRole::Synth)?;
+
+    let attachments =
+        Resolver::resolve_consult_attachments(&root, &args.attach, inline_budget, sandbox).await?;
+    Resolver::gate_consult_image_attachments(
+        &attachments,
+        synth.caps.vision,
+        &synth.model,
+        &cast.name,
+    )?;
+
+    // Only stand up a session store when a `--session` was named; a stateless consult
+    // never opens the db. A failed open is a loud setup error naming the escape hatch.
+    let sessions = if args.session.is_some() {
+        Some(open_sessions(persistence, session_capacity, resolver).await?)
+    } else {
+        None
+    };
+    let session = match (&sessions, &args.session) {
+        (Some(s), Some(id)) => Some((s, id.as_str())),
+        _ => None,
+    };
+
+    let cfg = ConsultConfig {
+        explore: ExploreConfig {
+            phase: PhaseContext {
+                progress: Arc::new(TerminalSink),
+                house_rules: resolver.house_rules(&root)?,
+                prompts: resolver.resolved_prompts(&cast),
+                orientation: resolver.orientation(&root).await?,
+                call_deadline,
+            },
+            explorer_max_turns: args.explorer_max_turns.unwrap_or(default_explorer_turns),
+            sandbox: sandbox.clone(),
+        },
+        synth_max_turns: args.synth_max_turns.unwrap_or(default_synth_turns),
+        attachments,
+    };
+
+    match consult(
+        &args.question,
+        args.context.as_deref(),
+        root,
+        &explorer,
+        &synth,
+        &cfg,
+        session,
+    )
+    .await
+    {
+        Ok(out) => {
+            emit_answer(args, &out, &cast.name, &explorer.model, &synth.model);
+            Ok(EXIT_OK)
+        }
+        // A provider/model-loop failure is its own exit code — the consultation ran and
+        // failed, distinct from a setup rejection. Reuse the server's classified text.
+        Err(e) => {
+            let text = consultation_failure_text("consult", &cast.name, e);
+            if args.json {
+                println!("{}", error_envelope("consultation_failure", &text));
+            } else {
+                eprintln!("kaibo: {text}");
+            }
+            Ok(EXIT_CONSULT_FAILURE)
+        }
+    }
+}
+
+/// Open the durable session store when persistence is enabled, else an in-memory one.
+/// The durable store is fed the resolver's allowed set so its containment guard
+/// refuses a state db inside any project tree — the same wiring `main` uses.
+async fn open_sessions(
+    persistence: &crate::config::PersistenceConfig,
+    session_capacity: std::num::NonZeroUsize,
+    resolver: &Resolver,
+) -> Result<Sessions, SetupError> {
+    if !persistence.enabled {
+        return Ok(Sessions::Memory(MemSessionStore::new(session_capacity)));
+    }
+    let path = persistence.path.clone().ok_or_else(|| SetupError {
+        kind: "config",
+        message: "persistence is enabled but no state-db path resolved".to_string(),
+        code: EXIT_USAGE,
+    })?;
+    let allowed = resolver.allowed_set();
+    let allowed_refs: Vec<&std::path::Path> = allowed.iter().map(PathBuf::as_path).collect();
+    let store = crate::store::SessionStore::open(&path, session_capacity, &allowed_refs)
+        .await
+        .map_err(|e| SetupError {
+            kind: "persistence",
+            message: format!(
+                "failed to open the persistence state db at {}: {e:#}. \
+                 Fix the path/permissions, or pass --no-persistence.",
+                path.display()
+            ),
+            code: EXIT_SETUP,
+        })?;
+    Ok(Sessions::Persistent(store))
+}
+
+/// Print a successful consult answer: the JSON envelope on stdout under `--json`, else
+/// the answer with the same provenance footer the MCP tool appends. Progress and logs
+/// already went to stderr, so stdout carries only the answer — clean for a pipe.
+fn emit_answer(
+    args: &ConsultArgs,
+    out: &ConsultOutput,
+    cast: &str,
+    explorer_model: &str,
+    synth_model: &str,
+) {
+    if args.json {
+        println!(
+            "{}",
+            consult_envelope(out, cast, explorer_model, synth_model, args.include_report)
+        );
+        return;
+    }
+    let answer = with_provenance(
+        out.answer.clone(),
+        cast,
+        &[("explorer", explorer_model), ("synth", synth_model)],
+        &out.usage,
+    );
+    println!("{answer}");
+    // The report is opt-in extra; keep it off stdout's answer line — send it to stderr
+    // so a pipe still captures just the answer.
+    if args.include_report && !out.report.is_empty() {
+        eprintln!("\n--- explorer report ---\n{}", out.report);
+    }
+}
+
+/// The `--json` success envelope: the raw answer (no footer), provenance, and usage —
+/// a stable shape for a script. Pure, so it's unit-testable without a model.
+fn consult_envelope(
+    out: &ConsultOutput,
+    cast: &str,
+    explorer_model: &str,
+    synth_model: &str,
+    include_report: bool,
+) -> serde_json::Value {
+    let mut env = serde_json::json!({
+        "answer": out.answer,
+        "cast": cast,
+        "models": { "explorer": explorer_model, "synth": synth_model },
+        "usage": {
+            "input_tokens": out.usage.input_tokens,
+            "output_tokens": out.usage.output_tokens,
+            "reasoning_tokens": out.usage.reasoning_tokens,
+            "cached_input_tokens": out.usage.cached_input_tokens,
+            "cache_creation_input_tokens": out.usage.cache_creation_input_tokens,
+        },
+    });
+    if include_report {
+        env["report"] = serde_json::Value::String(out.report.clone());
+    }
+    env
+}
+
+/// The `--json` error envelope: `{ "error": …, "kind": … }`. Pure and testable.
+fn error_envelope(kind: &str, message: &str) -> serde_json::Value {
+    serde_json::json!({ "error": message, "kind": kind })
+}
+
+/// Run `kaibo config`: print the resolved configuration the way the `kaibo://config`
+/// resource renders it — reusing the exact renderer so the two never drift.
+pub fn run_config(common: CommonArgs) -> i32 {
+    init_cli_logging();
+    let config = match load_config(&common) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("kaibo: config error: {e:#}");
+            return EXIT_USAGE;
+        }
+    };
+    let persistence_enabled = config.persistence.enabled;
+    let resolver = match Resolver::from_config(Arc::new(config)) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("kaibo: {e:#}");
+            return EXIT_SETUP;
+        }
+    };
+    // `active` reflects whether a real invocation would hold the store open — for a
+    // one-shot `config` print we don't open it, but persistence being enabled is what
+    // a consult here would activate, so report that.
+    let body = render_config_resource(
+        &resolver.config,
+        resolver.allowed_trees(),
+        resolver.default_root_ref(),
+        resolver.default_root_inferred(),
+        resolver.followed_worktrees(),
+        persistence_enabled,
+    );
+    println!("{body}");
+    EXIT_OK
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn clap_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn bare_invocation_is_the_implicit_serve() {
+        // No subcommand → the server path; the flattened serve args carry the flags.
+        let cli = Cli::try_parse_from(["kaibo", "--root", "/tmp"]).expect("bare parse");
+        assert!(
+            cli.command.is_none(),
+            "bare kaibo has no subcommand (implicit serve)"
+        );
+        assert_eq!(
+            cli.serve.common.root.as_deref(),
+            Some(std::path::Path::new("/tmp"))
+        );
+    }
+
+    #[test]
+    fn explicit_serve_takes_the_same_flags() {
+        let cli = Cli::try_parse_from(["kaibo", "serve", "--no-oneshot", "--cast", "gemini"])
+            .expect("serve parse");
+        match cli.command {
+            Some(Command::Serve(s)) => {
+                assert!(s.no_oneshot);
+                assert_eq!(s.common.cast.as_deref(), Some("gemini"));
+                assert!(s.tool_disables().oneshot);
+            }
+            other => panic!("expected serve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn consult_subcommand_parses_its_flags() {
+        let cli = Cli::try_parse_from([
+            "kaibo",
+            "consult",
+            "why is this slow?",
+            "--cast",
+            "deepseek",
+            "--attach",
+            "a.rs",
+            "--attach",
+            "b.rs",
+            "--session",
+            "perf",
+            "--json",
+        ])
+        .expect("consult parse");
+        match cli.command {
+            Some(Command::Consult(c)) => {
+                assert_eq!(c.question, "why is this slow?");
+                assert_eq!(c.common.cast.as_deref(), Some("deepseek"));
+                assert_eq!(c.attach, vec!["a.rs".to_string(), "b.rs".to_string()]);
+                assert_eq!(c.session.as_deref(), Some("perf"));
+                assert!(c.json);
+            }
+            other => panic!("expected consult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_subcommand_parses() {
+        let cli =
+            Cli::try_parse_from(["kaibo", "config", "--root", "/srv/repo"]).expect("config parse");
+        assert!(matches!(cli.command, Some(Command::Config(_))));
+    }
+
+    #[test]
+    fn a_missing_consult_question_is_a_usage_error() {
+        // The positional question is required — clap rejects its absence (exit 2 class).
+        let err = Cli::try_parse_from(["kaibo", "consult"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn consult_envelope_carries_answer_provenance_and_usage() {
+        let out = ConsultOutput {
+            answer: "the answer".to_string(),
+            report: "the report".to_string(),
+            usage: rig_core::completion::Usage {
+                input_tokens: 10,
+                output_tokens: 20,
+                ..Default::default()
+            },
+        };
+        let env = consult_envelope(&out, "deepseek", "explorer-m", "synth-m", false);
+        assert_eq!(env["answer"], "the answer");
+        assert_eq!(env["cast"], "deepseek");
+        assert_eq!(env["models"]["explorer"], "explorer-m");
+        assert_eq!(env["models"]["synth"], "synth-m");
+        assert_eq!(env["usage"]["input_tokens"], 10);
+        assert_eq!(env["usage"]["output_tokens"], 20);
+        // The report is omitted unless requested.
+        assert!(env.get("report").is_none(), "report is opt-in");
+
+        let with_report = consult_envelope(&out, "deepseek", "e", "s", true);
+        assert_eq!(with_report["report"], "the report");
+    }
+
+    #[test]
+    fn error_envelope_shape() {
+        let env = error_envelope("consultation_failure", "it broke");
+        assert_eq!(env["kind"], "consultation_failure");
+        assert_eq!(env["error"], "it broke");
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,13 +8,19 @@
 //! MCP continues on the CLI and back. Two contracts a script can rely on:
 //!
 //! - **stdout is the answer, stderr is everything else.** The answer (with the same
-//!   provenance footer the MCP tool returns) goes to stdout; progress beats and logs
-//!   go to stderr (via [`TerminalSink`](crate::progress::TerminalSink)). `--json`
-//!   swaps stdout for a structured envelope (answer + provenance + usage).
-//! - **exit codes have teeth.** `0` = an answer; `2` = a usage/config error; `3` = a
-//!   containment or setup rejection (bad path/cast/attachment/key); `4` = the
-//!   consultation itself failed (provider/model-loop). So an agent branches on the
-//!   code without parsing prose.
+//!   provenance footer the MCP tool returns) goes to stdout; progress beats, logs, and
+//!   any non-fatal warnings go to stderr (via
+//!   [`TerminalSink`](crate::progress::TerminalSink)). `--json` swaps stdout for a
+//!   structured envelope (answer + provenance + usage + warnings) — and the `answer`
+//!   field is the model's raw words, never kaibo's injected notices.
+//! - **exit codes have teeth.** `0` = an answer; `2` = a **usage** error — a bad
+//!   argument, an unknown or wrong-for-the-tool cast, an image on a vision-blind cast
+//!   (also clap's own arg-parse errors, and config load); `3` = a **setup/containment**
+//!   rejection — a path or attachment outside the allowed set, a missing/unbuildable
+//!   provider key; `4` = the consultation itself ran and failed (provider/model-loop).
+//!   So an agent branches on the code without parsing prose. (An arg-parse error is
+//!   clap's: usage on stderr, exit 2, nothing on stdout — the envelope is guaranteed
+//!   only once args parse.)
 //!
 //! `--help` is model-facing text: an agent reads it the way an MCP client reads a
 //! tool description, so the top-level `about` front-loads what kaibo is and every
@@ -34,10 +40,12 @@ use crate::session::{SessionStore as MemSessionStore, Sessions};
 
 /// Exit codes, distinct so an agent caller branches without parsing prose.
 pub const EXIT_OK: i32 = 0;
-/// A usage or config-load error (also clap's own arg-error code).
+/// A usage or config-load error (also clap's own arg-error code): a bad argument, an
+/// unknown or wrong-for-the-tool cast, bad model-override args, an image on a
+/// vision-blind cast.
 pub const EXIT_USAGE: i32 = 2;
-/// A containment or setup rejection: bad `--path`/`--root`, unknown cast, an
-/// attachment outside the boundary, a missing provider key.
+/// A setup/containment rejection: a `--path`/`--root`/attachment outside the allowed
+/// boundary, or a missing/unbuildable provider key.
 pub const EXIT_SETUP: i32 = 3;
 /// The consultation ran but failed (provider overload, model-loop error, timeout).
 pub const EXIT_CONSULT_FAILURE: i32 = 4;
@@ -50,15 +58,24 @@ pub const EXIT_CONSULT_FAILURE: i32 = 4;
 /// configuration.
 #[derive(Parser, Debug)]
 #[command(name = "kaibo", version)]
-#[command(args_conflicts_with_subcommands = true)]
 pub struct Cli {
+    /// The shared flags (config discovery, containment, cast, house-rules,
+    /// persistence). Defined once here as clap `global` args, so they work **before or
+    /// after** the subcommand — `kaibo --cast x consult …` and `kaibo consult … --cast
+    /// x` both reach the consult, and `kaibo --cast x` alone reaches the implicit serve.
+    #[command(flatten)]
+    pub common: CommonArgs,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// The implicit `serve` flags: a bare `kaibo` (no subcommand) runs the MCP
-    /// server, so every existing client config keeps working unchanged.
+    /// The implicit-serve tool gates: a bare `kaibo` (no subcommand) runs the MCP
+    /// server, so every existing client config keeps working unchanged. Serve-only —
+    /// they're read only on the serve path; the subcommands ignore them. (We don't use
+    /// `args_conflicts_with_subcommands` because it would also fence the shared globals
+    /// off a subcommand, defeating `kaibo --cast x consult …`.)
     #[command(flatten)]
-    pub serve: ServeArgs,
+    pub gates: ServeGates,
 }
 
 #[derive(Subcommand, Debug)]
@@ -67,11 +84,11 @@ pub struct Cli {
 #[allow(clippy::large_enum_variant)]
 pub enum Command {
     /// Run the MCP server on stdio (the explicit form of a bare `kaibo`).
-    Serve(ServeArgs),
+    Serve(ServeGates),
     /// Ask one read-only consultation question; the cited answer prints to stdout.
     Consult(ConsultArgs),
     /// Print the resolved runtime configuration (the `kaibo://config` document).
-    Config(CommonArgs),
+    Config,
 }
 
 /// Flags shared by every front door: config discovery, the containment boundary, the
@@ -129,13 +146,10 @@ pub struct CommonArgs {
     pub state_db: Option<PathBuf>,
 }
 
-/// The MCP server flags: the shared set plus the per-tool `--no-<tool>` gates (which
-/// only make sense for the long-lived server).
-#[derive(Args, Debug, Clone)]
-pub struct ServeArgs {
-    #[command(flatten)]
-    pub common: CommonArgs,
-
+/// The per-tool `--no-<tool>` gates — serve-only (they only make sense for the
+/// long-lived server). The shared flags live on [`Cli::common`] as globals.
+#[derive(Args, Debug, Clone, Default)]
+pub struct ServeGates {
     /// Don't advertise the `consult` tool.
     #[arg(long)]
     pub no_consult: bool,
@@ -156,7 +170,7 @@ pub struct ServeArgs {
     pub no_batch: bool,
 }
 
-impl ServeArgs {
+impl ServeGates {
     /// The `--no-<tool>` flags as a [`ToolDisables`].
     pub fn tool_disables(&self) -> ToolDisables {
         ToolDisables {
@@ -170,12 +184,10 @@ impl ServeArgs {
     }
 }
 
-/// `kaibo consult` — one read-only consultation.
+/// `kaibo consult` — one read-only consultation. The shared flags come from
+/// [`Cli::common`] (globals); these are the consult-specific ones.
 #[derive(Args, Debug)]
 pub struct ConsultArgs {
-    #[command(flatten)]
-    pub common: CommonArgs,
-
     /// The question to investigate. Say in prose what you did or want to know — kaibo
     /// locates and reads the real, current code itself, so your intent beats a diff.
     pub question: String,
@@ -227,8 +239,10 @@ pub struct ConsultArgs {
     #[arg(long)]
     pub include_report: bool,
 
-    /// Emit a JSON envelope on stdout (answer + provenance + usage) instead of prose,
-    /// for a script caller.
+    /// Emit a JSON envelope on stdout (answer + provenance + usage + warnings) instead
+    /// of prose, for a script caller. Note: an argument-parse error prints usage to
+    /// stderr and exits 2 with nothing on stdout — the JSON envelope is guaranteed only
+    /// once the arguments parse.
     #[arg(long)]
     pub json: bool,
 }
@@ -287,10 +301,10 @@ fn fail_setup(json: bool, kind: &str, message: String, code: i32) -> i32 {
 /// Run `kaibo consult`. Returns the process exit code (never panics on an expected
 /// failure — a bad cast, a provider outage, and a clean answer all return through
 /// here with their own code).
-pub async fn run_consult(args: ConsultArgs) -> i32 {
+pub async fn run_consult(common: CommonArgs, args: ConsultArgs) -> i32 {
     init_cli_logging();
 
-    let config = match load_config(&args.common) {
+    let config = match load_config(&common) {
         Ok(c) => c,
         Err(e) => {
             return fail_setup(
@@ -317,9 +331,11 @@ pub async fn run_consult(args: ConsultArgs) -> i32 {
         }
     };
 
-    // Resolution stage — every refusable thing (bad path/cast/key/attachment) is an
-    // EXIT_SETUP rejection, distinct from a consultation that ran and failed.
+    // Resolution stage — every refusable thing is either a usage (exit 2) or a
+    // setup/containment (exit 3) rejection, distinct from a consultation that ran and
+    // failed (exit 4). Each call site tags its own class; see `resolve_and_run`.
     let outcome = resolve_and_run(
+        &common,
         &args,
         &resolver,
         inline_budget,
@@ -341,15 +357,36 @@ pub async fn run_consult(args: ConsultArgs) -> i32 {
     }
 }
 
-/// A setup-stage rejection carrying the exit code it maps to.
+/// A resolution-stage rejection carrying the exit code it maps to. There is
+/// deliberately **no** blanket `From<McpError>`: a `McpError` alone can't tell a
+/// usage mistake from a boundary block (both are `invalid_params` on the wire), so
+/// each resolution call site tags its failure with [`usage`](Self::usage) or
+/// [`setup`](Self::setup) explicitly — that's what keeps the exit-code contract at
+/// the top of this module honest.
 struct SetupError {
     kind: &'static str,
     message: String,
     code: i32,
 }
 
-impl From<McpError> for SetupError {
-    fn from(e: McpError) -> Self {
+impl SetupError {
+    /// A **usage** rejection (exit 2, like clap's own argument errors): the caller
+    /// named something invalid — a cast that doesn't exist or is wrong for the tool
+    /// (a batch/direct cast on interactive `consult`), bad model-override args, or an
+    /// image attached to a vision-blind cast. "Fix your command."
+    fn usage(e: McpError) -> Self {
+        SetupError {
+            kind: "usage",
+            message: e.message.to_string(),
+            code: EXIT_USAGE,
+        }
+    }
+
+    /// A **setup/containment** rejection (exit 3): a valid-looking request the
+    /// environment or boundary blocked — a path or attachment outside the allowed
+    /// set, a missing or unbuildable provider key, a house-rules/orientation read
+    /// failure. Not the caller's argument mistake; the surroundings.
+    fn setup(e: McpError) -> Self {
         SetupError {
             kind: "setup",
             message: e.message.to_string(),
@@ -360,6 +397,7 @@ impl From<McpError> for SetupError {
 
 #[allow(clippy::too_many_arguments)]
 async fn resolve_and_run(
+    common: &CommonArgs,
     args: &ConsultArgs,
     resolver: &Resolver,
     inline_budget: usize,
@@ -370,36 +408,56 @@ async fn resolve_and_run(
     persistence: &crate::config::PersistenceConfig,
     session_capacity: std::num::NonZeroUsize,
 ) -> Result<i32, SetupError> {
-    let root = resolver.resolve_root(args.path.clone())?;
-    let mut cast = resolver.resolve_cast(args.common.cast.clone())?;
-    resolver.reject_offline_cast(&cast, "consult")?;
-    resolver.apply_model_override(
-        &mut cast,
-        ModelRole::Explorer,
-        args.explorer_model.as_deref(),
-        args.explorer_backend.as_deref(),
-        "explorer_model",
-        "explorer_backend",
-    )?;
-    resolver.apply_model_override(
-        &mut cast,
-        ModelRole::Synth,
-        args.synth_model.as_deref(),
-        args.synth_backend.as_deref(),
-        "synth_model",
-        "synth_backend",
-    )?;
-    let explorer = resolver.arm(&cast, ModelRole::Explorer)?;
-    let synth = resolver.arm(&cast, ModelRole::Synth)?;
+    // Each call tags its failure explicitly (see `SetupError`): a path/attachment
+    // outside the boundary or an unbuildable key is `setup` (exit 3); a wrong-for-the-tool
+    // cast, bad override args, or an image on a blind cast is `usage` (exit 2).
+    let root = resolver
+        .resolve_root(args.path.clone())
+        .map_err(SetupError::setup)?;
+    let mut cast = resolver
+        .resolve_cast(common.cast.clone())
+        .map_err(SetupError::usage)?;
+    resolver
+        .reject_offline_cast(&cast, "consult")
+        .map_err(SetupError::usage)?;
+    resolver
+        .apply_model_override(
+            &mut cast,
+            ModelRole::Explorer,
+            args.explorer_model.as_deref(),
+            args.explorer_backend.as_deref(),
+            "explorer_model",
+            "explorer_backend",
+        )
+        .map_err(SetupError::usage)?;
+    resolver
+        .apply_model_override(
+            &mut cast,
+            ModelRole::Synth,
+            args.synth_model.as_deref(),
+            args.synth_backend.as_deref(),
+            "synth_model",
+            "synth_backend",
+        )
+        .map_err(SetupError::usage)?;
+    let explorer = resolver
+        .arm(&cast, ModelRole::Explorer)
+        .map_err(SetupError::setup)?;
+    let synth = resolver
+        .arm(&cast, ModelRole::Synth)
+        .map_err(SetupError::setup)?;
 
     let attachments =
-        Resolver::resolve_consult_attachments(&root, &args.attach, inline_budget, sandbox).await?;
+        Resolver::resolve_consult_attachments(&root, &args.attach, inline_budget, sandbox)
+            .await
+            .map_err(SetupError::setup)?;
     Resolver::gate_consult_image_attachments(
         &attachments,
         synth.caps.vision,
         &synth.model,
         &cast.name,
-    )?;
+    )
+    .map_err(SetupError::usage)?;
 
     // Only stand up a session store when a `--session` was named; a stateless consult
     // never opens the db. A failed open is a loud setup error naming the escape hatch.
@@ -417,9 +475,12 @@ async fn resolve_and_run(
         explore: ExploreConfig {
             phase: PhaseContext {
                 progress: Arc::new(TerminalSink),
-                house_rules: resolver.house_rules(&root)?,
+                house_rules: resolver.house_rules(&root).map_err(SetupError::setup)?,
                 prompts: resolver.resolved_prompts(&cast),
-                orientation: resolver.orientation(&root).await?,
+                orientation: resolver
+                    .orientation(&root)
+                    .await
+                    .map_err(SetupError::setup)?,
                 call_deadline,
             },
             explorer_max_turns: args.explorer_max_turns.unwrap_or(default_explorer_turns),
@@ -482,7 +543,10 @@ async fn open_sessions(
             kind: "persistence",
             message: format!(
                 "failed to open the persistence state db at {}: {e:#}. \
-                 Fix the path/permissions, or pass --no-persistence.",
+                 Fix the path/permissions, or point elsewhere with --state-db. \
+                 Or pass --no-persistence to run this `--session` in memory for this \
+                 invocation only — the thread works now but is lost when the process exits \
+                 (it won't survive or be shared with the MCP server).",
                 path.display()
             ),
             code: EXIT_SETUP,
@@ -514,6 +578,12 @@ fn emit_answer(
         &out.usage,
     );
     println!("{answer}");
+    // Non-fatal warnings (a failed session record) go to STDERR, never stdout — stdout
+    // stays the model's answer, clean for a pipe. (`--json` carries them structured
+    // instead; see `consult_envelope`.)
+    for w in &out.warnings {
+        eprintln!("kaibo: {w}");
+    }
     // The report is opt-in extra; keep it off stdout's answer line — send it to stderr
     // so a pipe still captures just the answer.
     if args.include_report && !out.report.is_empty() {
@@ -531,6 +601,9 @@ fn consult_envelope(
     include_report: bool,
 ) -> serde_json::Value {
     let mut env = serde_json::json!({
+        // The raw model answer — no footer, no injected notices. A machine consumer
+        // (`jq -r .answer`) gets the model's words uncorrupted; kaibo's own non-fatal
+        // notices ride the separate `warnings` array below.
         "answer": out.answer,
         "cast": cast,
         "models": { "explorer": explorer_model, "synth": synth_model },
@@ -541,6 +614,9 @@ fn consult_envelope(
             "cached_input_tokens": out.usage.cached_input_tokens,
             "cache_creation_input_tokens": out.usage.cache_creation_input_tokens,
         },
+        // Non-fatal notices about this turn (e.g. a failed session record). Always
+        // present (empty when the turn was clean) so a consumer can rely on the key.
+        "warnings": out.warnings,
     });
     if include_report {
         env["report"] = serde_json::Value::String(out.report.clone());
@@ -599,27 +675,28 @@ mod tests {
 
     #[test]
     fn bare_invocation_is_the_implicit_serve() {
-        // No subcommand → the server path; the flattened serve args carry the flags.
+        // No subcommand → the server path; the shared flags live on `cli.common`.
         let cli = Cli::try_parse_from(["kaibo", "--root", "/tmp"]).expect("bare parse");
         assert!(
             cli.command.is_none(),
             "bare kaibo has no subcommand (implicit serve)"
         );
         assert_eq!(
-            cli.serve.common.root.as_deref(),
+            cli.common.root.as_deref(),
             Some(std::path::Path::new("/tmp"))
         );
     }
 
     #[test]
     fn explicit_serve_takes_the_same_flags() {
+        // `--cast` is a shared global (on cli.common); `--no-oneshot` is a serve gate.
         let cli = Cli::try_parse_from(["kaibo", "serve", "--no-oneshot", "--cast", "gemini"])
             .expect("serve parse");
+        assert_eq!(cli.common.cast.as_deref(), Some("gemini"));
         match cli.command {
-            Some(Command::Serve(s)) => {
-                assert!(s.no_oneshot);
-                assert_eq!(s.common.cast.as_deref(), Some("gemini"));
-                assert!(s.tool_disables().oneshot);
+            Some(Command::Serve(gates)) => {
+                assert!(gates.no_oneshot);
+                assert!(gates.tool_disables().oneshot);
             }
             other => panic!("expected serve, got {other:?}"),
         }
@@ -642,10 +719,11 @@ mod tests {
             "--json",
         ])
         .expect("consult parse");
+        // `--cast` is the shared global; the rest are consult-specific.
+        assert_eq!(cli.common.cast.as_deref(), Some("deepseek"));
         match cli.command {
             Some(Command::Consult(c)) => {
                 assert_eq!(c.question, "why is this slow?");
-                assert_eq!(c.common.cast.as_deref(), Some("deepseek"));
                 assert_eq!(c.attach, vec!["a.rs".to_string(), "b.rs".to_string()]);
                 assert_eq!(c.session.as_deref(), Some("perf"));
                 assert!(c.json);
@@ -658,7 +736,12 @@ mod tests {
     fn config_subcommand_parses() {
         let cli =
             Cli::try_parse_from(["kaibo", "config", "--root", "/srv/repo"]).expect("config parse");
-        assert!(matches!(cli.command, Some(Command::Config(_))));
+        assert!(matches!(cli.command, Some(Command::Config)));
+        // The shared `--root` global reaches the config subcommand.
+        assert_eq!(
+            cli.common.root.as_deref(),
+            Some(std::path::Path::new("/srv/repo"))
+        );
     }
 
     #[test]
@@ -668,17 +751,22 @@ mod tests {
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
-    #[test]
-    fn consult_envelope_carries_answer_provenance_and_usage() {
-        let out = ConsultOutput {
-            answer: "the answer".to_string(),
+    fn out_with(answer: &str, warnings: Vec<String>) -> ConsultOutput {
+        ConsultOutput {
+            answer: answer.to_string(),
             report: "the report".to_string(),
             usage: rig_core::completion::Usage {
                 input_tokens: 10,
                 output_tokens: 20,
                 ..Default::default()
             },
-        };
+            warnings,
+        }
+    }
+
+    #[test]
+    fn consult_envelope_carries_answer_provenance_usage_and_warnings() {
+        let out = out_with("the answer", vec![]);
         let env = consult_envelope(&out, "deepseek", "explorer-m", "synth-m", false);
         assert_eq!(env["answer"], "the answer");
         assert_eq!(env["cast"], "deepseek");
@@ -686,6 +774,9 @@ mod tests {
         assert_eq!(env["models"]["synth"], "synth-m");
         assert_eq!(env["usage"]["input_tokens"], 10);
         assert_eq!(env["usage"]["output_tokens"], 20);
+        // `warnings` is always present (empty when the turn was clean) so a consumer
+        // can rely on the key.
+        assert_eq!(env["warnings"], serde_json::json!([]));
         // The report is omitted unless requested.
         assert!(env.get("report").is_none(), "report is opt-in");
 
@@ -693,10 +784,99 @@ mod tests {
         assert_eq!(with_report["report"], "the report");
     }
 
+    /// A record-failure warning rides the `warnings` array — NOT the `answer` field, which
+    /// stays the model's raw words (the #77 Gemini fix: `jq -r .answer` must be clean).
+    #[test]
+    fn consult_envelope_keeps_warnings_out_of_the_answer_field() {
+        let out = out_with(
+            "clean model words",
+            vec!["⚠️ Session turn NOT recorded (persistence error: disk full).".to_string()],
+        );
+        let env = consult_envelope(&out, "deepseek", "e", "s", false);
+        assert_eq!(
+            env["answer"], "clean model words",
+            "the answer field must be the model's raw words, no injected notices"
+        );
+        assert_eq!(env["warnings"][0], out.warnings[0]);
+    }
+
     #[test]
     fn error_envelope_shape() {
         let env = error_envelope("consultation_failure", "it broke");
         assert_eq!(env["kind"], "consultation_failure");
         assert_eq!(env["error"], "it broke");
+    }
+
+    /// A global flag placed BEFORE the subcommand (`kaibo --cast x consult "q"`)
+    /// propagates to the subcommand — the clap `global = true` contract on `CommonArgs`.
+    #[test]
+    fn a_global_flag_before_the_subcommand_reaches_it() {
+        let cli = Cli::try_parse_from(["kaibo", "--cast", "gemini", "consult", "why?"])
+            .expect("global flag before subcommand parses");
+        assert_eq!(
+            cli.common.cast.as_deref(),
+            Some("gemini"),
+            "a pre-subcommand --cast must parse and land on the shared common args"
+        );
+        match cli.command {
+            Some(Command::Consult(c)) => assert_eq!(c.question, "why?"),
+            other => panic!("expected consult, got {other:?}"),
+        }
+    }
+
+    /// A batch/direct cast on interactive `consult` is a USAGE error (exit 2, kind
+    /// "usage") — the offline-cast refusal must classify as usage, not a setup/containment
+    /// rejection. Offline: `reject_offline_cast` fires before any model/key is touched.
+    #[tokio::test]
+    async fn an_offline_cast_on_consult_is_a_usage_error_exit_2() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::builtin();
+        config.root = Some(dir.path().to_path_buf());
+        let inline_budget = config.defaults.inline_attach_budget;
+        let call_deadline = config.defaults.call_deadline;
+        let et = config.defaults.explorer_max_turns;
+        let st = config.defaults.synth_max_turns;
+        let sandbox = config.sandbox.clone();
+        let persistence = config.persistence.clone();
+        let cap = config.defaults.session_capacity;
+        let resolver = Resolver::from_config(Arc::new(config)).unwrap();
+
+        // `anthropic-batch` is a built-in whose synth runs on the batch lane; `--cast`
+        // is a shared global, so it lands on `cli.common`.
+        let cli = Cli::parse_from([
+            "kaibo",
+            "consult",
+            "q",
+            "--cast",
+            "anthropic-batch",
+            "--json",
+        ]);
+        let common = cli.common.clone();
+        let args = match cli.command {
+            Some(Command::Consult(c)) => c,
+            _ => unreachable!("parsed a consult subcommand"),
+        };
+
+        let err = resolve_and_run(
+            &common,
+            &args,
+            &resolver,
+            inline_budget,
+            call_deadline,
+            et,
+            st,
+            &sandbox,
+            &persistence,
+            cap,
+        )
+        .await
+        .expect_err("a batch cast on consult must be refused");
+        assert_eq!(
+            err.code, EXIT_USAGE,
+            "offline-cast refusal is exit 2 (usage)"
+        );
+        assert_eq!(err.kind, "usage");
+        // And the JSON envelope a script would see carries kind "usage".
+        assert_eq!(error_envelope(err.kind, &err.message)["kind"], "usage");
     }
 }

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -365,16 +365,26 @@ impl Arm {
 }
 
 /// The result of a consult: the final answer, the explorer's report (kept so
-/// callers can inspect/debug the hand-off, and for future session storage), and the
+/// callers can inspect/debug the hand-off, and for future session storage), the
 /// token [`Usage`] the whole consult reported — the synth loop plus every delegated
 /// `explore′` sweep, summed. Zero-valued when no provider reported usage (the
 /// existing "unknown" sentinel), so a footer can tell "cost this much" from "the
 /// backend told us nothing".
+///
+/// `warnings` carries non-fatal, caller-visible notices about the turn that are
+/// **separate from the answer text** — today only a failed session `record()` (the
+/// answer is paid-for and stands, but the turn won't replay next time). Kept off
+/// `answer` deliberately: a machine consumer of the answer (e.g. `jq -r .answer` on
+/// the CLI `--json` envelope) must get the model's words uncorrupted by kaibo's own
+/// injected notes. Each front door decides how to surface them — the MCP server
+/// appends them to the result text (client-visible behavior unchanged), the CLI
+/// prints them to stderr (prose) or as a `warnings` array (`--json`).
 #[derive(Debug, Clone)]
 pub struct ConsultOutput {
     pub answer: String,
     pub report: String,
     pub usage: Usage,
+    pub warnings: Vec<String>,
 }
 
 /// The forced-finish instruction we append when a phase exhausts its turn cap.
@@ -1288,6 +1298,9 @@ pub(crate) async fn consult_with(
         answer,
         report,
         usage,
+        // Populated downstream (`consult_session_turn` on a record failure); the raw
+        // consult loop has no non-fatal notices of its own.
+        warnings: Vec::new(),
     })
 }
 
@@ -1328,9 +1341,10 @@ pub(crate) async fn consult_session_turn(
     // Record failure is NON-fatal: by here the model has answered (a paid-for result), so
     // losing that answer over a bookkeeping write would be the wrong trade — and it mirrors
     // the non-fatal batch-handle record. Instead, keep the answer and surface the failure
-    // LOUDLY (never a silent fallback): warn on the log, and append a visible line to the
-    // answer so the caller knows this turn won't be in the thread next time. The in-memory
-    // arm never errors, so today's default is byte-for-byte unchanged.
+    // LOUDLY (never a silent fallback): warn on the log, and record a caller-visible notice
+    // on `out.warnings` — kept OFF the answer text so a machine consumer of the answer gets
+    // the model's words uncorrupted (each front door renders warnings its own way). The
+    // in-memory arm never errors, so today's default is byte-for-byte unchanged.
     if let Some((store, id)) = session {
         if let Err(e) = store
             .record(id, QaTurn::new(question, out.answer.clone()))
@@ -1341,9 +1355,9 @@ pub(crate) async fn consult_session_turn(
                 error = %e,
                 "session turn not recorded — the answer stands, but this thread won't replay it"
             );
-            out.answer.push_str(&format!(
-                "\n\n⚠️ Session turn NOT recorded (persistence error: {e}). \
-                 The answer above is complete, but this `session_id` won't include it on your \
+            out.warnings.push(format!(
+                "⚠️ Session turn NOT recorded (persistence error: {e}). \
+                 The answer is complete, but this `session_id` won't include it on your \
                  next turn — retry, or continue without relying on this turn as context."
             ));
         }
@@ -3515,10 +3529,17 @@ mod tests {
             "the paid-for answer must be preserved: {:?}",
             out.answer
         );
+        // The record failure rides on `out.warnings`, NOT the answer text — so a machine
+        // consumer of the answer gets the model's words uncorrupted (the #77 Gemini fix).
         assert!(
-            out.answer.contains("NOT recorded"),
-            "the record failure must be surfaced loudly on the result: {:?}",
+            !out.answer.contains("NOT recorded"),
+            "the answer text must stay clean of kaibo's injected notices: {:?}",
             out.answer
+        );
+        assert!(
+            out.warnings.iter().any(|w| w.contains("NOT recorded")),
+            "the record failure must be surfaced loudly on out.warnings: {:?}",
+            out.warnings
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod attach;
 pub mod batch;
+pub mod cli;
 pub mod config;
 pub mod consult;
 pub mod context;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use rmcp::service::ServiceExt;
 use rmcp::transport::io::stdio;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use kaibo::cli::{Cli, Command, ServeArgs};
+use kaibo::cli::{Cli, Command, CommonArgs, ServeGates};
 use kaibo::config::Config;
 use kaibo::mcp_log::{self, McpBridgeLayer};
 use kaibo::server::KaiboHandler;
@@ -28,25 +28,29 @@ use kaibo::server::KaiboHandler;
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+    // The shared flags live on `cli.common` (globals, usable before or after the
+    // subcommand); each arm consumes them alongside its own payload.
     match cli.command {
         // Bare `kaibo` and explicit `kaibo serve` both run the MCP server on the same
         // flags — the compatibility contract for existing client configs.
-        None => serve(cli.serve).await,
-        Some(Command::Serve(args)) => serve(args).await,
+        None => serve(cli.common, cli.gates).await,
+        Some(Command::Serve(gates)) => serve(cli.common, gates).await,
         // The CLI front doors own their exit codes (0 answer / 2 usage / 3 setup /
         // 4 consultation failure), so they return a code and we exit on it.
-        Some(Command::Consult(args)) => std::process::exit(kaibo::cli::run_consult(args).await),
-        Some(Command::Config(args)) => std::process::exit(kaibo::cli::run_config(args)),
+        Some(Command::Consult(args)) => {
+            std::process::exit(kaibo::cli::run_consult(cli.common, args).await)
+        }
+        Some(Command::Config) => std::process::exit(kaibo::cli::run_config(cli.common)),
     }
 }
 
 /// Run the MCP server on stdio. The body of a bare `kaibo` / `kaibo serve` — behavior
-/// is byte-for-byte what it was before the CLI restructure.
-async fn serve(args: ServeArgs) -> Result<()> {
+/// is byte-for-byte what it was before the CLI restructure. `common` carries the shared
+/// flags; `gates` the serve-only `--no-<tool>` toggles.
+async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
     // Load config before logging so `server.log` can set the filter. A config error
     // is fatal and must be visible even though tracing isn't up yet — go to stderr.
-    let config_path = args
-        .common
+    let config_path = common
         .config
         .clone()
         .or_else(|| std::env::var_os("KAIBO_CONFIG").map(PathBuf::from));
@@ -61,15 +65,15 @@ async fn serve(args: ServeArgs) -> Result<()> {
     // CLI is the top layer: overlay it over the loaded config. A non-empty `allow_path`
     // list replaces the env/file layer.
     config.apply_cli(
-        args.common.root.clone(),
-        args.common.cast.clone(),
-        args.tool_disables(),
-        args.common.allow_path.clone(),
-        args.common.no_follow_worktrees,
-        args.common.project_context_file.clone(),
-        args.common.user_context_file.clone(),
-        args.common.no_persistence,
-        args.common.state_db.clone(),
+        common.root.clone(),
+        common.cast.clone(),
+        gates.tool_disables(),
+        common.allow_path.clone(),
+        common.no_follow_worktrees,
+        common.project_context_file.clone(),
+        common.user_context_file.clone(),
+        common.no_persistence,
+        common.state_db.clone(),
     );
 
     // Logs MUST go to stderr; stdout carries the MCP protocol. RUST_LOG wins, else

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,16 @@
-//! kaibo (解剖) — stdio MCP server. Ask `consult` a question about a codebase;
-//! kaibo explores it read-only through kaish and returns a cited answer.
+//! kaibo (解剖) — read-only codebase consultation, as a stdio MCP server and a CLI.
 //!
-//! stdio only, by design: kaibo can read a filesystem, so it must never bind a
-//! network socket. Logs go to stderr — stdout is the MCP transport.
+//! Bare `kaibo` (and `kaibo serve`) is the MCP server: ask `consult` a question about
+//! a codebase; kaibo explores it read-only through kaish and returns a cited answer.
+//! stdio only, by design — kaibo can read a filesystem, so it must never bind a
+//! network socket. Logs go to stderr; stdout carries the MCP transport.
+//!
+//! `kaibo consult "…"` and `kaibo config` are the CLI front door (see `kaibo::cli`),
+//! for CLI-first agents, scripts, and humans without an MCP client. Every existing
+//! MCP client config keeps working unchanged: a bare invocation is still the server.
 //!
 //! Configuration layers, highest wins: CLI flags > `KAIBO_*` env > the XDG
-//! `config.toml` > built-in defaults. See `docs/config.md`. The flags here are the
-//! top layer; they override whatever the config resolved.
+//! `config.toml` > built-in defaults. See `docs/config.md`.
 
 use std::path::PathBuf;
 
@@ -16,121 +20,33 @@ use rmcp::service::ServiceExt;
 use rmcp::transport::io::stdio;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use kaibo::config::{Config, ToolDisables};
+use kaibo::cli::{Cli, Command, ServeArgs};
+use kaibo::config::Config;
 use kaibo::mcp_log::{self, McpBridgeLayer};
 use kaibo::server::KaiboHandler;
 
-#[derive(Parser)]
-#[command(
-    name = "kaibo",
-    version,
-    about = "kaibo (解剖) — read-only codebase consult MCP server (stdio)"
-)]
-struct Args {
-    /// Path to config.toml. Overrides $KAIBO_CONFIG; default is
-    /// $XDG_CONFIG_HOME/kaibo/config.toml (absent → built-in defaults).
-    #[arg(long, value_name = "FILE")]
-    config: Option<PathBuf>,
-
-    /// Default project root to explore when a call omits `path`. Also joins the
-    /// containment allowed set: a call's `path` must resolve to at-or-under --root
-    /// or one of the --allow-path trees. With neither flag the allowed set defaults
-    /// to the launch cwd (MCP clients start stdio servers with cwd = workspace), and
-    /// that cwd is also adopted as the inferred default root — so a call may omit
-    /// `path` without configuring anything. (An --allow-path that excludes the cwd
-    /// leaves no default root, since we never default to a path containment rejects.)
-    /// A leading `~` is expanded by your shell, not by kaibo; in config.toml / KAIBO_*
-    /// kaibo expands it for you.
-    #[arg(long, value_name = "DIR")]
-    root: Option<PathBuf>,
-
-    /// Additional allowed path tree. Repeatable. A per-call `path` must resolve
-    /// to at-or-under --root or one of these; use --allow-path / to lift all
-    /// limits. Also settable via KAIBO_ALLOW_PATHS (colon-separated) or
-    /// [server] allow_paths in config.toml — those expand a leading `~`; on the CLI
-    /// your shell does (a quoted '~/src' arrives literal and fails canonicalization).
-    /// A non-empty set of --allow-path flags replaces the env/file layer.
-    #[arg(long = "allow-path", value_name = "DIR", action = clap::ArgAction::Append)]
-    allow_path: Vec<PathBuf>,
-
-    /// Don't follow git worktrees: a per-call `path` in a linked worktree of an
-    /// already-allowed repo is rejected like any other outside path. By default
-    /// kaibo admits such worktrees (resolved by reading git's link files, never by
-    /// running git), so a sibling worktree you spin up mid-session is reachable
-    /// without an --allow-path. Also settable via KAIBO_NO_FOLLOW_WORKTREES or
-    /// [server] follow_worktrees = false.
-    #[arg(long)]
-    no_follow_worktrees: bool,
-
-    /// Default cast when a call omits it (a built-in name or a cast defined in
-    /// config.toml). Built-ins: anthropic | deepseek | gemini | openrouter |
-    /// openai-local (plus aliases: claude, google, local, …) and the batch casts
-    /// gemini-batch | anthropic-batch. Replaces the old --provider flag
-    /// (clap rejects the unknown flag loudly).
-    #[arg(long)]
-    cast: Option<String>,
-
-    /// Don't advertise the `consult` tool.
-    #[arg(long)]
-    no_consult: bool,
-
-    /// Don't advertise the `explore` tool.
-    #[arg(long)]
-    no_explore: bool,
-
-    /// Don't advertise the `deliberate` tool.
-    #[arg(long)]
-    no_deliberate: bool,
-
-    /// Don't advertise the `oneshot` tool.
-    #[arg(long)]
-    no_oneshot: bool,
-
-    /// Don't advertise the `run_kaish` tool.
-    #[arg(long)]
-    no_run_kaish: bool,
-
-    /// Don't advertise `batch_submit`. The shared `job_get`/`job_cancel`/`job_list` verbs remain as
-    /// long as `consult` is on (they also collect consult jobs); they drop only when both
-    /// `--no-batch` and `--no-consult` are set.
-    #[arg(long)]
-    no_batch: bool,
-
-    /// Project house-rules file spliced into each consultation tool's preamble,
-    /// resolved relative to the project root and read only if present. Repeatable.
-    /// Defaults to AGENTS.md; passing any replaces that default. Also settable via
-    /// KAIBO_PROJECT_FILES (colon-separated) or [context] project_files.
-    #[arg(long = "project-context-file", value_name = "FILE", action = clap::ArgAction::Append)]
-    project_context_file: Vec<String>,
-
-    /// User house-rules file (e.g. ~/.claude/CLAUDE.md) spliced into each
-    /// consultation tool's preamble; read unconditionally (missing is an error).
-    /// Repeatable. Also settable via KAIBO_USER_FILES (colon-separated) or
-    /// [context] user_files.
-    #[arg(long = "user-context-file", value_name = "FILE", action = clap::ArgAction::Append)]
-    user_context_file: Vec<PathBuf>,
-
-    /// Don't persist sessions or batch handles — run fully in-memory (session threads
-    /// are lost on restart, batch handles held nowhere). By default kaibo keeps a small
-    /// state db so a session survives a restart and is shared across front doors. Also
-    /// settable via KAIBO_NO_PERSISTENCE or [persistence] enabled = false.
-    #[arg(long)]
-    no_persistence: bool,
-
-    /// Path to the persistence state db. Overrides KAIBO_STATE_DB / [persistence] path /
-    /// the default ($XDG_STATE_HOME/kaibo/state.db, else ~/.local/state/kaibo/state.db).
-    /// A leading `~` is expanded by your shell, not by kaibo.
-    #[arg(long = "state-db", value_name = "FILE")]
-    state_db: Option<PathBuf>,
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let cli = Cli::parse();
+    match cli.command {
+        // Bare `kaibo` and explicit `kaibo serve` both run the MCP server on the same
+        // flags — the compatibility contract for existing client configs.
+        None => serve(cli.serve).await,
+        Some(Command::Serve(args)) => serve(args).await,
+        // The CLI front doors own their exit codes (0 answer / 2 usage / 3 setup /
+        // 4 consultation failure), so they return a code and we exit on it.
+        Some(Command::Consult(args)) => std::process::exit(kaibo::cli::run_consult(args).await),
+        Some(Command::Config(args)) => std::process::exit(kaibo::cli::run_config(args)),
+    }
+}
 
+/// Run the MCP server on stdio. The body of a bare `kaibo` / `kaibo serve` — behavior
+/// is byte-for-byte what it was before the CLI restructure.
+async fn serve(args: ServeArgs) -> Result<()> {
     // Load config before logging so `server.log` can set the filter. A config error
     // is fatal and must be visible even though tracing isn't up yet — go to stderr.
     let config_path = args
+        .common
         .config
         .clone()
         .or_else(|| std::env::var_os("KAIBO_CONFIG").map(PathBuf::from));
@@ -142,26 +58,18 @@ async fn main() -> Result<()> {
         }
     };
 
-    // CLI is the top layer: overlay it over the loaded config. `disable` carries the
-    // --no-<tool> flags (true = the user asked to drop that tool). A non-empty
-    // `allow_path` list replaces the env/file layer.
+    // CLI is the top layer: overlay it over the loaded config. A non-empty `allow_path`
+    // list replaces the env/file layer.
     config.apply_cli(
-        args.root.clone(),
-        args.cast.clone(),
-        ToolDisables {
-            consult: args.no_consult,
-            explore: args.no_explore,
-            deliberate: args.no_deliberate,
-            oneshot: args.no_oneshot,
-            run_kaish: args.no_run_kaish,
-            batch: args.no_batch,
-        },
-        args.allow_path.clone(),
-        args.no_follow_worktrees,
-        args.project_context_file.clone(),
-        args.user_context_file.clone(),
-        args.no_persistence,
-        args.state_db.clone(),
+        args.common.root.clone(),
+        args.common.cast.clone(),
+        args.tool_disables(),
+        args.common.allow_path.clone(),
+        args.common.no_follow_worktrees,
+        args.common.project_context_file.clone(),
+        args.common.user_context_file.clone(),
+        args.common.no_persistence,
+        args.common.state_db.clone(),
     );
 
     // Logs MUST go to stderr; stdout carries the MCP protocol. RUST_LOG wins, else

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -112,6 +112,29 @@ impl ProgressSink for TracingSink {
     }
 }
 
+/// A [`ProgressSink`] that renders each [`PhaseEvent`] as one concise line on
+/// **stderr** — the CLI front door's liveness channel. stdout carries the answer
+/// (so a script can capture it cleanly); progress and logs go to stderr, so a
+/// human watching a `kaibo consult` sees the same "watch it work" narrative an MCP
+/// client gets over `notifications/progress`, without polluting the captured answer.
+///
+/// Each line reuses [`PhaseEvent::message`] — the identical glanceable one-liner
+/// the MCP wire streams — prefixed `kaibo:` so it reads as tool chatter, not answer
+/// text. `emit` stays sync and infallible per the [`ProgressSink`] contract; a
+/// failed stderr write is dropped rather than allowed to sink the consult.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TerminalSink;
+
+impl ProgressSink for TerminalSink {
+    fn emit(&self, event: PhaseEvent) {
+        // `writeln!` to a locked stderr handle; ignore a write error — losing a
+        // progress beat must never fail the consultation (fire-and-forget contract).
+        use std::io::Write;
+        let mut err = std::io::stderr().lock();
+        let _ = writeln!(err, "kaibo: {}", event.message());
+    }
+}
+
 /// A [`ProgressSink`] decorator that remembers the most recent beat while teeing each
 /// event to an inner sink. An async `consult` job streams its progress to the caller
 /// through `job_wait` (the inner [`TracingSink`] → notification ring); a caller polling with
@@ -278,6 +301,24 @@ mod tests {
         // The thin adapter must take every event (levels are verified live / by the pure
         // predicate above, not by a flaky subscriber-capture test).
         let sink = TracingSink;
+        sink.emit(PhaseEvent::PhaseStarted { phase: "consult" });
+        sink.emit(PhaseEvent::KaishRun {
+            script: "grep -rn TODO .".into(),
+        });
+        sink.emit(PhaseEvent::SweepStarted {
+            question: "where?".into(),
+        });
+        sink.emit(PhaseEvent::SweepFinished);
+        sink.emit(PhaseEvent::TurnCapReached);
+        sink.emit(PhaseEvent::PhaseFinished { phase: "consult" });
+    }
+
+    #[test]
+    fn terminal_sink_handles_every_variant_without_panic() {
+        // The CLI's stderr sink must take every event; the line content is
+        // `PhaseEvent::message` (covered above), so here we only assert it can't panic
+        // or block on any variant (the fire-and-forget contract).
+        let sink = TerminalSink;
         sink.emit(PhaseEvent::PhaseStarted { phase: "consult" });
         sink.emit(PhaseEvent::KaishRun {
             script: "grep -rn TODO .".into(),

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -22,7 +22,7 @@ use super::ToolGating;
 /// values. The backend struct stores sources, not secrets; this renderer reads only
 /// those source fields. If Config ever gains a resolved-key cache, do not read it here.
 /// Tests in this file assert the contract holds.
-pub(super) fn render_config_resource(
+pub(crate) fn render_config_resource(
     config: &Config,
     allowed_set: &[PathBuf],
     default_root: Option<&Path>,

--- a/src/server/containment.rs
+++ b/src/server/containment.rs
@@ -5,9 +5,9 @@
 //! tree (`--root` / `--allow-path`, or a followed worktree of one) before kaish ever
 //! mounts it. Attachments obey the same boundary and are read *through the read-only
 //! kaish VFS*, so a symlink swapped in after the check can't escape the mount at read
-//! time. These are a split inherent `impl` on [`super::KaiboHandler`]; the shared
+//! time. These are a split inherent `impl` on [`super::Resolver`]; the shared
 //! predicates they call (`containing_tree`, `containment_error`) live with the rest of
-//! the handler in the parent module.
+//! the resolver in `resolver.rs`.
 
 use std::path::PathBuf;
 
@@ -15,7 +15,7 @@ use rmcp::ErrorData as McpError;
 
 use crate::sandbox::KaishWorker;
 
-impl super::KaiboHandler {
+impl super::Resolver {
     /// Resolve a call's project root with containment enforcement:
     ///
     /// 1. Select the raw path: the explicit `path` arg, else the effective default
@@ -29,7 +29,7 @@ impl super::KaiboHandler {
     ///    widening knobs (`--allow-path`, `KAIBO_ALLOW_PATHS`, `[server] allow_paths`).
     ///
     /// Returns the CANONICALIZED path so the kaish mount target is always resolved.
-    pub(super) fn resolve_root(&self, path: Option<String>) -> Result<PathBuf, McpError> {
+    pub(crate) fn resolve_root(&self, path: Option<String>) -> Result<PathBuf, McpError> {
         // Step 1: select the raw path. The default root is the explicit `--root` or
         // the inferred launch cwd (already canonicalized and dir-checked at startup,
         // and guaranteed inside the allowed set); the steps below re-validate it

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use kaish_kernel::tools::ToolSchema;
 use rig_core::completion::Usage;
 use rmcp::handler::server::router::tool::ToolRouter;
@@ -46,13 +46,19 @@ use crate::session::{SessionStore, Sessions};
 mod config_resource;
 mod containment;
 mod render;
+mod resolver;
 
-use config_resource::render_config_resource;
+pub use resolver::Resolver;
+
+// Re-exported for the CLI front door (`crate::cli`), which renders the same answer
+// footer, failure text, and `kaibo://config` document the MCP handler does.
+pub(crate) use config_resource::render_config_resource;
+pub(crate) use render::{consultation_failure_text, with_provenance};
+
 use render::{
-    batch_poll_brief, batch_within_window, consult_result, consultation_failed,
-    consultation_failure_text, fmt_usage, is_batch_handle, now_epoch_secs, parse_batch_handle,
-    render_job, render_jobs_section, render_wait, wait_level_floor, wait_level_label,
-    with_provenance, BATCH_RECENCY_WINDOW_SECS,
+    batch_poll_brief, batch_within_window, consult_result, consultation_failed, fmt_usage,
+    is_batch_handle, now_epoch_secs, parse_batch_handle, render_job, render_jobs_section,
+    render_wait, wait_level_floor, wait_level_label, BATCH_RECENCY_WINDOW_SECS,
 };
 
 /// kaibo's resource URI namespace. Everything kaish-related hangs off `kaibo://kaish/`.
@@ -510,21 +516,13 @@ pub struct KaiboHandler {
     /// clone — and the drain task in `main` — share the one cell; a `setLevel` on any
     /// request takes effect immediately for the whole server.
     mcp_log_level: Arc<AtomicU8>,
-    /// The canonicalized allowed path trees. A per-call path must canonicalize to
-    /// at-or-under one of these. Computed once at construction from config.root and
-    /// config.allow_paths; falls back to the canonicalized cwd when both are empty.
-    /// `Arc` because rmcp clones the handler per request.
-    allowed_set: Arc<Vec<PathBuf>>,
-    /// The effective default root a call uses when it omits `path` — the explicit
-    /// `--root`/config value, or the launch cwd inferred when it falls inside the
-    /// allowed set. Canonicalized. `None` only when no root was configured *and* the
-    /// cwd is outside the allowed set (an `--allow-path` that excludes the cwd), in
-    /// which case an omitted `path` stays a parameter error. `Arc` for cheap clone.
-    default_root: Arc<Option<PathBuf>>,
-    /// True when [`Self::default_root`] was inferred from the launch cwd rather than
-    /// configured explicitly. Surfaced as "(inferred from launch cwd)" in the scope
-    /// section and `kaibo://config` so the boundary stays legible.
-    default_root_inferred: bool,
+    /// The shared resolution glue both front doors run (`resolve_root`,
+    /// `resolve_cast`, model overrides, `arm`, house rules / orientation / prompts,
+    /// attachment resolution + vision gates) plus the canonicalized containment
+    /// boundary (allowed set + inferred default root). Extracted so the CLI front door
+    /// runs the *identical* resolution without a full handler; the handler keeps thin
+    /// delegating shims over it (see [`Resolver`]). Cheap `Clone` (all `Arc`).
+    resolver: Resolver,
     /// How the batch handlers build provider clients — the injection seam. `new` seeds
     /// [`LiveBatchProviders`](crate::batch::LiveBatchProviders) (the real network
     /// builders); tests swap in a scripted double via
@@ -669,64 +667,6 @@ impl KaiboHandler {
             }
         }
 
-        // Build the canonicalized allowed set. Each entry must be canonicalized now
-        // so `resolve_root`'s Path::starts_with check is sound (symlinks resolved,
-        // `..` collapsed). A nonexistent path can't bound anything — loud error.
-        let mut allowed: Vec<PathBuf> = Vec::new();
-        // The explicit default root, if `--root` was configured — canonicalized so it
-        // doubles as both an allowed tree and the call's default root.
-        let mut explicit_root: Option<PathBuf> = None;
-        if let Some(root) = &config.root {
-            let canon = std::fs::canonicalize(root)
-                .with_context(|| format!("canonicalizing --root {}", root.display()))?;
-            if !canon.is_dir() {
-                anyhow::bail!("--root {} is not a directory", canon.display());
-            }
-            allowed.push(canon.clone());
-            explicit_root = Some(canon);
-        }
-        for p in &config.allow_paths {
-            let canon = std::fs::canonicalize(p)
-                .with_context(|| format!("canonicalizing --allow-path {}", p.display()))?;
-            if !canon.is_dir() {
-                anyhow::bail!("--allow-path {} is not a directory", canon.display());
-            }
-            allowed.push(canon);
-        }
-
-        // Resolve the default root and the allowed-set cwd fallback together. With an
-        // explicit `--root`, that is the default root and no cwd is consulted. Without
-        // one, the launch cwd does double duty: MCP clients start stdio servers with
-        // cwd = workspace, so it is both the zero-config allowed tree *and* the natural
-        // default root — adopt it as the inferred default root whenever it falls inside
-        // the allowed set, so a call may omit `path` in the common single-workspace
-        // case. We never adopt a cwd the containment check would then reject (an
-        // `--allow-path` that excludes the cwd leaves the default root unset, and an
-        // omitted `path` stays a parameter error).
-        let (default_root, default_root_inferred): (Option<PathBuf>, bool) = match explicit_root {
-            Some(root) => (Some(root), false),
-            None => {
-                let cwd = std::env::current_dir()
-                    .context("could not determine current directory for the default root")?;
-                let cwd_canon = std::fs::canonicalize(&cwd)
-                    .with_context(|| format!("canonicalizing cwd {}", cwd.display()))?;
-                if allowed.is_empty() {
-                    // Zero config: the workspace is the whole boundary. Push it here,
-                    // *before* the guard below, so the `starts_with` check sees it and
-                    // adopts cwd as the default root in the zero-config case.
-                    allowed.push(cwd_canon.clone());
-                }
-                // Mirror `resolve_root`'s containment check (step 3): only adopt cwd
-                // when it falls inside the allowed set, so we never default to a path
-                // the call-time check would reject.
-                if allowed.iter().any(|tree| cwd_canon.starts_with(tree)) {
-                    (Some(cwd_canon), true)
-                } else {
-                    (None, false)
-                }
-            }
-        };
-
         // Stamp the live cast roster onto the consultation tools' `cast` param as a
         // JSON-Schema `enum`, so an agent choosing a team reads the menu off the tool
         // schema it already fills arguments from — not only the handshake prose, which
@@ -781,8 +721,15 @@ impl KaiboHandler {
         // report) is heavier than a session's lean Q&A pair, so `job_capacity` is a
         // separate, smaller knob (`[defaults] job_capacity` / `KAIBO_JOB_CAPACITY`).
         let jobs = JobStore::new(config.defaults.job_capacity);
+        // Wrap the config once and hand a clone to the resolver — the single point that
+        // computes the canonicalized allowed set and inferred default root, so the CLI
+        // front door bounds its own invocation cwd by the exact same rule (see
+        // `Resolver::from_config`). The handler keeps its own `Arc<Config>` clone (the
+        // same allocation) for its many `self.config` uses.
+        let config = Arc::new(config);
+        let resolver = Resolver::from_config(config.clone())?;
         Ok(Self {
-            config: Arc::new(config),
+            config,
             tool_router,
             tool_schemas: Arc::new(builtin_schemas()?),
             sessions,
@@ -792,12 +739,17 @@ impl KaiboHandler {
             // for a test has a valid, empty buffer and `job_wait` simply drains nothing.
             notifications: crate::mcp_log::NotificationBuffer::new(512),
             mcp_log_level: Arc::new(AtomicU8::new(mcp_log::rank(mcp_log::DEFAULT_LEVEL))),
-            allowed_set: Arc::new(allowed),
-            default_root: Arc::new(default_root),
-            default_root_inferred,
+            resolver,
             // The real network-client builders; tests swap in a scripted double.
             batch_providers: Arc::new(crate::batch::LiveBatchProviders),
         })
+    }
+
+    /// The shared resolver behind this handler — the CLI front door borrows the same
+    /// resolution glue from a config without standing up a full handler. Exposed so a
+    /// caller that already has a handler (tests, diagnostics) can reach it directly.
+    pub fn resolver(&self) -> &Resolver {
+        &self.resolver
     }
 
     /// Swap in the shared notification ring `main` also handed the bridge layer, so the
@@ -861,7 +813,7 @@ impl KaiboHandler {
     /// resolved path must be at-or-under one of these. Exposed for tests and for
     /// startup logging / the `kaibo://config` resource.
     pub fn allowed_set(&self) -> Vec<PathBuf> {
-        (*self.allowed_set).clone()
+        self.resolver.allowed_set()
     }
 
     /// The effective default root — what a call resolves to when it omits `path`.
@@ -869,254 +821,24 @@ impl KaiboHandler {
     /// (see [`Self::default_root_inferred`]); `None` when neither applies. Exposed
     /// for tests and the `kaibo://config` resource.
     pub fn default_root(&self) -> Option<PathBuf> {
-        (*self.default_root).clone()
+        self.resolver.default_root()
     }
 
     /// Whether [`Self::default_root`] was inferred from the launch cwd rather than
     /// configured explicitly.
     pub fn default_root_inferred(&self) -> bool {
-        self.default_root_inferred
+        self.resolver.default_root_inferred()
     }
 
-    /// The allowed tree (or followed-worktree root) that contains `canon`, or `None` when
-    /// it's outside the boundary — the *which-tree* sibling of [`contained`](Self::contained)
-    /// (which is just `is_some()` on this). A static `allow_path` wins over a followed
-    /// worktree, matching the precedence in `contained`'s original form. The returned root
-    /// is what an attachment read mounts a read-only kaish worker at, so the VFS refuses a
-    /// symlink escaping *that* tree (see [`resolve_attachments`](Self::resolve_attachments)).
-    fn containing_tree(&self, canon: &std::path::Path) -> Option<PathBuf> {
-        if let Some(tree) = self.allowed_set.iter().find(|tree| canon.starts_with(tree)) {
-            return Some(tree.clone());
-        }
-        if self.config.follow_worktrees {
-            for tree in self.allowed_set.iter() {
-                if let Some(common) = crate::worktree::common_git_dir(tree) {
-                    if let Some(wt) = crate::worktree::vouched_worktrees(&common)
-                        .into_iter()
-                        .find(|wt| canon.starts_with(wt))
-                    {
-                        return Some(wt);
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    /// The shared "outside the allowed set" rejection, naming the boundary and the three
-    /// widening knobs. Used wherever [`contained`](Self::contained) says no, so the
-    /// caller always learns where the edge is and how to move it.
-    fn containment_error(&self, raw: &std::path::Path, canon: &std::path::Path) -> McpError {
-        let trees: Vec<String> = self
-            .allowed_set
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect();
-        McpError::invalid_params(
-            format!(
-                "path {} resolves to {}, which is outside the allowed set [{}]. \
-                 To widen the boundary: pass --allow-path DIR on the command line, \
-                 set KAIBO_ALLOW_PATHS=DIR (colon-separated), or add \
-                 `[server] allow_paths = [\"DIR\"]` in config.toml. The config and env \
-                 forms expand `$VAR` / `${{VAR}}` and a leading `~`, so a scratch dir \
-                 reads portably as `\"$TMPDIR\"` / `\"$XDG_RUNTIME_DIR/...\"`.",
-                raw.display(),
-                canon.display(),
-                trees.join(", "),
-            ),
-            None,
-        )
-    }
-
-    /// Resolve caller-named `consult`/`explore` attachments: attach means *the model
-    /// sees the bytes*. A text file within `budget` (cumulative, caller order) is read
-    /// server-side and inlined into the driver prompt; a text file past it is demoted to
-    /// a named path the prompt directs the model to read WHOLE through its shell —
-    /// loudly, never a silent drop. An image is routed to `view_image` (never inlined
-    /// here). Each path must canonicalize to a regular file *under `root`* (returned
-    /// root-relative, `cat`'d from cwd) — the only real tree the consult shell mounts;
-    /// anything out of reach is refused with guidance.
-    ///
-    /// **Inlined bytes are read through the read-only kaish VFS**, exactly like
-    /// [`resolve_attachments`](Self::resolve_attachments) and for the same reason: these
-    /// bytes enter the model's context, so a raced symlink-swap must be refused at the
-    /// mount layer, not merely at a canonicalize-then-read check. Demoted files are
-    /// never read here at all — the model's own `cat` goes through the same VFS.
+    /// Shim over [`Resolver::resolve_consult_attachments`] (static — the sandbox
+    /// rides in as a param, so the resolution glue is shared with the CLI front door).
     async fn resolve_consult_attachments(
         root: &std::path::Path,
         attach: &[String],
         budget: usize,
         sandbox: &crate::sandbox::SandboxConfig,
     ) -> Result<Vec<crate::consult::ConsultAttachment>, McpError> {
-        use crate::attach::{check_attachment_bounds, DEFAULT_MAX_ATTACHMENTS};
-        // Count cap only (total pinned to 0, so the byte-budget arm never fires): a
-        // stray thousand-file glob is refused before any canonicalize/read work. There
-        // is deliberately NO cumulative byte cap on this path — `budget` bounds
-        // everything that's actually read (inlined), and a demoted file is never read
-        // here at all, so there's nothing left for a cumulative cap to protect.
-        check_attachment_bounds(
-            attach.len(),
-            0,
-            DEFAULT_MAX_ATTACHMENTS,
-            crate::attach::DEFAULT_MAX_TOTAL_BYTES,
-        )
-        .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
-        // One read-only worker rooted at the consult root, spawned lazily on the first
-        // inlined read (a demote-everything call — budget 0, say — spawns none).
-        let mut worker: Option<crate::sandbox::KaishWorker> = None;
-        let mut remaining = budget as u64;
-        let mut out = Vec::with_capacity(attach.len());
-        for p in attach {
-            let raw = std::path::PathBuf::from(p);
-            // A relative path reads from the project root (where the model's shell starts).
-            let joined = if raw.is_absolute() {
-                raw.clone()
-            } else {
-                root.join(&raw)
-            };
-            let canon = std::fs::canonicalize(&joined).map_err(|e| {
-                McpError::invalid_params(
-                    format!("attached file {} could not be resolved: {e}", raw.display()),
-                    None,
-                )
-            })?;
-            let meta = std::fs::metadata(&canon).map_err(|e| {
-                McpError::invalid_params(
-                    format!("attached file {} could not be read: {e}", canon.display()),
-                    None,
-                )
-            })?;
-            if !meta.is_file() {
-                return Err(McpError::invalid_params(
-                    format!("attached file {} is not a regular file", canon.display()),
-                    None,
-                ));
-            }
-            // The consult model reads attachments through its shell, which mounts exactly
-            // one real tree: the project root. A path under root is passed root-relative
-            // (the model `cat`s it from cwd); anything out of reach gets a refusal naming
-            // the project root.
-            let display_path = if let Ok(rel) = canon.strip_prefix(root) {
-                rel.display().to_string()
-            } else {
-                return Err(McpError::invalid_params(
-                    format!(
-                        "attached file {} resolves outside the project root {} — consult reads \
-                         attachments through its shell, which only mounts that. Paste it into \
-                         `context`, or use `oneshot`/`batch` attach (which inline a file from \
-                         anywhere in the allowed set).",
-                        raw.display(),
-                        root.display(),
-                    ),
-                    None,
-                ));
-            };
-            // Sniff the file's type by content, not extension — a 16-byte prefix covers
-            // every magic number `sniff_mime` knows.
-            //
-            // This prefix is read with `std::fs`, NOT through the kaish VFS — a
-            // deliberate, bounded exception that only ever *routes*: the 16 bytes feed
-            // `sniff_mime` to a bool and are dropped, and kaibo's adversary is the
-            // *model*, which has no control over filesystem timing to drive a swap. For
-            // an image the authoritative read still goes through the read-only VFS in
-            // `view_image` at view time (full bytes, full containment, re-sniffed); for
-            // a demoted text file the model's own `cat` does. Anything we INLINE below
-            // is read through the VFS and re-sniffed from its full bytes, so the worst
-            // case of a raced swap here is a misrouted hint the model recovers from,
-            // never an escape or a leak. An unreadable prefix simply reads as text.
-            let prefix_is_image = {
-                use std::io::Read;
-                let mut buf = [0u8; 16];
-                let n = std::fs::File::open(&canon)
-                    .and_then(|mut f| f.read(&mut buf))
-                    .unwrap_or(0);
-                crate::view_image::sniff_mime(&buf[..n]).is_some()
-            };
-            if prefix_is_image {
-                out.push(crate::consult::ConsultAttachment::Image { path: display_path });
-                continue;
-            }
-            // Text past the remaining inline budget is demoted, not refused: unlike the
-            // tool-less tools, this model CAN read the file itself, and the prompt
-            // orders it to — whole, paged past the output cap.
-            if meta.len() > remaining {
-                out.push(crate::consult::ConsultAttachment::TextOversize {
-                    path: display_path,
-                    size: meta.len(),
-                });
-                continue;
-            }
-            // Within budget: inline. The read is VFS-mounted (see doc-comment) — these
-            // bytes enter the model's context.
-            if worker.is_none() {
-                worker = Some(
-                    crate::sandbox::KaishWorker::spawn_with(root, sandbox.clone()).map_err(
-                        |e| {
-                            McpError::internal_error(
-                                format!("attachment reader for {}: {e:#}", root.display()),
-                                None,
-                            )
-                        },
-                    )?,
-                );
-            }
-            // Read at most one byte past `remaining`. The `meta.len()` gate above is a
-            // stat, and stat-then-read is a TOCTOU: a file swapped to something enormous
-            // in that window would slurp whole into memory if the read were unbounded.
-            // Capping the read at `remaining + 1` bounds that window — a raced-huge file
-            // comes back as `remaining + 1` bytes, which the length check below reads as
-            // "over budget" and demotes to `TextOversize` (the model then `cat`s it
-            // itself), never an OOM. So the demotion path does double duty: it catches
-            // both an honest over-budget file and a raced swap, from the one length test.
-            let bytes = worker
-                .as_ref()
-                .expect("worker was just spawned")
-                .read_file_capped(canon.clone(), remaining + 1)
-                .await
-                .map_err(|e| {
-                    McpError::invalid_params(
-                        format!("attached file {} could not be read: {e:#}", canon.display()),
-                        None,
-                    )
-                })?;
-            // Re-sniff from the (capped) bytes — authoritative for anything inlined; a
-            // magic number lives in the first few bytes, so the cap never blinds it.
-            if crate::view_image::sniff_mime(&bytes).is_some() {
-                out.push(crate::consult::ConsultAttachment::Image { path: display_path });
-                continue;
-            }
-            if bytes.len() as u64 > remaining {
-                out.push(crate::consult::ConsultAttachment::TextOversize {
-                    path: display_path,
-                    size: bytes.len() as u64,
-                });
-                continue;
-            }
-            match std::str::from_utf8(&bytes) {
-                Ok(text) => {
-                    remaining -= bytes.len() as u64;
-                    out.push(crate::consult::ConsultAttachment::Text {
-                        path: display_path,
-                        body: text.to_string(),
-                    });
-                }
-                // Neither text nor image: refuse loudly — it can't be inlined honestly,
-                // and the model's shell would refuse to `cat` binary too, so naming it
-                // would burn a turn on a dead end.
-                Err(_) => {
-                    return Err(McpError::invalid_params(
-                        format!(
-                            "attached file {display_path} is neither valid UTF-8 text nor a \
-                             recognized image (png/jpeg/gif/webp) — kaibo won't inline binary, \
-                             and the model's shell can't read it either. Convert it first, or \
-                             paste the relevant text into `context`."
-                        ),
-                        None,
-                    ));
-                }
-            }
-        }
-        Ok(out)
+        Resolver::resolve_consult_attachments(root, attach, budget, sandbox).await
     }
 
     /// Resolve attachments for a sweep-only tool (`explore`, `deliberate`'s dossier
@@ -1146,40 +868,18 @@ impl KaiboHandler {
         Ok(attachments)
     }
 
-    /// Refuse an image attachment to a vision-blind consult synth — the consult analog of
-    /// [`gate_image_attachments`]. consult never inlines an image's bytes; the model opens
-    /// an attached image with the `view_image` tool, which is only wired into the toolset
-    /// when the synth is vision-capable (see `consult_tools`). So an image attached to a
-    /// blind synth could never be seen — refuse honestly up front, naming the cast, rather
-    /// than let the prompt name a file the model has no way to open. Text attachments (and
-    /// the no-attachment case) always pass.
+    /// Shim over [`Resolver::gate_consult_image_attachments`] — the resolution glue
+    /// lives on the shared resolver so the CLI runs the same gate.
     fn gate_consult_image_attachments(
         attachments: &[crate::consult::ConsultAttachment],
         vision: bool,
         model: &str,
         cast: &str,
     ) -> Result<(), McpError> {
-        if !vision && attachments.iter().any(|a| a.is_image()) {
-            return Err(McpError::invalid_params(
-                format!(
-                    "an image was attached, but the consult synth `{model}` on cast `{cast}` \
-                     can't see images — consult opens an attached image with its `view_image` \
-                     tool, which only a vision-capable synth carries. Use a vision-capable \
-                     cast, or attach only text files. `kaibo://config` lists each slot's \
-                     `vision`."
-                ),
-                None,
-            ));
-        }
-        Ok(())
+        Resolver::gate_consult_image_attachments(attachments, vision, model, cast)
     }
 
-    /// Refuse image attachments to a vision-blind model, naming the cast so the caller
-    /// can pick a vision-capable one. Shared by the tool-less attach surfaces (`batch` and
-    /// `oneshot`) so the refusal reads identically and lives in one place; a blind model
-    /// would silently ignore or error on an image part, so we refuse honestly up front
-    /// (the project posture) rather than ship a no-op image. Text-only attachments (and
-    /// the no-attachment case) always pass.
+    /// Shim over [`Resolver::gate_image_attachments`].
     pub fn gate_image_attachments(
         &self,
         vision: bool,
@@ -1187,126 +887,38 @@ impl KaiboHandler {
         model: &str,
         cast: &str,
     ) -> Result<(), McpError> {
-        if !vision
-            && attachments
-                .iter()
-                .any(|a| matches!(a, crate::attach::Attachment::Image { .. }))
-        {
-            return Err(McpError::invalid_params(
-                format!(
-                    "an image attachment was given, but the model `{model}` on cast `{cast}` \
-                     doesn't accept image input. Use a vision-capable cast/model, or attach \
-                     only text files. `kaibo://config` lists each slot's `vision`."
-                ),
-                None,
-            ));
-        }
-        Ok(())
+        self.resolver
+            .gate_image_attachments(vision, attachments, model, cast)
     }
 
-    /// The worktrees the follow feature currently admits *beyond* the static allowed
-    /// set — for the `kaibo://config` runtime section, so the live boundary stays
-    /// legible. Recomputed on each read (it reflects worktrees that exist now, which
-    /// can change between calls). Empty when the feature is off or nothing extra is
-    /// reachable. Deduplicated and sorted for a stable resource.
+    /// Shim over [`Resolver::followed_worktrees`].
     fn followed_worktrees(&self) -> Vec<PathBuf> {
-        if !self.config.follow_worktrees {
-            return Vec::new();
-        }
-        let mut found: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
-        for tree in self.allowed_set.iter() {
-            let Some(common) = crate::worktree::common_git_dir(tree) else {
-                continue;
-            };
-            for wt in crate::worktree::vouched_worktrees(&common) {
-                // Skip worktrees already covered by the static set — those aren't
-                // "extra"; the runtime section reports only what follow adds.
-                if !self.allowed_set.iter().any(|t| wt.starts_with(t)) {
-                    found.insert(wt);
-                }
-            }
-        }
-        found.into_iter().collect()
+        self.resolver.followed_worktrees()
     }
 
-    /// Assemble the operator's house rules for this call against the resolved
-    /// `root`: the `[context]` files read here, in trusted server-side Rust, and
-    /// folded into the phase preamble. A missing *declared* user file is a loud
-    /// `internal_error`, never a silent skip — the operator was counting on that
-    /// guidance reaching the model. `None` when nothing's configured/present.
+    /// Shim over [`Resolver::house_rules`].
     fn house_rules(&self, root: &std::path::Path) -> Result<Option<Arc<str>>, McpError> {
-        self.config
-            .context
-            .assemble(root)
-            .map(|opt| opt.map(Arc::from))
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))
+        self.resolver.house_rules(root)
     }
 
-    /// Assemble the static repo-orientation map for this call against the resolved
-    /// `root` — the `[orientation]` block injected into the exploring preamble. Runs
-    /// the kernel's own `glob` server-side (no model turn). A repo over the file
-    /// ceiling gets a directory map, and one too large for even that gets a short
-    /// discover-as-you-go note — never a refusal, per `OrientationConfig::assemble`.
-    /// Errors here are real failures (kernel spawn, unparseable enumeration), not
-    /// size. Only the *exploring* tools call this.
+    /// Shim over [`Resolver::orientation`].
     async fn orientation(&self, root: &std::path::Path) -> Result<Option<Arc<str>>, McpError> {
-        self.config
-            .orientation
-            .assemble(root, self.config.sandbox.clone())
-            .await
-            .map(|opt| opt.map(Arc::from))
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))
+        self.resolver.orientation(root).await
     }
 
-    /// Resolve this call's per-phase system prompts for `cast` — the per-slot `preamble`
-    /// over the global `[prompts]` table. Thin wrapper over [`Cast::resolved_prompts`]
-    /// (the shared layering the `kaibo://prompts/{cast}` resource also renders); `cast`
-    /// is the post-override clone, so a per-call model override (a bare slot) correctly
-    /// carries no preamble.
+    /// Shim over [`Resolver::resolved_prompts`].
     fn resolved_prompts(&self, cast: &Cast) -> PromptOverrides {
-        cast.resolved_prompts(&self.config.prompts)
+        self.resolver.resolved_prompts(cast)
     }
 
-    /// Resolve a call's cast: the explicit name (looked up in the registry, by
-    /// name or alias), else the server's default cast. An unknown name is a
-    /// parameter error naming the available casts. Returns an owned clone so the
-    /// caller can layer per-call model overrides onto it.
+    /// Shim over [`Resolver::resolve_cast`].
     fn resolve_cast(&self, cast: Option<String>) -> Result<Cast, McpError> {
-        let name = cast.unwrap_or_else(|| self.config.default_cast.clone());
-        self.config
-            .resolve_cast(&name)
-            .cloned()
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))
+        self.resolver.resolve_cast(cast)
     }
 
-    /// Refuse an interactive tool (`consult`/`consult_submit`/`oneshot`) on a cast whose
-    /// synth runs on an offline lane. A `Batch` synth is a big, slow, expensive model
-    /// tuned for free offline batch latency (Gemini Pro, Claude Opus); a `Direct` synth
-    /// is a big local model kaibo runs itself, taking the time it takes — either way,
-    /// driving it through an interactive tool loop is the wrong-and-costly mistake this
-    /// gate exists to stop. Points the caller at the lane that fits.
+    /// Shim over [`Resolver::reject_offline_cast`].
     fn reject_offline_cast(&self, cast: &Cast, tool: &str) -> Result<(), McpError> {
-        match cast.synth_lane() {
-            Some(Lane::Batch) => Err(McpError::invalid_params(
-                format!(
-                    "cast `{}`'s synth runs on the `batch` lane — submit it with \
-                     `batch_submit`, not `{tool}`. It's a big, slow model tuned for free \
-                     offline batch latency; running it interactively would be slow and \
-                     expensive. Pick an interactive cast for `{tool}`.",
-                    cast.name
-                ),
-                None,
-            )),
-            Some(Lane::Direct) => Err(McpError::invalid_params(
-                format!(
-                    "cast `{}`'s synth runs offline (`lane = \"direct\"`) — interactive \
-                     tools need an interactive synth. Pick an interactive cast for `{tool}`.",
-                    cast.name
-                ),
-                None,
-            )),
-            None => Ok(()),
-        }
+        self.resolver.reject_offline_cast(cast, tool)
     }
 
     /// Refuse `batch_submit` on a cast whose synth isn't on the `batch` lane
@@ -1401,16 +1013,10 @@ impl KaiboHandler {
         Ok(lane)
     }
 
-    /// Apply a per-call model override to one of `cast`'s slots.
-    ///
-    /// The model id rides *verbatim* — an id containing `/` (HuggingFace-style
-    /// `org/model`) is still one id, never parsed for a backend, so an org prefix
-    /// that happens to match a backend alias (`google/…`, `gemma/…`) can never
-    /// silently retarget the call. Retargeting is the explicit `backend` arg's
-    /// job: when set, it resolves (aliases included) and the slot is replaced
-    /// wholesale, which also works on a role the cast doesn't carry. Either way
-    /// the configured slot's pins/tunables are dropped — they described the
-    /// *configured* model; the new id classifies fresh.
+    /// Shim over [`Resolver::override_model`]. Only the offline model-override tests
+    /// still reach it directly (the live callers go through `apply_model_override`),
+    /// so it's test-scoped to stay dead-code-clean in a normal build.
+    #[cfg(test)]
     fn override_model(
         &self,
         cast: &mut Cast,
@@ -1418,43 +1024,10 @@ impl KaiboHandler {
         model: &str,
         backend: Option<&str>,
     ) -> Result<(), McpError> {
-        let model = model.trim();
-        if model.is_empty() {
-            // Same loud rule config load applies to slots (config.rs): an empty
-            // model id is a typo, never an intent — it would otherwise surface
-            // as a baffling provider 404 mid-call.
-            return Err(McpError::invalid_params(
-                format!("the {} model id is empty", role.key()),
-                None,
-            ));
-        }
-        let backend = match backend {
-            Some(name) => self
-                .config
-                .resolve_backend(name)
-                .map_err(|e| McpError::invalid_params(e.to_string(), None))?
-                .name
-                .clone(),
-            None => cast.slot(role).map(|s| s.backend.clone()).ok_or_else(|| {
-                McpError::invalid_params(
-                    format!(
-                        "cast {:?} has no {} slot to override — pass the matching \
-                         backend override arg to target one",
-                        cast.name,
-                        role.key()
-                    ),
-                    None,
-                )
-            })?,
-        };
-        cast.slots.insert(role, ModelSlot::bare(backend, model));
-        Ok(())
+        self.resolver.override_model(cast, role, model, backend)
     }
 
-    /// The tool-input face of [`override_model`](Self::override_model): folds one
-    /// tool's `(model, backend)` override args onto `cast`'s `role` slot. A
-    /// backend arg without its model arg is a loud parameter error naming both
-    /// spellings — there is no configured id to guess at on a foreign backend.
+    /// Shim over [`Resolver::apply_model_override`].
     fn apply_model_override(
         &self,
         cast: &mut Cast,
@@ -1464,35 +1037,27 @@ impl KaiboHandler {
         model_arg: &str,
         backend_arg: &str,
     ) -> Result<(), McpError> {
-        match (model, backend) {
-            (Some(model), backend) => self.override_model(cast, role, model, backend),
-            (None, Some(_)) => Err(McpError::invalid_params(
-                format!(
-                    "{backend_arg} was sent without {model_arg} — a backend override \
-                     needs the model id to run there"
-                ),
-                None,
-            )),
-            (None, None) => Ok(()),
-        }
+        self.resolver
+            .apply_model_override(cast, role, model, backend, model_arg, backend_arg)
     }
 
-    /// Resolve one of `cast`'s slots into a live [`Arm`] for `role`. A missing
-    /// slot is the loud call-time gap ("cast `x` has no synth slot" — absent =
-    /// capability absent); a backend that fails to build (key resolution,
-    /// client init) is an internal error.
+    /// Shim over [`Resolver::arm`].
     fn arm(&self, cast: &Cast, role: ModelRole) -> Result<Arm, McpError> {
-        let slot = cast
-            .require_slot(role)
-            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-        // The slot's backend ref is canonical (load) or alias-resolved (override),
-        // so a failure here is a server bug, not a caller mistake.
-        let backend = self
-            .config
-            .resolve_backend(&slot.backend)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        Arm::from_slot(backend, slot, role, &self.config.defaults)
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))
+        self.resolver.arm(cast, role)
+    }
+
+    /// Shim over [`Resolver::resolve_root`] — the containment check both front doors
+    /// share (see `containment.rs`).
+    pub(crate) fn resolve_root(&self, path: Option<String>) -> Result<PathBuf, McpError> {
+        self.resolver.resolve_root(path)
+    }
+
+    /// Shim over [`Resolver::resolve_attachments`].
+    pub async fn resolve_attachments(
+        &self,
+        paths: &[String],
+    ) -> Result<Vec<crate::attach::Attachment>, McpError> {
+        self.resolver.resolve_attachments(paths).await
     }
 
     #[tool(
@@ -2751,9 +2316,9 @@ impl rmcp::ServerHandler for KaiboHandler {
             // is what re-reads a newly-set key.
             instructions: Some(kaibo_instructions_with_scope(
                 &self.config,
-                &self.allowed_set,
-                self.default_root.as_deref(),
-                self.default_root_inferred,
+                self.resolver.allowed_trees(),
+                self.resolver.default_root_ref(),
+                self.resolver.default_root_inferred(),
                 self.config
                     .default_cast_usability(|k| std::env::var(k).ok()),
                 &self.config.usable_casts(|k| std::env::var(k).ok()),
@@ -2808,9 +2373,9 @@ impl rmcp::ServerHandler for KaiboHandler {
             &request.uri,
             &self.tool_schemas,
             &self.config,
-            &self.allowed_set,
-            self.default_root.as_deref(),
-            self.default_root_inferred,
+            self.resolver.allowed_trees(),
+            self.resolver.default_root_ref(),
+            self.resolver.default_root_inferred(),
             self.followed_worktrees(),
             self.sessions.store().is_some(),
         )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -56,9 +56,10 @@ pub(crate) use config_resource::render_config_resource;
 pub(crate) use render::{consultation_failure_text, with_provenance};
 
 use render::{
-    batch_poll_brief, batch_within_window, consult_result, consultation_failed, fmt_usage,
-    is_batch_handle, now_epoch_secs, parse_batch_handle, render_job, render_jobs_section,
-    render_wait, wait_level_floor, wait_level_label, BATCH_RECENCY_WINDOW_SECS,
+    append_warnings, batch_poll_brief, batch_within_window, consult_result, consultation_failed,
+    fmt_usage, is_batch_handle, now_epoch_secs, parse_batch_handle, render_job,
+    render_jobs_section, render_wait, wait_level_floor, wait_level_label,
+    BATCH_RECENCY_WINDOW_SECS,
 };
 
 /// kaibo's resource URI namespace. Everything kaish-related hangs off `kaibo://kaish/`.
@@ -1180,8 +1181,11 @@ impl KaiboHandler {
         // Provenance: name the cast and the models that answered, so a caller (a
         // cross-model study especially) sees which model produced this without
         // digging into `kaibo://config`. consult runs two arms — both are named.
+        // Fold any non-fatal warnings (a failed session record) back into the answer
+        // text before the footer — the MCP client has no structured warnings channel, so
+        // it sees them inline exactly as #76 shipped (the CLI keeps them off `--json`).
         let answer = with_provenance(
-            out.answer,
+            append_warnings(out.answer, &out.warnings),
             &cast.name,
             &[("explorer", &explorer.model), ("synth", &synth.model)],
             &out.usage,
@@ -1296,7 +1300,7 @@ impl KaiboHandler {
             {
                 Ok(out) => {
                     let answer = with_provenance(
-                        out.answer,
+                        append_warnings(out.answer, &out.warnings),
                         &cast_name,
                         &[
                             ("explorer", explorer_model.as_str()),

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -355,6 +355,21 @@ pub(super) fn parse_batch_handle(handle: &str) -> Result<(&str, &str), McpError>
         })
 }
 
+/// Fold a consult's non-fatal [`warnings`](crate::consult::ConsultOutput) back into the
+/// answer text for the MCP client, appended after the answer body (so, with the
+/// provenance footer added around this, they sit between the answer and the footer —
+/// the exact position #76 shipped). The warnings live *off* the answer on the engine
+/// seam so a machine consumer of the CLI `--json` `answer` field gets clean text; the
+/// MCP client has no such structured channel, so here we render them inline, keeping
+/// the client-visible behavior unchanged. A no-op when there are no warnings.
+pub(crate) fn append_warnings(mut answer: String, warnings: &[String]) -> String {
+    for w in warnings {
+        answer.push_str("\n\n");
+        answer.push_str(w);
+    }
+    answer
+}
+
 pub(crate) fn with_provenance(
     answer: String,
     cast: &str,
@@ -406,6 +421,23 @@ pub(super) fn fmt_usage(usage: &Usage) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The MCP path renders a consult's warnings inline (after the answer body), so the
+    /// client sees them exactly as #76 shipped even though they now live off the answer
+    /// on the engine seam. No warnings → the answer is untouched.
+    #[test]
+    fn append_warnings_folds_notices_after_the_answer_and_is_a_noop_when_empty() {
+        assert_eq!(
+            append_warnings("the answer".to_string(), &[]),
+            "the answer",
+            "no warnings must leave the answer byte-for-byte"
+        );
+        let folded = append_warnings(
+            "the answer".to_string(),
+            &["⚠️ notice one".to_string(), "⚠️ notice two".to_string()],
+        );
+        assert_eq!(folded, "the answer\n\n⚠️ notice one\n\n⚠️ notice two");
+    }
 
     #[test]
     fn wait_level_floor_parses_the_salience_words_and_rejects_junk() {

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -112,7 +112,7 @@ pub(super) fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) ->
 /// errored — the body of [`consultation_failed`], split out so the async path
 /// ([`consult_submit`]) can store a ready string in a [`JobState::Failed`] and the
 /// unified `job_get` wrap it without re-classifying.
-pub(super) fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> String {
+pub(crate) fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> String {
     let detail = format!("{err:#}");
     let guidance = match classify_failure(&err) {
         FailureKind::TransientProvider => {
@@ -355,7 +355,7 @@ pub(super) fn parse_batch_handle(handle: &str) -> Result<(&str, &str), McpError>
         })
 }
 
-pub(super) fn with_provenance(
+pub(crate) fn with_provenance(
     answer: String,
     cast: &str,
     roles: &[(&str, &str)],

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -1,0 +1,587 @@
+//! The shared **resolution glue** both front doors run: the MCP handler
+//! ([`super::KaiboHandler`]) and the CLI (`crate::cli`). A [`Resolver`] holds the
+//! resolved [`Config`] plus the canonicalized containment state (allowed trees +
+//! the inferred default root), and turns a call's raw inputs into the concrete
+//! pieces a consultation needs: a contained project root, a cast, per-call model
+//! overrides, live [`Arm`]s, the operator's house rules / orientation / prompts,
+//! and classified attachments (with the vision gate).
+//!
+//! The two front doors differ only in transport (MCP notifications vs. stderr
+//! lines) and lifecycle (a long-lived server vs. a one-shot process); the
+//! *resolution* is identical, so it lives here once. [`Resolver::from_config`] is
+//! the single construction point — it computes the allowed set and the default
+//! root exactly as the server always has, so a CLI invocation's cwd joins the
+//! boundary the same way a launched stdio server's cwd does.
+//!
+//! The containment methods (`resolve_root`, `resolve_attachments`, and the private
+//! `contained`/`containing_tree`) live in the sibling `containment.rs` as a split
+//! `impl Resolver`, next to the boundary doc-comment they belong with.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use rmcp::ErrorData as McpError;
+
+use crate::config::{Cast, Config, Lane, ModelRole, ModelSlot};
+use crate::consult::{Arm, PromptOverrides};
+
+/// The resolution state shared by the MCP handler and the CLI: the resolved
+/// config plus the canonicalized containment boundary. Cheap to `Clone` (every
+/// field is an `Arc` or `Copy`), so the per-request handler clones share one.
+#[derive(Clone)]
+pub struct Resolver {
+    /// The resolved configuration: backend + cast registries, defaults, default
+    /// root and cast. `Arc` because it's immutable after startup and shared with
+    /// the handler (which keeps its own clone of the same `Arc`).
+    pub(crate) config: Arc<Config>,
+    /// The canonicalized allowed path trees. A per-call path must canonicalize to
+    /// at-or-under one of these. Computed once from config.root/allow_paths;
+    /// falls back to the canonicalized cwd when both are empty.
+    allowed_set: Arc<Vec<PathBuf>>,
+    /// The effective default root a call uses when it omits `path` — the explicit
+    /// `--root`/config value, or the launch/invocation cwd inferred when it falls
+    /// inside the allowed set. Canonicalized. `None` only when no root was
+    /// configured *and* the cwd is outside the allowed set. `pub(super)` so the
+    /// split containment `impl` in `containment.rs` reads it.
+    pub(super) default_root: Arc<Option<PathBuf>>,
+    /// True when [`default_root`](Self::default_root) was inferred from the cwd
+    /// rather than configured explicitly. Surfaced in the scope section and
+    /// `kaibo://config` so the boundary stays legible.
+    default_root_inferred: bool,
+}
+
+impl Resolver {
+    /// Build the resolver from a resolved [`Config`], computing the canonicalized
+    /// allowed set and the default root — the containment setup both front doors
+    /// share. A nonexistent or non-directory entry in root / allow_paths is a loud
+    /// construction error (a path that can't be canonicalized can't bound anything).
+    ///
+    /// Without an explicit `--root`, the process cwd does double duty: it is both the
+    /// zero-config allowed tree *and* the inferred default root — adopted whenever it
+    /// falls inside the allowed set, so a call may omit `path` in the common
+    /// single-workspace case. A cwd the containment check would reject is never
+    /// adopted (an `--allow-path` that excludes it leaves the default root unset).
+    pub fn from_config(config: Arc<Config>) -> Result<Self> {
+        // Build the canonicalized allowed set. Each entry is canonicalized now so
+        // the `starts_with` containment check is sound (symlinks resolved, `..`
+        // collapsed). A nonexistent path can't bound anything — loud error.
+        let mut allowed: Vec<PathBuf> = Vec::new();
+        // The explicit default root, if `--root` was configured — canonicalized so it
+        // doubles as both an allowed tree and the call's default root.
+        let mut explicit_root: Option<PathBuf> = None;
+        if let Some(root) = &config.root {
+            let canon = std::fs::canonicalize(root)
+                .with_context(|| format!("canonicalizing --root {}", root.display()))?;
+            if !canon.is_dir() {
+                anyhow::bail!("--root {} is not a directory", canon.display());
+            }
+            allowed.push(canon.clone());
+            explicit_root = Some(canon);
+        }
+        for p in &config.allow_paths {
+            let canon = std::fs::canonicalize(p)
+                .with_context(|| format!("canonicalizing --allow-path {}", p.display()))?;
+            if !canon.is_dir() {
+                anyhow::bail!("--allow-path {} is not a directory", canon.display());
+            }
+            allowed.push(canon);
+        }
+
+        // Resolve the default root and the allowed-set cwd fallback together. With an
+        // explicit `--root`, that is the default root and no cwd is consulted. Without
+        // one, the launch/invocation cwd is both the zero-config allowed tree and the
+        // natural default root — adopt it whenever it falls inside the allowed set. We
+        // never adopt a cwd the containment check would then reject.
+        let (default_root, default_root_inferred): (Option<PathBuf>, bool) = match explicit_root {
+            Some(root) => (Some(root), false),
+            None => {
+                let cwd = std::env::current_dir()
+                    .context("could not determine current directory for the default root")?;
+                let cwd_canon = std::fs::canonicalize(&cwd)
+                    .with_context(|| format!("canonicalizing cwd {}", cwd.display()))?;
+                if allowed.is_empty() {
+                    // Zero config: the workspace is the whole boundary. Push it here,
+                    // before the guard below, so the `starts_with` check adopts cwd as
+                    // the default root in the zero-config case.
+                    allowed.push(cwd_canon.clone());
+                }
+                if allowed.iter().any(|tree| cwd_canon.starts_with(tree)) {
+                    (Some(cwd_canon), true)
+                } else {
+                    (None, false)
+                }
+            }
+        };
+
+        Ok(Self {
+            config,
+            allowed_set: Arc::new(allowed),
+            default_root: Arc::new(default_root),
+            default_root_inferred,
+        })
+    }
+
+    /// The canonicalized allowed path trees (owned clone) — for startup logging,
+    /// the `kaibo://config` resource, and tests.
+    pub(crate) fn allowed_set(&self) -> Vec<PathBuf> {
+        (*self.allowed_set).clone()
+    }
+
+    /// The canonicalized allowed path trees as a borrowed slice — the cheap read
+    /// path for renderers that only need to iterate.
+    pub(crate) fn allowed_trees(&self) -> &[PathBuf] {
+        &self.allowed_set
+    }
+
+    /// The effective default root a call resolves to when it omits `path`.
+    pub(crate) fn default_root(&self) -> Option<PathBuf> {
+        (*self.default_root).clone()
+    }
+
+    /// The effective default root, borrowed.
+    pub(crate) fn default_root_ref(&self) -> Option<&Path> {
+        (*self.default_root).as_deref()
+    }
+
+    /// Whether [`default_root`](Self::default_root) was inferred from the cwd.
+    pub(crate) fn default_root_inferred(&self) -> bool {
+        self.default_root_inferred
+    }
+
+    /// The allowed tree (or followed-worktree root) that contains `canon`, or `None`
+    /// when it's outside the boundary — the *which-tree* sibling of `contained` (which
+    /// is just `is_some()` on this). A static `allow_path` wins over a followed
+    /// worktree. The returned root is what an attachment read mounts a read-only kaish
+    /// worker at, so the VFS refuses a symlink escaping *that* tree.
+    pub(super) fn containing_tree(&self, canon: &Path) -> Option<PathBuf> {
+        if let Some(tree) = self.allowed_set.iter().find(|tree| canon.starts_with(tree)) {
+            return Some(tree.clone());
+        }
+        if self.config.follow_worktrees {
+            for tree in self.allowed_set.iter() {
+                if let Some(common) = crate::worktree::common_git_dir(tree) {
+                    if let Some(wt) = crate::worktree::vouched_worktrees(&common)
+                        .into_iter()
+                        .find(|wt| canon.starts_with(wt))
+                    {
+                        return Some(wt);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// The shared "outside the allowed set" rejection, naming the boundary and the
+    /// three widening knobs.
+    pub(super) fn containment_error(&self, raw: &Path, canon: &Path) -> McpError {
+        let trees: Vec<String> = self
+            .allowed_set
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        McpError::invalid_params(
+            format!(
+                "path {} resolves to {}, which is outside the allowed set [{}]. \
+                 To widen the boundary: pass --allow-path DIR on the command line, \
+                 set KAIBO_ALLOW_PATHS=DIR (colon-separated), or add \
+                 `[server] allow_paths = [\"DIR\"]` in config.toml. The config and env \
+                 forms expand `$VAR` / `${{VAR}}` and a leading `~`, so a scratch dir \
+                 reads portably as `\"$TMPDIR\"` / `\"$XDG_RUNTIME_DIR/...\"`.",
+                raw.display(),
+                canon.display(),
+                trees.join(", "),
+            ),
+            None,
+        )
+    }
+
+    /// The worktrees the follow feature currently admits *beyond* the static allowed
+    /// set — for the `kaibo://config` runtime section, so the live boundary stays
+    /// legible. Recomputed on each read (it reflects worktrees that exist now).
+    /// Empty when the feature is off or nothing extra is reachable. Deduplicated and
+    /// sorted for a stable resource.
+    pub(crate) fn followed_worktrees(&self) -> Vec<PathBuf> {
+        if !self.config.follow_worktrees {
+            return Vec::new();
+        }
+        let mut found: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
+        for tree in self.allowed_set.iter() {
+            let Some(common) = crate::worktree::common_git_dir(tree) else {
+                continue;
+            };
+            for wt in crate::worktree::vouched_worktrees(&common) {
+                if !self.allowed_set.iter().any(|t| wt.starts_with(t)) {
+                    found.insert(wt);
+                }
+            }
+        }
+        found.into_iter().collect()
+    }
+
+    /// Resolve a call's cast: the explicit name (looked up in the registry, by name
+    /// or alias), else the server's default cast. An unknown name is a parameter error
+    /// naming the available casts. Returns an owned clone so the caller can layer
+    /// per-call model overrides onto it.
+    pub(crate) fn resolve_cast(&self, cast: Option<String>) -> Result<Cast, McpError> {
+        let name = cast.unwrap_or_else(|| self.config.default_cast.clone());
+        self.config
+            .resolve_cast(&name)
+            .cloned()
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))
+    }
+
+    /// Refuse an interactive tool (`consult`/`consult_submit`/`oneshot`) on a cast
+    /// whose synth runs on an offline lane. A `Batch` synth is a big, slow, expensive
+    /// model tuned for free offline batch latency; a `Direct` synth is a big local
+    /// model kaibo runs itself — either way, driving it through an interactive tool
+    /// loop is the wrong-and-costly mistake this gate stops. Points the caller at the
+    /// lane that fits.
+    pub(crate) fn reject_offline_cast(&self, cast: &Cast, tool: &str) -> Result<(), McpError> {
+        match cast.synth_lane() {
+            Some(Lane::Batch) => Err(McpError::invalid_params(
+                format!(
+                    "cast `{}`'s synth runs on the `batch` lane — submit it with \
+                     `batch_submit`, not `{tool}`. It's a big, slow model tuned for free \
+                     offline batch latency; running it interactively would be slow and \
+                     expensive. Pick an interactive cast for `{tool}`.",
+                    cast.name
+                ),
+                None,
+            )),
+            Some(Lane::Direct) => Err(McpError::invalid_params(
+                format!(
+                    "cast `{}`'s synth runs offline (`lane = \"direct\"`) — interactive \
+                     tools need an interactive synth. Pick an interactive cast for `{tool}`.",
+                    cast.name
+                ),
+                None,
+            )),
+            None => Ok(()),
+        }
+    }
+
+    /// Apply a per-call model override to one of `cast`'s slots.
+    ///
+    /// The model id rides *verbatim* — an id containing `/` (HuggingFace-style
+    /// `org/model`) is still one id, never parsed for a backend. Retargeting is the
+    /// explicit `backend` arg's job: when set, it resolves (aliases included) and the
+    /// slot is replaced wholesale, which also works on a role the cast doesn't carry.
+    /// Either way the configured slot's pins/tunables are dropped — they described the
+    /// *configured* model; the new id classifies fresh.
+    pub(crate) fn override_model(
+        &self,
+        cast: &mut Cast,
+        role: ModelRole,
+        model: &str,
+        backend: Option<&str>,
+    ) -> Result<(), McpError> {
+        let model = model.trim();
+        if model.is_empty() {
+            return Err(McpError::invalid_params(
+                format!("the {} model id is empty", role.key()),
+                None,
+            ));
+        }
+        let backend = match backend {
+            Some(name) => self
+                .config
+                .resolve_backend(name)
+                .map_err(|e| McpError::invalid_params(e.to_string(), None))?
+                .name
+                .clone(),
+            None => cast.slot(role).map(|s| s.backend.clone()).ok_or_else(|| {
+                McpError::invalid_params(
+                    format!(
+                        "cast {:?} has no {} slot to override — pass the matching \
+                         backend override arg to target one",
+                        cast.name,
+                        role.key()
+                    ),
+                    None,
+                )
+            })?,
+        };
+        cast.slots.insert(role, ModelSlot::bare(backend, model));
+        Ok(())
+    }
+
+    /// The tool-input face of [`override_model`](Self::override_model): folds one
+    /// tool's `(model, backend)` override args onto `cast`'s `role` slot. A backend
+    /// arg without its model arg is a loud parameter error naming both spellings.
+    pub(crate) fn apply_model_override(
+        &self,
+        cast: &mut Cast,
+        role: ModelRole,
+        model: Option<&str>,
+        backend: Option<&str>,
+        model_arg: &str,
+        backend_arg: &str,
+    ) -> Result<(), McpError> {
+        match (model, backend) {
+            (Some(model), backend) => self.override_model(cast, role, model, backend),
+            (None, Some(_)) => Err(McpError::invalid_params(
+                format!(
+                    "{backend_arg} was sent without {model_arg} — a backend override \
+                     needs the model id to run there"
+                ),
+                None,
+            )),
+            (None, None) => Ok(()),
+        }
+    }
+
+    /// Resolve one of `cast`'s slots into a live [`Arm`] for `role`. A missing slot is
+    /// the loud call-time gap ("cast `x` has no synth slot"); a backend that fails to
+    /// build (key resolution, client init) is an internal error.
+    pub(crate) fn arm(&self, cast: &Cast, role: ModelRole) -> Result<Arm, McpError> {
+        let slot = cast
+            .require_slot(role)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let backend = self
+            .config
+            .resolve_backend(&slot.backend)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Arm::from_slot(backend, slot, role, &self.config.defaults)
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))
+    }
+
+    /// Assemble the operator's house rules for this call against the resolved `root`:
+    /// the `[context]` files read here, in trusted server-side Rust, and folded into
+    /// the phase preamble. A missing *declared* user file is a loud `internal_error`,
+    /// never a silent skip. `None` when nothing's configured/present.
+    pub(crate) fn house_rules(&self, root: &Path) -> Result<Option<Arc<str>>, McpError> {
+        self.config
+            .context
+            .assemble(root)
+            .map(|opt| opt.map(Arc::from))
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))
+    }
+
+    /// Assemble the static repo-orientation map for this call against the resolved
+    /// `root` — the `[orientation]` block injected into the exploring preamble. Runs
+    /// the kernel's own `glob` server-side (no model turn). Errors here are real
+    /// failures (kernel spawn, unparseable enumeration), not size.
+    pub(crate) async fn orientation(&self, root: &Path) -> Result<Option<Arc<str>>, McpError> {
+        self.config
+            .orientation
+            .assemble(root, self.config.sandbox.clone())
+            .await
+            .map(|opt| opt.map(Arc::from))
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))
+    }
+
+    /// Resolve this call's per-phase system prompts for `cast` — the per-slot
+    /// `preamble` over the global `[prompts]` table. `cast` is the post-override clone,
+    /// so a per-call model override (a bare slot) correctly carries no preamble.
+    pub(crate) fn resolved_prompts(&self, cast: &Cast) -> PromptOverrides {
+        cast.resolved_prompts(&self.config.prompts)
+    }
+
+    /// Resolve caller-named `consult`/`explore` attachments: attach means *the model
+    /// sees the bytes*. A text file within `budget` (cumulative, caller order) is read
+    /// server-side and inlined into the driver prompt; a text file past it is demoted
+    /// to a named path the prompt directs the model to read WHOLE through its shell.
+    /// An image is routed to `view_image`. Each path must canonicalize to a regular
+    /// file *under `root`* (returned root-relative). Static — the sandbox rides in as a
+    /// param so the caller's config drives the read-only VFS the bytes are read through.
+    pub(crate) async fn resolve_consult_attachments(
+        root: &Path,
+        attach: &[String],
+        budget: usize,
+        sandbox: &crate::sandbox::SandboxConfig,
+    ) -> Result<Vec<crate::consult::ConsultAttachment>, McpError> {
+        use crate::attach::{check_attachment_bounds, DEFAULT_MAX_ATTACHMENTS};
+        check_attachment_bounds(
+            attach.len(),
+            0,
+            DEFAULT_MAX_ATTACHMENTS,
+            crate::attach::DEFAULT_MAX_TOTAL_BYTES,
+        )
+        .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
+        let mut worker: Option<crate::sandbox::KaishWorker> = None;
+        let mut remaining = budget as u64;
+        let mut out = Vec::with_capacity(attach.len());
+        for p in attach {
+            let raw = PathBuf::from(p);
+            // A relative path reads from the project root (where the model's shell starts).
+            let joined = if raw.is_absolute() {
+                raw.clone()
+            } else {
+                root.join(&raw)
+            };
+            let canon = std::fs::canonicalize(&joined).map_err(|e| {
+                McpError::invalid_params(
+                    format!("attached file {} could not be resolved: {e}", raw.display()),
+                    None,
+                )
+            })?;
+            let meta = std::fs::metadata(&canon).map_err(|e| {
+                McpError::invalid_params(
+                    format!("attached file {} could not be read: {e}", canon.display()),
+                    None,
+                )
+            })?;
+            if !meta.is_file() {
+                return Err(McpError::invalid_params(
+                    format!("attached file {} is not a regular file", canon.display()),
+                    None,
+                ));
+            }
+            let display_path = if let Ok(rel) = canon.strip_prefix(root) {
+                rel.display().to_string()
+            } else {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "attached file {} resolves outside the project root {} — consult reads \
+                         attachments through its shell, which only mounts that. Paste it into \
+                         `context`, or use `oneshot`/`batch` attach (which inline a file from \
+                         anywhere in the allowed set).",
+                        raw.display(),
+                        root.display(),
+                    ),
+                    None,
+                ));
+            };
+            // Sniff the file's type by content, not extension. This prefix is read with
+            // `std::fs`, NOT through the kaish VFS — a bounded exception that only routes
+            // (the 16 bytes feed `sniff_mime` to a bool and are dropped). Anything INLINED
+            // below is read through the VFS and re-sniffed from full bytes.
+            let prefix_is_image = {
+                use std::io::Read;
+                let mut buf = [0u8; 16];
+                let n = std::fs::File::open(&canon)
+                    .and_then(|mut f| f.read(&mut buf))
+                    .unwrap_or(0);
+                crate::view_image::sniff_mime(&buf[..n]).is_some()
+            };
+            if prefix_is_image {
+                out.push(crate::consult::ConsultAttachment::Image { path: display_path });
+                continue;
+            }
+            // Text past the remaining inline budget is demoted, not refused: this model
+            // CAN read the file itself, and the prompt orders it to — whole, paged.
+            if meta.len() > remaining {
+                out.push(crate::consult::ConsultAttachment::TextOversize {
+                    path: display_path,
+                    size: meta.len(),
+                });
+                continue;
+            }
+            // Within budget: inline. The read is VFS-mounted — these bytes enter context.
+            if worker.is_none() {
+                worker = Some(
+                    crate::sandbox::KaishWorker::spawn_with(root, sandbox.clone()).map_err(
+                        |e| {
+                            McpError::internal_error(
+                                format!("attachment reader for {}: {e:#}", root.display()),
+                                None,
+                            )
+                        },
+                    )?,
+                );
+            }
+            // Read at most one byte past `remaining` — bounds the stat-then-read TOCTOU
+            // window: a raced-huge file comes back as `remaining + 1` bytes, which the
+            // length check below demotes to `TextOversize`, never an OOM.
+            let bytes = worker
+                .as_ref()
+                .expect("worker was just spawned")
+                .read_file_capped(canon.clone(), remaining + 1)
+                .await
+                .map_err(|e| {
+                    McpError::invalid_params(
+                        format!("attached file {} could not be read: {e:#}", canon.display()),
+                        None,
+                    )
+                })?;
+            // Re-sniff from the (capped) bytes — authoritative for anything inlined.
+            if crate::view_image::sniff_mime(&bytes).is_some() {
+                out.push(crate::consult::ConsultAttachment::Image { path: display_path });
+                continue;
+            }
+            if bytes.len() as u64 > remaining {
+                out.push(crate::consult::ConsultAttachment::TextOversize {
+                    path: display_path,
+                    size: bytes.len() as u64,
+                });
+                continue;
+            }
+            match std::str::from_utf8(&bytes) {
+                Ok(text) => {
+                    remaining -= bytes.len() as u64;
+                    out.push(crate::consult::ConsultAttachment::Text {
+                        path: display_path,
+                        body: text.to_string(),
+                    });
+                }
+                Err(_) => {
+                    return Err(McpError::invalid_params(
+                        format!(
+                            "attached file {display_path} is neither valid UTF-8 text nor a \
+                             recognized image (png/jpeg/gif/webp) — kaibo won't inline binary, \
+                             and the model's shell can't read it either. Convert it first, or \
+                             paste the relevant text into `context`."
+                        ),
+                        None,
+                    ));
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Refuse an image attachment to a vision-blind consult synth. consult never
+    /// inlines an image's bytes; the model opens an attached image with the
+    /// `view_image` tool, only wired in when the synth is vision-capable. So an image
+    /// attached to a blind synth could never be seen — refuse honestly up front,
+    /// naming the cast. Text attachments (and the no-attachment case) always pass.
+    pub(crate) fn gate_consult_image_attachments(
+        attachments: &[crate::consult::ConsultAttachment],
+        vision: bool,
+        model: &str,
+        cast: &str,
+    ) -> Result<(), McpError> {
+        if !vision && attachments.iter().any(|a| a.is_image()) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "an image was attached, but the consult synth `{model}` on cast `{cast}` \
+                     can't see images — consult opens an attached image with its `view_image` \
+                     tool, which only a vision-capable synth carries. Use a vision-capable \
+                     cast, or attach only text files. `kaibo://config` lists each slot's \
+                     `vision`."
+                ),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Refuse image attachments to a vision-blind model, naming the cast so the caller
+    /// can pick a vision-capable one. Shared by the tool-less attach surfaces (`batch`
+    /// and `oneshot`). Text-only attachments (and the no-attachment case) always pass.
+    pub(crate) fn gate_image_attachments(
+        &self,
+        vision: bool,
+        attachments: &[crate::attach::Attachment],
+        model: &str,
+        cast: &str,
+    ) -> Result<(), McpError> {
+        if !vision
+            && attachments
+                .iter()
+                .any(|a| matches!(a, crate::attach::Attachment::Image { .. }))
+        {
+            return Err(McpError::invalid_params(
+                format!(
+                    "an image attachment was given, but the model `{model}` on cast `{cast}` \
+                     doesn't accept image input. Use a vision-capable cast/model, or attach \
+                     only text files. `kaibo://config` lists each slot's `vision`."
+                ),
+                None,
+            ));
+        }
+        Ok(())
+    }
+}

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -16,6 +16,14 @@
 //! The containment methods (`resolve_root`, `resolve_attachments`, and the private
 //! `contained`/`containing_tree`) live in the sibling `containment.rs` as a split
 //! `impl Resolver`, next to the boundary doc-comment they belong with.
+//!
+//! Not pure lookup glue: most methods here are cheap config/registry reads, but the
+//! attachment resolvers (`resolve_consult_attachments`, `resolve_attachments`) are the
+//! **heavyweight exception** — they spawn a read-only [`KaishWorker`](crate::sandbox::KaishWorker)
+//! and read file bytes through its VFS (which is *why* a `Resolver` carries the
+//! sandbox config, and why those two are `async`). Don't refactor on the assumption
+//! that resolution is side-effect-free I/O-free lookup; attachment resolution mounts a
+//! kernel and does real (read-only) filesystem work.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;


### PR DESCRIPTION
kaibo grows a second front door: the same read-only consultation, invokable from a shell. `kaibo consult "question" --cast deepseek --attach src/foo.rs --session NAME --json` — for agents that shell out rather than speak MCP (pi, Codex-style CLIs, scripts, CI) and for humans. Zero resident-token cost: unlike an MCP tool description, `--help` is only read when someone reaches for it.

## Decisions

- **Bare invocation is sacred.** `kaibo` with no subcommand runs the MCP server byte-for-byte as before — every existing client config keeps working. `kaibo serve` is the explicit spelling; clap's `args_conflicts_with_subcommands` keeps the two surfaces from bleeding into each other. Verified live: bare `kaibo` and `kaibo serve` emit identical startup sequences.
- **Resolver extraction, mechanical by design.** The resolution glue (root/containment, cast/arm construction, house rules, orientation, attachments + vision gating) moved from `KaiboHandler` methods into a shared `Resolver` that both front doors call. The handler keeps thin delegating shims with identical signatures, so ~130 internal call sites and the entire existing test suite are untouched — the extraction is reviewable as a move, not a redesign.
- **stdout is the answer, stderr is everything else.** Answer + provenance footer to stdout (pipe-clean); progress beats and logs to stderr via a new terminal sink over the existing `PhaseEvent` abstraction. `--json` emits `{answer, cast, models, usage}` for script callers. Exit codes have teeth: 0 answer / 2 usage-config / 3 containment-setup / 4 consultation failure — an agent branches without parsing prose.
- **`--session` closes the persistence loop** (the reason #76 exists): a thread started over MCP continues on the CLI and vice versa, through the XDG state db under MP-WAL. Live-verified: a two-turn CLI session replayed turn 1 verbatim from a separate invocation *while the MCP server held the same db open*. A stateless consult never opens the db. The non-fatal-but-loud `record()` posture from #76 surfaces on all three CLI channels (stderr warn, stdout answer text, `--json` envelope).
- **Containment on the CLI**: the invocation's cwd joins the allowed set exactly as a launched server's cwd does — same rule, per-invocation. `--root`/`--allow-path` behave as before.
- **`--help` is model-facing text** and was written under the repo's writing-for-models discipline: the top-level about front-loads what kaibo is (read-only, cited, cross-family) because CLI agents read `--help` the way MCP clients read tool descriptions.

Deviations from the design doc, deliberate: `--path` is a flag (mirroring the MCP arg) rather than positional; `--include-report` prints to stderr in prose mode (stdout stays answer-only) and rides the `--json` envelope as `report`.

## Scope

First CLI stage only: `consult` + `config` + the resolver seam. `oneshot` / `explore` / `kaish` / batch subcommands follow in later PRs, tracked in the living design doc.

## Verification

- Full suite green (358 lib + all integration incl. store 20); clippy `--all-targets` clean; fmt clean on touched regions (pre-existing tree drift untouched).
- Live smoke on the real binary: cited DeepSeek consult (exit 0, provenance footer), `--json` validated by `json.load`, exit-code paths 2/3 exercised, XDG db placement confirmed outside the project, cross-invocation session replay verbatim, bare/serve equivalence.
- Cross-family review: running now (DeepSeek consult + a second non-Anthropic lane over the branch, no diff, whole files) — findings will be triaged on this PR before merge, same process that caught the containment bypass on #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)