### PR TITLE
fix(batch): flag truncated batch answers instead of passing them off as clean (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,20 @@ the git log. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **A truncated batch answer no longer masquerades as a finished one.** When a batch
+  item hit its output-token budget mid-response — most often a big attached-file review
+  where max-effort thinking spends the whole budget before the answer is written — kaibo
+  presented whatever text came back as a clean result, with no signal it was cut off. A
+  caller skimming for findings could mistake a truncated reasoning fragment (no verdict,
+  no structure) for "the model found little." kaibo now reads each item's finish reason
+  (Gemini `finishReason`, Anthropic `stop_reason`): a clean finish is unchanged, but a
+  truncated or policy-halted one is flagged — the partial text is kept under a loud
+  `⚠️ INCOMPLETE` banner naming the reason, and an item that produced no answer at all
+  becomes an honest per-item failure instead of a blank success. The batch preamble also
+  now steers the model to write its conclusion first (reasoning and answer share one
+  output budget), and the example config documents raising a batch cast's `max_tokens`
+  for long reviews. (GH #75)
+
 - **A stalled backend can no longer hang a call overnight.** An interactive
   `consult` / `explore` / `oneshot` now runs under a whole-call wall-clock deadline
   (`call_deadline_secs`, default 1 hour; env `KAIBO_CALL_DEADLINE_SECS`), independent

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -381,6 +381,16 @@ batch    = true
 synth    = "gemini/gemini-pro-latest"        # batch-capable synth (Anthropic | Gemini); Pro is batch-only
 # Equivalent, spelled directly on the slot (no cast-level sugar):
 #   synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch" }
+#
+# OUTPUT BUDGET. Batch maxes the knobs: high effort + a 32768-token output-token FLOOR (it
+# never skimps on the cheap async lane). Reasoning bills against that same output budget, so a
+# big attached-file review at max thinking can spend the budget thinking and truncate the
+# answer — kaibo flags such a result INCOMPLETE with its finishReason rather than passing off
+# the cut-off fragment as a clean answer. Give batch more answer headroom by raising
+# `max_tokens` on the synth slot; it's a floor, so a higher value wins, and mind each model's
+# output ceiling (Gemini Pro is generous; some backends cap lower). `effort` / `thinking_budget`
+# ride the same slot if you want to tune reasoning depth:
+#   synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch", max_tokens = 65536 }
 
 # --- DELIBERATE casts: an interactive explorer PLUS an offline synth. `deliberate` runs
 #     the explorer live to build a cited dossier, then hands dossier+question to the offline

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -375,6 +375,64 @@ fn message_text(message: &Value) -> String {
         .unwrap_or_default()
 }
 
+/// Compose one batch item's answer from its assembled text and a *normalized* completion
+/// signal — the shared gate both providers pass their finish reason through. `Ok(())` is a
+/// clean finish; `Err(detail)` names an abnormal one (a truncation or policy halt). The
+/// point is that an abnormal finish is never presented as a clean completion (GH #75):
+///
+/// - clean + text → the answer as-is,
+/// - clean + empty → an honest per-item failure (a completed-but-empty answer is no answer),
+/// - abnormal + empty → a per-item failure naming the finish reason (e.g. the model spent
+///   its whole budget thinking and never reached an answer),
+/// - abnormal + text → the *partial* text kept under a loud INCOMPLETE banner, so a caller
+///   skimming for findings can't mistake a clipped fragment (often trailing reasoning, with
+///   none of the requested structure or verdict) for a finished answer. The text is kept,
+///   not dropped — a genuinely-clipped real answer stays useful — but it announces itself.
+fn finish_gated_answer(text: String, gate: Result<(), String>) -> Result<String, String> {
+    match gate {
+        Ok(()) => {
+            if text.trim().is_empty() {
+                Err("model returned an empty answer".to_string())
+            } else {
+                Ok(text)
+            }
+        }
+        Err(detail) => {
+            if text.trim().is_empty() {
+                Err(format!("model produced no answer — {detail}"))
+            } else {
+                Ok(format!(
+                    "⚠️ INCOMPLETE — {detail}\nThe text below is a truncated fragment, not a \
+                     finished answer (it may be trailing reasoning and is missing any requested \
+                     structure or verdict).\n\n{text}"
+                ))
+            }
+        }
+    }
+}
+
+/// Gate an Anthropic message's `stop_reason`. A toolless batch item finishes cleanly on
+/// `end_turn` / `stop_sequence`; `max_tokens` is the silent-truncation case this guards
+/// against, and any other value (a refusal, an unknown) is likewise abnormal. An absent
+/// reason (a real succeeded message always carries one) is treated as clean — the
+/// empty-text check still catches a genuinely empty response.
+fn anthropic_finish_gate(stop_reason: Option<&str>) -> Result<(), String> {
+    match stop_reason {
+        Some("end_turn") | Some("stop_sequence") | None => Ok(()),
+        Some(reason) => {
+            let note = match reason {
+                "max_tokens" => {
+                    "the response hit its output-token budget before finishing; \
+                    re-run with a higher max_tokens or a narrower prompt"
+                }
+                "refusal" => "the model declined to complete this request",
+                _ => "the response did not complete normally",
+            };
+            Err(format!("stop_reason={reason}: {note}"))
+        }
+    }
+}
+
 /// Parse the JSONL results body: one `{custom_id, result}` per line. A `succeeded`
 /// result yields the message text; `errored`/`canceled`/`expired` yield a per-item
 /// `Err(reason)` so a single bad item is reported, never silently dropped.
@@ -401,7 +459,8 @@ fn parse_results_jsonl(body: &str) -> Result<Vec<BatchAnswer>> {
                 let message = result
                     .get("message")
                     .ok_or_else(|| anyhow!("succeeded result has no `message`: {line}"))?;
-                Ok(message_text(message))
+                let stop = message.get("stop_reason").and_then(Value::as_str);
+                finish_gated_answer(message_text(message), anthropic_finish_gate(stop))
             }
             "errored" => {
                 // Prefer the human `error.message`, then its `type`, then the raw blob —
@@ -733,16 +792,20 @@ fn gemini_progress(meta: Option<&Value>) -> (u64, u64) {
     )
 }
 
-/// Join the non-thought `text` parts of a Gemini response's first candidate. With
-/// `includeThoughts` on, the reasoning rides as separate `"thought": true` parts; those
-/// are the model's scratchpad, not its answer, so the answer is the text parts that are
-/// *not* thoughts (a final answer part may still carry a `thoughtSignature` — that's not
-/// a thought part, so it stays).
-fn gemini_message_text(response: &Value) -> String {
-    response
+/// The answer text (non-thought parts joined) plus the candidate's `finishReason`.
+/// Separating the two lets result assembly gate on the finish reason instead of presenting
+/// an incomplete fragment as a clean answer (GH #75). With `includeThoughts` on, the model's
+/// reasoning rides as separate `"thought": true` parts — the scratchpad, not the answer — so
+/// the answer is the text parts that are *not* thoughts. A finished answer part may still
+/// carry a `thoughtSignature`: under a clean `STOP` that's a real answer, so it stays; under
+/// a truncated finish (`MAX_TOKENS`) it's trailing reasoning that lost its `thought` marker,
+/// which the finish-reason gate catches — the signal we can't get from the parts alone.
+fn gemini_candidate(response: &Value) -> (String, Option<String>) {
+    let cand = response
         .get("candidates")
         .and_then(Value::as_array)
-        .and_then(|c| c.first())
+        .and_then(|c| c.first());
+    let text = cand
         .and_then(|c| c.get("content"))
         .and_then(|c| c.get("parts"))
         .and_then(Value::as_array)
@@ -754,7 +817,37 @@ fn gemini_message_text(response: &Value) -> String {
                 .collect::<Vec<_>>()
                 .join("")
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    let finish = cand
+        .and_then(|c| c.get("finishReason"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    (text, finish)
+}
+
+/// Gate a Gemini `finishReason`. `STOP` is a clean completion; an absent reason (a real
+/// candidate always carries one) is treated as clean too. Every other value is abnormal —
+/// `MAX_TOKENS` is the common one for attached-file reviews at max thinking (the exact
+/// GH #75 case: the whole output budget spent thinking, no answer reached), so its note
+/// points at the fix; the policy halts name themselves.
+fn gemini_finish_gate(finish: Option<&str>) -> Result<(), String> {
+    match finish {
+        Some("STOP") | None => Ok(()),
+        Some(reason) => {
+            let note = match reason {
+                "MAX_TOKENS" => {
+                    "the response hit its output-token budget before finishing — \
+                    common when a big attached-file review spends the budget thinking; re-run \
+                    with a higher max_tokens or a narrower prompt"
+                }
+                "SAFETY" | "PROHIBITED_CONTENT" | "BLOCKLIST" | "RECITATION" | "SPII" => {
+                    "the provider halted generation on a content policy"
+                }
+                _ => "the response did not complete normally",
+            };
+            Err(format!("finishReason={reason}: {note}"))
+        }
+    }
 }
 
 /// Locate a batch's inlined per-item responses. Gemini puts them in the long-running
@@ -785,7 +878,8 @@ fn parse_gemini_inlined(arr: &[Value]) -> Vec<BatchAnswer> {
                 .unwrap_or("")
                 .to_string();
             let text = if let Some(resp) = el.get("response") {
-                Ok(gemini_message_text(resp))
+                let (answer, finish) = gemini_candidate(resp);
+                finish_gated_answer(answer, gemini_finish_gate(finish.as_deref()))
             } else if let Some(err) = el.get("error") {
                 let detail = err
                     .get("message")
@@ -1619,7 +1713,7 @@ mod tests {
     #[test]
     fn results_jsonl_succeeded_and_failed_per_item() {
         let body = concat!(
-            r#"{"custom_id":"0","result":{"type":"succeeded","message":{"content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}]}}}"#,
+            r#"{"custom_id":"0","result":{"type":"succeeded","message":{"stop_reason":"end_turn","content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}]}}}"#,
             "\n",
             r#"{"custom_id":"1","result":{"type":"errored","error":{"type":"overloaded"}}}"#,
             "\n",
@@ -1632,11 +1726,47 @@ mod tests {
             answers[0],
             BatchAnswer {
                 custom_id: "0".into(),
+                // A clean `end_turn` passes through untouched — no banner.
                 text: Ok("hello world".into())
             }
         );
         assert!(matches!(&answers[1].text, Err(m) if m.contains("overloaded")));
         assert!(matches!(&answers[2].text, Err(m) if m.contains("expired")));
+    }
+
+    /// An Anthropic item that hit `stop_reason: max_tokens` is *not* a clean completion:
+    /// its partial text is kept but announces itself under an INCOMPLETE banner naming the
+    /// stop reason, so a caller can't mistake a clipped answer for a finished one (GH #75).
+    #[test]
+    fn results_jsonl_max_tokens_is_flagged_incomplete() {
+        let body = concat!(
+            r#"{"custom_id":"0","result":{"type":"succeeded","message":{"stop_reason":"max_tokens","content":[{"type":"text","text":"partial finding, cut off mid-"}]}}}"#,
+            "\n",
+        );
+        let answers = parse_results_jsonl(body).unwrap();
+        let text = answers[0]
+            .text
+            .as_ref()
+            .expect("partial text kept, not an Err");
+        assert!(text.contains("INCOMPLETE"), "banner present: {text}");
+        assert!(text.contains("max_tokens"), "names the stop reason: {text}");
+        assert!(
+            text.contains("partial finding, cut off mid-"),
+            "the partial text is kept, not dropped: {text}"
+        );
+    }
+
+    /// An Anthropic item that truncated before emitting *any* answer text is an honest
+    /// per-item failure naming the stop reason — never a silent empty success.
+    #[test]
+    fn results_jsonl_max_tokens_empty_is_failure() {
+        let body = r#"{"custom_id":"0","result":{"type":"succeeded","message":{"stop_reason":"max_tokens","content":[]}}}"#;
+        let answers = parse_results_jsonl(body).unwrap();
+        assert!(
+            matches!(&answers[0].text, Err(m) if m.contains("no answer") && m.contains("max_tokens")),
+            "empty + truncated is a failure naming the reason: {:?}",
+            answers[0].text
+        );
     }
 
     /// The Anthropic provider refuses any non-Anthropic backend at construction — the
@@ -1977,11 +2107,13 @@ mod tests {
         let v = json!({
             "metadata": { "state": "BATCH_STATE_SUCCEEDED" },
             "response": { "inlinedResponses": { "inlinedResponses": [
-                { "metadata": { "key": "0" }, "response": { "candidates": [ { "content": { "parts": [
-                    { "text": "thinking out loud", "thought": true },
-                    { "text": "the ", "thoughtSignature": "sig" },
-                    { "text": "answer" }
-                ] } } ] } },
+                { "metadata": { "key": "0" }, "response": { "candidates": [ {
+                    "finishReason": "STOP",
+                    "content": { "parts": [
+                        { "text": "thinking out loud", "thought": true },
+                        { "text": "the ", "thoughtSignature": "sig" },
+                        { "text": "answer" }
+                    ] } } ] } },
                 { "metadata": { "key": "1" }, "error": { "code": 7, "message": "permission denied" } }
             ] } }
         });
@@ -1992,9 +2124,114 @@ mod tests {
         };
         assert_eq!(answers.len(), 2);
         assert_eq!(answers[0].custom_id, "0");
-        // Thought part dropped; the two real text parts joined; the signature is irrelevant.
+        // Clean STOP: thought part dropped; the two real text parts joined; a final answer
+        // part keeping its thoughtSignature stays (a signatured part is a real answer under
+        // STOP). No banner.
         assert_eq!(answers[0].text, Ok("the answer".to_string()));
         assert!(matches!(&answers[1].text, Err(m) if m.contains("permission denied")));
+    }
+
+    /// GH #75, ground-truthed against the real durable payload
+    /// (`gemini/batches/laaxe5t0oa9181hhc1y65282fow9fksnpz6i`): a `MAX_TOKENS` batch item
+    /// whose budget was spent thinking. The response has a `thought:true` summary part and a
+    /// *second* non-thought part that carries a `thoughtSignature` but is really trailing
+    /// reasoning — it starts mid-sentence and never reaches the requested structure. The old
+    /// code emitted that fragment as a clean answer; now the finish reason gates it into a
+    /// loud INCOMPLETE banner (the partial text kept, but unmistakably not a finished review).
+    #[test]
+    fn gemini_max_tokens_leaked_reasoning_is_flagged() {
+        let v = json!({
+            "metadata": { "state": "BATCH_STATE_SUCCEEDED" },
+            "response": { "inlinedResponses": { "inlinedResponses": [
+                { "metadata": { "key": "0" }, "response": { "candidates": [ {
+                    "finishReason": "MAX_TOKENS",
+                    "content": { "role": "model", "parts": [
+                        { "text": "**Comprehensive Lexer Review**\nMy task is to review...", "thought": true },
+                        { "text": "has_bracket_pair` is true. The parser will see `Int(1)`, `MinusAlone`.", "thoughtSignature": "Ct8B..." }
+                    ] } } ] } }
+            ] } }
+        });
+        let answers = match parse_gemini_poll(&v).unwrap() {
+            BatchPoll::Done(a) => a,
+            other => panic!("expected Done, got {other:?}"),
+        };
+        let text = answers[0]
+            .text
+            .as_ref()
+            .expect("partial text kept, not an Err");
+        assert!(text.contains("INCOMPLETE"), "banner present: {text}");
+        assert!(
+            text.contains("MAX_TOKENS"),
+            "names the finish reason: {text}"
+        );
+        // The thought *summary* is still dropped; the leaked-reasoning fragment is what's
+        // kept (under the banner) — never presented as a clean answer.
+        assert!(
+            !text.contains("Comprehensive Lexer Review"),
+            "the thought-summary part is still filtered out: {text}"
+        );
+        assert!(
+            text.contains("has_bracket_pair"),
+            "the truncated fragment is kept under the banner: {text}"
+        );
+    }
+
+    /// A `MAX_TOKENS` finish that produced *only* a thought part (no answer text at all) is a
+    /// per-item failure naming the reason — "model produced no answer" beats a blank success.
+    #[test]
+    fn gemini_max_tokens_only_thoughts_is_failure() {
+        let v = json!({
+            "metadata": { "state": "BATCH_STATE_SUCCEEDED" },
+            "response": { "inlinedResponses": { "inlinedResponses": [
+                { "metadata": { "key": "0" }, "response": { "candidates": [ {
+                    "finishReason": "MAX_TOKENS",
+                    "content": { "parts": [
+                        { "text": "still reasoning about the lexer...", "thought": true }
+                    ] } } ] } }
+            ] } }
+        });
+        let answers = match parse_gemini_poll(&v).unwrap() {
+            BatchPoll::Done(a) => a,
+            other => panic!("expected Done, got {other:?}"),
+        };
+        assert!(
+            matches!(&answers[0].text, Err(m) if m.contains("no answer") && m.contains("MAX_TOKENS")),
+            "only-thoughts + truncated is a failure naming the reason: {:?}",
+            answers[0].text
+        );
+    }
+
+    /// The pure finish-gate + compose contract, straight — including the paths the
+    /// inlined-parse tests don't reach (a policy halt, a clean-but-empty answer).
+    #[test]
+    fn finish_gate_and_compose_contract() {
+        // Clean finishes pass text through untouched, both providers.
+        assert!(gemini_finish_gate(Some("STOP")).is_ok());
+        assert!(gemini_finish_gate(None).is_ok());
+        assert!(anthropic_finish_gate(Some("end_turn")).is_ok());
+        assert!(anthropic_finish_gate(Some("stop_sequence")).is_ok());
+        assert_eq!(
+            finish_gated_answer("answer".into(), gemini_finish_gate(Some("STOP"))),
+            Ok("answer".into())
+        );
+        // A clean finish with no text is an honest failure, not a blank success.
+        assert!(
+            matches!(finish_gated_answer(String::new(), Ok(())), Err(m) if m.contains("empty"))
+        );
+        // A policy halt is abnormal and names itself; an empty one is a per-item failure.
+        let safety = gemini_finish_gate(Some("SAFETY"));
+        assert!(matches!(&safety, Err(m) if m.contains("SAFETY") && m.contains("policy")));
+        assert!(
+            matches!(finish_gated_answer(String::new(), safety), Err(m) if m.contains("no answer"))
+        );
+        // A refusal on the Anthropic side likewise gates into a banner with kept text.
+        let out = finish_gated_answer(
+            "as far as I got".into(),
+            anthropic_finish_gate(Some("refusal")),
+        );
+        assert!(
+            matches!(&out, Ok(t) if t.contains("INCOMPLETE") && t.contains("refusal") && t.contains("as far as I got"))
+        );
     }
 
     /// A cancelled batch with no partial results is a [`BatchPoll::Failed`] naming the

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -298,6 +298,15 @@ pub fn oneshot_preamble() -> String {
 /// - **Depth is free.** The lane forces high effort + a generous token floor precisely
 ///   because the latency is already accepted. The prompt says so out loud — spend the
 ///   room on depth — rather than leaving that intent only in the knobs.
+/// - **The written answer comes before the depth (GH #75).** Reasoning and answer draw
+///   on one shared output budget, so a big attached-file review at max thinking can spend
+///   the whole budget thinking and get truncated *before* the answer is written — the
+///   caller then sees a cut-off reasoning fragment with no verdict. Depth stays free, but
+///   it can't be free at the cost of an unwritten answer, so the prompt orders it: land
+///   the conclusion in full first, then let the reasoning build under it. (kaibo also now
+///   *flags* a truncated batch result rather than passing the fragment off as clean — see
+///   `finish_gated_answer` in `batch.rs` — so this prompt nudge and the parser guard are
+///   the two halves of the same fix.)
 /// - **Primary answer, not a footnote.** Batch is for asking the best model the hard
 ///   question, so the "second opinion" framing under-positions it; the load-bearing
 ///   part is "for another agent" (an external advisor owns no context), which we keep.
@@ -310,11 +319,15 @@ pub fn batch_preamble() -> String {
      from the material it provides and your own knowledge — this call has no codebase \
      access and no tools, so the caller owns all the context you have. This is your \
      single response: there is no follow-up turn and the caller cannot clarify, so make \
-     the answer complete and self-contained, and spend the room you have on depth — \
-     reason the problem all the way through. Be direct and precise. Ground every claim \
-     in the material or your own knowledge, and say where the evidence runs out. Where \
-     something you'd need is missing, state the assumption you're making, answer under \
-     it, and flag what would change if the assumption is wrong."
+     the answer complete and self-contained. The lane gives you room and high effort — \
+     spend it on depth, but spend it on the *written* answer: lead with the conclusion \
+     (the findings, the verdict, the recommendation) and write it in full, then let your \
+     reasoning build under it. Your thinking and your answer draw on one shared output \
+     budget, so land the deliverable the caller can act on first — don't reason at length \
+     and leave the answer unfinished. Be direct and precise. Ground every claim in the \
+     material or your own knowledge, and say where the evidence runs out. Where something \
+     you'd need is missing, state the assumption you're making, answer under it, and flag \
+     what would change if the assumption is wrong."
         .to_string()
 }
 
@@ -613,10 +626,10 @@ mod tests {
         }
     }
 
-    /// The batch preamble encodes the async lane's distinct contract — the three things
-    /// a cross-model review flagged the oneshot wording getting wrong for batch. These
-    /// are behavioral promises, so they get a test that fails if the prose drifts back
-    /// toward the synchronous oneshot framing.
+    /// The batch preamble encodes the async lane's distinct contract — the things a
+    /// cross-model review flagged the oneshot wording getting wrong for batch, plus the
+    /// GH #75 output-discipline promise. These are behavioral promises, so they get a test
+    /// that fails if the prose drifts back toward the synchronous oneshot framing.
     #[test]
     fn batch_preamble_encodes_the_offline_one_shot_contract() {
         let p = batch_preamble();
@@ -628,6 +641,13 @@ mod tests {
         );
         // (2) Depth is free here — spend the budget the lane forces on.
         assert!(lower.contains("depth"), "batch must ask for depth: {p}");
+        // (2b) GH #75: the written answer comes before the depth. Reasoning and answer
+        // share one output budget, so lead with the conclusion rather than reasoning at
+        // length into a truncated, verdict-less fragment.
+        assert!(
+            lower.contains("lead with the conclusion") && lower.contains("shared output budget"),
+            "batch must order the written answer ahead of the depth (GH #75): {p}"
+        );
         // (3) Assume-and-answer, not flag-and-stall: state the assumption and answer
         // under it (the synchronous oneshot would say "name what you'd need").
         assert!(
@@ -893,8 +913,12 @@ mod tests {
                 text_attach("notes.md", "note body"),
             ],
         );
-        let inline_at = prompt.find("<file path=\"notes.md\">").expect("text inlines");
-        let oversize_at = prompt.find("- src/big.rs (500000 bytes)").expect("oversize listed");
+        let inline_at = prompt
+            .find("<file path=\"notes.md\">")
+            .expect("text inlines");
+        let oversize_at = prompt
+            .find("- src/big.rs (500000 bytes)")
+            .expect("oversize listed");
         let image_at = prompt.find("- docs/shot.png").expect("image listed");
         let question_at = prompt.find("Assess the change.").expect("question present");
         assert!(
@@ -914,10 +938,7 @@ mod tests {
             "q",
             None,
             &[],
-            &[
-                oversize_attach(evil, 42),
-                image_attach("img\nfake.png"),
-            ],
+            &[oversize_attach(evil, 42), image_attach("img\nfake.png")],
         );
         assert!(
             !prompt.contains("\n- /etc/shadow"),


### PR DESCRIPTION
Closes #75.

## The bug, ground-truthed

A `gemini-batch` code review (gemini-pro-latest, ~4,400-line `lexer.rs` attached) came back as a rambly chain-of-thought fragment — starts mid-sentence, ends mid-analysis, no findings, no verdict — carrying **no error or truncation marker**. A caller skimming for findings could mistake it for "the model found little."

I fetched the durable handle from the issue (`gemini/batches/laaxe5t0oa9181hhc1y65282fow9fksnpz6i`). It shows exactly why:

- `finishReason: **MAX_TOKENS**` — the response was truncated at the output-token budget.
- `usageMetadata`: `thoughtsTokenCount: 31455` + `candidatesTokenCount: 1309` ≈ the 32768 `BATCH_MAX_TOKENS_FLOOR` — **thinking consumed essentially the whole budget**.
- The candidate's parts: part[0] is `thought:true` (correctly filtered today); part[1] has **no `thought` marker**, carries a `thoughtSignature`, and is trailing reasoning. The old `gemini_message_text` keeps any non-thought text part and returned it as the answer, reading `finishReason` nowhere.

The old comment — *"a final answer part may still carry a `thoughtSignature`… so it stays"* — is the exact assumption that broke: under `MAX_TOKENS`, a signatured non-thought part is trailing reasoning, not an answer.

## The fix (decisions, with Amy)

- **Gate on the finish reason, both providers.** A shared `finish_gated_answer` composes each item from its text + a normalized finish signal (Gemini `finishReason`, Anthropic `stop_reason` — the Anthropic path had the **identical latent bug**). Clean finish → unchanged; truncated / policy-halted → partial text kept under a loud `⚠️ INCOMPLETE` banner naming the reason; truncated-with-no-answer → an honest per-item failure instead of a blank success. Partial text is kept, not dropped, so a genuinely-clipped real answer stays useful — but it announces itself.
- **The signal is the finish reason, not the parts.** A `thoughtSignature` part is a real answer under `STOP` but trailing reasoning under `MAX_TOKENS`; they're structurally indistinguishable, so the gate is the finish reason.
- **Leave the 32K floor; steer the prompt.** Per-model output ceilings differ, so a blind global bump risks 400s. Instead the batch preamble now orders the written answer ahead of the depth (reasoning and answer share one output budget), and `docs/config.example.toml` documents raising a batch cast's `max_tokens` per-slot for long reviews.

## Tests & verification

- Ground-truthed offline tests: Gemini leaked-reasoning (the real payload's shape), only-thoughts→failure, clean `STOP`; Anthropic `max_tokens`→banner and empty→failure; the pure gate/compose contract (incl. the policy-halt and clean-empty paths). **Verified they fail on the pre-fix behavior.**
- Drove the real 303 KB payload through `parse_gemini_poll` → `render_poll` and confirmed a caller now sees the `⚠️ INCOMPLETE — finishReason=MAX_TOKENS` banner with the fragment kept below.
- Full offline suite green; clippy clean.

## Review

Cross-family (DeepSeek via kaibo's own `consult`) review in flight; will fold in findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)