### PR TITLE
fix(shaping): route every Gemini id to thinkingLevel so the effort lever reaches Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,11 +440,21 @@ the git log. Each later release appends a new section at the top.
   the bare `gemini-3-…` form — so the `-latest` aliases and the dotted 3.x ids (e.g.
   `gemini-3.1-pro-preview`) fell through to the retired 2.5-era `thinkingBudget` path,
   which pins depth to a fixed number and silently drops the per-role `effort` lever.
-  Setting `effort = "low"` (or `"high"`, `"max"`, …) on a Gemini slot had no effect. kaibo
-  now routes every Gemini id to `thinkingLevel` — the knob Google's current API documents
-  across the whole 3-line — so the effort you configure is the reasoning depth Gemini
-  runs at. (kaibo targets the Gemini 3-line and newer; the legacy 2.5 budget knob is no
-  longer modeled — a pre-3.x id fails loud rather than silently mis-shaping.)
+  Setting `effort = "low"` (or `"high"`, `"max"`, …) on an interactive Gemini slot had no
+  effect. kaibo now routes every Gemini id to `thinkingLevel` — the knob Google's current
+  API documents across the whole 3-line — so an interactive Gemini slot's configured
+  effort is the reasoning depth it runs at. (The batch lane still runs at its own forced
+  max effort, by design. kaibo targets the Gemini 3-line and newer; the legacy 2.5 budget
+  knob is no longer modeled — a pre-3.x id fails loud rather than silently mis-shaping.)
+
+- **A Gemini or Anthropic-adaptive slot with a large `thinking_budget` no longer fails to
+  load.** The `thinking_budget < max_tokens` load check (Anthropic 400s on an inverted
+  pair) was gated on the provider *kind*, so it also rejected slots whose model sends no
+  budget at all — a Gemini slot (takes a `thinkingLevel`) or an Anthropic *adaptive* slot
+  (takes an `output_config.effort`) with, say, `max_tokens = 4096` and the default
+  `thinking_budget = 8192` was refused even though that budget never reaches the wire. The
+  check now gates on whether the resolved model shape actually *sends* a budget, so an
+  inert `thinking_budget` no longer blocks a valid config.
 
 - **A truncated batch answer no longer masquerades as a finished one.** When a batch
   item hit its output-token budget mid-response — most often a big attached-file review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,18 @@ the git log. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **A Gemini slot's reasoning-effort setting now actually reaches Gemini.** kaibo's
+  Gemini casts (the default `gemini` synth, the `gemini-batch` Pro synth, the Flash-Lite
+  explorer) all name 3.x-line models, but the thinking-knob classifier recognized only
+  the bare `gemini-3-…` form — so the `-latest` aliases and the dotted 3.x ids (e.g.
+  `gemini-3.1-pro-preview`) fell through to the retired 2.5-era `thinkingBudget` path,
+  which pins depth to a fixed number and silently drops the per-role `effort` lever.
+  Setting `effort = "low"` (or `"high"`, `"max"`, …) on a Gemini slot had no effect. kaibo
+  now routes every Gemini id to `thinkingLevel` — the knob Google's current API documents
+  across the whole 3-line — so the effort you configure is the reasoning depth Gemini
+  runs at. (kaibo targets the Gemini 3-line and newer; the legacy 2.5 budget knob is no
+  longer modeled — a pre-3.x id fails loud rather than silently mis-shaping.)
+
 - **A truncated batch answer no longer masquerades as a finished one.** When a batch
   item hit its output-token budget mid-response — most often a big attached-file review
   where max-effort thinking spends the whole budget before the answer is written — kaibo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,7 +268,11 @@ the git log. Each later release appends a new section at the top.
   tool and a short argument summary; a `run_kaish` span additionally carries
   `kaish.exit_code` and `kaish.output_bytes`, so a trace can distinguish a read that
   *truncated* (exit `3`) at the output cap — and forced narrow re-reads — from one the
-  model chose to slice, rather than every script reading as a plain success.
+  model chose to slice, rather than every script reading as a plain success. Each phase's
+  `run_phase` span carries `gen_ai.request.thinking` — the exact reasoning/sampling blob
+  it shipped (Gemini's `thinkingLevel`, an Anthropic adaptive `effort`, a DeepSeek
+  `reasoning_effort`) — so a trace shows *whether and at what depth* thinking was on, the
+  wire truth behind each `chat` span's `reasoning_tokens`.
 - **A failed provider doesn't fail your turn.** When a model or its provider misbehaves
   (a 429/529 overload, a connection reset, a wedged backend that hits the
   `request_timeout`), `consult`/`oneshot` return a *clean tool-result error* naming the

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -95,8 +95,8 @@ synth_temperature    = 0.3
 top_p                = 0.95
 
 # Reasoning depth, per role, for the models that take an effort param (Anthropic
-# adaptive tier, DeepSeek). A passthrough string the provider validates — bump
-# synth_effort to "max"/"xhigh" for heavier runs without a kaibo release.
+# adaptive tier, DeepSeek, Gemini's thinkingLevel, OpenRouter). A passthrough string
+# the provider validates — bump synth_effort to "max"/"xhigh" for heavier runs.
 explorer_effort = "high"
 synth_effort    = "high"
 
@@ -388,8 +388,9 @@ synth    = "gemini/gemini-pro-latest"        # batch-capable synth (Anthropic | 
 # answer — kaibo flags such a result INCOMPLETE with its finishReason rather than passing off
 # the cut-off fragment as a clean answer. Give batch more answer headroom by raising
 # `max_tokens` on the synth slot; it's a floor, so a higher value wins, and mind each model's
-# output ceiling (Gemini Pro is generous; some backends cap lower). `effort` / `thinking_budget`
-# ride the same slot if you want to tune reasoning depth:
+# output ceiling (Gemini Pro is generous; some backends cap lower). Batch forces effort to
+# high and ignores a per-slot `thinking_budget` (Gemini takes a level; Anthropic floors it),
+# so `max_tokens` is the knob worth setting here:
 #   synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch", max_tokens = 65536 }
 
 # --- DELIBERATE casts: an interactive explorer PLUS an offline synth. `deliberate` runs

--- a/docs/config.md
+++ b/docs/config.md
@@ -185,9 +185,11 @@ The `[defaults]` knobs themselves:
 
 - **`max_tokens` / `thinking_budget`** (16384 / 8192): output headroom and
   reasoning budget. Reasoning eats the *completion* budget, so `max_tokens` must
-  sit well above `thinking_budget` — for slots on Anthropic- or Gemini-kind
-  backends an inverted pair is rejected at load on the slot's *resolved* values
-  (Anthropic would 400 on it mid-call).
+  sit well above `thinking_budget` — for a slot whose model actually *sends* a
+  budget (Anthropic's legacy `budget_tokens` tier) an inverted pair is rejected at
+  load on the slot's *resolved* values (Anthropic would 400 on it mid-call). A slot
+  with no budget sink (Gemini takes a `thinkingLevel`, Anthropic's adaptive tier an
+  effort) carries an inert `thinking_budget`, so the pair isn't checked there.
 - **`explorer_temperature` / `synth_temperature` / `top_p`** (0.1 / 0.3 / 0.95):
   sampling per role — the explorer gathers exact citations, so it runs cold; the
   synth composes the answer, so it gets a touch more room. Sent where a model

--- a/docs/config.md
+++ b/docs/config.md
@@ -199,14 +199,14 @@ The `[defaults]` knobs themselves:
   per slot, an out-of-range value is rejected at load, not clamped.
 - **`explorer_effort` / `synth_effort`** (`"high"` both): reasoning depth for the
   models that take an effort param — Anthropic's adaptive tier
-  (→ `output_config.effort`), DeepSeek (→ `reasoning_effort`), the Gemini
-  3-line (→ `thinkingLevel`: the values align, `"high"`/`"low"`), and OpenRouter
-  (→ its unified `{"reasoning":{"effort":…}}`, forwarded verbatim to whatever the
-  pinned model actually supports). A passthrough string the provider validates
-  (like a model id), so a new level lands without a code change — set a synth
+  (→ `output_config.effort`), DeepSeek (→ `reasoning_effort`), Gemini
+  (→ `thinkingLevel`: the values align, `"minimal"`/`"low"`/`"medium"`/`"high"`),
+  and OpenRouter (→ its unified `{"reasoning":{"effort":…}}`, forwarded verbatim to
+  whatever the pinned model actually supports). A passthrough string the provider
+  validates (like a model id), so a new level lands without a code change — set a synth
   slot's `effort = "max"`/`"xhigh"` for heavier runs; OpenRouter is where those
   deeper rungs are actually reachable today. Ignored by models with no effort
-  sink (budget-tier Anthropic/Gemini, OpenAI).
+  sink (budget-tier Anthropic, OpenAI).
 - **`thinking_style`** (`auto` | `adaptive` | `budget`, default `auto`) forces the
   Anthropic thinking shape instead of the built-in classifier. `auto` picks
   adaptive for Opus 4.6+/Sonnet 4.6/Fable 5 and enabled-budget for older models +

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -64,6 +64,44 @@ batch example claiming `effort` tunes depth (batch forces it). GPT's remaining n
 as effective) — is pre-existing and now tracked in `issues.md` beside the sibling
 `thinking_style` render gap, not fixed here.
 
+**Then we made the fix verifiable on the wire.** Validating the collapse meant reading a
+`chat` span's `reasoning_tokens` and *inferring* the request shape — kaibo traced response
+usage, never the outbound request. Amy asked to fix the spans, so the `run_phase` span now
+records `gen_ai.request.thinking`: the exact `additional_params` blob a phase ships
+(thinkingLevel/budget + effort + sampling), declared `Empty` in the instrument and filled
+in the body only when `thinking` is `Some` — inert with no exporter, and a toggle-less
+provider records nothing. With it, the fix stopped being a claim: a live flash-lite →
+`gemini-3.5-flash` → `gemini-pro-latest` ladder each showed `thinkingLevel: "high"` on the
+wire (explorer at `temperature 0.1`, synth at `0.3`, sampling correctly nested in
+`generationConfig`) — every one of which misses the old `gemini-3` prefix and would have
+shipped `thinkingBudget` on main. That also answered the question that started the
+investigation — *were Pro batches thinking-off before?* No: `gemini-pro-latest` fell to a
+fixed `thinkingBudget: 8192` with the per-role effort dropped, so it thought at a flat
+depth and the batch lane's forced effort was ignored; now it's `thinkingLevel` at the
+forced `BATCH_EFFORT`.
+
+Landing the span meant a test that captures it, which meant confronting the callsite-
+interest-poisoning flake `tool_span.rs` had already solved. Rather than a second copy, we
+promoted the fix (`CAPTURE_SERIAL`, `force_multi_dispatcher`, `serialized_capture`) into the
+shared `test_support` module: one serial guard now covers the whole unit-test binary, which
+is the *correct* scope — a `run_phase` capture and a `tool` capture must serialize against
+each other, and it's a *third* no-subscriber test that poisons a callsite, so a per-module
+guard was never enough. The new `run_phase_span_carries_the_thinking_params` discriminates
+on both edges (records the exact Gemini `thinkingLevel` blob with params, records nothing
+without) and was teeth-proven the repo's way — neuter the `record` call, watch it go RED
+(`[None, None]`), restore. Cross-family review of the fold-in ran on `gemini-pro-latest`
+itself (reading the uncommitted worktree), which independently confirmed the field's
+inertness, that sharing one guard *improves* the flake guarantee, and the test's teeth:
+"safe and robustly tested… good to go."
+
+One gap stays open by design: `run_phase` covers the *interactive* lanes. The batch lane
+builds its own request in `batch.rs::gemini_batch_body`, outside `run_phase`, so a live Pro
+*batch* can't be wire-checked the way the interactive ladder was — its
+`thinkingLevel`-at-`BATCH_EFFORT` shape rests on offline tests
+(`gemini_3_line_uses_thinking_level_at_batch_effort`,
+`gemini_shaping_nests_thinking_in_generation_config`). A span in the batch builder is the
+follow-up that would make the batch lane as legible as the interactive one.
+
 ## 2026-07-05 — the build bootstrap: never-fired workflow → verified first release, in a day
 
 The release plan (PR #25, `docs/releases.md`) had sat unmerged since 2026-06-25 with its

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,39 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-07-18 — Gemini's effort lever was silently disconnected
+
+Investigating batch truncation (#79, already fixed) turned up a *separate* correctness
+bug: the Gemini thinking-knob classifier, `is_gemini3_level`, matched only the bare
+`gemini-3` / `gemini-3-*` form. But every Gemini id kaibo actually ships is a 3.x-line
+model the substring test missed — the `-latest` aliases the built-in casts pin
+(`gemini-flash-lite-latest` explorer, `gemini-pro-latest` batch synth) carry no
+`gemini-3` at all, and the dotted previews they resolve to (`gemini-3.1-pro-preview`)
+put a dot after the 3. All of them fell to the `GeminiBudget` arm, which emits a fixed
+`thinkingBudget` and **drops the per-role `effort`**. A user setting `effort = "low"`/
+`"high"` on a Gemini synth was quietly ignored — no crash, since both knobs are accepted
+on the wire, just the wrong one sent.
+
+The prior code deliberately kept `gemini-3.5-flash` on budget, citing a 2026-06-06 live
+test that confirmed budget *works* there. The flaw in that reasoning: "budget works"
+never established "level fails" — and if both work, `thinkingLevel` is strictly better
+because it carries the effort lever. Rather than re-probe, we went to Google's current
+[thinking doc](https://ai.google.dev/gemini-api/docs/thinking): it lists `thinkingLevel`
+(`minimal|low|medium|high`) across the whole 3-line — 3-pro, 3-flash, **3.5-flash**,
+3.1-pro — and doesn't mention `thinkingBudget` at all; that's the retired 2.5-era knob.
+
+So the fix isn't a wider classifier — it's a *collapse*. Amy's call: kaibo targets the
+Gemini 3-line and newer, and we say so. `ProviderKind::Gemini` always resolves to
+`GeminiLevel`; `is_gemini3_level` and the whole `GeminiBudget` `ThinkingStyle` variant
+are gone (dead surface once nothing produces it — there's no `thinking_style` override
+for Gemini). A pre-3.x id now emits a level and fails loud at the provider, the honest
+"unsupported" signal, over silently mis-shaping. TDD: a failing test pinning the
+configured ids' effort → `thinkingLevel` came first (RED on `gemini-flash-lite-latest`),
+then the collapse turned it green. Dependent tests that used 2.5 ids as fixtures moved
+to 3.x; the engine per-arm straddle test — which had leaned on the now-defunct
+*intra-Gemini* budget/level split — was re-aimed at a stronger cross-*provider* straddle
+(Anthropic-adaptive synth vs Gemini-level explorer, structurally disjoint param trees).
+
 ## 2026-07-05 — the build bootstrap: never-fired workflow → verified first release, in a day
 
 The release plan (PR #25, `docs/releases.md`) had sat unmerged since 2026-06-25 with its

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -47,6 +47,23 @@ to 3.x; the engine per-arm straddle test — which had leaned on the now-defunct
 *intra-Gemini* budget/level split — was re-aimed at a stronger cross-*provider* straddle
 (Anthropic-adaptive synth vs Gemini-level explorer, structurally disjoint param trees).
 
+The cross-family review earned its keep. DeepSeek's pass came back clean and, usefully,
+independently confirmed `includeThoughts: true` is *not* a stale 2.5-era field — the batch
+`#75` truncation detector depends on those thought parts arriving. GPT (via OpenRouter)
+went deeper and caught what the classifier collapse left behind: the `thinking_budget <
+max_tokens` load check (`config.rs`, `engine.rs::from_slot`) was still gated on
+`ProviderKind::{Anthropic, Gemini}`. Now that Gemini sends no budget, that gate *falsely
+refused* a valid Gemini slot (e.g. `max_tokens = 4096` under the default
+`thinking_budget = 8192`) — and it had always wrongly refused Anthropic *adaptive* slots
+too, whose budget is equally inert. The right gate is the resolved shape's
+`sinks_thinking_budget()`, not the kind: only a style that actually puts a budget on the
+wire can starve the answer. Fixed both sites (TDD: RED on the adaptive/Gemini accept
+cases), plus the doc drift GPT flagged — the effort-taker lists that omitted Gemini, the
+batch example claiming `effort` tunes depth (batch forces it). GPT's remaining note — the
+`kaibo://config` inert-tunables render is lane-blind (a batch slot's forced `effort` shows
+as effective) — is pre-existing and now tracked in `issues.md` beside the sibling
+`thinking_style` render gap, not fixed here.
+
 ## 2026-07-05 — the build bootstrap: never-fired workflow → verified first release, in a day
 
 The release plan (PR #25, `docs/releases.md`) had sat unmerged since 2026-06-25 with its

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -527,6 +527,14 @@ global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
   `effort = "low"` on a `lane = "batch"` slot is a silent no-op the render doesn't flag.
   Same display-accuracy class as the `thinking_style` gap above; make the inert check
   lane-aware — mark batch `effort` as overridden and batch sampling as inert.
+- **The `inert_tunables` render resolves the shape differently from validation**
+  (deepseek review, 2026-07-18): the render resolves `thinking_style` via
+  `unwrap_or_default()` (→ `Auto`), while the validation/`slot.tunables` path uses the
+  `defaults.thinking_style` fallback — so a `[defaults].thinking_style = "adaptive"` set
+  without a per-slot override is missed by the render, which can mislabel a
+  `thinking_budget`'s inertness on an actually-adaptive Anthropic slot. Display-only,
+  no wire effect. The clean fix for this whole render-accuracy cluster: resolve the
+  slot's shape in the render exactly as `slot.tunables` does.
 
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -520,6 +520,13 @@ global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
   `temperature` per slot (`config_resource.rs`), but a `thinking_style` set on a
   slot whose kind ignores the override (anything non-Anthropic) renders as if
   effective. Display accuracy only; add it to the inert check alongside the others.
+- **The `inert_tunables` render is lane-blind** (or-gpt review, 2026-07-18): it
+  resolves only the model *shape*, not the slot's `lane`, so a **batch** slot renders
+  `effort` and `temperature` as effective even though `batch_shaping` forces
+  `BATCH_EFFORT` (ignoring the slot's `effort`) and passes `None` sampling. A configured
+  `effort = "low"` on a `lane = "batch"` slot is a silent no-op the render doesn't flag.
+  Same display-accuracy class as the `thinking_style` gap above; make the inert check
+  lane-aware — mark batch `effort` as overridden and batch sampling as inert.
 
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -496,17 +496,12 @@ P1 entry):
 `ModelShape` (`consult.rs`) resolves request params per (kind, model), fit per
 *arm* with the slot's tunables via `Arm::from_slot` (each falling back to the
 per-role `[defaults]`). Thinking is model-aware across all providers (Anthropic
-adaptive vs enabled-budget, Gemini 3-line `thinkingLevel` vs 2.5/3.5
-`thinkingBudget`), reasoning depth is per-role effort (with `thinkingLevel` as
-the 3-line's effort sink), and `thinking_style` (per slot or `[defaults]`)
-overrides the Anthropic classifier. `max_tokens`/`thinking_budget` are per-slot
-tunables — if a provider caps output low, cap that slot, not the global, per the
-`large-token-headroom` memory. Remaining knobs on the same seam:
-- **Gemini 3.5 boundary is empirical.** The classifier (`is_gemini3_level`) flips
-  only the pure `gemini-3-*` line to `thinkingLevel`; `gemini-3.5-flash` stays on
-  budget because the 2026-06-06 live test confirmed budget works there. If a future
-  3.5 build *rejects* budget, widen the classifier — but confirm with a live probe,
-  don't guess.
+adaptive vs enabled-budget; Gemini is single-tier — the whole 3-line, which is all
+kaibo targets, takes `thinkingLevel`), reasoning depth is per-role effort (with
+`thinkingLevel` as Gemini's effort sink), and `thinking_style` (per slot or
+`[defaults]`) overrides the Anthropic classifier. `max_tokens`/`thinking_budget`
+are per-slot tunables — if a provider caps output low, cap that slot, not the
+global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
 - **Anthropic adaptive boundary is empirical.** `is_anthropic_adaptive` flips Opus
   4.6+/Sonnet 4.6/Fable 5 to adaptive (the rest stay enabled-budget). Add ids as models
   ship, or set `thinking_style` on the slot to override; confirm a new id with the

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1913,8 +1913,10 @@ mod tests {
 
     // --- Gemini ------------------------------------------------------------
 
-    /// Gemini's maxed shape lands in `generationConfig` (the completion budget is nested
-    /// there, not top-level): a budget-tier id carries `thinkingConfig.thinkingBudget`.
+    /// Gemini's maxed shape lands in `generationConfig` (the completion budget nests
+    /// there, not top-level): a Gemini slot carries `thinkingConfig.thinkingLevel`, and
+    /// `max_tokens` is floored to the batch minimum. The whole 3-line is single-tier, so
+    /// batch forces the level and never a token budget.
     #[test]
     fn gemini_shaping_nests_thinking_in_generation_config() {
         let (max_tokens, params) = batch_shaping(
@@ -1925,16 +1927,21 @@ mod tests {
         assert!(max_tokens >= BATCH_MAX_TOKENS_FLOOR);
         let params = params.expect("a gemini slot carries a thinking block");
         let tc = &params["generationConfig"]["thinkingConfig"];
+        assert_eq!(
+            tc["thinkingLevel"], BATCH_EFFORT,
+            "gemini batch forces the level, nested in generationConfig: {params}"
+        );
         assert!(
-            tc["thinkingBudget"].as_u64().unwrap() >= BATCH_THINKING_BUDGET,
-            "gemini batch floors the thinking budget: {params}"
+            tc.get("thinkingBudget").is_none(),
+            "Gemini has no budget tier — the level is the only knob: {params}"
         );
     }
 
-    /// A pure `gemini-3-*` line id takes `thinkingLevel`, forced to BATCH_EFFORT — the
-    /// per-role effort lever, not a token budget. (The `gemini-batch` cast itself synths
-    /// `gemini-pro-latest`, which classifies as a *budget*-tier id; this exercises the
-    /// other Gemini thinking tier so both paths through `batch_shaping` are covered.)
+    /// A 3-line id takes `thinkingLevel`, forced to BATCH_EFFORT — the per-role effort
+    /// lever, not a token budget — even when the slot asked for a shallower "low". (The
+    /// `gemini-batch` cast synths `gemini-pro-latest`, also a level-tier id now that the
+    /// whole Gemini 3-line takes a level; every Gemini id runs this one path through
+    /// `batch_shaping`.)
     #[test]
     fn gemini_3_line_uses_thinking_level_at_batch_effort() {
         let (_max, params) = batch_shaping(

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::consult::{ModelCaps, PromptOverrides, ThinkingStyleOverride};
+use crate::consult::{ModelCaps, ModelShape, PromptOverrides, ThinkingStyleOverride};
 use crate::context::ContextConfig;
 use crate::credentials::{self, ProviderKind, PLACEHOLDER_OPENAI_KEY};
 use crate::orientation::OrientationConfig;
@@ -64,9 +64,10 @@ pub struct Defaults {
     /// lever.
     pub top_p: f64,
     /// Per-role reasoning effort for the models that take one as a request param
-    /// (Anthropic adaptive's `output_config.effort`, DeepSeek's `reasoning_effort`).
-    /// A passthrough string — the provider validates it. Default `"high"` both roles;
-    /// bump a synth slot's `effort` to `"max"`/`"xhigh"` for heavier synth runs.
+    /// (Anthropic adaptive's `output_config.effort`, DeepSeek's `reasoning_effort`,
+    /// Gemini's `thinkingLevel`, OpenRouter's unified `reasoning.effort`). A passthrough
+    /// string — the provider validates it. Default `"high"` both roles; bump a synth
+    /// slot's `effort` to `"max"`/`"xhigh"` for heavier synth runs.
     pub explorer_effort: String,
     pub synth_effort: String,
     /// Force the Anthropic thinking style (`auto`/`adaptive`/`budget`) instead of the
@@ -1219,12 +1220,16 @@ impl Config {
                     }
                 }
                 // Thinking-on kinds need output headroom above the reasoning budget;
-                // Anthropic *requires* max_tokens > budget_tokens (see consult.rs).
-                // Validate the slot's *resolved* values (per-slot override else
-                // defaults) so an inverted pair is caught here, not as a 400 mid-call.
+                // Anthropic *requires* max_tokens > budget_tokens (see consult.rs). The
+                // rule binds only where the budget actually reaches the wire — gate on
+                // the resolved shape's budget sink, not the kind: Gemini takes a
+                // `thinkingLevel` and Anthropic adaptive an `output_config.effort`, so an
+                // inverted pair there is inert, not a starve. Validate the slot's
+                // *resolved* values (per-slot override else defaults) so a real inverted
+                // pair is caught here, not as a 400 mid-call.
                 let kind = backends[&slot.backend].kind;
                 let t = slot.tunables(*role, &defaults);
-                if matches!(kind, ProviderKind::Anthropic | ProviderKind::Gemini)
+                if ModelShape::resolve(kind, &slot.id, t.thinking_style).sinks_thinking_budget()
                     && t.thinking_budget >= t.max_tokens
                 {
                     bail!(
@@ -3711,28 +3716,42 @@ mod tests {
         assert!(err.contains("claimed by both"), "got: {err}");
     }
 
-    /// A slot whose resolved thinking budget would starve its resolved max_tokens
-    /// on a thinking-on kind is caught at load, not as a 400 mid-call.
+    /// A slot whose resolved thinking budget would starve its resolved max_tokens is
+    /// caught at load — but only where the budget actually reaches the wire. The rule
+    /// is an Anthropic legacy-budget requirement (Anthropic 400s on
+    /// `max_tokens <= budget_tokens`); a shape with no budget sink has an inert budget,
+    /// so an inverted pair there is harmless and must load. The gate is the resolved
+    /// shape's budget sink, not the provider kind.
     #[test]
-    fn an_inverted_thinking_budget_is_a_load_error() {
+    fn an_inverted_thinking_budget_is_a_load_error_only_where_the_budget_is_sunk() {
+        // Anthropic legacy-budget tier (Haiku 4.5) puts the budget on the wire → rejected.
         let err = Config::from_toml_str(
             r#"
             [casts.x]
-            synth = { backend = "anthropic", id = "claude-sonnet-4-6", max_tokens = 1000, thinking_budget = 2000 }
+            synth = { backend = "anthropic", id = "claude-haiku-4-5", max_tokens = 1000, thinking_budget = 2000 }
             "#,
         )
         .unwrap_err()
         .to_string();
         assert!(err.contains("thinking_budget"), "got: {err}");
         assert!(err.contains("max_tokens"), "got: {err}");
-        // The same pair on a non-thinking-budget kind is accepted.
-        Config::from_toml_str(
-            r#"
-            [casts.x]
-            synth = { backend = "openai-local", id = "m", max_tokens = 1000, thinking_budget = 2000 }
-            "#,
-        )
-        .unwrap();
+        // Shapes with no budget sink accept the same inverted pair — the budget never
+        // leaves the process, so it can't starve anything: Anthropic adaptive (Sonnet
+        // 4.6) expresses depth via `output_config.effort`, Gemini takes a `thinkingLevel`,
+        // and the generic openai path has no thinking toggle at all.
+        for (backend, id) in [
+            ("anthropic", "claude-sonnet-4-6"),
+            ("gemini", "gemini-3.5-flash"),
+            ("openai-local", "m"),
+        ] {
+            Config::from_toml_str(&format!(
+                "[casts.x]\n\
+                 synth = {{ backend = \"{backend}\", id = \"{id}\", max_tokens = 1000, thinking_budget = 2000 }}\n"
+            ))
+            .unwrap_or_else(|e| {
+                panic!("{backend}/{id} has no budget sink; the inverted pair must load: {e}")
+            });
+        }
     }
 
     /// An unknown cast at resolve time names the known casts.

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -654,7 +654,20 @@ fn split_for_resume(mut history: Vec<Message>) -> (Vec<Message>, Message) {
 // span and nests under this one, so a phase's whole model loop (every `chat` turn,
 // every `tool` call) hangs off one `run_phase` span carrying the model. Inert
 // unless an exporter is attached (telemetry off → no subscriber records it).
-#[tracing::instrument(name = "run_phase", skip_all, fields(model = %model_name, max_turns = max_turns))]
+#[tracing::instrument(
+    name = "run_phase",
+    skip_all,
+    fields(
+        model = %model_name,
+        max_turns = max_turns,
+        // The resolved wire blob (thinkingLevel/thinkingBudget + effort + sampling) as
+        // actually sent — ground truth for "what reasoning shape shipped", which the
+        // response-usage spans can only hint at. Empty here, filled in the body once it's
+        // known non-None, so a `None` (toggle-less) provider records nothing and
+        // telemetry-off stays a no-op.
+        gen_ai.request.thinking = tracing::field::Empty,
+    )
+)]
 pub(crate) async fn run_phase<M, F>(
     model: &M,
     model_name: &str,
@@ -679,6 +692,13 @@ where
     // the transcript and re-enters here (holistic review, Gemini Pro 2026-06-22).
     let mut prompt: Message = initial_prompt;
     let mut history: Vec<Message> = Vec::new();
+
+    // Surface the exact reasoning/sampling params this phase ships (constant across the
+    // resume loop), so a trace shows whether — and at what depth — thinking was on: the
+    // wire truth behind the `chat` spans' `reasoning_tokens`. Inert with no exporter.
+    if let Some(t) = thinking {
+        tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
+    }
 
     loop {
         // Outer turn budget: rig's `max_turns` resets each resume, so subtract the
@@ -2888,6 +2908,158 @@ mod tests {
                 r.additional_params
             );
         }
+    }
+
+    /// The `run_phase` span surfaces the exact reasoning params it ships, so a trace can
+    /// show whether — and at what depth — thinking was on (the wire truth behind the
+    /// `chat` spans' `reasoning_tokens`). Discriminating on both edges: a phase carrying
+    /// `additional_params` records `gen_ai.request.thinking` equal to the blob it sent
+    /// (here the on-theme Gemini `thinkingLevel`), and a toggle-less phase
+    /// (`thinking == None`) records nothing — so a regression that always-records or
+    /// never-records fails one branch. The field is filled in the body via
+    /// `Span::current().record`, so the capture merges `on_record` into per-span state,
+    /// exactly like the `tool` span harness.
+    #[test]
+    fn run_phase_span_carries_the_thinking_params() {
+        use crate::test_support::serialized_capture;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::{Context, SubscriberExt};
+        use tracing_subscriber::registry::LookupSpan;
+        use tracing_subscriber::Layer;
+
+        /// Grabs the one field we care about; a `%display` value lands as a debug value.
+        #[derive(Default)]
+        struct Grab(Option<String>);
+        impl tracing::field::Visit for Grab {
+            fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+                if f.name() == "gen_ai.request.thinking" {
+                    self.0 = Some(format!("{v:?}"));
+                }
+            }
+        }
+        #[derive(Default)]
+        struct Stored(Option<String>);
+        /// Collects, per closed `run_phase` span, whatever `gen_ai.request.thinking` held.
+        #[derive(Clone, Default)]
+        struct PhaseCapture(Arc<Mutex<Vec<Option<String>>>>);
+        impl<S: tracing::Subscriber + for<'a> LookupSpan<'a>> Layer<S> for PhaseCapture {
+            fn on_new_span(
+                &self,
+                attrs: &tracing::span::Attributes<'_>,
+                id: &tracing::Id,
+                ctx: Context<'_, S>,
+            ) {
+                if attrs.metadata().name() != "run_phase" {
+                    return;
+                }
+                let mut g = Grab::default();
+                attrs.record(&mut g); // Empty at open — the body records it later.
+                ctx.span(id).unwrap().extensions_mut().insert(Stored(g.0));
+            }
+            fn on_record(
+                &self,
+                id: &tracing::Id,
+                values: &tracing::span::Record<'_>,
+                ctx: Context<'_, S>,
+            ) {
+                let mut g = Grab::default();
+                values.record(&mut g);
+                if let (Some(v), Some(span)) = (g.0, ctx.span(id)) {
+                    // Only run_phase spans carry a `Stored`; others (chat/tool) no-op.
+                    if let Some(st) = span.extensions_mut().get_mut::<Stored>() {
+                        st.0 = Some(v);
+                    }
+                }
+            }
+            fn on_close(&self, id: tracing::Id, ctx: Context<'_, S>) {
+                let span = ctx.span(&id).unwrap();
+                if span.name() != "run_phase" {
+                    return;
+                }
+                let v = span.extensions().get::<Stored>().and_then(|s| s.0.clone());
+                self.0.lock().unwrap().push(v);
+            }
+        }
+
+        // A driver that delegates one sweep then answers; the sweep returns a report.
+        // Same shape as the request-shaping tests — the mock ignores the blob's content,
+        // we only assert what the span recorded.
+        fn client() -> ScriptedClient {
+            const SYNTH: &str = "gemini-3.5-flash";
+            const EXPLORER: &str = "gemini-flash-lite-latest";
+            ScriptedClient::builder()
+                .on_model(SYNTH, |req| {
+                    if transcript_text(req).contains("REPORT") {
+                        Ok(text_response("ANSWER"))
+                    } else {
+                        Ok(tool_call_response("s1", "explore", json!({ "question": "q" })))
+                    }
+                })
+                .on_model(EXPLORER, |_req| Ok(text_response("REPORT: src/foo.rs:1")))
+                .build()
+        }
+        const SYNTH: &str = "gemini-3.5-flash";
+        const EXPLORER: &str = "gemini-flash-lite-latest";
+
+        // On-theme: the Gemini 3-line thinkingLevel blob — the very shape PR 80 routes.
+        let expected =
+            thinking_params(ProviderKind::Gemini, SYNTH, 8192).expect("gemini sends params");
+        let expected_str = expected.to_string();
+        assert!(
+            expected_str.contains("thinkingLevel"),
+            "fixture must be the level blob, got {expected_str}"
+        );
+
+        // Positive: both arms carry the blob → every run_phase span records it.
+        let cap = PhaseCapture::default();
+        serialized_capture(async {
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
+            let cl = client();
+            let dir = project_with_marker();
+            consult_with(
+                "q",
+                dir.path(),
+                &arm_with(&cl, EXPLORER, Some(expected.clone())),
+                &arm_with(&cl, SYNTH, Some(expected.clone())),
+                &ConsultConfig::default(),
+            )
+            .await
+            .unwrap();
+        });
+        let seen = cap.0.lock().unwrap().clone();
+        assert!(
+            seen.len() >= 2,
+            "both the driver and its sweep must emit a run_phase span, got {seen:?}"
+        );
+        assert!(
+            seen.iter().all(|v| v.as_deref() == Some(expected_str.as_str())),
+            "every run_phase span must record the exact thinking blob, got {seen:?}"
+        );
+
+        // Negative: no params → the field stays Empty → recorded as absent.
+        let cap = PhaseCapture::default();
+        serialized_capture(async {
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
+            let cl = client();
+            let dir = project_with_marker();
+            consult_with(
+                "q",
+                dir.path(),
+                &arm(&cl, EXPLORER),
+                &arm(&cl, SYNTH),
+                &ConsultConfig::default(),
+            )
+            .await
+            .unwrap();
+        });
+        let seen = cap.0.lock().unwrap().clone();
+        assert!(!seen.is_empty(), "run_phase spans must still have fired");
+        assert!(
+            seen.iter().all(|v| v.is_none()),
+            "a toggle-less phase must record no thinking blob, got {seen:?}"
+        );
     }
 
     /// The per-phase payoff: when a cast's synth and explorer straddle a thinking-shape

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -211,14 +211,16 @@ impl Arm {
         defaults: &Defaults,
     ) -> Result<Self> {
         let t = slot.tunables(role, defaults);
+        let shape = ModelShape::resolve(backend.kind, &slot.id, t.thinking_style);
         // Re-assert the budget rule at the single live construction point: config
         // load validates every *configured* slot, but per-call overrides build
         // bare slots that never saw it — an inverted pair must be the same
-        // keyworded boundary error here, not a provider 400 mid-call. Checked
-        // before key resolution so it fires with no key configured.
-        if matches!(backend.kind, ProviderKind::Anthropic | ProviderKind::Gemini)
-            && t.thinking_budget >= t.max_tokens
-        {
+        // keyworded boundary error here, not a provider 400 mid-call. Gate on the
+        // shape's budget sink, not the kind: only a style that puts a budget on the
+        // wire can starve the answer — Gemini (`thinkingLevel`) and Anthropic adaptive
+        // (`output_config.effort`) carry no budget. Checked before key resolution so it
+        // fires with no key configured.
+        if shape.sinks_thinking_budget() && t.thinking_budget >= t.max_tokens {
             return Err(anyhow!(
                 "model {:?} (backend {:?}): thinking_budget ({}) must be < max_tokens \
                  ({}) — reasoning would starve the answer (Anthropic rejects it \
@@ -229,7 +231,7 @@ impl Arm {
                 t.max_tokens
             ));
         }
-        let params = ModelShape::resolve(backend.kind, &slot.id, t.thinking_style).to_params(
+        let params = shape.to_params(
             t.thinking_budget,
             Some(t.temperature),
             Some(t.top_p),
@@ -3290,6 +3292,39 @@ mod tests {
         let msg = format!("{err:#}");
         assert!(msg.contains("thinking_budget"), "got: {msg}");
         assert!(msg.contains("max_tokens"), "got: {msg}");
+    }
+
+    /// The mirror: a shape with no budget sink (Gemini takes a `thinkingLevel`, not a
+    /// budget) carries an inert `thinking_budget`, so an inverted pair can't starve the
+    /// answer and must not be refused here. The arm may still fail later on key
+    /// resolution (no key configured), but never with the inverted-budget error — that
+    /// distinguishes the fix from the pre-gate behavior, which refused Gemini the same
+    /// way it refuses a budget-tier Anthropic slot.
+    #[test]
+    fn arm_from_slot_accepts_an_inverted_budget_with_no_budget_sink() {
+        let defaults = crate::config::Defaults {
+            max_tokens: 4096,
+            thinking_budget: 8192, // inverted vs max_tokens, but inert for Gemini
+            ..crate::config::Defaults::default()
+        };
+        let backend = crate::config::Backend {
+            name: "gemini".into(),
+            kind: ProviderKind::Gemini,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: false,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+        };
+        let slot = ModelSlot::bare("gemini", "gemini-3.5-flash");
+        if let Err(e) = Arm::from_slot(&backend, &slot, ModelRole::Explorer, &defaults) {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("thinking_budget"),
+                "Gemini carries no budget; the inverted pair must not be refused: {msg}"
+            );
+        }
     }
 
     /// `run_phase` builds the toolset twice — once for the main loop, again for the

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -2888,15 +2888,18 @@ mod tests {
         }
     }
 
-    /// The per-phase payoff: when a cast's synth and explorer straddle the Gemini
-    /// 3-line capability boundary, each request must carry the thinking shape fit to
-    /// *its own* model — the driver `thinkingLevel`, the sweep `thinkingBudget`. A
-    /// regression that resolved thinking once and shared it — the old
-    /// profile-level shape — would put one model's params on the other's request.
+    /// The per-phase payoff: when a cast's synth and explorer straddle a thinking-shape
+    /// boundary, each request must carry the shape fit to *its own* model — never one
+    /// resolved once and shared. Here an Anthropic-adaptive driver (top-level
+    /// `thinking:{type:adaptive}` + `output_config.effort`) runs beside a Gemini-level
+    /// explorer (nested `generationConfig.thinkingConfig.thinkingLevel`): structurally
+    /// disjoint blobs, so a regression that shared one arm's params would land the wrong
+    /// keys on the other's request and this test would catch it. (A cross-*provider*
+    /// straddle now that Gemini is single-tier — the whole 3-line takes a level.)
     #[tokio::test]
     async fn each_phase_gets_thinking_fit_to_its_own_model() {
-        const SYNTH: &str = "gemini-3-pro-preview"; // 3-line → thinkingLevel
-        const EXPLORER: &str = "gemini-2.5-flash"; // 2.5 → thinkingBudget
+        const SYNTH: &str = "claude-sonnet-4-6"; // Anthropic adaptive → output_config.effort
+        const EXPLORER: &str = "gemini-flash-lite-latest"; // Gemini → thinkingLevel
 
         let client = ScriptedClient::builder()
             .on_model(SYNTH, |req| {
@@ -2927,30 +2930,41 @@ mod tests {
             &arm_with(
                 &client,
                 SYNTH,
-                thinking_params(ProviderKind::Gemini, SYNTH, 4096),
+                thinking_params(ProviderKind::Anthropic, SYNTH, 4096),
             ),
             &cfg,
         )
         .await
         .unwrap();
 
-        let tc = |r: &crate::test_support::RecordedRequest| {
-            r.additional_params.as_ref().unwrap()["generationConfig"]["thinkingConfig"].clone()
-        };
+        let params =
+            |r: &crate::test_support::RecordedRequest| r.additional_params.as_ref().unwrap().clone();
+        // The adaptive synth: top-level adaptive thinking + effort, no Gemini nesting.
         for r in client.requests_for(SYNTH) {
-            let cfg = tc(&r);
-            assert_eq!(cfg["thinkingLevel"], "high", "3-line driver wants a level");
+            let p = params(&r);
+            assert_eq!(
+                p["thinking"]["type"], "adaptive",
+                "adaptive driver wants adaptive thinking"
+            );
+            assert_eq!(
+                p["output_config"]["effort"], "high",
+                "adaptive depth rides output_config.effort"
+            );
             assert!(
-                cfg.get("thinkingBudget").is_none(),
-                "level and budget are exclusive"
+                p.get("generationConfig").is_none(),
+                "the Gemini nesting must not leak onto the Anthropic arm"
             );
         }
+        // The Gemini explorer: nested thinkingLevel, none of the adaptive keys.
         for r in client.requests_for(EXPLORER) {
-            let cfg = tc(&r);
-            assert_eq!(cfg["thinkingBudget"], 4096, "2.5 explorer wants a budget");
+            let p = params(&r);
+            assert_eq!(
+                p["generationConfig"]["thinkingConfig"]["thinkingLevel"], "high",
+                "the Gemini sweep wants a level"
+            );
             assert!(
-                cfg.get("thinkingLevel").is_none(),
-                "level and budget are exclusive"
+                p.get("thinking").is_none() && p.get("output_config").is_none(),
+                "the adaptive keys must not leak onto the Gemini arm"
             );
         }
     }

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -13,19 +13,6 @@ use crate::credentials::ProviderKind;
 /// Anthropic additionally *requires* `max_tokens > budget_tokens`.
 pub const THINKING_BUDGET: u64 = 8192;
 
-/// Does this Gemini id belong to the *pure* 3-line (e.g. `gemini-3-pro-preview`),
-/// which takes `thinkingLevel` rather than the 2.5-era `thinkingBudget`?
-///
-/// The boundary is **empirical, not nominal**: `gemini-3.5-flash` *accepted*
-/// `thinkingBudget` in the 2026-06-06 live test, so switching it to `thinkingLevel`
-/// would be a silent regression of a working default. We only flip the ids the
-/// official API + gemini-cli confirm want a level — `gemini-3-…` — and leave the
-/// `3.5` minor line (and 2.x) on budget. Any new id past these wants a live probe,
-/// not a guess. See `docs/issues.md` "Per-model request shaping".
-fn is_gemini3_level(model: &str) -> bool {
-    model == "gemini-3" || model.starts_with("gemini-3-")
-}
-
 /// The per-role thinking-depth lever for the models that expose one as a request
 /// param (Anthropic adaptive's `output_config.effort`, DeepSeek's `reasoning_effort`).
 /// A passthrough string the provider validates — like a model id — so a new level
@@ -36,13 +23,12 @@ pub const DEFAULT_EFFORT: &str = "high";
 /// Which Anthropic models want **adaptive** thinking (`{type:"adaptive"}` plus an
 /// `output_config.effort`) instead of the legacy `{type:"enabled", budget_tokens}`.
 ///
-/// **Empirical — confirm by probe** (the discipline of [`is_gemini3_level`]): Opus
-/// 4.7/4.8 and Fable 5 *reject* enabled/budget and sampling outright (400); Opus 4.6 /
-/// Sonnet 4.6 take adaptive too — it's the recommended shape, `budget_tokens` is
-/// deprecated there. Everything older, and Haiku 4.5, stays on enabled/budget. Matched
-/// by `contains` (not `starts_with`, unlike `is_gemini3_level`) so a vendor-prefixed id
-/// still resolves. Add ids as they ship; a slot (or `[defaults]`) can force a tier
-/// via `thinking_style`.
+/// **Empirical — confirm by probe**: Opus 4.7/4.8 and Fable 5 *reject* enabled/budget
+/// and sampling outright (400); Opus 4.6 / Sonnet 4.6 take adaptive too — it's the
+/// recommended shape, `budget_tokens` is deprecated there. Everything older, and Haiku
+/// 4.5, stays on enabled/budget. Matched by `contains` so a vendor-prefixed id still
+/// resolves. Add ids as they ship; a slot (or `[defaults]`) can force a tier via
+/// `thinking_style`.
 fn is_anthropic_adaptive(model: &str) -> bool {
     ["opus-4-6", "opus-4-7", "opus-4-8", "sonnet-4-6", "fable-5"]
         .iter()
@@ -145,10 +131,11 @@ enum ThinkingStyle {
     AnthropicBudget,
     /// Anthropic 4.6+: `{thinking:{type:"adaptive"}}` + `output_config.effort`.
     AnthropicAdaptive,
-    /// Gemini 3-line: `generationConfig.thinkingConfig.thinkingLevel`.
+    /// Gemini (3.x+): `generationConfig.thinkingConfig.thinkingLevel`. kaibo supports
+    /// the Gemini 3-line and newer only — the whole line takes a level; the legacy
+    /// 2.5-era `thinkingBudget` knob is not modeled (a pre-3.x id would emit a level
+    /// and fail loud at the provider, the intended "unsupported" signal).
     GeminiLevel,
-    /// Gemini 2.5/3.5: `generationConfig.thinkingConfig.thinkingBudget`.
-    GeminiBudget,
     /// DeepSeek V4 hybrids: `{thinking:{type:"enabled"}, reasoning_effort:<role>}`.
     DeepSeekEffort,
     /// OpenRouter's unified reasoning param: `{reasoning:{effort:<role>}}`. The gateway
@@ -228,13 +215,12 @@ impl ModelShape {
                     ThinkingStyle::AnthropicBudget
                 }
             }
-            ProviderKind::Gemini => {
-                if is_gemini3_level(model) {
-                    ThinkingStyle::GeminiLevel
-                } else {
-                    ThinkingStyle::GeminiBudget
-                }
-            }
+            // kaibo targets the Gemini 3-line and newer, whose whole family takes
+            // `thinkingLevel` (Google's current thinking doc lists level for 3-pro /
+            // 3-flash / 3.1-pro / 3.5-flash and drops `thinkingBudget` entirely — that
+            // knob is the retired 2.5-era shape). So every Gemini id routes to level;
+            // the per-role effort rides it. A pre-3.x id fails loud, not silent.
+            ProviderKind::Gemini => ThinkingStyle::GeminiLevel,
             ProviderKind::DeepSeek => ThinkingStyle::DeepSeekEffort,
             ProviderKind::OpenRouter => ThinkingStyle::OpenRouterEffort,
             ProviderKind::Openai => ThinkingStyle::None,
@@ -255,16 +241,14 @@ impl ModelShape {
         }
     }
 
-    /// Does this shape have a sink for a `thinking_budget` tunable? Only the two
-    /// explicit-budget styles emit it (`budget_tokens` / `thinkingBudget`); the
-    /// effort-driven styles (Anthropic adaptive, the Gemini 3-line, DeepSeek) and the
-    /// toggle-less openai path ignore a budget entirely. Lets the `kaibo://config`
-    /// render flag a per-slot `thinking_budget` that will never leave the process.
+    /// Does this shape have a sink for a `thinking_budget` tunable? Only the
+    /// Anthropic legacy-budget style emits one (`budget_tokens`); every other style —
+    /// the effort-driven ones (Anthropic adaptive, Gemini's `thinkingLevel`, DeepSeek,
+    /// OpenRouter) and the toggle-less openai path — ignores a budget entirely. Lets the
+    /// `kaibo://config` render flag a per-slot `thinking_budget` that will never leave
+    /// the process.
     pub fn sinks_thinking_budget(&self) -> bool {
-        matches!(
-            self.thinking,
-            ThinkingStyle::AnthropicBudget | ThinkingStyle::GeminiBudget
-        )
+        matches!(self.thinking, ThinkingStyle::AnthropicBudget)
     }
 
     /// Does this shape have a sink for an `effort` tunable? Only the effort-driven
@@ -367,21 +351,15 @@ impl ModelShape {
                 obj.insert("output_config".into(), json!({ "effort": effort }));
             }
             ThinkingStyle::GeminiLevel => {
-                // The 3-line's depth lever IS the per-role effort: the values align
-                // ("high"/"low" are valid levels; the default "high" matches
-                // gemini-cli's investigator, rig deserializes it to
-                // ThinkingLevel::High), and like every effort it's a passthrough
-                // string the provider validates. Dropping it for a hardcoded
-                // "high" would silently ignore a slot's `effort = "low"`.
+                // Gemini's depth lever IS the per-role effort: the values align (Google's
+                // thinking doc lists `minimal|low|medium|high` across the 3-line; the
+                // default "high" matches gemini-cli's investigator, rig deserializes it to
+                // ThinkingLevel::High), and like every effort it's a passthrough string
+                // the provider validates. Dropping it for a hardcoded "high" would
+                // silently ignore a slot's `effort = "low"`.
                 obj.insert(
                     "generationConfig".into(),
                     json!({ "thinkingConfig": { "thinkingLevel": effort, "includeThoughts": true } }),
-                );
-            }
-            ThinkingStyle::GeminiBudget => {
-                obj.insert(
-                    "generationConfig".into(),
-                    json!({ "thinkingConfig": { "thinkingBudget": budget, "includeThoughts": true } }),
                 );
             }
             ThinkingStyle::DeepSeekEffort => {
@@ -516,6 +494,51 @@ mod tests {
             params["generationConfig"]["thinkingConfig"]["thinkingLevel"],
             "high"
         );
+    }
+
+    /// Every Gemini slot kaibo actually ships routes the per-role effort as
+    /// `thinkingLevel` — including the ones a nominal `gemini-3-…` substring test would
+    /// miss: the `-latest` aliases the built-in casts pin
+    /// (`gemini-flash-lite-latest`/`gemini-pro-latest`/`gemini-flash-latest`, no
+    /// `gemini-3` substring at all) and the concrete 3.x previews with a *dot* after the
+    /// 3 (`gemini-3.1-pro-preview`, `gemini-3.5-flash`). Google's thinking doc lists
+    /// `thinkingLevel` across the whole 3-line, so it's the native depth knob and the
+    /// sink the effort lever rides. The classifier must reach all of them; a shape that
+    /// dropped effort into a fixed `thinkingBudget` would silently ignore a slot's
+    /// `effort = "low"`. This asserts the effort reaches the wire as the level, and no
+    /// budget rides along.
+    #[test]
+    fn configured_gemini_ids_take_the_effort_as_thinking_level() {
+        // The literal ids kaibo classifies from (config.rs `default_models` + the
+        // built-in `gemini-batch` cast), plus the concrete 3.x previews they resolve to.
+        let ids = [
+            "gemini-flash-lite-latest", // built-in Gemini explorer default
+            "gemini-3.5-flash",         // built-in gemini synth default
+            "gemini-pro-latest",        // built-in gemini-batch synth
+            "gemini-flash-latest",      // a -latest alias with no version in the id
+            "gemini-3.1-pro-preview",   // a dotted 3.x id the old dash test missed
+        ];
+        for id in ids {
+            let shape = ModelShape::resolve(ProviderKind::Gemini, id, ThinkingStyleOverride::Auto);
+            assert!(
+                shape.sinks_effort(),
+                "{id}: a Gemini slot must route the per-role effort, not drop it"
+            );
+            assert!(
+                !shape.sinks_thinking_budget(),
+                "{id}: Gemini has no budget sink — a per-slot thinking_budget is inert"
+            );
+            let params = shape.to_params(8192, None, None, "low").unwrap();
+            let cfg = &params["generationConfig"]["thinkingConfig"];
+            assert_eq!(
+                cfg["thinkingLevel"], "low",
+                "{id}: the slot's effort must land as thinkingLevel"
+            );
+            assert!(
+                cfg.get("thinkingBudget").is_none(),
+                "{id}: Gemini takes the level, not a fixed budget"
+            );
+        }
     }
 
     /// OpenRouter's unified reasoning knob: the per-role effort must land as

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -416,3 +416,62 @@ impl crate::progress::ProgressSink for RecordingSink {
             .push(event);
     }
 }
+
+// --- Span-capture harness -----------------------------------------------------
+//
+// Reusable machinery for the crate's tracing-field tests (the `tool` span in
+// `tool_span.rs`, the `run_phase` span in `consult/engine.rs`). Centralized here so
+// every capture test in the lib's unit-test binary shares ONE serial guard and ONE
+// keepalive dispatcher — the correctness reason: two per-module `CAPTURE_SERIAL`s
+// wouldn't serialize a `tool` capture against a `run_phase` capture, and it's a
+// *third* no-subscriber test that poisons a callsite, so the guard must span modules.
+
+/// Serializes the span-capturing tests so their `set_default` installs and teardowns —
+/// which mutate *process-global* tracing state (the callsite interest cache, the
+/// live-dispatcher set, the global max-level) via `Dispatch::new` →
+/// `callsite::register_dispatch` — never interleave with each other. Belt to the
+/// [`force_multi_dispatcher`] suspenders.
+pub static CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
+
+/// A leaked, permanently-registered second dispatcher, established once.
+///
+/// The flake this kills: an `info_span!` callsite registers *lazily*, on first hit.
+/// While tracing's `has_just_one` fast path holds — true whenever ≤1 dispatcher is
+/// registered, which is exactly our case since each test installs a single subscriber —
+/// that first registration computes the callsite's interest from **the registering
+/// thread's current default**, not from the installed subscriber. So when a
+/// no-subscriber test (this binary is full of them) wins the race to first-touch a
+/// captured callsite during a capture test's window, it caches `Interest::never()`
+/// against `NoSubscriber`, gating the span off — an empty capture, the ~5% full-suite
+/// flake. Serializing the capture tests can't prevent that: the poisoning thread is a
+/// *third* test with no subscriber.
+///
+/// Holding a second registered dispatcher forever forces `has_just_one` false, so every
+/// callsite registration instead consults the registered-dispatcher set — which
+/// contains a span-enabling registry — regardless of which thread triggers it. It is
+/// never a thread's default, so it receives no events; it exists only to keep the
+/// registration path honest. Leaked deliberately: it must outlive every test.
+pub fn force_multi_dispatcher() {
+    use std::sync::OnceLock;
+    static KEEPALIVE: OnceLock<()> = OnceLock::new();
+    KEEPALIVE.get_or_init(|| {
+        let keep = tracing::Dispatch::new(tracing_subscriber::registry());
+        std::mem::forget(keep);
+    });
+}
+
+/// Drive an async body to completion on a private current-thread runtime while holding
+/// [`CAPTURE_SERIAL`]. Sync (not `#[tokio::test]`) so the ordering guard isn't held
+/// across an `.await`, and `block_on` polls the future on *this* thread — the one whose
+/// `set_default` is in scope, so the spans route to the test's capture.
+pub fn serialized_capture<F: std::future::Future>(body: F) {
+    let _serial = CAPTURE_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    force_multi_dispatcher();
+    tokio::runtime::Builder::new_current_thread()
+        // Timers/IO on: a captured body may drive the full consult loop (deadlines,
+        // request timeouts), not just a bare tool call.
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(body);
+}

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -116,57 +116,13 @@ fn arg_summary(args: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::serialized_capture;
     use serde::Deserialize;
     use serde_json::json;
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::layer::{Context, SubscriberExt};
     use tracing_subscriber::registry::LookupSpan;
     use tracing_subscriber::Layer;
-
-    /// Serializes the span-capturing tests so their `set_default` installs and
-    /// teardowns — which mutate *process-global* tracing state (the callsite interest
-    /// cache, the live-dispatcher set, the global max-level) via
-    /// `Dispatch::new` → `callsite::register_dispatch` — never interleave with each
-    /// other. Belt to the [`force_multi_dispatcher`] suspenders below.
-    static CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
-
-    /// A leaked, permanently-registered second dispatcher, established once.
-    ///
-    /// The flake this kills: `info_span!("tool")` registers its callsite *lazily*, on
-    /// first hit. While tracing's `has_just_one` fast path holds — true whenever ≤1
-    /// dispatcher is registered, which is exactly our case since each test installs a
-    /// single subscriber — that first registration computes the callsite's interest
-    /// from **the registering thread's current default**, not from the installed
-    /// subscriber. So when a no-subscriber `consult` test (this binary is full of them)
-    /// wins the race to first-touch the `tool` callsite during a capture test's window,
-    /// it caches `Interest::never()` against `NoSubscriber`, gating the span off — an
-    /// empty capture, the ~5% full-suite flake. Serializing the two capture tests can't
-    /// prevent that: the poisoning thread is a *third* test with no subscriber.
-    ///
-    /// Holding a second registered dispatcher forever forces `has_just_one` false, so
-    /// every callsite registration instead consults the registered-dispatcher set —
-    /// which contains a span-enabling registry — regardless of which thread triggers
-    /// it. It is never a thread's default, so it receives no events; it exists only to
-    /// keep the registration path honest. Leaked deliberately: it must outlive every
-    /// test in the process.
-    ///
-    /// A subtlety worth stating, because it looks like a residual race and isn't: a
-    /// no-subscriber test *can* poison the `tool` callsite to `never` before the first
-    /// capture test runs. But registering a dispatcher (`Dispatch::new` →
-    /// `callsite::register_dispatch`) *rebuilds the interest cache for every already-
-    /// registered callsite* against the live set — so this very call un-poisons `tool`,
-    /// and the test's own `set_default` rebuilds it again. The only window that ever
-    /// mattered was poisoning *after* those rebuilds but before the span fires, by a
-    /// concurrent first-touch under `has_just_one` — which is exactly the window forcing
-    /// `has_just_one` false closes. Hence 0/150 full-suite runs (was ~5%).
-    fn force_multi_dispatcher() {
-        use std::sync::OnceLock;
-        static KEEPALIVE: OnceLock<()> = OnceLock::new();
-        KEEPALIVE.get_or_init(|| {
-            let keep = tracing::Dispatch::new(tracing_subscriber::registry());
-            std::mem::forget(keep);
-        });
-    }
 
     /// A trivial tool to wrap: echoes its `msg`, or errors on "boom".
     struct Echo;
@@ -346,19 +302,6 @@ mod tests {
                 self.0.lock().unwrap().push(row);
             }
         }
-    }
-
-    /// Drive an async body to completion on a private current-thread runtime while
-    /// holding [`CAPTURE_SERIAL`]. Sync (not `#[tokio::test]`) so the ordering guard
-    /// isn't held across an `.await`, and `block_on` polls the future on *this* thread
-    /// — the one whose `set_default` is in scope, so the span routes to our capture.
-    fn serialized_capture<F: std::future::Future>(body: F) {
-        let _serial = CAPTURE_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-        force_multi_dispatcher();
-        tokio::runtime::Builder::new_current_thread()
-            .build()
-            .unwrap()
-            .block_on(body);
     }
 
     /// A success emits a `tool` span tagged with the tool's name, an args summary,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -700,14 +700,16 @@ fn zero_request_timeout_is_rejected_loudly() {
 
 #[test]
 fn an_inverted_thinking_budget_is_rejected_at_the_resolved_slot() {
-    // Anthropic requires max_tokens > thinking_budget; catch the inverted pair at
-    // load, not as a runtime 400 — validated on the slot's RESOLVED values.
+    // The rule (Anthropic requires max_tokens > thinking_budget) binds only where the
+    // model actually *sends* a budget; catch the inverted pair at load, not as a runtime
+    // 400 — validated on the slot's RESOLVED values.
 
-    // Per-slot override pair, inverted.
+    // Per-slot override pair, inverted, on a budget-tier model (Haiku 4.5 sends
+    // `budget_tokens`).
     let err = Config::from_toml_str(
         r#"
         [casts.x]
-        synth = { backend = "anthropic", id = "claude-sonnet-4-6", max_tokens = 1000, thinking_budget = 2000 }
+        synth = { backend = "anthropic", id = "claude-haiku-4-5", max_tokens = 1000, thinking_budget = 2000 }
         "#,
     )
     .unwrap_err();
@@ -715,23 +717,28 @@ fn an_inverted_thinking_budget_is_rejected_at_the_resolved_slot() {
     assert!(msg.contains("thinking_budget (2000)"), "got: {msg}");
     assert!(msg.contains("max_tokens (1000)"), "got: {msg}");
 
-    // The inversion can also arrive purely through [defaults]: a global
-    // max_tokens below the default 8192 budget breaks the built-in anthropic
-    // and gemini slots at resolution time.
+    // The inversion can also arrive purely through [defaults]: a global max_tokens below
+    // the default 8192 budget breaks the built-in budget-tier Anthropic slot (Haiku
+    // explorer) at resolution time.
     let err = Config::from_toml_str("[defaults]\nmax_tokens = 4096\n").unwrap_err();
     assert!(
         format!("{err:#}").contains("thinking_budget"),
         "got: {err:#}"
     );
 
-    // The same inverted pair on a non-thinking-budget kind is accepted.
-    Config::from_toml_str(
-        r#"
-        [casts.x]
-        synth = { backend = "openai-local", id = "m", max_tokens = 1000, thinking_budget = 2000 }
-        "#,
-    )
-    .expect("openai-kind slots have no budget/headroom coupling");
+    // The same inverted pair is accepted where the model sends no budget: the generic
+    // openai path (no thinking toggle), Gemini (takes a `thinkingLevel`), and Anthropic's
+    // adaptive tier (takes an `output_config.effort`) all carry an inert `thinking_budget`.
+    for (backend, id) in [
+        ("openai-local", "m"),
+        ("gemini", "gemini-3.5-flash"),
+        ("anthropic", "claude-sonnet-4-6"),
+    ] {
+        Config::from_toml_str(&format!(
+            "[casts.x]\nsynth = {{ backend = \"{backend}\", id = \"{id}\", max_tokens = 1000, thinking_budget = 2000 }}\n"
+        ))
+        .unwrap_or_else(|e| panic!("{backend}/{id} has no budget sink; the inverted pair must load: {e}"));
+    }
 }
 
 #[test]

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -121,13 +121,14 @@ fn thinking_is_enabled_for_kinds_with_a_request_toggle() {
         "adaptive carries no budget"
     );
 
-    // Gemini 2.5: nested under generationConfig.thinkingConfig with camelCase keys —
-    // rig parses these into a typed GenerationConfig, so the shape must be exact.
-    let g = thinking_params(ProviderKind::Gemini, "gemini-2.5-flash", THINKING_BUDGET)
+    // Gemini (3.x+): nested under generationConfig.thinkingConfig with camelCase keys —
+    // rig parses these into a typed GenerationConfig, so the shape must be exact. The
+    // whole 3-line takes a level; the default effort rides it as thinkingLevel.
+    let g = thinking_params(ProviderKind::Gemini, "gemini-3.5-flash", THINKING_BUDGET)
         .expect("gemini has a thinking toggle");
     assert_eq!(
-        g["generationConfig"]["thinkingConfig"]["thinkingBudget"],
-        THINKING_BUDGET
+        g["generationConfig"]["thinkingConfig"]["thinkingLevel"],
+        "high"
     );
     assert_eq!(
         g["generationConfig"]["thinkingConfig"]["includeThoughts"],
@@ -136,53 +137,39 @@ fn thinking_is_enabled_for_kinds_with_a_request_toggle() {
 }
 
 #[test]
-fn gemini_3_line_takes_thinking_level_not_budget() {
-    // Gemini 3 officially uses `thinkingLevel` (mutually exclusive with budget); rig's
-    // typed ThinkingConfig carries both, serializing the level as snake_case "high".
-    // The boundary is empirical: the pure 3-line flips, but `gemini-3.5-flash` (a
-    // confirmed-working default on budget) and 2.x stay on budget — switching them
-    // would silently regress a request that works (docs/issues.md).
-    let g3 = thinking_params(
-        ProviderKind::Gemini,
-        "gemini-3-pro-preview",
-        THINKING_BUDGET,
-    )
-    .expect("gemini 3 has a thinking toggle");
-    let tc = &g3["generationConfig"]["thinkingConfig"];
-    assert_eq!(tc["thinkingLevel"], "high", "the 3-line wants a level");
-    assert!(
-        tc.get("thinkingBudget").is_none(),
-        "level and budget are mutually exclusive"
-    );
-    assert_eq!(tc["includeThoughts"], true);
-
-    // The minor 3.5 line and 2.x stay on budget (the conservative, evidence-backed arm).
-    for id in ["gemini-3.5-flash", "gemini-2.5-pro"] {
+fn every_gemini_id_takes_thinking_level_not_budget() {
+    // kaibo targets the Gemini 3-line and newer, whose whole family uses `thinkingLevel`
+    // (mutually exclusive with the retired 2.5-era budget); rig's typed ThinkingConfig
+    // serializes the level as snake_case "high". Every Gemini id kaibo ships must route
+    // there — the dash 3-line, the dotted 3.x previews, and the `-latest` aliases whose
+    // literal id carries no version at all.
+    for id in [
+        "gemini-3-pro-preview",     // dash 3-line
+        "gemini-3.1-pro-preview",   // dotted 3.x preview
+        "gemini-3.5-flash",         // built-in gemini synth default
+        "gemini-flash-lite-latest", // built-in explorer default (a -latest alias)
+        "gemini-pro-latest",        // built-in gemini-batch synth (a -latest alias)
+    ] {
         let g = thinking_params(ProviderKind::Gemini, id, THINKING_BUDGET).expect("toggle");
         let tc = &g["generationConfig"]["thinkingConfig"];
-        assert_eq!(
-            tc["thinkingBudget"], THINKING_BUDGET,
-            "{id} stays on budget"
-        );
+        assert_eq!(tc["thinkingLevel"], "high", "{id} wants a level");
         assert!(
-            tc.get("thinkingLevel").is_none(),
-            "{id} must not send a level"
+            tc.get("thinkingBudget").is_none(),
+            "{id}: level and budget are mutually exclusive"
         );
+        assert_eq!(tc["includeThoughts"], true, "{id} includes thoughts");
     }
 }
 
 #[test]
 fn thinking_budget_is_threaded_through_not_hardcoded() {
-    // A per-slot budget must reach the request, not the old global constant. Use a
-    // budget-tier Anthropic model (Haiku 4.5) — the adaptive tier carries no budget.
+    // A per-slot budget must reach the request, not the old global constant. The one
+    // remaining budget sink is legacy-tier Anthropic (Haiku 4.5) — the adaptive tier
+    // carries no budget, and Gemini takes a level not a budget — so Haiku is what
+    // exercises budget threading.
     let a = thinking_params(ProviderKind::Anthropic, "claude-haiku-4-5", 4096)
         .expect("anthropic toggle");
     assert_eq!(a["thinking"]["budget_tokens"], 4096);
-    let g = thinking_params(ProviderKind::Gemini, "gemini-2.5-flash", 4096).expect("gemini toggle");
-    assert_eq!(
-        g["generationConfig"]["thinkingConfig"]["thinkingBudget"],
-        4096
-    );
 }
 
 #[test]
@@ -191,7 +178,7 @@ fn request_params_places_sampling_where_each_wire_format_wants_it() {
     // the thinkingConfig — one merged blob, not two.
     let g = request_params(
         ProviderKind::Gemini,
-        "gemini-2.5-flash",
+        "gemini-3.5-flash",
         THINKING_BUDGET,
         Some(0.1),
         Some(0.95),
@@ -201,7 +188,7 @@ fn request_params_places_sampling_where_each_wire_format_wants_it() {
     assert_eq!(gc["temperature"], 0.1);
     assert_eq!(gc["topP"], 0.95, "Gemini uses camelCase topP");
     assert_eq!(
-        gc["thinkingConfig"]["thinkingBudget"], THINKING_BUDGET,
+        gc["thinkingConfig"]["thinkingLevel"], "high",
         "thinking still rides along"
     );
     assert!(
@@ -398,7 +385,25 @@ fn effort_is_per_role_and_provider_mapped() {
     .expect("deepseek params");
     assert_eq!(deepseek["reasoning_effort"], "max");
 
-    // Budget-tier Anthropic and Gemini have no effort sink — the value is ignored, not leaked.
+    // Gemini's wire field for effort is thinkingLevel, nested in generationConfig — a
+    // level ("low"), not the reasoning_effort/output_config the other providers use.
+    let gemini = ModelShape::resolve(
+        ProviderKind::Gemini,
+        "gemini-3.5-flash",
+        ThinkingStyleOverride::Auto,
+    )
+    .to_params(THINKING_BUDGET, None, None, "low")
+    .expect("gemini params");
+    assert_eq!(
+        gemini["generationConfig"]["thinkingConfig"]["thinkingLevel"], "low",
+        "Gemini effort rides thinkingLevel"
+    );
+    assert!(
+        gemini.get("reasoning_effort").is_none() && gemini.get("output_config").is_none(),
+        "Gemini uses its own field, not another provider's"
+    );
+
+    // Budget-tier Anthropic (Haiku 4.5) has no effort sink — the value is ignored, not leaked.
     let budget = ModelShape::resolve(
         ProviderKind::Anthropic,
         "claude-haiku-4-5",
@@ -410,18 +415,6 @@ fn effort_is_per_role_and_provider_mapped() {
         budget.get("output_config").is_none(),
         "budget tier has no effort sink"
     );
-    let gemini = ModelShape::resolve(
-        ProviderKind::Gemini,
-        "gemini-2.5-flash",
-        ThinkingStyleOverride::Auto,
-    )
-    .to_params(THINKING_BUDGET, None, None, "xhigh")
-    .expect("gemini params");
-    assert!(
-        gemini.get("reasoning_effort").is_none(),
-        "Gemini has no effort sink"
-    );
-    assert!(gemini.get("output_config").is_none());
 
     // Per-role resolution through the slot fallback: with no per-slot override, the
     // explorer and synth arms of the *same* slot resolve their own [defaults] effort
@@ -1369,7 +1362,7 @@ async fn oneshot_answers_from_pasted_context() {
 
 // Live thinking-on checks for the keyed providers. They exercise the risky paths:
 // Anthropic's thinking blocks round-tripping through the tool loop, and Gemini's
-// thinkingConfig shape (thinkingBudget vs the Gemini-3 thinkingLevel split).
+// thinkingConfig shape (the thinkingLevel the whole 3-line takes).
 #[tokio::test]
 #[ignore = "hits the DeepSeek API (consult); run with --ignored and a key"]
 async fn two_phase_consult_via_deepseek() {


### PR DESCRIPTION
## What & why

kaibo's Gemini casts all name 3.x-line models (default `gemini` synth `gemini-3.5-flash`, `gemini-batch` Pro synth `gemini-pro-latest`, Flash-Lite explorer `gemini-flash-lite-latest`), but the thinking-knob classifier `is_gemini3_level` matched only the bare `gemini-3` / `gemini-3-*` form. So the `-latest` aliases (no `gemini-3` substring at all) and the dotted 3.x ids (`gemini-3.1-pro-preview` — dot after the 3) fell through to the retired 2.5-era `thinkingBudget` path, which pins depth to a fixed number and **silently drops the per-role `effort` lever**. Setting `effort = "low"`/`"high"`/`"max"` on an interactive Gemini slot had no effect — no crash, since both knobs are accepted on the wire, just the wrong one sent.

## Decision

Google's [current thinking doc](https://ai.google.dev/gemini-api/docs/thinking) lists `thinkingLevel` (`minimal|low|medium|high`) across the whole 3-line — 3-pro, 3-flash, **3.5-flash**, 3.1-pro — and no longer documents `thinkingBudget`; that's the legacy 2.5-era knob. The prior "keep 3.5-flash on budget" pin rested on a probe that only showed budget *works*, never that level *fails* — and if both work, level is strictly better because it carries the effort lever.

So the fix isn't a wider classifier, it's a **collapse** (Amy's call): kaibo targets the Gemini **3-line and newer**, stated plainly. `ProviderKind::Gemini` always resolves to `GeminiLevel`; `is_gemini3_level` and the now-dead `GeminiBudget` `ThinkingStyle` variant are removed. A pre-3.x id emits a level and fails loud at the provider — the honest "unsupported" signal — over silently mis-shaping.

## Commits

1. **Collapse the classifier.** TDD: a failing test pinning the configured ids' `effort → thinkingLevel` came first (RED on `gemini-flash-lite-latest`), then the collapse turned it green. Dependent tests using 2.5 ids as fixtures moved to 3.x; the engine per-arm straddle test — which leaned on the now-defunct *intra-Gemini* budget/level split — was re-aimed at a stronger cross-*provider* straddle (Anthropic-adaptive synth vs Gemini-level explorer, structurally disjoint param trees).
2. **Fix the validation fallout** (caught by the GPT cross-family review): the `thinking_budget < max_tokens` load check was gated on `matches!(kind, Anthropic | Gemini)`. With Gemini no longer sending a budget, that gate falsely refused a valid Gemini slot (e.g. `max_tokens=4096` under the default `thinking_budget=8192`), and it had always wrongly refused Anthropic *adaptive* slots too (budget equally inert). Now gated on the resolved shape's `sinks_thinking_budget()` at both sites — only a style that actually sends a budget can starve the answer. Plus the doc drift the review flagged (effort-taker lists omitting Gemini; the batch example claiming `effort` tunes depth when batch forces it).
3. **Track** a cosmetic render-accuracy nit surfaced by the focused review (doc-only).

## Review (dogfooded, cross-family)

- **DeepSeek** (deep, commit 1): clean — verified all five ids route to `thinkingLevel`, zero dead-code hits, render helpers correct, tests have teeth; independently confirmed `includeThoughts: true` is **not** stale (the batch #75 truncation detector depends on those thought parts arriving).
- **GPT / OpenRouter** (deep, commit 1): surfaced the two "Medium" follow-ups above — the stale budget validation (fixed in commit 2) and the batch-render lane-blindness (pre-existing, tracked).
- **DeepSeek** (focused, commit 2): confirmed the `sinks_thinking_budget()` gating is correct and complete — no 400/starve path, both sites consistent, batch clamps safely, no missed site.
- Gemini cast was 503-ing throughout (provider overload), hence GPT stood in as the second family.

## Not in scope (tracked in `docs/issues.md`)

The `kaibo://config` inert-tunables render has a cluster of pre-existing display-only gaps (lane-blindness to a batch slot's forced effort; shape resolution that skips the `defaults.thinking_style` fallback). All cosmetic, no wire effect — tracked for a follow-up that reconciles the render's shape resolution with `slot.tunables`.

## Verification

`cargo test` (595 pass), `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)