### PR TITLE
feat(telemetry): a batch_submit span so the batch lane is wire-legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,7 +272,10 @@ the git log. Each later release appends a new section at the top.
   `run_phase` span carries `gen_ai.request.thinking` — the exact reasoning/sampling blob
   it shipped (Gemini's `thinkingLevel`, an Anthropic adaptive `effort`, a DeepSeek
   `reasoning_effort`) — so a trace shows *whether and at what depth* thinking was on, the
-  wire truth behind each `chat` span's `reasoning_tokens`.
+  wire truth behind each `chat` span's `reasoning_tokens`. The **batch** lane is equally
+  legible: a `batch_submit` span records the same `gen_ai.request.thinking` (the forced
+  `BATCH_EFFORT` shape) plus the `model` and item count, so a batch fan-out shows what it
+  shipped even though it's assembled outside `run_phase`.
 - **A failed provider doesn't fail your turn.** When a model or its provider misbehaves
   (a 429/529 overload, a connection reset, a wedged backend that hits the
   `request_timeout`), `consult`/`oneshot` return a *clean tool-result error* naming the

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -180,6 +180,31 @@ pub fn batch_shaping(
     (max_tokens, params)
 }
 
+/// The batch-lane analog of the `run_phase` span (`consult/engine.rs`): a `batch_submit`
+/// span carrying the resolved request shape, so a trace shows what a batch shipped —
+/// `model`, the item count, and `gen_ai.request.thinking` (the forced thinking/effort
+/// blob from [`batch_shaping`], e.g. Gemini's `thinkingLevel` at [`BATCH_EFFORT`]). The
+/// batch request is assembled outside `run_phase`, so without this the batch lane is
+/// wire-invisible where the interactive lane is legible.
+///
+/// Sync, and returns the span (rather than an `#[instrument]` on the network-bound
+/// `submit`) so it owns *both* the field declaration and the record and is fully
+/// unit-testable without a live submit; each provider's `submit` holds it for the call's
+/// lifetime. Inert with no exporter — a disabled span skips the `%model` format and the
+/// `record` is a no-op — and a toggle-less shape (`params == None`) records nothing.
+fn batch_request_span(model: &str, params: Option<&Value>, items: usize) -> tracing::Span {
+    let span = tracing::info_span!(
+        "batch_submit",
+        model = %model,
+        items = items,
+        gen_ai.request.thinking = tracing::field::Empty,
+    );
+    if let Some(p) = params {
+        span.record("gen_ai.request.thinking", tracing::field::display(p));
+    }
+    span
+}
+
 /// Build one Anthropic message `content` for a prompt plus the shared attachments.
 /// With no attachments it stays a plain string (the unchanged wire shape — a bare
 /// prompt). With attachments it becomes a content-block array: the attachments first
@@ -663,6 +688,9 @@ impl BatchProvider for AnthropicBatch {
         if items.is_empty() {
             return Err(anyhow!("a batch needs at least one prompt"));
         }
+        // Record the resolved batch request shape (held for the submit's lifetime) — the
+        // batch-lane analog of run_phase's gen_ai.request.thinking.
+        let _span = batch_request_span(&self.model, self.params.as_ref(), items.len());
         let body = anthropic_batch_body(
             &self.model,
             self.max_tokens,
@@ -1171,6 +1199,9 @@ impl BatchProvider for GeminiBatch {
         if items.is_empty() {
             return Err(anyhow!("a batch needs at least one prompt"));
         }
+        // Record the resolved batch request shape (held for the submit's lifetime) — the
+        // batch-lane analog of run_phase's gen_ai.request.thinking.
+        let _span = batch_request_span(&self.model, self.params.as_ref(), items.len());
         let body = gemini_batch_body(self.max_tokens, system, &self.params, attachments, items);
         let url = format!(
             "{}/models/{}:batchGenerateContent",
@@ -1953,6 +1984,146 @@ mod tests {
         assert_eq!(
             params["generationConfig"]["thinkingConfig"]["thinkingLevel"], BATCH_EFFORT,
             "the 3-line forces BATCH_EFFORT as thinkingLevel: {params}"
+        );
+    }
+
+    /// The `batch_submit` span makes the batch lane wire-legible like `run_phase`: it must
+    /// record `model` and the resolved `gen_ai.request.thinking` blob (here a Gemini
+    /// `thinkingLevel` at `BATCH_EFFORT`), and record *no* thinking field for a toggle-less
+    /// shape (`params == None`). Discriminating on both edges, so a regression that drops
+    /// the field or records it unconditionally fails one branch. `batch_request_span` owns
+    /// both the field declaration and the record, so this covers the exact production
+    /// span-builder without a live submit.
+    #[test]
+    fn batch_submit_span_carries_the_thinking_params() {
+        use crate::test_support::serialized_capture;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::{Context, SubscriberExt};
+        use tracing_subscriber::registry::LookupSpan;
+        use tracing_subscriber::Layer;
+
+        fn dbg_str(v: &dyn std::fmt::Debug) -> String {
+            format!("{v:?}")
+        }
+        #[derive(Default)]
+        struct Grab {
+            model: Option<String>,
+            thinking: Option<String>,
+        }
+        impl tracing::field::Visit for Grab {
+            fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+                match f.name() {
+                    "model" => self.model = Some(dbg_str(v)),
+                    "gen_ai.request.thinking" => self.thinking = Some(dbg_str(v)),
+                    _ => {}
+                }
+            }
+        }
+        #[derive(Default)]
+        struct Stored {
+            model: Option<String>,
+            thinking: Option<String>,
+        }
+        /// One closed `batch_submit` span's `(model, thinking)`.
+        type Captured = (Option<String>, Option<String>);
+        /// Collects each closed `batch_submit` span's fields.
+        #[derive(Clone, Default)]
+        struct Cap(Arc<Mutex<Vec<Captured>>>);
+        impl<S: tracing::Subscriber + for<'a> LookupSpan<'a>> Layer<S> for Cap {
+            fn on_new_span(
+                &self,
+                attrs: &tracing::span::Attributes<'_>,
+                id: &tracing::Id,
+                ctx: Context<'_, S>,
+            ) {
+                if attrs.metadata().name() != "batch_submit" {
+                    return;
+                }
+                let mut g = Grab::default(); // model lands here (%model at creation)
+                attrs.record(&mut g);
+                ctx.span(id).unwrap().extensions_mut().insert(Stored {
+                    model: g.model,
+                    thinking: g.thinking, // Empty at open — the record fills it below.
+                });
+            }
+            fn on_record(
+                &self,
+                id: &tracing::Id,
+                values: &tracing::span::Record<'_>,
+                ctx: Context<'_, S>,
+            ) {
+                let mut g = Grab::default();
+                values.record(&mut g);
+                if let (Some(t), Some(span)) = (g.thinking, ctx.span(id)) {
+                    if let Some(st) = span.extensions_mut().get_mut::<Stored>() {
+                        st.thinking = Some(t);
+                    }
+                }
+            }
+            fn on_close(&self, id: tracing::Id, ctx: Context<'_, S>) {
+                let span = ctx.span(&id).unwrap();
+                if span.name() != "batch_submit" {
+                    return;
+                }
+                let (m, t) = span
+                    .extensions()
+                    .get::<Stored>()
+                    .map(|s| (s.model.clone(), s.thinking.clone()))
+                    .unwrap_or_default();
+                self.0.lock().unwrap().push((m, t));
+            }
+        }
+
+        // The on-theme Gemini batch shape: thinkingLevel forced to BATCH_EFFORT.
+        let (_max, params) = batch_shaping(
+            ProviderKind::Gemini,
+            "gemini-pro-latest",
+            &tunables("low", 100),
+        );
+        let expected = params.expect("gemini carries a thinking block").to_string();
+        assert!(
+            expected.contains("thinkingLevel"),
+            "fixture must be the level blob, got {expected}"
+        );
+
+        let cap = Cap::default();
+        serialized_capture(async {
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
+            // Positive: a real Gemini shape → model + thinking recorded.
+            let (_m, params) = batch_shaping(
+                ProviderKind::Gemini,
+                "gemini-pro-latest",
+                &tunables("low", 100),
+            );
+            drop(batch_request_span(
+                "gemini-pro-latest",
+                params.as_ref(),
+                3,
+            ));
+            // Negative: no thinking block → the field stays absent.
+            drop(batch_request_span("poll-only", None, 1));
+        });
+
+        let seen = cap.0.lock().unwrap().clone();
+        assert_eq!(seen.len(), 2, "both spans closed, got {seen:?}");
+        let pos = seen
+            .iter()
+            .find(|(m, _)| m.as_deref() == Some("gemini-pro-latest"))
+            .expect("the gemini submit span");
+        assert_eq!(
+            pos.1.as_deref(),
+            Some(expected.as_str()),
+            "the batch_submit span must record the exact thinking blob"
+        );
+        let neg = seen
+            .iter()
+            .find(|(m, _)| m.as_deref() == Some("poll-only"))
+            .expect("the toggle-less span");
+        assert!(
+            neg.1.is_none(),
+            "a toggle-less shape records no thinking blob, got {:?}",
+            neg.1
         );
     }
 


### PR DESCRIPTION
## What & why

PR #80 made the **interactive** lane wire-legible — `run_phase` records `gen_ai.request.thinking`, the exact resolved reasoning/sampling blob a phase ships. But the **batch** lane assembles its request in the provider submitters (`anthropic_batch_body` / `gemini_batch_body`), *outside* `run_phase`, so a batch fan-out shipped its forced `BATCH_EFFORT` thinking shape invisibly. A live Pro *batch* couldn't be verified on the wire the way the interactive ladder was. This is the follow-up PR #80's devlog named.

## The change

A `batch_submit` span records `model`, item count, and `gen_ai.request.thinking` (the `batch_shaping` blob), held for each provider `submit`'s lifetime.

## Decisions

- **A sync `batch_request_span(model, params, items) -> Span` that owns both the field declaration and the record**, rather than an `#[instrument]` on the network-bound `submit`. That's what makes it testable: a unit test drives the *exact* production span-builder with no network — closing the teeth gap that instrumenting the async `submit` would leave (its span is only reachable through a live HTTP call).
- **Held, not entered.** It's a leaf data-recording span, not a parent — holding a `Span` (which is `Send + Sync`) across the submit's awaits is correct; an `Entered` guard would be `!Send` and would wrongly reparent any subscriber-injected HTTP spans. Fields are recorded synchronously at construction, so even a cancelled/timed-out submit still carries its shape.
- **After the submit guards**, so a poll-only client (no model) or an empty-items submit emits nothing — it isn't submitting anything.
- Inert with no exporter; a toggle-less shape (`params == None`) records no thinking field.

## Review (dogfooded, cross-family)

Reviewed holistically by **DeepSeek** (`deepseek-v4-pro`, a different family than authored it; no diff supplied — read the worktree). Verdict: *"correct, well-tested, and thoughtfully designed… No gaps where the batch thinking shape could be silently dropped."* It independently confirmed the inertness, that a non-entered `Span` across awaits is the correct choice for a leaf record span, that placement-after-guards emits nothing for poll-only/empty submits, and that the test is discriminating with teeth on both edges. Two non-blocking notes: `max_tokens` isn't recorded (intentional — the thinking block was the invisible piece; `run_phase` doesn't record it either), and a Gemini header-style difference (not a bug).

## Verification

New discriminating test `batch_submit_span_carries_the_thinking_params` (records the exact Gemini `thinkingLevel`-at-`BATCH_EFFORT` blob with params; records nothing without), **teeth-proven** — removed the `record`, watched it go RED (`None` vs the expected blob), restored. Full offline suite green (380 lib tests), `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
