### PR TITLE
docs(readme): document the CLI front door

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ project and cannot run external commands.
 ## Working here
 
 - **TDD.** Tests that can and will fail. The sandbox boundary gets failing-first
-  tests — and we prove they have teeth (mount the project writable with
+  tests — and we prove they actually work (e.g. mount the project writable with
   `LocalFs::new` instead of `read_only`, watch the write-denial tests fail).
 - **`docs/sandbox-probes.md` is the read-only/containment audit runbook.** The
   `cargo test` suites are the continuous guard; that doc is how we *live-test* the
@@ -302,7 +302,7 @@ even for a one-line doc fix.
   hand-picked 16 MiB literal with the constant kaish itself documents for embedders
   (`docs/EMBEDDING.md` in the kaish tree); live-probed with `f() { f; }; f`, which now
   fails loudly (`"maximum recursion depth (48) exceeded"`) instead of risking a SIGSEGV.
-  Offline suite green (531 tests), boundary tests still have teeth. Precedent that a bump
+  Offline suite green (531 tests), boundary tests are effective. Precedent that a bump
   *can* move call sites: `0.8.4 → 0.9.0` renamed the `mcp()` config constructors to
   `agent()` in `sandbox.rs`. Keep this current per the **Working here** kaish-bump
   discipline before cutting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,18 @@ the git log. Each later release appends a new section at the top.
   read-only FAQ; and Backends/Roles/Casts moved below Tools with a one-line "a cast
   is just a named team" opener.
 
+- **The README documents the CLI.** The `kaibo consult`/`oneshot`/`explore`/`kaish`/
+  `batch`/`config` subcommand surface shipped in earlier PRs (#77, #78) with zero
+  README coverage — a reader had no way to discover it existed. A new **CLI** section
+  (an MCP-tool-to-subcommand table, the stdout-is-the-answer/stderr-is-everything-else
+  + `--json` + exit-code contract, and where `--session`/batch-handle state actually
+  lives on disk) now sits right after Installation; the Introduction and the
+  container-image section point at it too (the same image runs as a CLI — drop `-i`,
+  append a subcommand). `consult_submit`/`job_wait` and `deliberate`'s direct lane are
+  the one gap: their job handles are in-memory on a long-running server process, so a
+  one-shot CLI invocation would exit and take the job with it before it could be
+  collected — tracked as [#82](https://github.com/tobert/kaibo/issues/82).
+
 - **The read-only shell under `consult` / `explore` / `run_kaish` speaks kaish 0.12.**
   Native collections land in the toolbox the models drive: list/record literals
   (`xs=[a b c]`, `{port: 8080}`), typed subscripts and slices (`${xs[0]}`, `${r[key]}`,

--- a/README.md
+++ b/README.md
@@ -234,12 +234,11 @@ human at a terminal can drive kaibo directly:
 kaibo consult "does anything still busy-poll in job_wait?" --cast deepseek
 ```
 
-**Bare `kaibo` with no subcommand is the stdio MCP server**
-`kaibo serve` is the explicit spelling for the same thing and may become required
-in the future.
+**Bare `kaibo` with no subcommand is the stdio MCP server.** `kaibo serve` is the
+explicit spelling for the same thing, and may become required in the future.
 
 `consult_submit`/`job_wait` and `deliberate`'s direct lane are not fully implemented
-on the cli yet. [#82](https://github.com/tobert/kaibo/issues/82).
+on the CLI yet — tracked as [#82](https://github.com/tobert/kaibo/issues/82).
 
 **stdout is the answer, stderr is everything else.** Progress, logs, and warnings
 go to stderr, so piping stays clean; the answer (with the same provenance footer
@@ -247,13 +246,14 @@ the MCP tool appends) is the only thing on stdout. `--json` swaps that for a
 structured envelope (`{answer, cast, models, usage, warnings}`) for a script
 caller — its `answer` field is always the model's raw words, never a kaibo notice.
 
-**Exit codes have teeth**, so a caller branches on the code instead of parsing
-prose: `0` an answer, `2` a usage error (bad flag, unknown or wrong-for-the-tool
-cast), `3` a setup/containment rejection (a path outside the allowed set, a
-missing provider key), `4` the work ran and failed at runtime (a provider
-error, a model-loop failure). `kaibo kaish` is the one exception — it passes
-through kaish's own exit code (`0` ok, `126` blocked, `124` timed out) instead,
-since a script branches on *that* to know what the sandboxed command did.
+**Exit codes have defined behavior**, so a caller branches on the code instead
+of parsing prose: `0` an answer, `2` a usage error (bad flag, unknown or
+wrong-for-the-tool cast), `3` a setup/containment rejection (a path outside
+the allowed set, a missing provider key), `4` the work ran and failed at
+runtime (a provider error, a model-loop failure). `kaibo kaish` is the one
+exception — it passes through kaish's own exit code (`0` ok, `126` blocked,
+`124` timed out) instead, since a script branches on *that* to know what the
+sandboxed command did. The same table is in `kaibo --help`.
 
 The shared flags (`--root`, `--allow-path`, `--cast`, `--config`, house-rules
 files, …) work before or after the subcommand and are documented in `kaibo

--- a/README.md
+++ b/README.md
@@ -234,11 +234,12 @@ human at a terminal can drive kaibo directly:
 kaibo consult "does anything still busy-poll in job_wait?" --cast deepseek
 ```
 
-**Bare `kaibo` (no subcommand) is still the MCP server** — every existing client
-config keeps working unchanged; `kaibo serve` is the explicit spelling for the
-same thing. `consult_submit`/`job_wait` and `deliberate`'s direct lane are the
-one gap — every other tool in the table above has a CLI subcommand; queued as
-[#82](https://github.com/tobert/kaibo/issues/82).
+**Bare `kaibo` with no subcommand is the stdio MCP server**
+`kaibo serve` is the explicit spelling for the same thing and may become required
+in the future.
+
+`consult_submit`/`job_wait` and `deliberate`'s direct lane are not fully implemented
+on the cli yet. [#82](https://github.com/tobert/kaibo/issues/82).
 
 **stdout is the answer, stderr is everything else.** Progress, logs, and warnings
 go to stderr, so piping stays clean; the answer (with the same provenance footer

--- a/README.md
+++ b/README.md
@@ -259,19 +259,40 @@ The shared flags (`--root`, `--allow-path`, `--cast`, `--config`, house-rules
 files, …) work before or after the subcommand and are documented in `kaibo
 --help`; each subcommand's own flags are in `kaibo <subcommand> --help`.
 
-**State: where `--session` lives.** A `--session NAME` thread (and every
-`batch_submit`/`kaibo batch submit` handle) is durable by default, in a small
-[turso](https://github.com/tursodatabase/turso) db at a fixed path kaibo picks —
-`$XDG_STATE_HOME/kaibo/state.db` (`~/.local/state/kaibo/state.db` when unset) —
-never inside your project and never a path a model controls. It's what lets a
-session started over MCP continue on the CLI and back, and a batch handle survive
-a restart. It stores only the lean `(question, answer)` turns of sessions you
-name and each batch's `{backend, provider-id}` — never anything else, and never a
-source of truth: safe to delete, or move it with `--state-db FILE`
-(`KAIBO_STATE_DB`), or skip it for one run with `--no-persistence`
-(`KAIBO_NO_PERSISTENCE`) to go fully in-memory. See
-[Persistence](docs/config.md#persistence-persistence) for the full contract
-(what's excluded, the fail-loud-on-a-bad-path behavior, the one Windows carve-out).
+A `--session NAME` thread and a submitted batch job both stick around between
+runs — see [What kaibo remembers](#what-kaibo-remembers) below for what that
+means and where it lives.
+
+## What kaibo remembers
+
+Most of what kaibo does is a single question in, a single answer out —
+nothing to remember, nothing saved. Two things stick around on your machine,
+and both are things you opted into by name:
+
+- **A conversation you named.** Pass `--session NAME` on the CLI, or
+  `session_id` over MCP, and kaibo keeps that thread's back-and-forth so you
+  can pick it up later — from the CLI, from your MCP client, doesn't matter,
+  they share the same memory. Ask a one-off question with no session name and
+  nothing is kept.
+- **A batch job you submitted.** `batch_submit` (or `kaibo batch submit`)
+  hands back a handle right away; kaibo remembers that handle so `kaibo batch
+  list` (or `job_list`) can find it again later — even after a restart —
+  without you having to keep it written down somewhere.
+
+That's genuinely all of it: no chat history beyond a session you named, no
+file contents, nothing about your project. It lives in one small file on
+your machine, separate from your project, that the read-only models kaibo
+consults never see or touch — by default `~/.local/state/kaibo/state.db`
+(`$XDG_STATE_HOME/kaibo/state.db` if you have that set).
+
+You never have to manage this file. It's a convenience cache, not a record
+you depend on: delete it any time and kaibo just starts fresh, nothing
+breaks. Prefer kaibo forgets everything between runs? `--no-persistence` (or
+`KAIBO_NO_PERSISTENCE`) turns it off entirely. Want it somewhere else?
+`--state-db FILE` (or `KAIBO_STATE_DB`) moves it. The full technical
+contract — exactly which fields are stored, what's deliberately left out,
+and the one platform-specific edge case — is in
+[`docs/config.md`](docs/config.md#persistence-persistence).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ summary back.
 kaibo integrates as a stdio [MCP](https://modelcontextprotocol.io) server and supports
 Anthropic, Gemini, DeepSeek, OpenRouter (one key reaching every major model family),
 and any OpenAI-compatible endpoint, including local services like llama.cpp. It's a
-tool your *agent* uses — any MCP-capable client can drive it. Each
-agent is set up to mix small models for exploration with larger models for synthesis,
-to help keep your API spend down.
+tool your *agent* uses — any MCP-capable client can drive it — and it's also a
+[CLI](#cli) for scripts, CI, and terminals that would rather shell out than speak
+MCP. Each agent is set up to mix small models for exploration with larger models
+for synthesis, to help keep your API spend down.
 
 The agents reach your code through one tool: a [kaish](https://github.com/tobert/kaish)
 shell. kaish has all of its commands built in and mounts your project through a
@@ -169,6 +170,14 @@ claude mcp add kaibo -- docker run --rm -i \
 - The `:ro` mount is an OS-enforced belt under kaibo's own read-only sandbox:
   kaibo never writes either way, this just makes the kernel agree.
 
+The same image is a [CLI](#cli) too — append a subcommand and drop `-i` (there's no
+stdio transport to hold open for a one-shot run):
+
+```sh
+docker run --rm -v "$PWD:/work:ro" -e DEEPSEEK_API_KEY \
+  ghcr.io/tobert/kaibo:latest consult "what does this project do?" --cast deepseek
+```
+
 The package is public — pulling (and `COPY --from`) needs no registry login.
 The image is signed and attested by the same machinery as the archives — verify
 with `gh attestation verify oci://ghcr.io/tobert/kaibo:<tag> -R tobert/kaibo`,
@@ -206,6 +215,62 @@ for you:
   }
 }
 ```
+
+## CLI
+
+Every tool below is also a command — no MCP client needed, so scripts, CI, and a
+human at a terminal can drive kaibo directly:
+
+| MCP tool | CLI equivalent |
+|---|---|
+| `consult` | `kaibo consult "question" [--cast … --attach … --session … --json]` |
+| `oneshot` | `kaibo oneshot "prompt" [--attach … --json]` (context also via stdin: `oneshot "review this" < diff.txt`) |
+| `explore` | `kaibo explore "question" [--cast … --json]` |
+| `run_kaish` | `kaibo kaish -c 'script'` |
+| `batch_submit`, `job_get`/`job_list` (batch handles) | `kaibo batch submit \| get \| list` |
+| `kaibo://config` resource | `kaibo config` |
+
+```sh
+kaibo consult "does anything still busy-poll in job_wait?" --cast deepseek
+```
+
+**Bare `kaibo` (no subcommand) is still the MCP server** — every existing client
+config keeps working unchanged; `kaibo serve` is the explicit spelling for the
+same thing. `consult_submit`/`job_wait` and `deliberate`'s direct lane are the
+one gap — every other tool in the table above has a CLI subcommand; queued as
+[#82](https://github.com/tobert/kaibo/issues/82).
+
+**stdout is the answer, stderr is everything else.** Progress, logs, and warnings
+go to stderr, so piping stays clean; the answer (with the same provenance footer
+the MCP tool appends) is the only thing on stdout. `--json` swaps that for a
+structured envelope (`{answer, cast, models, usage, warnings}`) for a script
+caller — its `answer` field is always the model's raw words, never a kaibo notice.
+
+**Exit codes have teeth**, so a caller branches on the code instead of parsing
+prose: `0` an answer, `2` a usage error (bad flag, unknown or wrong-for-the-tool
+cast), `3` a setup/containment rejection (a path outside the allowed set, a
+missing provider key), `4` the work ran and failed at runtime (a provider
+error, a model-loop failure). `kaibo kaish` is the one exception — it passes
+through kaish's own exit code (`0` ok, `126` blocked, `124` timed out) instead,
+since a script branches on *that* to know what the sandboxed command did.
+
+The shared flags (`--root`, `--allow-path`, `--cast`, `--config`, house-rules
+files, …) work before or after the subcommand and are documented in `kaibo
+--help`; each subcommand's own flags are in `kaibo <subcommand> --help`.
+
+**State: where `--session` lives.** A `--session NAME` thread (and every
+`batch_submit`/`kaibo batch submit` handle) is durable by default, in a small
+[turso](https://github.com/tursodatabase/turso) db at a fixed path kaibo picks —
+`$XDG_STATE_HOME/kaibo/state.db` (`~/.local/state/kaibo/state.db` when unset) —
+never inside your project and never a path a model controls. It's what lets a
+session started over MCP continue on the CLI and back, and a batch handle survive
+a restart. It stores only the lean `(question, answer)` turns of sessions you
+name and each batch's `{backend, provider-id}` — never anything else, and never a
+source of truth: safe to delete, or move it with `--state-db FILE`
+(`KAIBO_STATE_DB`), or skip it for one run with `--no-persistence`
+(`KAIBO_NO_PERSISTENCE`) to go fully in-memory. See
+[Persistence](docs/config.md#persistence-persistence) for the full contract
+(what's excluded, the fail-loud-on-a-bad-path behavior, the one Windows carve-out).
 
 ## Configuration
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,22 @@ pub const EXIT_SETUP: i32 = 3;
 /// kaish script/blocked/timeout outcome is not this: it returns kaish's own exit code.
 pub const EXIT_CONSULT_FAILURE: i32 = 4;
 
+/// The `EXIT CODES` block appended to `kaibo --help` (long form only — `-h` stays a
+/// terse usage line). This is the one place the taxonomy is spelled out for a human
+/// or script reading `--help` cold, rather than the doc-comments above or the README.
+const EXIT_CODES_HELP: &str = "\
+EXIT CODES
+    0  an answer
+    2  usage error — a bad argument, an unknown or wrong-for-the-tool cast, an
+       image on a vision-blind cast, or a clap argument-parse error
+    3  setup/containment rejection — a path or attachment outside the allowed
+       set, a missing or unbuildable provider key
+    4  the work ran and failed — a provider/model-loop failure, or a kaish
+       worker infra crash
+
+`kaibo kaish` is the one exception: it exits with kaish's own code instead of
+this table (0 ok, 126 blocked, 124 timed out).";
+
 /// kaibo (解剖) — read-only codebase consultation from a model outside your own
 /// family. Ask a question; a capable model (DeepSeek, Gemini, Anthropic, OpenRouter,
 /// or local — pick with `--cast`) reads the project READ-ONLY and answers with
@@ -70,7 +86,7 @@ pub const EXIT_CONSULT_FAILURE: i32 = 4;
 /// (stdio); `kaibo consult` is the one-shot CLI; `kaibo config` prints the resolved
 /// configuration.
 #[derive(Parser, Debug)]
-#[command(name = "kaibo", version)]
+#[command(name = "kaibo", version, after_long_help = EXIT_CODES_HELP)]
 pub struct Cli {
     /// The shared flags (config discovery, containment, cast, house-rules,
     /// persistence). Defined once here as clap `global` args, so they work **before or
@@ -1598,6 +1614,28 @@ mod tests {
     #[test]
     fn clap_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    /// `kaibo --help` (long form) documents the exit-code taxonomy — the only place a
+    /// script author reading `--help` cold learns it. `-h` (short form) stays terse.
+    #[test]
+    fn long_help_documents_exit_codes() {
+        let long_help = Cli::command().render_long_help().to_string();
+        assert!(
+            long_help.contains("EXIT CODES"),
+            "long --help should carry the exit-code table:\n{long_help}"
+        );
+        for code in ["0  an answer", "2  usage error", "3  setup/containment", "4  the work ran"] {
+            assert!(
+                long_help.contains(code),
+                "long --help should document exit code {code:?}:\n{long_help}"
+            );
+        }
+        let short_help = Cli::command().render_help().to_string();
+        assert!(
+            !short_help.contains("EXIT CODES"),
+            "short -h should stay terse, not carry the full exit-code table"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

`kaibo consult`/`oneshot`/`explore`/`kaish`/`batch`/`config` shipped in #77/#78
but the README never got a CLI section — a reader had no way to discover the
CLI existed at all, only the changelog and `src/cli.rs`'s own doc-comment.

## Changes

- New **`## CLI`** section: MCP-tool → CLI-subcommand table, the
  stdout-is-the-answer/stderr-is-everything-else + `--json` + exit-code
  contract, and where `--session`/batch-handle state actually lives on disk
  (default XDG path, what's stored, `--state-db`/`--no-persistence` escape
  hatches).
- Introduction now mentions the CLI as a second front door.
- The container-image subsection gets a `docker run … kaibo consult …`
  example (drop `-i`, append a subcommand — no stdio transport to hold open
  for a one-shot run).
- Filed #82 for the one gap: `consult_submit`/`job_wait` and `deliberate`'s
  direct lane aren't CLI-reachable — their job handles are in-memory on a
  long-running server process, so a one-shot CLI invocation would exit and
  take the job with it before collection. README links it instead of
  re-explaining the architecture inline.
- CHANGELOG entry under `### Changed`.

Reviewed with `kaibo consult` (cast `deepseek`) against `src/cli.rs`,
`src/main.rs`, `Dockerfile`, and `docs/config.md`'s persistence section —
every factual claim (subcommand names, flags, exit codes, JSON envelope
shape, the `docs/config.md#persistence-persistence` anchor, the docker
entrypoint behavior) checked out. One wording nit it flagged ("every
synchronous tool" being imprecise since `batch` isn't synchronous) is fixed
in this diff.

## Test plan

- [x] `cargo build --bin kaibo`
- [x] Live-ran `kaibo --help`, `kaibo config`, `kaibo oneshot … --cast openrouter`
      (real answer + provenance footer) to confirm the documented behavior
      matches reality
- [x] Verified the `docs/config.md#persistence-persistence` anchor slug
- [x] Cross-model review via `kaibo consult` (cast `deepseek`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)