### PR TITLE
chore(deps): bump kaish-kernel 0.12.0 -> 0.13.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,27 +282,21 @@ even for a one-line doc fix.
   fresh asset (`gh attestation verify`, `cosign verify-blob` with the new tag's
   identity) — the tag-gated publish job signs releases, and signing an operator can't
   verify is theater, so prove it the way a user would.
-- **kaish pin.** Currently `kaish-kernel = "0.12.0"`. The `0.11.0 → 0.12.0` bump was
-  again API-compatible — **zero** call-site changes, `cargo build`/`clippy`/`cargo tree -i
-  aws-lc-rs` all clean. The changelog's **BREAKING (embedders)** entries all land on
-  compiled-out or unused surface: `ExecContext.tool_schemas` moving `Vec<ToolSchema>` →
-  `Arc<[ToolSchema]>` only bites direct field assignment (kaibo never constructs
-  `ExecContext`), and `JobStatus`/`JobInfo`/`ToolResult` going `#[non_exhaustive]` (plus
-  the new `JobStatus::Latched` variant and `LatchRequest.job_id`) only bites background
-  jobs and confirmation latches — kaibo compiles with `subprocess`/`host`/`os-integration`
-  off, so `bg`/`fg`/`jobs`/`kill`/`spawn` and the whole latch surface don't exist in this
-  binary. Two things *did* change kaibo's own text and code, both improvements landing
-  for free from upstream fixes: `grep -r PATTERN FILE` (GH #105) now searches the file
-  instead of silently finding nothing, so `KAISH_SANDBOX_ADDENDUM`'s single-file caveat
-  (`kaish_syntax.rs`) was stale and dropped, and the matching `docs/issues.md` tracker
-  entry (already shipped) was deleted. And the new `MAX_RECURSION_DEPTH`
-  (48)/`RECOMMENDED_STACK_SIZE` (12 MiB) matched pair — kaish's own guard against a
-  runaway `$(...)`/shell-function/`.kai`-source recursion overflowing the native stack —
-  is now what sizes `KaishWorker`'s dedicated thread in `sandbox.rs`, replacing a
-  hand-picked 16 MiB literal with the constant kaish itself documents for embedders
-  (`docs/EMBEDDING.md` in the kaish tree); live-probed with `f() { f; }; f`, which now
-  fails loudly (`"maximum recursion depth (48) exceeded"`) instead of risking a SIGSEGV.
-  Offline suite green (531 tests), boundary tests are effective. Precedent that a bump
-  *can* move call sites: `0.8.4 → 0.9.0` renamed the `mcp()` config constructors to
-  `agent()` in `sandbox.rs`. Keep this current per the **Working here** kaish-bump
-  discipline before cutting.
+- **kaish pin.** Currently `kaish-kernel = "0.13.0"`. The `0.12.0 → 0.13.0` bump was
+  again API-compatible — **zero** call-site changes, `cargo build`/`clippy --all-targets`/
+  full `cargo test` (598 passed) all clean, `cargo tree -i aws-lc-rs` and `-i mimalloc`
+  both empty. A large release (six crates bumped, ~270 changelog lines: lexer/parser
+  fixes, stricter binary-input handling across several builtins, a browser/wasm target)
+  but its **BREAKING (embedders)** entries all land on surface kaibo doesn't touch:
+  buffered stdin going `Vec<u8>` instead of `String` (`ExecContext::stdin`/
+  `ExecuteOptions::stdin`, `read_stdin_to_string` removed) only bites a caller that
+  feeds/reads kaish's own stdin, which kaibo never does (`cli.rs`'s `--attach`/piped-stdin
+  handling is unrelated CLI-level plumbing, not kaish's `ExecContext`); `ToolArgs::to_argv()`
+  returning `Result` instead of a bare `Vec<String>` only bites a caller that calls it —
+  `Blocked::execute` (`sandbox.rs`) receives a `ToolArgs` parameter but never calls
+  `.to_argv()` on it; and `output_limit::spill_aware_collect` + its private helpers being
+  removed is internal plumbing behind `OutputLimitConfig` (`.agent()`/`.set_limit()`/
+  `.with_output_limit()` in `sandbox.rs`), which the kaish changelog states explicitly is
+  unaffected. Precedent that a bump *can* move call sites: `0.8.4 → 0.9.0` renamed the
+  `mcp()` config constructors to `agent()` in `sandbox.rs`. Keep this current per the
+  **Working here** kaish-bump discipline before cutting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,6 +451,18 @@ the git log. Each later release appends a new section at the top.
   whole-first goes further. Attached files the caller flagged as central keep the
   read-it-ALL directive — there the full cost is deliberate.)
 
+- **The read-only shell now speaks kaish 0.13.** A bug-fix release, inherited for
+  free (no kaibo-side change needed): `wc`/`xxd` now refuse invalid UTF-8 loudly
+  instead of lossy-decoding it into wrong char/word counts or corrupt bytes; a
+  failed `$((...))` arithmetic expansion propagates its real error instead of
+  silently splicing in an empty string; `push` accepts a bracket-path target
+  (`push services[web][tags] item`), not just a top-level name; case patterns
+  accept dash/plus bare words (`--`, `-h|--help) ...`); `printf`/`awk`'s `%Ns`
+  width now pads by display width, so a CJK or emoji argument lines up instead
+  of under-padding; and several heredoc/arithmetic/quoting parser fixes (nested
+  `${X:-${Y}}` defaults, arithmetic inside command substitution, an apostrophe in
+  a heredoc body no longer poisoning later arithmetic).
+
 ### Fixed
 
 - **A Gemini slot's reasoning-effort setting now actually reaches Gemini.** kaibo's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743a50dfd43176ebbf9937414d25c0297c388822552d648d7cf4cbcd3ad58df0"
+checksum = "9d1b83e11685a62a96a9a15f67a574db1042e98087d6523d9112c6d302fcbf6d"
 dependencies = [
  "async-trait",
  "ignore",
@@ -1851,18 +1851,18 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42b8c076e569b5f43658232f52795362fbb474cb4d1002d2b7de41282cbff11"
+checksum = "f6237b6de41c07f23a2d182f9321131f00dce98240d1d37e8294b269158b9b1d"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1630ff9099d8499c5eb5080e5130b2b07aa2058a528be5bb523e849335c6ebdc"
+checksum = "3e36030288cdb9a235c3ef27f98d63da96d1e06c62949535c6245d0c1d724e75"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1902,13 +1902,14 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-opentelemetry 0.32.1",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc5938c7abe6e2101df2d61aecc507ed4ae5ca4975ed1ea76e3c87ccc7feab2"
+checksum = "a1d1852d1bb674446c6d80f7d8d8615d16fbac2adb6b4a5c6b1791081e242826"
 dependencies = [
  "async-trait",
  "clap",
@@ -1917,22 +1918,23 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43846e2eae7ace733e86bc5dea173c08438ce0ecb5f20cc3a8cc8d88bd370bd6"
+checksum = "550e90c247c8fd0815a2224a1bde0a4c6dea7944edc391b1ba2387efeeb3c116"
 dependencies = [
  "base64",
  "serde",
  "serde_json",
  "thiserror",
  "tokio-util",
+ "web-time",
 ]
 
 [[package]]
 name = "kaish-vfs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0bb521e87439f50c540dcf712493a2da52718eb2de8abc84fd964ffaa8251b"
+checksum = "acfd478a3979372cecd0416a78a0e8de99da4bb3774b6e683f97281c82351791"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # `os-integration` (trash) OFF — so those builtins are never compiled in. kaibo's
 # read-only safety is thus structural (the dangerous surface doesn't exist),
 # backed by the runtime read-only mount; see src/sandbox.rs.
-kaish-kernel = { version = "0.12.0", default-features = false, features = ["localfs"] }
+kaish-kernel = { version = "0.13.0", default-features = false, features = ["localfs"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
 async-trait = "0.1"
 anyhow = "1"

--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -215,7 +215,7 @@ cargo test --test containment --test sandbox --test run_kaish_tool
 ```
 
 These prove the same four properties with failing-first fixtures (and we prove the
-fixtures have teeth — e.g. mount the project with `LocalFs::new` instead of
+fixtures actually work — e.g. mount the project with `LocalFs::new` instead of
 `read_only` and watch the write-denial tests fail). A green run here plus a clean
 live battery is the bar for trusting the read-only claim.
 
@@ -245,3 +245,15 @@ toolset has drifted from the direct one and that's the bug.
   probe re-run on the local `openai` cast (gemma4, after raising its window to 131072)
   reproduced the direct results exactly. Update this line each pass; git history is
   the rest of the record.
+- **2026-07-18** — Batteries A/B/C direct via `kaibo kaish` (built binary, base
+  commit `c1267bd` + the `kaish-kernel` 0.12.0 → 0.13.0 bump, branch
+  `chore/kaish-0.13.0`), specifically to spot-check that bump against the sandbox
+  boundary. All clear: every write in Battery A refused with `permission denied:
+  filesystem is read-only` and nothing landed on real disk; every external command
+  in Battery B came back `command not found` (exit 127); every out-of-mount read in
+  Battery C (`/etc/passwd`, `..` traversal, `~/.ssh`, the adjacent-secret probe) came
+  back `not found`, and `env`/the key-var check came back empty. Full `cargo test`
+  (598 passed) green on the same build. Batteries D/E (path containment, the
+  persistence store) not re-run live this pass — unaffected by a kaish-kernel bump
+  and already covered by `tests/containment.rs`/`tests/store.rs` in that same green
+  run.


### PR DESCRIPTION
## What & why

kaish 0.13.0 is on crates.io — pulling it in before cutting the next RC per
AGENTS.md's kaish-bump discipline.

## Changes

- `Cargo.toml`/`Cargo.lock`: `kaish-kernel = "0.13.0"` (+5 sibling crates:
  `kaish-glob`/`kaish-help`/`kaish-tool-api`/`kaish-types`/`kaish-vfs`).
- **API-compatible, zero call-site changes.** It's a large release upstream
  (six crates, ~270 changelog lines: lexer/parser fixes, stricter
  binary-input handling, a browser/wasm target) but every **BREAKING
  (embedders)** entry lands on surface kaibo doesn't touch — walked each one
  against the actual call sites and wrote up why in `AGENTS.md`'s kaish-pin
  paragraph:
  - buffered stdin → `Vec<u8>` (`ExecContext::stdin`/`ExecuteOptions::stdin`,
    `read_stdin_to_string` removed) — kaibo never touches kaish's stdin
    (its own `cli.rs` `--attach`/piped-stdin handling is unrelated
    CLI-level plumbing).
  - `ToolArgs::to_argv()` now returns `Result` — `Blocked::execute`
    (`sandbox.rs`) receives a `ToolArgs` but never calls `.to_argv()`.
  - `output_limit::spill_aware_collect` + helpers removed — internal
    plumbing behind `OutputLimitConfig`, which the kaish changelog states
    explicitly is unaffected.
- `CHANGELOG.md`: a `### Changed` entry naming the model-facing behavior
  fixes that land for free (loud-instead-of-lossy UTF-8 handling in
  `wc`/`xxd`, arithmetic errors no longer swallowed, `push` bracket-path
  targets, dash/plus case patterns, display-width `printf`/`awk` padding,
  assorted heredoc/quoting parser fixes).
- `docs/sandbox-probes.md`: re-ran the live Batteries A/B/C (writes,
  external commands, read-escape) against the rebuilt binary — a
  kaish-kernel bump is exactly the kind of change worth spot-checking
  against the read-only boundary — and stamped a new "Last run" entry.
  Also scrubbed the one remaining "have teeth" idiom instance in that file
  (matches the AGENTS.md/README cleanup in #83).

## Test plan

- [x] `cargo build --bin kaibo`
- [x] Full `cargo test` (598 passed, 0 failed)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo tree -i aws-lc-rs` / `-i mimalloc` both empty
- [x] Live sandbox-probes Batteries A/B/C via `kaibo kaish -c` against the
      rebuilt binary — every write refused (nothing on real disk), every
      external command `command not found` (127), every out-of-mount read
      `not found`, env empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)