### PR TITLE
chore: bump to 0.2.0-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "解剖 — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
Version bump for a smoke-test RC: CLI mode via the release binaries and the
container image, on top of the README CLI docs (#83) and the kaish-kernel
0.13.0 bump (#84) that just landed, plus the telemetry/shaping work already
on main since rc.5 (#80, #81).

Glance-scale change — the build proves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)