### PR TITLE
Allow anthropic-kind backends to set base_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,14 @@ the git log. Each later release appends a new section at the top.
   shows live + store-recovered handles). Each carries `--json` (its `answer`/`report`
   field is the model's raw words) and the same stdout-is-payload / exit-code contract.
   An interactive REPL is deliberately later.
+- **An `anthropic`-kind backend can now set `base_url`.** Unset still dials rig's
+  built-in `https://api.anthropic.com`; set, it points the Anthropic Messages API
+  wire protocol at a compatible gateway or proxy instead (a corporate LLM
+  gateway, a Tailscale-fronted endpoint, etc.) — the same escape hatch the
+  `openai` kind already had, extended to the one other kind whose wire protocol a
+  proxy can plausibly reimplement. Every other keyed kind (DeepSeek, Gemini,
+  OpenRouter) still rejects `base_url` at load; rig fixes those endpoints. See
+  `docs/config.md`.
 
 ### Changed
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -196,8 +196,11 @@ scratch_limit_bytes = 67108864
 #
 # Keys are referenced, never inlined: api_key_env names an env var, api_key_file a
 # path (~ ok). env wins over file. key_optional=true falls back to a placeholder
-# bearer token (keyless local servers). base_url is only legal on the openai kind
-# (rig fixes the keyed endpoints — a base_url there is a loud load error).
+# bearer token (keyless local servers). base_url is legal on the openai kind
+# (required for a new backend) and the anthropic kind (optional — unset still
+# dials rig's built-in api.anthropic.com; set it to point at an Anthropic-
+# Messages-API-compatible gateway/proxy instead). Every other keyed kind rejects
+# base_url at load (rig fixes those endpoints).
 # ---------------------------------------------------------------------------
 
 # --- The five built-ins, shown with their current defaults. You only need to
@@ -210,6 +213,10 @@ scratch_limit_bytes = 67108864
 kind = "anthropic"
 api_key_env  = "ANTHROPIC_API_KEY"
 api_key_file = "~/.anthropic-key.txt"
+# Uncomment to dial an Anthropic-Messages-API-compatible gateway/proxy (e.g. a
+# corporate LLM gateway) instead of api.anthropic.com directly. Optional —
+# unlike the openai kind, unset still resolves to rig's built-in endpoint.
+# base_url = "https://llm-gateway.example.internal"
 
 [backends.deepseek]
 kind = "deepseek"

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,9 +71,13 @@ Connection knobs only — models never live here:
   local llama.cpp servers, an Ollama box) be live at once, each its own name.
   A *new* openai-kind backend must set it: the `OPENAI_BASE_URL`/local-default
   fallback belongs to the built-in `openai-local` backend alone, so a forgotten
-  `base_url` is a load error, not a silent dial of the wrong server. For the
-  keyed kinds rig fixes the endpoint, so a `base_url` there is a config error,
-  surfaced loudly — not silently ignored.
+  `base_url` is a load error, not a silent dial of the wrong server. It is also
+  meaningful — but *optional* — for `kind = "anthropic"`: unset still resolves to
+  rig's built-in `https://api.anthropic.com`; set, it points the Anthropic wire
+  protocol at any Anthropic-Messages-API-compatible gateway/proxy instead (a
+  corporate LLM gateway, say). For every *other* keyed kind rig fixes the
+  endpoint, so a `base_url` there is a config error, surfaced loudly — not
+  silently ignored.
 - A backend resolves its key from `api_key_env` then `api_key_file` (env wins).
   **Secrets never live inline in the TOML** — only the *name* of an env var or the
   *path* to a key file. A config you can commit or paste shouldn't leak a key.
@@ -296,7 +300,7 @@ today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submi
 
 | backend | kind | base_url | key env / file | aliases |
 |---|---|---|---|---|
-| `anthropic` | anthropic | — | `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` | `claude` |
+| `anthropic` | anthropic | — *(optional)* | `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` | `claude` |
 | `deepseek` | deepseek | — | `DEEPSEEK_API_KEY` / `~/.deepseek-key` | — |
 | `gemini` | gemini | — | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
 | `openrouter` | openrouter | — *(fixed)* | `OPENROUTER_API_KEY` / `~/.openrouter-key` | — |
@@ -856,9 +860,11 @@ operator) the full picture:
   `files`, `defaults`, `auto_gitignore`, `global_gitignore`, `scope`
 - `defaults` — the global tunables every slot falls back to (rendered so the
   per-slot values below read as deltas against it)
-- `backends` — each connection: its kind, the *resolved* `base_url` (openai kind),
-  key source env var name and key file path (never the resolved key value),
-  `key_optional`, and `request_timeout_secs`
+- `backends` — each connection: its kind, `base_url` (the *resolved* value for the
+  openai kind — env/local-default fallback applied; the raw configured value,
+  when set, for the anthropic kind; absent for every other kind), key source env
+  var name and key file path (never the resolved key value), `key_optional`, and
+  `request_timeout_secs`
 - `backend_aliases` / `cast_aliases` — alias → canonical name, built-in and
   file-declared both: every name a `cast` param, slot ref, or per-call backend
   override will resolve

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -48,8 +48,10 @@ use crate::attach::Attachment;
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot, SlotTunables};
 use crate::credentials::ProviderKind;
 
-/// Anthropic's API base. The keyed Anthropic backend carries no `base_url` (rig fixes
-/// its endpoint), so batch addresses the service directly.
+/// Anthropic's default API base, used when the backend sets no `base_url` of its own
+/// (the common case — rig fixes the endpoint for most keyed kinds, but the anthropic
+/// kind may override it to dial an Anthropic-Messages-API-compatible gateway/proxy;
+/// see [`AnthropicBatch::base_url`]).
 const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com";
 
 /// The effort batch runs every item at — the maxed knob. Equal to
@@ -594,6 +596,7 @@ pub fn render_list(
 pub struct AnthropicBatch {
     http: reqwest::Client,
     api_key: String,
+    base_url: String,
     /// Submit-only: empty on a poll/cancel-only client.
     model: String,
     max_tokens: u64,
@@ -617,6 +620,16 @@ impl AnthropicBatch {
         Ok(())
     }
 
+    /// The backend's configured `base_url`, if it set one (an Anthropic-Messages-API
+    /// -compatible gateway/proxy), else [`ANTHROPIC_API_BASE`] — mirrors
+    /// [`GeminiBatch::base_url`].
+    fn base_url(backend: &Backend) -> String {
+        backend
+            .base_url
+            .clone()
+            .unwrap_or_else(|| ANTHROPIC_API_BASE.to_string())
+    }
+
     /// A submit-capable client: the cast's synth slot, shaped to batch's maxed knobs.
     pub fn from_slot(backend: &Backend, slot: &ModelSlot, defaults: &Defaults) -> Result<Self> {
         Self::require_anthropic(backend)?;
@@ -625,6 +638,7 @@ impl AnthropicBatch {
         Ok(Self {
             http: batch_http_client(backend)?,
             api_key: backend.resolve_key()?,
+            base_url: Self::base_url(backend),
             model: slot.id.clone(),
             max_tokens,
             params,
@@ -638,6 +652,7 @@ impl AnthropicBatch {
         Ok(Self {
             http: batch_http_client(backend)?,
             api_key: backend.resolve_key()?,
+            base_url: Self::base_url(backend),
             model: String::new(),
             max_tokens: 0,
             params: None,
@@ -699,7 +714,7 @@ impl BatchProvider for AnthropicBatch {
             attachments,
             items,
         );
-        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches");
+        let url = format!("{}/v1/messages/batches", self.base_url);
         let resp = self
             .auth(self.http.post(&url))
             .body(serde_json::to_vec(&body)?)
@@ -720,7 +735,7 @@ impl BatchProvider for AnthropicBatch {
     }
 
     async fn poll(&self, batch_id: &str) -> Result<BatchPoll> {
-        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches/{batch_id}");
+        let url = format!("{}/v1/messages/batches/{batch_id}", self.base_url);
         let resp = self
             .auth(self.http.get(&url))
             .send()
@@ -746,7 +761,7 @@ impl BatchProvider for AnthropicBatch {
     }
 
     async fn cancel(&self, batch_id: &str) -> Result<()> {
-        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches/{batch_id}/cancel");
+        let url = format!("{}/v1/messages/batches/{batch_id}/cancel", self.base_url);
         let resp = self
             .auth(self.http.post(&url))
             .send()
@@ -764,7 +779,7 @@ impl BatchProvider for AnthropicBatch {
         // One page at the API's max (100), newest-first by default. `has_more` rides
         // back so a truncated view announces itself — orphan recovery wants the recent
         // tail, and a caller who needs deeper history polls a known handle directly.
-        let url = format!("{ANTHROPIC_API_BASE}/v1/messages/batches?limit=100");
+        let url = format!("{}/v1/messages/batches?limit=100", self.base_url);
         let resp = self
             .auth(self.http.get(&url))
             .send()
@@ -786,8 +801,10 @@ impl BatchProvider for AnthropicBatch {
 
 // --- Gemini provider -------------------------------------------------------
 
-/// Gemini's API base. The keyed Gemini backend carries no `base_url` (rig fixes its
-/// endpoint), so batch addresses the service directly, as Anthropic does.
+/// Gemini's default API base, used when the backend sets no `base_url` of its own.
+/// The keyed Gemini backend cannot set one today (rig fixes the endpoint), unlike the
+/// anthropic kind — but [`GeminiBatch::base_url`] already reads `backend.base_url` in
+/// case that changes, the same pattern [`AnthropicBatch::base_url`] follows now.
 const GEMINI_API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
 
 /// A reqwest client carrying the backend's per-request deadline — the shared
@@ -1823,6 +1840,31 @@ mod tests {
                 "error should explain the anthropic-only constraint: {err}"
             );
         }
+    }
+
+    /// A backend's configured `base_url` (an Anthropic-Messages-API-compatible
+    /// gateway/proxy) must actually reach the batch client — the bug a cross-family
+    /// review caught: `AnthropicBatch` once hardcoded `ANTHROPIC_API_BASE` and
+    /// silently ignored `backend.base_url`, so interactive `consult` reached a custom
+    /// gateway while batch calls kept dialing api.anthropic.com. Both constructors
+    /// must resolve it, and an unset `base_url` must still fall back to the default.
+    #[test]
+    fn base_url_reaches_the_batch_client() {
+        let mut b = anthropic_backend();
+        b.base_url = Some("https://gateway.example.ts.net".to_string());
+        b.key_optional = true;
+        let slot = ModelSlot::bare(&b.name, "claude-sonnet-4-6");
+
+        let submit_client = AnthropicBatch::from_slot(&b, &slot, &Defaults::default()).unwrap();
+        assert_eq!(submit_client.base_url, "https://gateway.example.ts.net");
+
+        let poll_client = AnthropicBatch::from_backend(&b).unwrap();
+        assert_eq!(poll_client.base_url, "https://gateway.example.ts.net");
+
+        let mut default_backend = anthropic_backend();
+        default_backend.key_optional = true;
+        let default_client = AnthropicBatch::from_backend(&default_backend).unwrap();
+        assert_eq!(default_client.base_url, ANTHROPIC_API_BASE);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1508,7 +1508,8 @@ fn backend_template(kind: ProviderKind, defaults: &Defaults) -> Backend {
         kind,
         // No base_url baked in: `resolved_base_url` supplies the default (or
         // OPENAI_BASE_URL, for the openai kind) at use-time, keeping construction
-        // pure. A keyed kind with an explicit base_url is rejected in `merge`.
+        // pure. Every keyed kind except anthropic rejects an explicit base_url
+        // at load (see the validation loop above); anthropic's is optional.
         base_url: None,
         api_key_env: Some(kind.env_var().to_string()),
         api_key_file: Some(format!("~/{}", kind.key_file_name())),

--- a/src/config.rs
+++ b/src/config.rs
@@ -411,8 +411,11 @@ pub struct Backend {
     pub name: String,
     /// Which wire protocol / rig client to construct.
     pub kind: ProviderKind,
-    /// Endpoint base URL. Meaningful only for `kind = Openai`; a `Some` on any keyed
-    /// kind is rejected at load (rig fixes those endpoints).
+    /// Endpoint base URL. Meaningful for `kind = Openai` (required for a new
+    /// backend) and `kind = Anthropic` (optional — unset falls back to rig's
+    /// built-in `https://api.anthropic.com`, e.g. for an Anthropic-Messages-API
+    /// -compatible gateway/proxy). A `Some` on any other keyed kind is rejected
+    /// at load (rig fixes those endpoints).
     pub base_url: Option<String>,
     /// Env var to read the API key from (checked before `api_key_file`).
     pub api_key_env: Option<String>,
@@ -1083,11 +1086,17 @@ impl Config {
                     b.name
                 );
             }
-            // A base_url on a keyed kind: rig fixes those endpoints.
-            if b.kind != ProviderKind::Openai && b.base_url.is_some() {
+            // A base_url on a keyed kind: rig fixes those endpoints — except Anthropic,
+            // which also accepts one (for an Anthropic-Messages-API-compatible
+            // gateway/proxy in front of the real backend), optionally: unset still
+            // dials rig's built-in https://api.anthropic.com.
+            if b.kind != ProviderKind::Openai
+                && b.kind != ProviderKind::Anthropic
+                && b.base_url.is_some()
+            {
                 bail!(
-                    "backend {:?} (kind {:?}) sets base_url, but only the `openai` kind \
-                     has a configurable endpoint",
+                    "backend {:?} (kind {:?}) sets base_url, but only the `openai` and \
+                     `anthropic` kinds have a configurable endpoint",
                     b.name,
                     b.kind
                 );
@@ -3641,7 +3650,7 @@ mod tests {
     }
 
     /// A new backend must declare a kind; redeclaring a different kind on an
-    /// existing one is a loud error; base_url is openai-kind only.
+    /// existing one is a loud error; base_url is openai/anthropic-kind only.
     #[test]
     fn backend_stanza_validation_is_loud() {
         let err = Config::from_toml_str("[backends.mine]\nbase_url = \"http://x\"\n")
@@ -3654,10 +3663,26 @@ mod tests {
             .to_string();
         assert!(err.contains("already exists as kind"), "got: {err}");
 
-        let err = Config::from_toml_str("[backends.anthropic]\nbase_url = \"http://x\"\n")
+        // A keyed kind other than anthropic still rejects base_url — rig fixes
+        // that endpoint.
+        let err = Config::from_toml_str("[backends.gemini]\nbase_url = \"http://x\"\n")
             .unwrap_err()
             .to_string();
-        assert!(err.contains("only the `openai` kind"), "got: {err}");
+        assert!(err.contains("only the `openai` and `anthropic` kinds"), "got: {err}");
+    }
+
+    /// The anthropic kind, uniquely among the keyed kinds, may set base_url — for
+    /// an Anthropic-Messages-API-compatible gateway/proxy in front of the real
+    /// backend. Unset still resolves to rig's built-in api.anthropic.com (proven
+    /// by the builtin_anthropic_cast_and_backend-style tests having no base_url).
+    #[test]
+    fn anthropic_backend_accepts_a_base_url() {
+        let cfg = Config::from_toml_str(
+            "[backends.anthropic]\nbase_url = \"http://ai.example.ts.net\"\n",
+        )
+        .unwrap();
+        let b = cfg.backends.get("anthropic").unwrap();
+        assert_eq!(b.base_url.as_deref(), Some("http://ai.example.ts.net"));
     }
 
     /// A backend name containing '/' is refused at load. Both the slot ref

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -256,9 +256,15 @@ impl Arm {
 
         match backend.kind {
             ProviderKind::Anthropic => {
+                // base_url is optional here (unlike the openai kind): unset dials
+                // rig's built-in https://api.anthropic.com; set, it points at an
+                // Anthropic-Messages-API-compatible gateway/proxy instead.
                 let key = backend.resolve_key()?;
-                let client = anthropic::Client::builder()
-                    .api_key(&key)
+                let mut builder = anthropic::Client::builder().api_key(&key);
+                if let Some(base_url) = backend.base_url.as_deref() {
+                    builder = builder.base_url(base_url);
+                }
+                let client = builder
                     .http_client(http)
                     .build()
                     .map_err(|e| anyhow!("anthropic client init: {e}"))?;

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -3283,6 +3283,40 @@ mod tests {
         );
     }
 
+    /// An anthropic-kind backend pointed at a custom `base_url` (an Anthropic-
+    /// Messages-API-compatible gateway/proxy, auth via network identity rather than
+    /// a real key) must still build offline, exactly like the keyless openai arm
+    /// above — proving the conditional `.base_url(...)` call in the Anthropic arm
+    /// of `Arm::from_slot` doesn't disturb the builder chain (the ordering a
+    /// cross-family review flagged for a closer look).
+    #[test]
+    fn arm_from_slot_builds_an_anthropic_arm_with_a_custom_base_url() {
+        let defaults = crate::config::Defaults::default();
+        let backend = crate::config::Backend {
+            name: "anthropic".into(),
+            kind: ProviderKind::Anthropic,
+            base_url: Some("https://gateway.example.ts.net".into()),
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: true,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+        };
+        let slot = ModelSlot::bare("anthropic", "claude-sonnet-4-6");
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyless anthropic arm with a custom base_url builds offline");
+        assert_eq!(arm.model, "claude-sonnet-4-6");
+
+        // An anthropic backend with no base_url must still build (the default
+        // rig endpoint applies) — the conditional branch must not be required.
+        let default_backend = crate::config::Backend {
+            base_url: None,
+            ..backend
+        };
+        Arm::from_slot(&default_backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyless anthropic arm with no base_url still builds offline");
+    }
+
     /// The OpenRouter arm's full params assembly — `to_params` chained through
     /// `inject_output_budget` at the single live construction point. The reasoning
     /// object (thinking on by default), the rig-defect budget workaround, and the

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -183,7 +183,9 @@ pub(crate) fn render_config_resource(
         kind: String,
         /// Resolved endpoint for openai-kind backends (explicit base_url, else
         /// OPENAI_BASE_URL, else the built-in default) — the "resolved runtime
-        /// state" promise. Other kinds have fixed endpoints baked into rig.
+        /// state" promise. The raw configured value for anthropic-kind backends,
+        /// when set (an Anthropic-Messages-API-compatible gateway/proxy); absent
+        /// otherwise. Every other kind has a fixed endpoint baked into rig.
         #[serde(skip_serializing_if = "Option::is_none")]
         base_url: Option<String>,
         /// Env var name whose value is the API key (checked first). The NAME, not

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -613,17 +613,33 @@ fn alias_collisions_are_loud_at_each_level() {
 
 #[test]
 fn base_url_on_a_keyed_backend_is_rejected() {
-    // rig fixes the keyed kinds' endpoints; a base_url there is a config mistake.
+    // rig fixes most keyed kinds' endpoints; a base_url there is a config mistake.
+    // (Anthropic is the one exception — see `anthropic_backend_accepts_a_base_url`.)
     let err = Config::from_toml_str(
         r#"
-        [backends.anthropic]
+        [backends.gemini]
         base_url = "https://example.test/v1"
         "#,
     )
     .unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("base_url"), "got: {msg}");
-    assert!(msg.contains("only the `openai` kind"), "got: {msg}");
+    assert!(msg.contains("only the `openai` and `anthropic` kinds"), "got: {msg}");
+}
+
+#[test]
+fn anthropic_backend_accepts_a_base_url() {
+    // Unlike the other keyed kinds, anthropic may point at a compatible
+    // gateway/proxy (e.g. a corporate LLM gateway) instead of api.anthropic.com.
+    let cfg = Config::from_toml_str(
+        r#"
+        [backends.anthropic]
+        base_url = "https://example.test/v1"
+        "#,
+    )
+    .unwrap();
+    let b = cfg.backends.get("anthropic").unwrap();
+    assert_eq!(b.base_url.as_deref(), Some("https://example.test/v1"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- The `anthropic` backend kind can now set `base_url` (optionally — unset still resolves to rig's built-in `https://api.anthropic.com`), mirroring the escape hatch the `openai` kind already had. This lets kaibo point at an Anthropic-Messages-API-compatible gateway/proxy (e.g. a corporate LLM gateway) instead of dialing Anthropic directly. Every other keyed kind (DeepSeek, Gemini, OpenRouter) still rejects `base_url` at load, since rig fixes those endpoints.
- A cross-family review (kaibo consulting itself, `cast=anthropic`, against a real gateway) caught a real bug in the first pass: `AnthropicBatch` hardcoded `api.anthropic.com` and never read `backend.base_url`, so `consult_submit`/`batch_submit` would have silently dialed the real Anthropic API instead of the configured gateway even though interactive `consult` worked. Fixed by mirroring `GeminiBatch`'s existing base_url-with-fallback pattern, plus refreshed three now-stale comments the review flagged.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (full suite, including new `anthropic_backend_accepts_a_base_url` (config.rs + tests/config.rs), `base_url_reaches_the_batch_client` (batch.rs), and `arm_from_slot_builds_an_anthropic_arm_with_a_custom_base_url` (engine.rs) tests)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo tree -i aws-lc-rs` / `-i mimalloc` still empty (no dependency changes)
- [x] Manually verified end-to-end: configured `~/.config/kaibo/config.toml` with `[backends.anthropic] base_url = "..."`, reconnected, ran a live `consult` through the gateway and got a correctly-cited answer
- [x] Cross-family review via kaibo's own `consult` (cast=anthropic) before and after the batch fix
- [x] Validated works with irl gateway by reviewing this PR with a fresh kaibo build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
