### PR TITLE
docs: the state db is the user's data, not a disposable cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,8 +357,9 @@ the git log. Each later release appends a new section at the top.
   design. Turn it off with `--no-persistence` / `KAIBO_NO_PERSISTENCE` / `[persistence]
   enabled = false` to run fully in-memory, or move the db with `--state-db <FILE>` /
   `KAIBO_STATE_DB` / `[persistence] path`. If the store can't open, kaibo **fails to start
-  loudly** naming that escape hatch rather than silently losing your sessions. The db is a
-  convenience layer, safe to delete. See `docs/config.md`.
+  loudly** naming that escape hatch rather than silently losing your sessions. kaibo never
+  deletes that db — it holds answers you paid for, so moving it aside is always your call.
+  See `docs/config.md`.
 - **A CLI front door: `kaibo consult` and `kaibo config`.** kaibo now answers without
   an MCP client: `kaibo consult "question" [--cast … --attach … --session … --json]`
   runs the same read-only investigation from the command line — for agents that shell

--- a/docs/config.md
+++ b/docs/config.md
@@ -528,9 +528,10 @@ CLI/env: `--no-persistence` / `KAIBO_NO_PERSISTENCE` disable it (in-memory, like
 no TTL — same as the in-memory store), and the `{backend, provider-id, label}` of each
 batch you submit (so `job_list` can re-surface a handle after a restart). **What never
 persists:** background *consult/deliberate* job handles (`job-N` — in-memory, session-only
-by design) and exploration reports (ephemeral by design — they'd be stale bloat). The db
-is a convenience layer, **never a source of truth**: safe to delete, and its content is
-model output, never anything the calling model steers onto disk.
+by design) and exploration reports (ephemeral by design — they'd be stale bloat). Its
+content is model output, never anything the calling model steers onto disk — and because
+that output is **what you paid for**, kaibo treats the db as your data: it never removes
+the file, under any error, so moving it aside is always your decision.
 
 **Read-only toward your project is unchanged.** The store is handler-side, at the XDG
 path — kaish's read-only sandbox never sees it, kaibo still writes nothing into any
@@ -540,9 +541,9 @@ AGENTS.md.
 
 **Loud on failure, never a silent fallback.** If the store can't open (a bad path, a db
 inside a project, a network mount — turso's multiprocess mode is 64-bit-Unix + local-fs
-only), kaibo **fails to start** with an error naming the escape hatch and reminding you the
-db is a convenience layer safe to delete — rather than quietly dropping to memory and
-losing your sessions on the next restart.
+only), kaibo **fails to start** with an error naming the escape hatch and leaving the db
+untouched — rather than quietly dropping to memory and losing your sessions on the next
+restart.
 
 **One exception, Windows only.** On Windows (and other non-64-bit-Unix targets) the store
 is single-process. A *second* kaibo opening the same db — a second editor window — would,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -230,8 +230,8 @@ of live exploration — yet it lives only in memory until the offline synth cons
 Persist it to the state store (`src/store.rs`) on completion so a **failed synth hand-off
 can resubmit without re-exploring**, and a mid-explore failure can resume from the last
 checkpoint. Natural follow-on to the persistent session/batch store: a lean text artifact
-keyed by a deliberation/job id, disposable like the rest of the store (convenience, never
-source of truth). Dovetails the "deliberate dossier vs. caller timeout" entry above — a
+keyed by a deliberation/job id, and kept like the rest of the store — expensive model
+output we hold onto, not a scratch cache. Dovetails the "deliberate dossier vs. caller timeout" entry above — a
 persisted dossier also survives the caller dropping the connection. Surfaced by the
 DeepSeek CLI-subcommands review (2026-07-17).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,11 +223,13 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
             Err(e) => {
                 return Err(anyhow::anyhow!(
                     "failed to open the persistence state db at {}: {e}\n\
-                     The state db is a convenience layer — if it's corrupt it is safe to \
-                     delete by hand (kaibo creates a fresh empty one on the next start; it \
-                     never auto-deletes, since the error could be transient). Otherwise fix \
-                     the path/permissions, or run without persistence (--no-persistence, \
-                     KAIBO_NO_PERSISTENCE, or [persistence] enabled = false in config.toml).",
+                     kaibo never deletes this file: it holds your session history, which is \
+                     model output you paid for. Fix the path or permissions if that is the \
+                     problem, or run without persistence to get going right now without \
+                     touching it (--no-persistence, KAIBO_NO_PERSISTENCE, or [persistence] \
+                     enabled = false in config.toml). If the db really is corrupt, back it \
+                     up and move it aside by hand — kaibo creates a fresh one on the next \
+                     start.",
                     path.display()
                 ));
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -20,9 +20,15 @@
 //!   tree** (canonicalizing the parent dir, since the file may not exist yet). A model can
 //!   never coax a write onto disk through this file, because the file can never live
 //!   where a model can reach — see [`SessionStore::open`] and its containment tests.
-//! - The db is **reconstructible-or-disposable**: it is a convenience layer, never a
-//!   source of truth. Corruption is handled by deleting the file and starting over, never
-//!   by limping on — which keeps the "crash over corrupt data" principle intact.
+//! - **The db holds the user's data, and kaibo never removes it.** Its contents are paid
+//!   model output — a session turn log is answers someone spent tokens on — so the stance
+//!   is to keep them at most costs, not to treat the file as a cheap cache. That is
+//!   structurally guaranteed, not a promise: no removal call exists in production code
+//!   (`remove_file`/`remove_dir*` sit on `tests/no_write_path.rs`'s forbidden list), so an
+//!   open or integrity failure fails **loudly and leaves the file untouched** — moving it
+//!   aside is the operator's call, because only they know whether the history is worth
+//!   recovering. "Crash over corrupt data" means kaibo never limps along on a damaged db;
+//!   it has never meant the db is disposable.
 //!
 //! # The one open path, and why it is load-bearing
 //!


### PR DESCRIPTION
## Why

kaibo's prose called the persistence state db "a convenience layer, never a source of truth, safe to delete," and told operators that corruption is handled by deleting the file.

That framing has a traceable origin: `signoff.md`, during the turso engine evaluation — *"Beta risk acceptable: store data is low-stakes and reconstructible-or-disposable."* It was a **risk-acceptance argument for choosing an engine**, and it got promoted into `store.rs`'s module doc, `docs/config.md`, the startup error, and the changelog as though it were data-stewardship policy.

Amy's call: that was learning-phase talk from while we were building it. The stance now is that **we keep the user's data at most costs.**

It was also wrong on its own terms. A session turn log holds `(question, answer)` pairs — model output someone spent tokens on. "Safe to delete" was advice to discard purchased content.

## What changed

**No behavior changes.** There was never any delete code to remove — which is worth saying out loud, so the rewrite says it: kaibo never removes the file, and that is *structurally guaranteed* rather than promised, since `remove_file`/`remove_dir*` sit on `tests/no_write_path.rs`'s forbidden list.

- `src/store.rs:23-31` — module doc. Separates **"crash over corrupt data"** from disposability and restores its actual meaning: never limp along on a damaged db. It never meant the db is cheap.
- `src/main.rs:223-234` — operator-facing startup error, reordered to lead with what kaibo will *not* do, name what is at stake, then give remedies **least destructive first**: fix path/permissions → `--no-persistence` → only then back it up and move it aside by hand.
- `docs/config.md:532,544`, `CHANGELOG.md:360` — the shipped prose.
- `docs/issues.md:233` — the dossier-checkpointing entry called the dossier disposable two lines after calling it the expensive artifact.

Changelog edits the 0.2.0 feature description **in place** rather than adding a Changed entry — persistence ships in this same unreleased section, so the correction belongs in its own description.

## Review

Offline suite green (388 lib + full integration), clippy clean.

Cross-family pass via kaibo's own `consult` (cast `deepseek`), asked to *verify* the structural claim rather than accept it. It confirmed independently: `remove_file(`/`remove_dir(`/`remove_dir_all(` at `tests/no_write_path.rs:46-48`, zero hits in the production half of `store.rs`, and `build_database` (`:559-571`) has no cleanup path — turso errors and kaibo exits. It notes the guarantee is **stronger** than what the doc claims: production code has no mutate path to the file at all outside turso's own SQL. Judged the new error message as needing no change.

Out of scope, surfaced by the review: `docs/kaibo-persistence-and-cli.md` still carries the old framing, and is overdue for deletion by its own rule ("delete it — after the CLI ships"), which shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YK8bXDDZzQkRMuY6DXW4b