### PR TITLE
docs: add OpenAI API plan and agent-neutral guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ general write path; see the read-only invariant.)
 
 - Keep status explicit. If you change direction, say what changed and why. If a tool or
   sandbox blocks work, report the exact blocker and the safe next option.
-- Prefer a worktree for PR work. Amy's local convention is `~/src/wt/<repo>-<topic>`.
+- Prefer a worktree for PR work. Use `~/src/wt/<repo>-<topic>` for local worktrees.
 - Keep `signoff.md` as local, ignored session memory when useful; melt durable parts into
   checked-in docs before they go stale.
 - Use a little 日本語（にほんご）when it fits; add ふりがな for kanji.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,23 @@
 # AGENTS.md — kaibo (解剖)
 
 Kaibo is a stdio MCP server that provides an assistant agent **for other agents**.
-It augments a calling agent (Claude, etc.) with a team of models, lending one kind of
-help — *consultation*: grounded, cited, read-only answers about a codebase. The team
+It augments a calling agent (Codex, Claude, Gemini, local agents, etc.) with a team of
+models, lending one kind of help — *consultation*: grounded, cited, read-only answers
+about a codebase. The team
 *perceives* what fuses into its reasoning (image input today — `view_image` and image
 attachments on the model-driven tools; more modalities as the models gain them), but
 kaibo produces **no output artifacts** — it reasons over code, it doesn't render or
 emit. (If it ever needs to *record* something, that's a specific mediated tool, not a
 general write path; see the read-only invariant.)
+
+## For agents working here
+
+- Keep status explicit. If you change direction, say what changed and why. If a tool or
+  sandbox blocks work, report the exact blocker and the safe next option.
+- Prefer a worktree for PR work. Amy's local convention is `~/src/wt/<repo>-<topic>`.
+- Keep `signoff.md` as local, ignored session memory when useful; melt durable parts into
+  checked-in docs before they go stale.
+- Use a little 日本語（にほんご）when it fits; add ふりがな for kanji.
 
 **Consultation: one primitive, three tools.** The primitive is `run_phase`
 (`consult.rs`): a model + preamble + an *injected toolset*, run as a bounded tool
@@ -199,7 +209,7 @@ Two audiences are optimized differently:
 
 ## Driving the models
 
-How kaibo talks to LLMs — Amy's defaults, made local so any agent here inherits them.
+How kaibo talks to LLMs — project defaults, made local so any agent here inherits them.
 
 - **Thinking ON by default**, every model that supports it, both phases (Anthropic
   `thinking`, Gemini `thinkingConfig`, DeepSeek reasoners; in rig via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,10 @@ model or tool review that changed confidence or content (for example, a kaibo ca
 review). Prefer concrete names and stable identities when the host supplies them; if it
 doesn't, name the model/tool plainly in the PR body instead of inventing an email.
 
+Stage deliberately. Do not use `git add -A`, `git add .`, or broad globs when preparing
+commits; stage only the files intentionally changed for the current task. Check
+`git status --short` before committing, and leave unrelated/untracked user files alone.
+
 ## Pull requests & the changelog
 
 Every change lands through a pull request — `main` is never committed to directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,12 @@ change, **drawn from the conversation with the user**. Commit messages briefly e
 what happened as context for the more important task of explaining the decisions we
 made.
 
+Credit the loop in trailers when it materially shaped the change. Use `Co-authored-by`
+for an agent that wrote or substantially rewrote the patch and `Reviewed-by` for a
+model or tool review that changed confidence or content (for example, a kaibo cast
+review). Prefer concrete names and stable identities when the host supplies them; if it
+doesn't, name the model/tool plainly in the PR body instead of inventing an email.
+
 ## Pull requests & the changelog
 
 Every change lands through a pull request — `main` is never committed to directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ the git log. Each later release appends a new section at the top.
 
 ### Added
 
+- `docs/openai-api-plan.md`, a living plan for making hosted OpenAI a first-class kaibo
+  backend and clarifying that kaibo's OpenAI model calls use OpenAI Platform API keys, not
+  Codex subscription entitlement.
 - **`consult`** — the headline tool: ask a model *outside your own family* about a
   codebase and get a grounded, cited answer. A capable model reads precise spans
   directly and delegates broad sweeps to a cheap explorer sub-agent, then synthesizes

--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ and the one platform-specific edge case — is in
 ## Configuration
 
 The fastest way to set up is to let your agent do it. kaibo ships a **`configure`
-prompt** for exactly this; MCP clients expose prompts in different ways (for example,
-some show it as `/kaibo:configure`). Pass an optional goal such as
+prompt** for exactly this; MCP clients expose prompts in different ways, commonly as
+`/kaibo:configure`. Pass an optional goal such as
 `a local-only privacy cast`. It walks the agent through reading kaibo's config, asking
 which providers you have, and writing your `config.toml` — keeping keys in env vars or
 files, never inline.

--- a/README.md
+++ b/README.md
@@ -299,15 +299,15 @@ and the one platform-specific edge case — is in
 ## Configuration
 
 The fastest way to set up is to let your agent do it. kaibo ships a **`configure`
-prompt** for exactly this — in Claude Code it shows up as `/kaibo:configure` (pass an
-optional goal, e.g. `/kaibo:configure a local-only privacy cast`). It walks the agent
-through reading kaibo's config, asking which providers you have, and writing your
-`config.toml` — keeping keys in env vars or files, never inline.
+prompt** for exactly this; MCP clients expose prompts in different ways (for example,
+some show it as `/kaibo:configure`). Pass an optional goal such as
+`a local-only privacy cast`. It walks the agent through reading kaibo's config, asking
+which providers you have, and writing your `config.toml` — keeping keys in env vars or
+files, never inline.
 
-The file is written by your **host agent** (Claude Code) with its own permissions,
-the same way it edits any file — *not* by kaibo's sandboxed sub-agents, which remain
-strictly read-only and never touch disk. The prompt just hands your agent the
-knowledge to do it.
+The file is written by your **host agent** with its own permissions, the same way it
+edits any file — *not* by kaibo's sandboxed sub-agents, which remain strictly read-only
+and never touch disk. The prompt just hands your agent the knowledge to do it.
 
 The prompt leans on two MCP resources kaibo serves, which you can also read directly:
 
@@ -388,9 +388,9 @@ prices.
 ### `run_kaish` — direct read-only shell
 
 Drive the read-only kaish shell from your agent, no model in the loop: returns exit
-code + stdout + stderr. For a Claude Code user this offers little over the built-in
-Bash tool beyond *safety* — writes and external commands are refused, so exploration
-leaves nothing to review: there's no diff, because nothing it runs can change your tree.
+code + stdout + stderr. For an agent that already has a shell tool, this mostly adds
+*safety* — writes and external commands are refused, so exploration leaves nothing to
+review: there's no diff, because nothing it runs can change your tree.
 
 ---
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -559,7 +559,7 @@ open failure stays fatal.
 kaibo's models are *for other agents*, so it helps when they inherit the calling
 agent's conventions. `[context]` names files whose contents are spliced into each
 consultation tool's preamble (the system prompt) as standing guidance — an
-`AGENTS.md`, a shared `~/.claude/CLAUDE.md`, whatever you call yours. **Vendor-
+`AGENTS.md`, a shared user guidance file, whatever you call yours. **Vendor-
 neutral:** no filename is hardcoded in the product; the only default is the
 emerging cross-tool `AGENTS.md` convention, and that's just a config default you
 can change or turn off.
@@ -572,7 +572,7 @@ project_files = ["AGENTS.md", "docs/CONVENTIONS.md"]
 
 # Absolute/tilde paths, read UNCONDITIONALLY (a missing one is a startup-visible
 # error — you declared it, so kaibo won't silently drop it). Default: none.
-user_files = ["~/.claude/CLAUDE.md"]
+user_files = ["~/.config/kaibo/agent-guidance.md"]
 ```
 
 Two lists, two deliberately different failure semantics:
@@ -589,7 +589,7 @@ Two lists, two deliberately different failure semantics:
 **The trust boundary** (why `user_files` may sit outside the allowed set): these
 files are read in trusted server-side Rust at the tool handler — the same trust
 level as `config.toml` itself — and only their *contents* reach the model, never
-the path. The read-only kaish shell still cannot reach `~/.claude`; the model's
+the path. The read-only kaish shell still cannot reach the user guidance path; the model's
 read scope is *not* widened. That's the distinction from `[server] allow_paths`
 below: `allow_paths` widens what the *model* can explore, `[context]` injects
 fixed operator text the model never navigates to.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -22,6 +22,15 @@ the model-facing surface pass + the full consultation ladder (arc closeout, #37�
 
 ## P1 — High-leverage features & robustness
 
+### Hosted OpenAI as a first-class backend
+The current `openai` kind is generic OpenAI-compatible plumbing: good for local servers
+and usable for hosted GPT when configured manually, but not yet first-class hosted
+OpenAI behavior. The living plan is `docs/openai-api-plan.md`.
+
+Open work in that plan: copy-paste hosted config, live text/image probes with
+`OPENAI_API_KEY`, OpenAI reasoning shaping (today `ProviderKind::Openai` emits no thinking),
+Responses API evaluation, OpenAI Batch, and Platform data-control documentation.
+
 ### Media spine — perception in, production removed
 
 Direction settled 2026-06-28 (w/ Amy): `generate_image` removed and read-only becomes
@@ -249,7 +258,7 @@ GitHub-native tooling: `cosign` **keyless** signing + **SLSA provenance**
 `security-framework`, so we build native anyway); GoReleaser-OSS is an *optional later*
 back-half **only if** package channels (brew/scoop/winget/nfpm) multiply. **GoReleaser Pro
 and any release-as-a-service are off the table** (the latter doesn't viably exist — see the
-doc's axo note). No Windows ABI change — MSVC stays, so the CLAUDE.md invariant is
+doc's axo note). No Windows ABI change — MSVC stays, so the AGENTS.md invariant is
 untouched. The **ghcr image is a first-class, early distribution path** (multiarch, non-root
 default, devcontainer-friendly; an OS-enforced containment layer under kaibo's own read-only
 sandbox) — with a companion **`/reconfigure`** host-agent prompt to tame the docker/podman/
@@ -324,8 +333,7 @@ The `[context]` files are spliced into the preamble whole (`context.rs::assemble
 → `consult.rs::with_house_rules`), the preamble is re-sent on *every* model turn,
 and the block rides every codebase-reading phase — the `consult` driver and each
 nested `explore′` sweep (the toolless `oneshot` reads no project, so it gets none).
-A large `AGENTS.md` +
-`~/.claude/CLAUDE.md` is real token cost multiplied across turns *and* sweeps. No
+A large repo/user guidance bundle is real token cost multiplied across turns *and* sweeps. No
 truncation by design — silent truncation of operator guidance is the wrong failure
 — but a generous cap with a *loud* error (or a startup warning naming the byte
 count) would catch a runaway file before it quietly bloats every call. Measure a

--- a/docs/openai-api-plan.md
+++ b/docs/openai-api-plan.md
@@ -1,0 +1,180 @@
+# OpenAI API integration plan
+
+Living plan started 2026-07-25. Scope: make hosted OpenAI models a first-class kaibo
+backend while preserving the generic OpenAI-compatible path for local servers and gateways.
+
+## Entitlement answer
+
+Use an OpenAI Platform API key for kaibo's OpenAI model calls. Do not tell users that a
+Codex or ChatGPT subscription pays for kaibo's API traffic.
+
+The split matters:
+
+- Codex clients can sign in with ChatGPT subscription access. OpenAI's Codex help says
+  Codex CLI / IDE / web / app use ChatGPT sign-in, and that users who previously used the
+  CLI with an API key can switch to subscription-based access.
+- OpenAI's billing help says ChatGPT and the API Platform use separate billing systems.
+- The OpenAI API quickstart starts with creating/exporting an API key and adding API
+  credits for real application use.
+
+So the near-term product contract is:
+
+```sh
+export OPENAI_API_KEY="..."
+```
+
+plus a configured `kind = "openai"` backend pointed at `https://api.openai.com/v1`.
+
+A future Codex-specific integration would be a separate surface. It would control Codex as
+Codex, not act as a drop-in replacement for kaibo's provider-backed `CompletionModel` arms.
+
+Sources:
+
+- [Using Codex with your ChatGPT plan](https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan.pdf)
+- [Managing Billing Settings on ChatGPT Web and Platform](https://help.openai.com/en/articles/9039756-managing-your-work-in-the-api-platform-with-projects%25252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525253F.docx)
+- [OpenAI API quickstart](https://platform.openai.com/docs/quickstart/make-your-first-api-request)
+
+## Current state in kaibo
+
+- `ProviderKind::Openai` is the generic OpenAI-compatible wire path. It builds a
+  `rig::providers::openai::CompletionsClient` with the backend's `base_url`
+  (`src/consult/engine.rs`).
+- The built-in `openai-local` backend defaults to a local server URL and optional key;
+  hosted OpenAI already works by adding a new backend such as `gpt` with
+  `base_url = "https://api.openai.com/v1"` and `key_optional = false`
+  (`docs/config.md`, `docs/config.example.toml`).
+- Vision is opt-in for generic `openai` slots. A hosted multimodal GPT slot must set
+  `vision = true` until kaibo has a trustworthy OpenAI model-capability classifier.
+- `view_image` already handles the OpenAI transport mismatch: OpenAI-compatible wires do
+  not carry image bytes in tool results, so kaibo rewrites viewed images onto a user image
+  turn before resuming the model loop (`src/consult/shaping.rs`,
+  `src/consult/engine.rs`).
+- Request shaping is incomplete for hosted OpenAI. `ProviderKind::Openai` currently maps
+  to `ThinkingStyle::None`, so reasoning-capable GPT models do not receive OpenAI
+  reasoning params. `docs/issues.md` already tracks this.
+- OpenAI batch is not implemented. The existing batch lane supports Anthropic and Gemini;
+  `docs/issues.md` tracks OpenAI's file-based batch shape as the next provider.
+
+## Direction
+
+Keep two paths distinct:
+
+1. **Generic OpenAI-compatible** — local llama.cpp/Ollama/LM Studio gateways and other
+   `/v1/chat/completions`-compatible servers. Preserve maximum compatibility. Do not assume
+   reasoning, batch, Files, or Responses support.
+2. **Hosted OpenAI** — a named backend using OpenAI Platform auth and API semantics. This
+   is where OpenAI model defaults, reasoning params, Responses API evaluation, file inputs,
+   and OpenAI Batch belong.
+
+The existing `kind = "openai"` can keep carrying both only if hosted-only features are
+gated by explicit backend/slot capability. If that becomes awkward, split a first-class
+`openai-hosted` kind rather than weakening the local-compatible path.
+
+## Work plan
+
+### 1. Document the hosted OpenAI config
+
+Add a short README/config example that is copy-pasteable:
+
+```toml
+[backends.gpt]
+kind = "openai"
+base_url = "https://api.openai.com/v1"
+api_key_env = "OPENAI_API_KEY"
+key_optional = false
+
+[casts.gpt]
+explorer = { backend = "gpt", id = "gpt-5.6-luna" }
+synth = { backend = "gpt", id = "gpt-5.6-terra", vision = true }
+```
+
+Model IDs must be checked against current OpenAI docs when the implementation PR starts;
+provider defaults drift.
+
+### 2. Probe hosted OpenAI with the current implementation
+
+With `OPENAI_API_KEY` set:
+
+- `oneshot` text-only call on the hosted cast.
+- `oneshot` with an image attachment on a `vision = true` synth.
+- `consult` that calls `view_image`, verifying the user-turn rewrite reaches the model.
+- Failure probe with `vision = false`, verifying kaibo refuses image input before a
+  provider call.
+- Trace check for `gen_ai.request.thinking`; expected today: absent for `openai`.
+
+Record results in `docs/devlog.md` if they drive a change.
+
+### 3. Add OpenAI reasoning shaping
+
+Official current guidance for GPT-5.6 says to use the Responses API for reasoning,
+tool-calling, and multi-turn workflows, and to set `reasoning.effort` intentionally.
+OpenAI's API reference also exposes reasoning effort on modern response/chat shapes.
+
+Implementation choices to settle with tests:
+
+- If staying on rig's Chat Completions client, verify whether `additional_params` can
+  safely carry `reasoning_effort` and the correct output-token field for current hosted
+  GPT models.
+- If moving hosted OpenAI to Responses, add a small direct client arm rather than forcing
+  Responses semantics through the generic OpenAI-compatible path.
+- Preserve kaibo's doctrine: reasoning on by default where the model supports it; explicit
+  opt-out per slot; no silent "reasoning absent" for a reasoning-capable hosted model.
+
+Test shape:
+
+- `ModelShape::resolve(ProviderKind::Openai, "gpt-…")` emits the selected OpenAI reasoning
+  params.
+- `sinks_effort` / inert tunable rendering treat OpenAI reasoning-capable models as effort
+  sinks.
+- Non-reasoning/local OpenAI-compatible slots can remain no-reasoning by explicit shape or
+  backend capability.
+
+Sources:
+
+- [Latest OpenAI model guidance](https://developers.openai.com/api/docs/guides/latest-model)
+- [Responses streaming reference: reasoning](https://platform.openai.com/docs/api-reference/responses-streaming/response/refusal/delta?lang=curl)
+
+### 4. Re-evaluate Responses API for hosted OpenAI
+
+OpenAI's help recommends the Responses API unless it lacks a capability the older
+Completions APIs provide. For kaibo, the decision hinges on whether rig's current OpenAI
+provider preserves the features kaibo needs:
+
+- tool calling over repeated turns;
+- image input;
+- model reasoning controls;
+- output token caps with reasoning-token headroom;
+- usage reporting, especially reasoning tokens;
+- prompt caching controls if useful for long resident preambles.
+
+If Responses wins, keep the direct client narrow and test it offline with scripted request
+serialization before any live probe.
+
+### 5. Add OpenAI Batch after interactive hosted OpenAI is correct
+
+OpenAI Batch is file-based: upload JSONL, create a batch against an endpoint, poll, then
+download output/error files. That is a different body and lifecycle from Anthropic's and
+Gemini's current batch implementations.
+
+Open questions:
+
+- whether kaibo deletes OpenAI output files by default or leaves them for audit/debug;
+- whether OpenAI batch starts on `/v1/responses`, `/v1/chat/completions`, or both;
+- how image/file attachments are represented in JSONL without creating a model-steerable
+  write path.
+
+Source:
+
+- [OpenAI Batch API reference](https://platform.openai.com/docs/api-reference/batch/object?api-mode=responses)
+
+### 6. Security and privacy checks
+
+- Keep API keys out of config values; use env var names or key files only.
+- Document that OpenAI API data controls are Platform controls, not ChatGPT subscription
+  controls.
+- For image/file inputs, note OpenAI's endpoint data policy: the Platform docs say image
+  and file inputs can be scanned for safety even when some retention controls are enabled.
+
+Source:
+
+- [OpenAI Platform data controls](https://platform.openai.com/docs/models/default-usage-policies-by-endpoint)

--- a/docs/openai-api-plan.md
+++ b/docs/openai-api-plan.md
@@ -31,7 +31,7 @@ Codex, not act as a drop-in replacement for kaibo's provider-backed `CompletionM
 Sources:
 
 - [Using Codex with your ChatGPT plan](https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan.pdf)
-- [Managing Billing Settings on ChatGPT Web and Platform](https://help.openai.com/en/articles/9039756-managing-your-work-in-the-api-platform-with-projects%25252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525253F.docx)
+- [Managing Billing Settings on ChatGPT Web and Platform](https://help.openai.com/en/articles/9039756-managing-your-work-in-the-api-platform-with-projects)
 - [OpenAI API quickstart](https://platform.openai.com/docs/quickstart/make-your-first-api-request)
 
 ## Current state in kaibo

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -120,7 +120,7 @@ born signed.**
 
 This doc is the *pipeline* side only. The operator-side checklist for actually cutting
 a release (CHANGELOG retitle, kaish-kernel pin check, `docs/sandbox-probes.md` re-run,
-`cargo tree -i aws-lc-rs` empty, musl `not a dynamic executable`) lives in CLAUDE.md
+`cargo tree -i aws-lc-rs` empty, musl `not a dynamic executable`) lives in AGENTS.md
 **Cutting a release** — the two reference each other so neither drifts.
 
 ## The decisions (settled 2026-06-25, with Amy)
@@ -213,7 +213,7 @@ Validated and actionable, with their home PR:
 
 - **"C-free" is imprecise** (both reviewers). `ring` *does* compile C/asm (via `cc` /
   `zig cc`); the tree is free of *cmake/autotools/OpenSSL/aws-lc system-C*, not free of C.
-  Tighten the wording in `release.yml` comments and the CLAUDE.md **Build & release** /
+  Tighten the wording in `release.yml` comments and the AGENTS.md **Build & release** /
   **TLS** lines when PR 2/3 touches them. (No behavior change — the invariant holds; `cargo
   tree -i aws-lc-rs` stays empty.)
 - **cosign keyless `verify-blob` fails without identity flags** (Gemini). A bare verify
@@ -274,7 +274,7 @@ No framework, no ABI change — sharpen what's already there.
 - **Install `cargo-zigbuild` prebuilt** (a SHA-pinned installer action, e.g.
   `taiki-e/install-action`) instead of `cargo install --locked` compiling it from
   source on every run.
-- Tighten the **"C-free" wording** in the workflow comments (and CLAUDE.md if touched).
+- Tighten the **"C-free" wording** in the workflow comments (and AGENTS.md if touched).
 - **Validation gate:** the matrix already builds all five natively; confirm the musl binary
   is `not a dynamic executable` (`ldd`) and `cargo tree -i aws-lc-rs` is empty.
 - Cross-family review (release surface — a real look).
@@ -311,15 +311,15 @@ the meantime).
 
 ### Container UX: the configurator / `reconfigure` pass (related host-agent workstream)
 The Docker downside is real — a verbose `docker run -i -u … -v …` line is painful to get
-right in `claude mcp add`, and iterating means a frustrating remove/re-add loop. Fix it in
+right in an MCP registration command, and iterating can mean a frustrating remove/re-add loop. Fix it in
 two phases: a known-good **baseline** `mcp add` (cwd mounted read-only) connects you, then a
 companion **`/reconfigure`** rewrites the *stored* MCP config **in place** for the user's
 real setup — podman vs docker, UID mapping, extra roots/worktrees, network policy,
-devcontainer nesting — which kills the re-add loop (you edit `~/.claude.json`, you don't
-re-run `mcp add`).
+devcontainer nesting — which kills the re-add loop (you edit the stored MCP config, you
+don't re-run `mcp add`).
 
 **Where it lives matters for the invariants:** kaibo is read-only and runs no external
-commands, so it **cannot** write `~/.claude.json` or run docker itself. So `reconfigure` is
+commands, so it **cannot** write a host MCP config file or run docker itself. So `reconfigure` is
 a **host-agent skill / a kaibo-provided MCP *prompt***: kaibo *advises* (it already knows
 the roots/mounts it needs and exposes them via `kaibo://config`, so it can hand the agent
 the exact `-v` flags), and the host agent *acts* (edits the config with its own tools). That
@@ -363,9 +363,9 @@ reference for the signing/attestation layer other projects lack:
 - **Docker — RESOLVED (2026-06-25, with Amy): keep & promote** to a first-class, early
   distribution path (multiarch, non-root default, devcontainer-friendly). See decision 4 and
   PR 4.
-- **Configurator / `reconfigure` ownership & scope** — a kaibo MCP prompt, a Claude Code
+- **Configurator / `reconfigure` ownership & scope** — a kaibo MCP prompt, a host-agent
   skill, or both? How much does it auto-detect (podman/devcontainer/UID) vs. ask? It edits a
-  sensitive file (`~/.claude.json`) with the *host agent's* tools (kaibo can't), so consent/
+  sensitive MCP config file with the *host agent's* tools (kaibo can't), so consent/
   safety shape it. Design when PR 4's container UX is real.
 - **How many channels?** Few (a brew tap) → hand-roll, no GoReleaser. Many (brew+scoop+winget+nfpm)
   → bring in GoReleaser-OSS as the back-half. Decide when demand is real, not now.


### PR DESCRIPTION
## Summary

- keep `AGENTS.md` as the canonical cross-agent repo guidance and add a short front-door for agents working here
- neutralize current Claude-specific wording where the text is meant to apply to any host agent/client
- add `docs/openai-api-plan.md` as the living plan for first-class hosted OpenAI support
- record the OpenAI entitlement answer: kaibo model calls use OpenAI Platform API keys/billing, not Codex subscription entitlement

## Decisions

Amy clarified that `AGENTS.md` is already the right shared filename; we should not rename or move it. The tracked `CLAUDE.md` symlink remains a compatibility detail and does not need resident-token explanation.

The claudism pass is deliberately narrow. Historical devlog entries, concrete Claude Code observations, model names, and Claude-specific command examples stay where they carry real evidence or usage value. Current guidance and generic plans now say host agent / MCP client / user guidance instead.

For OpenAI: hosted GPT can already be configured through the generic `openai` kind, but it is not first-class yet. The plan keeps local OpenAI-compatible servers and hosted OpenAI semantically distinct, then sequences probes, reasoning shaping, Responses API evaluation, and OpenAI Batch.

## Attribution

Implementation assistance: Codex / Terra (OpenAI), working in the Codex harness.

Review: kaibo `consult` with cast `deepseek` (`deepseek-v4-flash` explorer, `deepseek-v4-pro` synth). The review found the broken billing URL and two wording nits; those landed as the follow-up commit `d69877b`.

Suggested merge-commit note: "Authored with Codex/Terra; reviewed with kaibo using the DeepSeek cast." No `Co-authored-by` or `Reviewed-by` trailers are included here because the agents did not provide stable email identities.

## Validation

- `git diff --check`
- kaibo/DeepSeek review of PR #90

No Rust tests were run; this is documentation-only.
