### PR TITLE
Route hosted GPT through Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ the git log. Each later release appends a new section at the top.
 
 ### Added
 
+- **Hosted OpenAI Platform backends now use the Responses API for interactive GPT calls.**
+  A `kind = "openai"` backend pointed exactly at `https://api.openai.com/v1` can run
+  current GPT-5.6 models through `oneshot` and `consult`, including image attachment and
+  `view_image`; generic/local OpenAI-compatible backends stay on the Chat Completions path.
 - `docs/openai-api-plan.md`, a living plan for making hosted OpenAI a first-class kaibo
   backend and clarifying that kaibo's OpenAI model calls use OpenAI Platform API keys, not
-  Codex subscription entitlement.
+  Codex subscription entitlement. It also tracks OpenAI's `/v1/batch` support and the
+  kaibo provider adapter still needed before Sol can run on kaibo's offline batch lane.
 - **`consult`** — the headline tool: ask a model *outside your own family* about a
   codebase and get a grounded, cited answer. A capable model reads precise spans
   directly and delegates broad sweeps to a cheap explorer sub-agent, then synthesizes
@@ -408,6 +413,9 @@ the git log. Each later release appends a new section at the top.
 
 ### Changed
 
+- Hosted GPT examples now use the current GPT-5.6 family: a fast/tool-capable
+  `gpt-5.6-luna` explorer paired with `gpt-5.6-sol` as the flagship consult synth, plus
+  `gpt-5.6-terra` as a balanced alternative.
 - **The README earns its shop window.** A nine-model reader panel (personas played
   by DeepSeek, GLM, GPT, Kimi, Qwen, Gemini, Claude — full study in the PR) read the
   page cold and told us where it lost them, so it changed: a real worked example up

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ key_optional = true
 # the answer. Two families, not two flavors of one.)
 [casts.mixed]
 explorer = "llama/qwen2.5-coder-7b"       # cheap, local sweeps — Qwen family
-synth    = "gpt/gpt-5"                     # the answer gets the big model — GPT family
+synth    = { backend = "gpt", id = "gpt-5.6-sol", vision = true, effort = "high" }
 ```
 
 Some default casts ship in code so kaibo runs with zero config; your `config.toml`

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -269,7 +269,7 @@ key_optional = true                          # keyless local default → placeho
 kind = "openai"
 base_url = "https://api.openai.com/v1"
 api_key_env = "OPENAI_API_KEY"
-aliases = ["oai"]                            # now `oai/gpt-5` resolves to this backend
+aliases = ["oai"]                            # now `oai/gpt-5.6-sol` resolves to this backend
 key_optional = false
 
 # A second local llama.cpp server on another port, keyless. A slow local model
@@ -365,11 +365,20 @@ synth    = { backend = "openrouter", id = "~anthropic/claude-sonnet-latest", eff
 explorer = { backend = "gemma", id = "Gemma-4-E4B-it-GGUF", preamble = "You are a careful reader. Quote exact numbered lines; never guess a path." }
 synth    = "claude/claude-sonnet-4-6"        # no per-model prompt → [prompts] or built-in
 
-# --- Hosted GPT end to end, both roles on the keyed backend above. ---
+# --- Hosted GPT end to end, both roles on the keyed backend above.
+#     Sol is the flagship synth; Luna is the fast/tool-capable explorer. Both slots
+#     pin vision because generic openai endpoints default blind until you say otherwise.
+#     Use `effort = "none"` / "low" / "medium" / "high" / "xhigh" / "max" per slot
+#     to trade latency/cost against reasoning depth on the GPT-5.6 family. ---
 
 [casts.gpt]
-explorer = "gpt/gpt-5-mini"
-synth    = "gpt/gpt-5"
+explorer = { backend = "gpt", id = "gpt-5.6-luna", vision = true, effort = "low" }
+synth    = { backend = "gpt", id = "gpt-5.6-sol",  vision = true, effort = "high" }
+
+# A cheaper balanced hosted GPT cast: same fast explorer, Terra as the answerer.
+[casts.gpt-balanced]
+explorer = { backend = "gpt", id = "gpt-5.6-luna",  vision = true, effort = "low" }
+synth    = { backend = "gpt", id = "gpt-5.6-terra", vision = true, effort = "medium" }
 
 # --- A custom batch cast: the offline `batch_submit` lane (max thinking). `lane = "batch"`
 #     on the SYNTH SLOT declares it (lane is a per-slot property, not a cast-level one —

--- a/docs/config.md
+++ b/docs/config.md
@@ -335,7 +335,7 @@ key_optional = true
 
 [casts.mixed]
 explorer = "llama/qwen2.5-coder-7b"     # sweeps stay local and free
-synth    = "gpt/gpt-5"                  # the answer gets the big model
+synth    = { backend = "gpt", id = "gpt-5.6-sol", vision = true, effort = "high" }
 ```
 
 `cast = "mixed"`, `cast = "gpt"` (if you define it), and the built-in

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -96,6 +96,42 @@ container-evaporation guard it must ship with, are in `issues.md`.
 
 ---
 
+## 2026-07-25 — hosted OpenAI moved onto Responses for current GPT
+
+After the OpenAI entitlement doc landed, Amy generated a Platform API key and we ran the
+hosted path through kaibo instead of guessing from the config. The first probe split the
+problem cleanly: the account and key were fine, but `gpt-5.6-sol` rejected the generic
+Chat Completions request because rig sent `max_tokens`. The fix was not a new credential
+story; it was a hosted-OpenAI request-shaping seam.
+
+We kept the product split explicit. `ProviderKind::Openai` still means the OpenAI-shaped
+wire protocol, so local llama.cpp/Ollama/LM Studio-style endpoints stay on the old
+permissive Chat Completions client. Only an exact hosted Platform endpoint
+(`https://api.openai.com/v1`) moves to rig's Responses client. That gives current GPT
+models the output-token mapping, image input, and tool-loop shape they expect without
+silently imposing hosted semantics on local gateways.
+
+The hosted seam is deliberately model-aware rather than just provider-aware. GPT-5-family
+slots send `reasoning.effort` and suppress sampling, because the live Sol probe rejected
+custom `temperature`. Older hosted chat models such as `gpt-4.1-mini` keep sampling and do
+not receive `reasoning.effort`, because a live probe rejected that field there. Unknown
+hosted OpenAI ids get no extra params until probed. `kaibo://config` now follows the same
+classification so an explicit per-slot `effort` or `temperature` is flagged inert only
+when that endpoint+model has no sink for it.
+
+The proof stack was live and offline. `gpt-5.6-sol` answered a text `oneshot`, read
+`docs/brand/banner-teal.png` through image attachment, and answered the same image question
+through `consult` + `view_image`; a `vision = false` synth refused the image locally before
+any provider call. `gpt-4.1-mini` stayed usable on the hosted Responses seam after the
+reasoning field was suppressed. Offline tests pin exact hosted endpoint detection, GPT-5.6
+Responses params, GPT-4.1 sampling behavior, and config-resource inert tunables.
+
+Config examples now show the intended consult pairing: `gpt-5.6-luna` as the fast,
+tool-capable explorer and `gpt-5.6-sol` as the flagship synth, with `gpt-5.6-terra` as a
+balanced alternative. OpenAI Batch is the next lane: OpenAI supports `/v1/batch` for
+`/v1/responses`, but kaibo still needs the file/JSONL provider adapter before Sol can be
+used offline the way Anthropic/Gemini batch casts are today.
+
 ## 2026-07-18 — Gemini's effort lever was silently disconnected
 
 Investigating batch truncation (#79, already fixed) turned up a *separate* correctness

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -22,14 +22,23 @@ the model-facing surface pass + the full consultation ladder (arc closeout, #37�
 
 ## P1 — High-leverage features & robustness
 
-### Hosted OpenAI as a first-class backend
-The current `openai` kind is generic OpenAI-compatible plumbing: good for local servers
-and usable for hosted GPT when configured manually, but not yet first-class hosted
-OpenAI behavior. The living plan is `docs/openai-api-plan.md`.
+### OpenAI Batch provider lane
 
-Open work in that plan: copy-paste hosted config, live text/image probes with
-`OPENAI_API_KEY`, OpenAI reasoning shaping (today `ProviderKind::Openai` emits no thinking),
-Responses API evaluation, OpenAI Batch, and Platform data-control documentation.
+Hosted OpenAI interactive calls now have a first-class Responses path, but kaibo's batch
+lane still supports only Anthropic and Gemini. OpenAI's Batch API is file-based: upload
+JSONL with purpose `batch`, create a batch for an endpoint such as `/v1/responses`, poll,
+then download output/error files. That lifecycle needs its own provider adapter, not a
+flag on the interactive OpenAI arm.
+
+The kaibo contract should match Anthropic/Gemini batch: no tools during the provider
+batch. `batch_submit` is one tool-less answer per item; `deliberate` is the codebase-aware
+path, using an interactive medium-tier model to build a cited dossier before handing that
+dossier to a Sol batch synth.
+
+Open work: decide whether the first OpenAI batch adapter is Responses-only or also carries
+a Chat Completions fallback, define output-file retention/deletion policy, and map direct
+`batch_submit` attachments into JSONL without adding a model-steerable write path. The
+living plan is `docs/openai-api-plan.md`.
 
 ### `deliberate` cannot be staffed by any built-in cast — advertised but DOA
 `cast_can_deliberate` (`config.rs:846`) needs an **offline synth lane plus an explorer
@@ -474,9 +483,11 @@ toolless, max-effort fan-out behind the `BatchProvider` seam, with the design ra
 in the module doc and `docs/devlog.md`. What's left:
 
 - **OpenAI batch** — file-based (upload JSONL, reference a file id, poll, download an
-  output file), unlike Anthropic's inline POST. The output file is left in place by
-  default; add a `config.toml` flag to opt into cleanup for callers who'd rather not
-  accrete files. The generic local `openai` kind stays ✗ (no batch endpoint).
+  output file), unlike Anthropic's inline POST. Same kaibo semantics as the existing
+  providers: no tools in the provider batch; `deliberate` builds the dossier first when
+  codebase context is needed. The output file is left in place by default; add a
+  `config.toml` flag to opt into cleanup for callers who'd rather not accrete files. The
+  generic local `openai` kind stays ✗ (no batch endpoint).
 - **The many-casts fork.** `batch_submit` today is many-prompts/**one**-cast (one
   provider batch). The diverse-opinion panel — one question across **many** casts — is N
   provider batches under a composite handle; deferred. The provenance footer already

--- a/docs/openai-api-plan.md
+++ b/docs/openai-api-plan.md
@@ -36,24 +36,40 @@ Sources:
 
 ## Current state in kaibo
 
-- `ProviderKind::Openai` is the generic OpenAI-compatible wire path. It builds a
-  `rig::providers::openai::CompletionsClient` with the backend's `base_url`
-  (`src/consult/engine.rs`).
+- `ProviderKind::Openai` still covers generic OpenAI-compatible endpoints. The built-in
+  `openai-local` backend stays on rig's Chat Completions client so local llama.cpp/Ollama/
+  LM Studio-style servers keep the permissive `/v1/chat/completions` shape.
+- A backend whose kind is `openai` and whose resolved base URL is exactly
+  `https://api.openai.com/v1` is treated as hosted OpenAI. That arm uses rig's Responses
+  client for interactive calls (`oneshot`/`consult`) so current GPT models get the output
+  token mapping and multimodal/tool-loop shape they expect.
 - The built-in `openai-local` backend defaults to a local server URL and optional key;
-  hosted OpenAI already works by adding a new backend such as `gpt` with
+  hosted OpenAI works by adding a new backend such as `gpt` with
   `base_url = "https://api.openai.com/v1"` and `key_optional = false`
   (`docs/config.md`, `docs/config.example.toml`).
+- Live probes on 2026-07-25 confirmed the hosted path:
+  - `gpt-5.6-sol` text `oneshot` passed through the Responses arm.
+  - `gpt-5.6-sol` `oneshot --attach docs/brand/banner-teal.png` saw the PNG and answered
+    `kaibo`.
+  - `gpt-5.6-sol` `consult` answered an image question through the model loop and
+    `view_image` rewrite path.
+  - A `vision = false` synth refused the same image locally before any provider call.
+  - `gpt-4.1-mini` remains usable on the hosted Responses seam with sampling and without
+    `reasoning.effort`.
 - Vision is opt-in for generic `openai` slots. A hosted multimodal GPT slot must set
   `vision = true` until kaibo has a trustworthy OpenAI model-capability classifier.
 - `view_image` already handles the OpenAI transport mismatch: OpenAI-compatible wires do
   not carry image bytes in tool results, so kaibo rewrites viewed images onto a user image
   turn before resuming the model loop (`src/consult/shaping.rs`,
   `src/consult/engine.rs`).
-- Request shaping is incomplete for hosted OpenAI. `ProviderKind::Openai` currently maps
-  to `ThinkingStyle::None`, so reasoning-capable GPT models do not receive OpenAI
-  reasoning params. `docs/issues.md` already tracks this.
-- OpenAI batch is not implemented. The existing batch lane supports Anthropic and Gemini;
-  `docs/issues.md` tracks OpenAI's file-based batch shape as the next provider.
+- Hosted OpenAI shaping is model-aware but intentionally conservative:
+  - GPT-5-family models receive `reasoning.effort` and no sampling knobs.
+  - Known older chat families (`gpt-4*`, `gpt-3.5*`, `chatgpt-*`) keep sampling and do
+    not receive `reasoning.effort`.
+  - Unknown hosted OpenAI IDs get no extra params until probed or explicitly classified.
+- OpenAI Batch is supported by OpenAI's API, including `/v1/responses`, but kaibo has not
+  implemented that provider lane yet. The existing kaibo batch lane supports Anthropic and
+  Gemini; OpenAI's file/JSONL batch lifecycle is tracked as the next provider.
 
 ## Direction
 
@@ -70,11 +86,9 @@ The existing `kind = "openai"` can keep carrying both only if hosted-only featur
 gated by explicit backend/slot capability. If that becomes awkward, split a first-class
 `openai-hosted` kind rather than weakening the local-compatible path.
 
-## Work plan
+## Shipped implementation slice
 
-### 1. Document the hosted OpenAI config
-
-Add a short README/config example that is copy-pasteable:
+### 1. Hosted OpenAI config
 
 ```toml
 [backends.gpt]
@@ -84,90 +98,102 @@ api_key_env = "OPENAI_API_KEY"
 key_optional = false
 
 [casts.gpt]
-explorer = { backend = "gpt", id = "gpt-5.6-luna" }
-synth = { backend = "gpt", id = "gpt-5.6-terra", vision = true }
+explorer = { backend = "gpt", id = "gpt-5.6-luna", vision = true, effort = "low" }
+synth    = { backend = "gpt", id = "gpt-5.6-sol",  vision = true, effort = "high" }
 ```
 
-Model IDs must be checked against current OpenAI docs when the implementation PR starts;
-provider defaults drift.
+The example pairs Sol with a fast/tool-capable Luna explorer for consult mode. OpenAI's
+current guidance describes Sol as the flagship model, Terra as the balanced model, and Luna
+as the efficient/high-volume model; all three are current GPT-5.6 Responses models with
+reasoning, vision input, and tool support.
 
-### 2. Probe hosted OpenAI with the current implementation
-
-With `OPENAI_API_KEY` set:
-
-- `oneshot` text-only call on the hosted cast.
-- `oneshot` with an image attachment on a `vision = true` synth.
-- `consult` that calls `view_image`, verifying the user-turn rewrite reaches the model.
-- Failure probe with `vision = false`, verifying kaibo refuses image input before a
-  provider call.
-- Trace check for `gen_ai.request.thinking`; expected today: absent for `openai`.
-
-Record results in `docs/devlog.md` if they drive a change.
-
-### 3. Add OpenAI reasoning shaping
+### 2. Responses shaping for current GPT
 
 Official current guidance for GPT-5.6 says to use the Responses API for reasoning,
 tool-calling, and multi-turn workflows, and to set `reasoning.effort` intentionally.
-OpenAI's API reference also exposes reasoning effort on modern response/chat shapes.
 
-Implementation choices to settle with tests:
+Implementation choices:
 
-- If staying on rig's Chat Completions client, verify whether `additional_params` can
-  safely carry `reasoning_effort` and the correct output-token field for current hosted
-  GPT models.
-- If moving hosted OpenAI to Responses, add a small direct client arm rather than forcing
-  Responses semantics through the generic OpenAI-compatible path.
-- Preserve kaibo's doctrine: reasoning on by default where the model supports it; explicit
-  opt-out per slot; no silent "reasoning absent" for a reasoning-capable hosted model.
+- Use rig's Responses client for exact hosted OpenAI Platform endpoints, leaving
+  `openai-local` and other OpenAI-compatible gateways on Chat Completions.
+- Keep reasoning on by default for GPT-5-family hosted slots through `reasoning.effort`.
+- Suppress custom sampling for current GPT reasoning models because the live provider probe
+  rejected `temperature` there.
+- Keep sampling for known older hosted chat models, and suppress `reasoning.effort` because
+  the live `gpt-4.1-mini` probe rejected it.
 
-Test shape:
+Tests pin:
 
-- `ModelShape::resolve(ProviderKind::Openai, "gpt-…")` emits the selected OpenAI reasoning
-  params.
-- `sinks_effort` / inert tunable rendering treat OpenAI reasoning-capable models as effort
-  sinks.
-- Non-reasoning/local OpenAI-compatible slots can remain no-reasoning by explicit shape or
-  backend capability.
+- exact hosted endpoint detection;
+- GPT-5.6 hosted arms using Responses params with `reasoning.effort`, no sampling, and no
+  legacy output-token field in `additional_params`;
+- GPT-4.1 hosted arms keeping sampling while omitting reasoning;
+- `kaibo://config` marking per-slot `effort`/`temperature` no-ops by endpoint and model,
+  not by provider alone.
 
 Sources:
 
 - [Latest OpenAI model guidance](https://developers.openai.com/api/docs/guides/latest-model)
-- [Responses streaming reference: reasoning](https://platform.openai.com/docs/api-reference/responses-streaming/response/refusal/delta?lang=curl)
+- [OpenAI model catalog](https://developers.openai.com/api/docs/models)
 
-### 4. Re-evaluate Responses API for hosted OpenAI
+## Remaining work plan
 
-OpenAI's help recommends the Responses API unless it lacks a capability the older
-Completions APIs provide. For kaibo, the decision hinges on whether rig's current OpenAI
-provider preserves the features kaibo needs:
+### 1. Add OpenAI Batch
 
-- tool calling over repeated turns;
-- image input;
-- model reasoning controls;
-- output token caps with reasoning-token headroom;
-- usage reporting, especially reasoning tokens;
-- prompt caching controls if useful for long resident preambles.
+OpenAI Batch is file-based: upload JSONL with purpose `batch`, create a batch against an
+endpoint, poll, then download output/error files. OpenAI's Batch API supports
+`/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/completions`, and
+`/v1/moderations`; GPT-5.6 Sol/Terra/Luna model pages list `v1/batch` as an endpoint.
 
-If Responses wins, keep the direct client narrow and test it offline with scripted request
-serialization before any live probe.
+That is a different body and lifecycle from Anthropic's and Gemini's current batch
+implementations, so this should be a dedicated provider adapter, not a thin flag on the
+interactive path.
 
-### 5. Add OpenAI Batch after interactive hosted OpenAI is correct
+The product shape should match the existing batch doctrine:
 
-OpenAI Batch is file-based: upload JSONL, create a batch against an endpoint, poll, then
-download output/error files. That is a different body and lifecycle from Anthropic's and
-Gemini's current batch implementations.
+- `batch_submit` stays tool-less. Each OpenAI batch item is one prompt plus shared
+  attachments, answered once from what it was handed. No kaish, no explorer, no tool loop.
+- `deliberate` is how OpenAI batch gets codebase understanding. An interactive explorer
+  builds the cited dossier first; the batch synth receives that dossier as text and reasons
+  over it offline.
+- Sol is a natural batch synth once the provider adapter exists. Pair it with a medium
+  dossier builder for deliberate rather than trying to give the batch request tools.
 
-Open questions:
+Intended config shape after the adapter ships:
+
+```toml
+[casts.gpt-batch]
+batch = true
+synth = "gpt/gpt-5.6-sol"
+
+[casts.gpt-deliberate]
+explorer = { backend = "gpt", id = "gpt-5.6-terra", vision = true, effort = "medium" }
+synth    = { backend = "gpt", id = "gpt-5.6-sol", lane = "batch" }
+```
+
+Open implementation questions:
 
 - whether kaibo deletes OpenAI output files by default or leaves them for audit/debug;
-- whether OpenAI batch starts on `/v1/responses`, `/v1/chat/completions`, or both;
-- how image/file attachments are represented in JSONL without creating a model-steerable
-  write path.
+- whether kaibo's first OpenAI batch adapter starts on `/v1/responses` only, or keeps a
+  fallback `/v1/chat/completions` body for older models;
+- how direct `batch_submit` image/file attachments are represented in OpenAI JSONL. For
+  `deliberate`, the synth should not receive images or tools directly; the explorer's
+  dossier is the handoff.
 
 Source:
 
 - [OpenAI Batch API reference](https://platform.openai.com/docs/api-reference/batch/object?api-mode=responses)
 
-### 6. Security and privacy checks
+### 2. Probe optional OpenAI surfaces
+
+- Codex-specialized model slugs exposed to some accounts: useful candidate for review casts,
+  but do not promote to the canonical example until probed through kaibo's Responses arm.
+- GPT-5.6 pro mode: possible fit for deliberate/deep review, but it changes latency and cost;
+  add only with explicit config/tests and a live comparison.
+- Persisted Responses/conversation state: likely not needed for kaibo's own bounded loops yet,
+  and may complicate the read-only/account-state boundary.
+
+### 3. Security and privacy checks
 
 - Keep API keys out of config values; use env var names or key files only.
 - Document that OpenAI API data controls are Platform controls, not ChatGPT subscription

--- a/src/config.rs
+++ b/src/config.rs
@@ -496,6 +496,16 @@ impl Backend {
             .unwrap_or_else(credentials::openai_base_url)
     }
 
+    /// True for a generic `openai` backend that is explicitly aimed at OpenAI
+    /// Platform. This is the narrow capability seam that lets kaibo use OpenAI's
+    /// first-party Responses shape for hosted GPT models while preserving the
+    /// local/OpenAI-compatible `/chat/completions` path for `openai-local` and
+    /// gateways that do not implement `/responses`.
+    pub fn is_hosted_openai(&self) -> bool {
+        self.kind == ProviderKind::Openai
+            && self.resolved_base_url().trim_end_matches('/') == credentials::HOSTED_OPENAI_BASE_URL
+    }
+
     /// Whether this backend has a usable credential, judged *without* committing to a
     /// network call or pulling the secret into the answer path — the non-fatal sibling
     /// of [`resolve_key`](Self::resolve_key). It mirrors the same precedence (env var,
@@ -3684,6 +3694,33 @@ mod tests {
         .unwrap();
         let b = cfg.backends.get("anthropic").unwrap();
         assert_eq!(b.base_url.as_deref(), Some("http://ai.example.ts.net"));
+    }
+
+    /// Hosted OpenAI is still `kind = "openai"`, but the first-party endpoint is
+    /// a capability signal: kaibo can use rig's Responses API there while leaving
+    /// local OpenAI-compatible servers on Chat Completions. Normalize a harmless
+    /// trailing slash; do not guess that any other OpenAI-compatible URL supports
+    /// `/responses`.
+    #[test]
+    fn hosted_openai_detection_is_endpoint_exact() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [backends.gpt]
+            kind = "openai"
+            base_url = "https://api.openai.com/v1/"
+
+            [backends.localish]
+            kind = "openai"
+            base_url = "http://localhost:13305/api/v1"
+
+            [casts.x]
+            synth = "gpt/gpt-5.6-sol"
+            "#,
+        )
+        .unwrap();
+        assert!(cfg.backends["gpt"].is_hosted_openai());
+        assert!(!cfg.backends["localish"].is_hosted_openai());
+        assert!(!cfg.backends["anthropic"].is_hosted_openai());
     }
 
     /// A backend name containing '/' is refused at load. Both the slot ref

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -63,6 +63,7 @@ trait PhaseRunner: Send + Sync {
         &'a self,
         preamble: &'a str,
         max_tokens: u64,
+        temperature: Option<f64>,
         initial_prompt: Message,
         max_turns: usize,
         params: Option<&'a Value>,
@@ -92,6 +93,7 @@ where
         &'a self,
         preamble: &'a str,
         max_tokens: u64,
+        temperature: Option<f64>,
         initial_prompt: Message,
         max_turns: usize,
         params: Option<&'a Value>,
@@ -104,6 +106,7 @@ where
             &self.name,
             preamble,
             max_tokens,
+            temperature,
             initial_prompt,
             max_turns,
             params,
@@ -129,6 +132,11 @@ pub struct Arm {
     /// reasoning eats this budget — it sits well above the thinking budget baked
     /// into `params`, validated at config load.
     pub max_tokens: u64,
+    /// Optional typed temperature for providers whose current client reads it
+    /// from rig's core request field rather than flattened `additional_params`.
+    /// Today this is hosted OpenAI Responses only; the legacy/generic paths keep
+    /// their existing provider-shaped params.
+    pub temperature: Option<f64>,
     /// The resolved `additional_params` blob (thinking + sampling + effort), fit
     /// to this arm's model by [`ModelShape`]. `None` when nothing is sent.
     pub params: Option<Value>,
@@ -143,6 +151,7 @@ impl std::fmt::Debug for Arm {
         f.debug_struct("Arm")
             .field("model", &self.model)
             .field("max_tokens", &self.max_tokens)
+            .field("temperature", &self.temperature)
             .field("params", &self.params)
             .field("caps", &self.caps)
             .finish_non_exhaustive()
@@ -185,6 +194,21 @@ impl Arm {
     where
         M: CompletionModel + 'static,
     {
+        Self::from_model_with_temperature(model_impl, model, max_tokens, None, params, caps)
+    }
+
+    /// Wrap a pre-built completion model with an optional typed temperature.
+    fn from_model_with_temperature<M>(
+        model_impl: M,
+        model: impl Into<String>,
+        max_tokens: u64,
+        temperature: Option<f64>,
+        params: Option<Value>,
+        caps: ModelCaps,
+    ) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
         let model = model.into();
         Self {
             runner: Arc::new(ModelArm {
@@ -193,6 +217,7 @@ impl Arm {
             }),
             model,
             max_tokens,
+            temperature,
             params,
             caps,
         }
@@ -237,6 +262,17 @@ impl Arm {
             Some(t.top_p),
             &t.effort,
         );
+        let hosted_openai = backend.is_hosted_openai();
+        let params = if hosted_openai {
+            super::shaping::hosted_openai_responses_params(&slot.id, Some(t.top_p), &t.effort)
+        } else {
+            params
+        };
+        let typed_temperature = if hosted_openai {
+            super::shaping::hosted_openai_responses_temperature(&slot.id, t.temperature)
+        } else {
+            None
+        };
         // OpenRouter drops rig's native `max_tokens` (see `inject_output_budget`), so
         // the budget must ride `additional_params` as `max_completion_tokens`. A no-op
         // for every other kind, whose `max_tokens` rig sends itself.
@@ -309,13 +345,30 @@ impl Arm {
                 // returns the configured key or a placeholder the server ignores.
                 let base_url = backend.resolved_base_url();
                 let key = backend.resolve_key()?;
-                let client = openai::CompletionsClient::builder()
-                    .api_key(&key)
-                    .base_url(&base_url)
-                    .http_client(http)
-                    .build()
-                    .map_err(|e| anyhow!("openai client init at {base_url}: {e}"))?;
-                Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
+                if hosted_openai {
+                    let client = openai::Client::builder()
+                        .api_key(&key)
+                        .base_url(&base_url)
+                        .http_client(http)
+                        .build()
+                        .map_err(|e| anyhow!("openai responses client init at {base_url}: {e}"))?;
+                    Ok(Self::from_model_with_temperature(
+                        client.completion_model(&slot.id),
+                        &slot.id,
+                        t.max_tokens,
+                        typed_temperature,
+                        params,
+                        caps,
+                    ))
+                } else {
+                    let client = openai::CompletionsClient::builder()
+                        .api_key(&key)
+                        .base_url(&base_url)
+                        .http_client(http)
+                        .build()
+                        .map_err(|e| anyhow!("openai client init at {base_url}: {e}"))?;
+                    Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
+                }
             }
         }
     }
@@ -361,6 +414,7 @@ impl Arm {
             .run_phase(
                 preamble,
                 self.max_tokens,
+                self.temperature,
                 initial_prompt,
                 max_turns,
                 self.params.as_ref(),
@@ -679,6 +733,7 @@ pub(crate) async fn run_phase<M, F>(
     model_name: &str,
     preamble: &str,
     max_tokens: u64,
+    temperature: Option<f64>,
     initial_prompt: Message,
     max_turns: usize,
     thinking: Option<&Value>,
@@ -721,6 +776,7 @@ where
                 model,
                 preamble,
                 max_tokens,
+                temperature,
                 thinking,
                 make_tools()?,
                 full,
@@ -732,6 +788,9 @@ where
         let mut builder = AgentBuilder::new(model.clone())
             .preamble(preamble)
             .max_tokens(max_tokens);
+        if let Some(t) = temperature {
+            builder = builder.temperature(t);
+        }
         // Thinking on (both phases) where the provider takes a request-time toggle.
         if let Some(params) = thinking {
             builder = builder.additional_params(params.clone());
@@ -769,6 +828,7 @@ where
                     model,
                     preamble,
                     max_tokens,
+                    temperature,
                     thinking,
                     make_tools()?,
                     *chat_history,
@@ -802,6 +862,7 @@ async fn finalize_after_max_turns<M>(
     model: &M,
     preamble: &str,
     max_tokens: u64,
+    temperature: Option<f64>,
     thinking: Option<&Value>,
     tools: Vec<Box<dyn ToolDyn>>,
     chat_history: Vec<Message>,
@@ -815,6 +876,9 @@ where
         .preamble(preamble)
         .max_tokens(max_tokens)
         .tool_choice(ToolChoice::None);
+    if let Some(t) = temperature {
+        builder = builder.temperature(t);
+    }
     if let Some(params) = thinking {
         builder = builder.additional_params(params.clone());
     }
@@ -3280,6 +3344,100 @@ mod tests {
             arm.params.unwrap()["temperature"],
             defaults.explorer_temperature,
             "explorer role takes the explorer-side default"
+        );
+    }
+
+    /// A hosted OpenAI Platform backend is still configured as kind `openai`, but
+    /// it is not the same request shape as `openai-local`: current GPT reasoning
+    /// models need rig's Responses client, where effort lives in
+    /// `additional_params`, output budget maps to `max_output_tokens`, and
+    /// sampling is model-aware. This pins the arm-level split so a future cleanup
+    /// does not route hosted GPT back through the local-compatible Chat Completions
+    /// path that sends `max_tokens`.
+    #[test]
+    fn hosted_openai_arm_uses_responses_shape() {
+        let defaults = crate::config::Defaults::default();
+        let backend = crate::config::Backend {
+            name: "gpt".into(),
+            kind: ProviderKind::Openai,
+            base_url: Some(crate::credentials::HOSTED_OPENAI_BASE_URL.into()),
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: true,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+        };
+        assert!(
+            backend.is_hosted_openai(),
+            "fixture must select the hosted seam"
+        );
+        let slot = ModelSlot {
+            vision: Some(true),
+            temperature: Some(0.4),
+            effort: Some("xhigh".into()),
+            ..ModelSlot::bare("gpt", "gpt-5.6-sol")
+        };
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("hosted OpenAI arm builds offline with a placeholder key");
+        assert_eq!(arm.model, "gpt-5.6-sol");
+        assert_eq!(
+            arm.temperature, None,
+            "current GPT reasoning models reject custom temperature"
+        );
+        let params = arm.params.expect("hosted OpenAI sends Responses params");
+        assert_eq!(
+            params["reasoning"]["effort"], "xhigh",
+            "the slot effort reaches hosted OpenAI reasoning"
+        );
+        assert!(
+            params.get("temperature").is_none() && params.get("top_p").is_none(),
+            "current GPT reasoning models get no sampling knobs"
+        );
+        assert!(
+            params.get("max_tokens").is_none() && params.get("max_completion_tokens").is_none(),
+            "rig's Responses client maps core max_tokens to max_output_tokens"
+        );
+        assert!(
+            arm.caps.vision,
+            "the vision pin survives into the hosted arm"
+        );
+    }
+
+    /// Older hosted GPT chat models keep sampling: the same Responses seam is used,
+    /// but model-aware shaping routes temperature through rig's typed field and
+    /// `top_p` through Responses additional parameters.
+    #[test]
+    fn hosted_openai_arm_keeps_sampling_for_compatible_gpt_models() {
+        let defaults = crate::config::Defaults::default();
+        let backend = crate::config::Backend {
+            name: "gpt".into(),
+            kind: ProviderKind::Openai,
+            base_url: Some(crate::credentials::HOSTED_OPENAI_BASE_URL.into()),
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: true,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+        };
+        let slot = ModelSlot {
+            temperature: Some(0.4),
+            ..ModelSlot::bare("gpt", "gpt-4.1-mini")
+        };
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("hosted OpenAI GPT-4.1 arm builds offline");
+        assert_eq!(
+            arm.temperature,
+            Some(0.4),
+            "sampling-compatible GPT models keep typed temperature"
+        );
+        let params = arm.params.expect("hosted OpenAI sends Responses params");
+        assert!(
+            params.get("reasoning").is_none(),
+            "GPT-4.1 rejected reasoning.effort in the live probe"
+        );
+        assert_eq!(
+            params["top_p"], defaults.top_p,
+            "sampling-compatible GPT models keep top_p"
         );
     }
 

--- a/src/consult/mod.rs
+++ b/src/consult/mod.rs
@@ -41,6 +41,7 @@ pub use prompts::{
     ConsultAttachment, Phase, PromptOverrides,
 };
 pub use shaping::{
-    inject_provider_prefs, request_params, thinking_params, ModelCaps, ModelShape,
-    ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
+    hosted_openai_accepts_reasoning, hosted_openai_accepts_sampling, inject_provider_prefs,
+    request_params, thinking_params, ModelCaps, ModelShape, ThinkingStyleOverride, DEFAULT_EFFORT,
+    THINKING_BUDGET,
 };

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -418,6 +418,51 @@ pub fn request_params(
     )
 }
 
+/// Additional params for hosted OpenAI through rig's Responses API client.
+///
+/// This is deliberately *not* the generic `ProviderKind::Openai` shape. Local
+/// OpenAI-compatible servers and gateways commonly implement only
+/// `/chat/completions`, so they stay on [`ThinkingStyle::None`]. A backend whose
+/// resolved base URL is OpenAI Platform gets this first-party Responses shape.
+/// Reasoning and sampling are independent model-family capabilities: current GPT
+/// reasoning models (`gpt-5*`, including `gpt-5.6-sol`) take `reasoning.effort`
+/// and reject custom `temperature`; older GPT chat families (`gpt-4*`,
+/// `gpt-3.5*`, `chatgpt-*`) take sampling and reject `reasoning.effort`.
+pub fn hosted_openai_responses_params(
+    model: &str,
+    top_p: Option<f64>,
+    effort: &str,
+) -> Option<Value> {
+    let mut obj = serde_json::Map::new();
+    if hosted_openai_accepts_reasoning(model) {
+        obj.insert("reasoning".into(), json!({ "effort": effort }));
+    }
+    if hosted_openai_accepts_sampling(model) {
+        if let Some(p) = top_p {
+            obj.insert("top_p".into(), json!(p));
+        }
+    }
+    (!obj.is_empty()).then_some(Value::Object(obj))
+}
+
+/// The typed temperature rig's Responses client should receive for hosted OpenAI.
+/// `None` means "use the provider default". This is intentionally conservative:
+/// current GPT reasoning models reject `temperature`; known older chat families
+/// accept it. Unknown hosted model IDs omit sampling until a live probe proves the
+/// shape.
+pub fn hosted_openai_responses_temperature(model: &str, temperature: f64) -> Option<f64> {
+    hosted_openai_accepts_sampling(model).then_some(temperature)
+}
+
+pub fn hosted_openai_accepts_sampling(model: &str) -> bool {
+    let m = model.trim().to_ascii_lowercase();
+    m.starts_with("gpt-4") || m.starts_with("gpt-3.5") || m.starts_with("chatgpt-")
+}
+
+pub fn hosted_openai_accepts_reasoning(model: &str) -> bool {
+    model.trim().to_ascii_lowercase().starts_with("gpt-5")
+}
+
 /// Fold this arm's output-token budget into `params` where the provider needs it
 /// carried out-of-band. **OpenRouter only, and it's a rig-defect workaround**: rig
 /// 0.38's `OpenrouterCompletionRequest` (openrouter/completion.rs) has no `max_tokens`
@@ -588,6 +633,60 @@ mod tests {
         assert!(
             params["reasoning"].get("effort").is_none(),
             "no effort string rides alongside the disable"
+        );
+    }
+
+    /// Hosted OpenAI uses rig's Responses client, whose native shape is
+    /// `reasoning.effort` plus typed `max_output_tokens` (from core max_tokens).
+    /// It is intentionally separate from the generic OpenAI-compatible
+    /// `/chat/completions` shape, which stays toggle-less for local servers.
+    #[test]
+    fn hosted_openai_responses_params_are_model_aware_about_sampling() {
+        let params = hosted_openai_responses_params("gpt-5.6-sol", Some(0.95), DEFAULT_EFFORT)
+            .expect("hosted OpenAI sends Responses params");
+        assert_eq!(
+            params["reasoning"]["effort"], "high",
+            "the per-role effort reaches OpenAI Responses"
+        );
+        assert!(
+            params.get("top_p").is_none(),
+            "current GPT reasoning models get no sampling knobs"
+        );
+        assert!(
+            hosted_openai_responses_temperature("gpt-5.6-sol", 0.4).is_none(),
+            "current GPT reasoning models reject temperature"
+        );
+        assert!(
+            params.get("max_tokens").is_none() && params.get("max_completion_tokens").is_none(),
+            "Responses maps core max_tokens to max_output_tokens itself"
+        );
+
+        let params = hosted_openai_responses_params("gpt-4.1-mini", Some(0.95), "low")
+            .expect("older chat GPT families keep sampling");
+        assert!(
+            params.get("reasoning").is_none(),
+            "older chat GPT families reject reasoning.effort"
+        );
+        assert_eq!(
+            params["top_p"], 0.95,
+            "known sampling-compatible GPT families keep top_p"
+        );
+        assert_eq!(
+            hosted_openai_responses_temperature("gpt-4.1-mini", 0.4),
+            Some(0.4),
+            "known sampling-compatible GPT families keep typed temperature"
+        );
+
+        let params = hosted_openai_responses_params("gpt-5.6-sol", None, "none").unwrap();
+        assert_eq!(
+            params["reasoning"]["effort"], "none",
+            "the explicit no-reasoning effort passes through to rig's Responses enum"
+        );
+        assert!(params.get("top_p").is_none());
+
+        assert!(
+            hosted_openai_responses_params("unknown-openai-model", Some(0.95), "high").is_none(),
+            "unknown hosted models get no guessed provider-specific params"
         );
     }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -27,6 +27,11 @@ use anyhow::{anyhow, Context, Result};
 /// `OPENAI_BASE_URL` env var (see [`openai_base_url`]).
 pub const DEFAULT_OPENAI_BASE_URL: &str = "http://localhost:13305/api/v1";
 
+/// Hosted OpenAI Platform endpoint. A generic `openai` backend pointed here can
+/// use OpenAI's first-party API semantics (not just local `/chat/completions`
+/// compatibility), such as the Responses API used by current GPT reasoning models.
+pub const HOSTED_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
 /// A model provider. The keyed providers (Anthropic/DeepSeek/Gemini/OpenRouter) each
 /// speak their own wire protocol and require an API key. [`ProviderKind::Openai`] is
 /// the generic OpenAI-compatible endpoint: any base URL speaking that protocol, with

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -313,20 +313,31 @@ pub(crate) fn render_config_resource(
                     // Resolve the slot's request shape so we can flag tunables it will
                     // never send (e.g. a budget on an effort-driven model) — making the
                     // invisible no-op visible rather than rendering it as if effective.
-                    let kind = config
+                    let backend = config
                         .resolve_backend(&slot.backend)
-                        .expect("a loaded cast's slot backend resolves")
-                        .kind;
-                    let shape =
-                        ModelShape::resolve(kind, &slot.id, thinking_style.unwrap_or_default());
+                        .expect("a loaded cast's slot backend resolves");
+                    let shape = ModelShape::resolve(
+                        backend.kind,
+                        &slot.id,
+                        thinking_style.unwrap_or_default(),
+                    );
+                    let hosted_openai = backend.is_hosted_openai();
                     let mut inert_tunables = Vec::new();
+                    let effort_sinks = shape.sinks_effort()
+                        || (hosted_openai
+                            && crate::consult::hosted_openai_accepts_reasoning(&slot.id));
+                    let sampling_sinks = if hosted_openai {
+                        crate::consult::hosted_openai_accepts_sampling(&slot.id)
+                    } else {
+                        shape.sinks_sampling()
+                    };
                     if thinking_budget.is_some() && !shape.sinks_thinking_budget() {
                         inert_tunables.push("thinking_budget");
                     }
-                    if effort.is_some() && !shape.sinks_effort() {
+                    if effort.is_some() && !effort_sinks {
                         inert_tunables.push("effort");
                     }
-                    if temperature.is_some() && !shape.sinks_sampling() {
+                    if temperature.is_some() && !sampling_sinks {
                         inert_tunables.push("temperature");
                     }
                     (
@@ -541,6 +552,18 @@ mod tests {
             # Anthropic adaptive: takes output_config.effort, no budget.
             [casts.ant_adaptive]
             synth = { backend = "anthropic", id = "claude-opus-4-8", effort = "high", thinking_budget = 2048 }
+
+            [backends.gpt]
+            kind = "openai"
+            base_url = "https://api.openai.com/v1"
+
+            # Hosted GPT-5 reasoning family: sinks effort, not budget or sampling.
+            [casts.gpt_reasoning]
+            synth = { backend = "gpt", id = "gpt-5.6-sol", effort = "high", thinking_budget = 2048, temperature = 0.7 }
+
+            # Older hosted GPT chat family: sinks sampling, not reasoning effort or budget.
+            [casts.gpt_chat]
+            synth = { backend = "gpt", id = "gpt-4.1-mini", effort = "high", thinking_budget = 2048, temperature = 0.7 }
             "#,
         )
         .unwrap();
@@ -579,6 +602,16 @@ mod tests {
             inert("ant_adaptive", "synth"),
             vec!["thinking_budget"],
             "adaptive sinks effort but rejects a budget"
+        );
+        assert_eq!(
+            inert("gpt_reasoning", "synth"),
+            vec!["thinking_budget", "temperature"],
+            "hosted GPT reasoning sinks effort but rejects budget and sampling"
+        );
+        assert_eq!(
+            inert("gpt_chat", "synth"),
+            vec!["thinking_budget", "effort"],
+            "hosted GPT chat sinks sampling but rejects reasoning effort and budget"
         );
     }
 


### PR DESCRIPTION
## Summary

- Route exact hosted OpenAI Platform backends (`kind = "openai"`, `base_url = "https://api.openai.com/v1"`) through rig's Responses client for interactive `oneshot`/`consult`.
- Preserve the generic/local OpenAI-compatible path on Chat Completions for `openai-local`, llama.cpp/Ollama/LM Studio-style gateways, and other non-hosted endpoints.
- Add conservative model-aware hosted GPT shaping:
  - GPT-5-family models get `reasoning.effort` and no sampling knobs.
  - Known older chat GPT families keep sampling and omit `reasoning.effort`.
  - Unknown hosted OpenAI IDs get no guessed extra params until probed.
- Update config rendering/tests so `kaibo://config` flags inert per-slot `effort`/`temperature` by endpoint and model.
- Refresh hosted GPT docs/examples around `gpt-5.6-luna` as the fast/tool-capable consult explorer, `gpt-5.6-sol` as flagship synth, and `gpt-5.6-terra` as balanced alternative.
- Record OpenAI Batch as the next provider lane: same kaibo semantics as Anthropic/Gemini batch, no tools in provider batch; `deliberate` should build the dossier first and hand it to a Sol batch synth.

## Validation

- `cargo test`
- `cargo build`
- `git diff --check origin/main..HEAD`
- Live hosted OpenAI probe: `gpt-5.6-sol` `oneshot` returned `kaibo-openai-gpt56-rebased-ok`.
- Live hosted OpenAI compatibility probe: `gpt-4.1-mini` `oneshot` returned `kaibo-openai-gpt41-rebased-ok`.
- Prior live image probes on this branch confirmed `gpt-5.6-sol` can read `docs/brand/banner-teal.png` via `oneshot --attach` and via `consult` + `view_image`, while a `vision = false` synth refuses locally before provider call.
- Dependency tripwires:
  - `cargo tree -i aws-lc-rs` → expected “did not match any packages”
  - `cargo tree -i mimalloc` → expected “did not match any packages”

## Review / attribution

- Co-authored-by: Codex <codex@openai.com>
- Reviewed-by: Claude via kaibo anthropic cast
- Reviewed-by: DeepSeek via kaibo deepseek cast
- Final rebased DeepSeek review: no blockers. Non-blocking notes were the expected conservative classifier upkeep for future GPT families, intentional `OPENAI_BASE_URL` retargeting behavior, OpenAI Batch remaining future work, and release-time dependency tripwires.

## OpenAI references used

- https://developers.openai.com/api/docs/guides/latest-model
- https://developers.openai.com/api/docs/models
- https://platform.openai.com/docs/api-reference/batch/object?api-mode=responses
