### PR TITLE
docs: name the worktree-follow rule in client-facing scope text

### DIFF
--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -310,13 +310,26 @@ pub fn kaibo_instructions_with_scope(
         .map(|p| format!("  - `{}`", p.display()))
         .collect::<Vec<_>>()
         .join("\n");
+    // A linked git worktree of an allowed tree is in scope too — kaibo vouches for it
+    // by reading git's own link files, never by trusting the candidate's `.git`. Only
+    // said when the (default-on) feature is actually live, so a `--no-follow-worktrees`
+    // server doesn't claim a boundary it isn't enforcing. Dropped in the Unconfigured
+    // case: the setup banner already owns that budget (see `unconfigured_instructions_
+    // fit_claude_code_budget`), and a fresh install with no key isn't calling `consult`
+    // against a worktree yet anyway.
+    let worktree_note = if config.follow_worktrees && usability != CastUsability::Unconfigured {
+        " (a git worktree of one counts too)"
+    } else {
+        ""
+    };
 
     format!(
         "{setup}{lead}\n\n\
          {casts}\
          ## Scope\n\
          Read-only, always: kaibo never writes and cannot run external commands. A \
-         per-call `path` must canonicalize to at-or-under one of these allowed trees:\n\n\
+         per-call `path` must canonicalize to at-or-under one of these allowed \
+         trees{worktree_note}:\n\n\
          {root_line}\n\
          - **Allowed trees:**\n\
          {allowed_lines}\n\n\

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -191,7 +191,8 @@ pub struct ConsultInput {
     pub context: Option<String>,
 
     /// Absolute path to the project to explore. Optional when the server has a default
-    /// root; must be at-or-under an allowed tree (`kaibo://config` shows the set).
+    /// root; must be at-or-under an allowed tree, or a linked git worktree of one
+    /// (`kaibo://config` shows the set).
     #[serde(default)]
     pub path: Option<String>,
 
@@ -268,7 +269,8 @@ pub struct ExploreInput {
     pub attach: Vec<String>,
 
     /// Absolute path to the project to explore. Optional when the server has a default
-    /// root; must be at-or-under an allowed tree (`kaibo://config` shows the set).
+    /// root; must be at-or-under an allowed tree, or a linked git worktree of one
+    /// (`kaibo://config` shows the set).
     #[serde(default)]
     pub path: Option<String>,
 
@@ -314,7 +316,8 @@ pub struct DeliberateInput {
     pub attach: Vec<String>,
 
     /// Absolute path to the project. Optional when the server has a default root; must
-    /// be at-or-under an allowed tree (`kaibo://config` shows the set).
+    /// be at-or-under an allowed tree, or a linked git worktree of one (`kaibo://config`
+    /// shows the set).
     #[serde(default)]
     pub path: Option<String>,
 
@@ -482,8 +485,9 @@ pub struct RunKaishInput {
     pub script: String,
 
     /// Absolute path to the project. Optional when the server has a default root; must be
-    /// at-or-under an allowed tree (`kaibo://config` shows the set). Each call starts fresh
-    /// at this root — there is no persistent cwd across calls.
+    /// at-or-under an allowed tree, or a linked git worktree of one (`kaibo://config`
+    /// shows the set). Each call starts fresh at this root — there is no persistent cwd
+    /// across calls.
     #[serde(default)]
     pub path: Option<String>,
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -133,3 +133,160 @@ fn resolve_commondir(gitdir: &Path) -> Option<PathBuf> {
         Err(_) => std::fs::canonicalize(gitdir).ok(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Pure filesystem tests: hand-craft git's link-file layout with no `git`
+    //! binary at all (unlike `tests/containment.rs`'s worktree-follow battery,
+    //! which shells out to real `git worktree add` and self-skips when git isn't
+    //! on PATH). These run unconditionally, on every host including a git-less
+    //! CI runner, so the core parsing/trust logic of this module is proven even
+    //! where the integration battery silently no-ops. They exercise exactly the
+    //! layout described in the module doc-comment, not `containing_tree`'s
+    //! allowed-set logic (that's `tests/containment.rs`'s job).
+
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Write git's real worktree-registration layout under `base`:
+    /// `repo/.git/` (a directory: the common dir) with one linked worktree
+    /// `name` registered at `wt`, wired exactly as git itself writes it —
+    /// `worktrees/<name>/gitdir` back-linking to `<wt>/.git`, and
+    /// `worktrees/<name>/commondir` as the relative `../..` git always writes
+    /// (two components: `worktrees/<name>`, popped to reach `.git`). Returns
+    /// `(repo, wt)`, both created but not canonicalized.
+    fn write_registered_worktree(base: &Path, name: &str) -> (PathBuf, PathBuf) {
+        let repo = base.join("repo");
+        let dotgit = repo.join(".git");
+        let wt_gitdir_folder = dotgit.join("worktrees").join(name);
+        std::fs::create_dir_all(&wt_gitdir_folder).unwrap();
+        let wt = base.join(name);
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(
+            wt.join(".git"),
+            format!("gitdir: {}\n", wt_gitdir_folder.display()),
+        )
+        .unwrap();
+        std::fs::write(
+            wt_gitdir_folder.join("gitdir"),
+            format!("{}\n", wt.join(".git").display()),
+        )
+        .unwrap();
+        std::fs::write(wt_gitdir_folder.join("commondir"), "../..\n").unwrap();
+        (repo, wt)
+    }
+
+    /// The headline shape: a linked worktree's `.git` file resolves, via its
+    /// registered git dir's `commondir`, to the exact same common dir the main
+    /// worktree's own `.git` directory *is* — proving `common_git_dir` is
+    /// symmetric regardless of which side you start walking from (the property
+    /// `sibling_reachable_when_rooted_at_linked_worktree` exercises end-to-end
+    /// in `tests/containment.rs`).
+    #[test]
+    fn common_git_dir_agrees_from_either_side() {
+        let base = tempdir().unwrap();
+        let (repo, wt) = write_registered_worktree(base.path(), "feature");
+
+        let from_main = common_git_dir(&repo).expect("main worktree resolves a common dir");
+        let from_linked = common_git_dir(&wt).expect("linked worktree resolves a common dir");
+        assert_eq!(
+            from_main, from_linked,
+            "both sides of one repo must agree on the common dir"
+        );
+        assert_eq!(
+            from_main,
+            std::fs::canonicalize(repo.join(".git")).unwrap(),
+            "the common dir must be the main worktree's own `.git`"
+        );
+    }
+
+    /// `vouched_worktrees` on that common dir names exactly the main worktree
+    /// plus the one registered linked worktree — the *only* paths the follow
+    /// feature will ever admit for this repo.
+    #[test]
+    fn vouched_worktrees_lists_main_plus_each_registered_linked_worktree() {
+        let base = tempdir().unwrap();
+        let (repo, wt) = write_registered_worktree(base.path(), "feature");
+        let common = common_git_dir(&repo).unwrap();
+
+        let vouched = vouched_worktrees(&common);
+        assert!(
+            vouched.contains(&std::fs::canonicalize(&repo).unwrap()),
+            "must vouch for the main worktree: {vouched:?}"
+        );
+        assert!(
+            vouched.contains(&std::fs::canonicalize(&wt).unwrap()),
+            "must vouch for the registered linked worktree: {vouched:?}"
+        );
+        assert_eq!(
+            vouched.len(),
+            2,
+            "must name exactly main + the one registered worktree, nothing else: {vouched:?}"
+        );
+    }
+
+    /// A `worktrees/<name>/` entry with no `gitdir` back-link file (a partial or
+    /// corrupt registration) must be skipped rather than panicking or fabricating
+    /// a path — `vouched_worktrees` reads options throughout precisely so a
+    /// malformed entry silently doesn't vouch for anything, instead of crashing
+    /// the whole containment check for every other call.
+    #[test]
+    fn vouched_worktrees_skips_a_registration_missing_its_gitdir_file() {
+        let base = tempdir().unwrap();
+        let (repo, _wt) = write_registered_worktree(base.path(), "feature");
+        // A second, malformed registration: the directory exists but never got
+        // its `gitdir` back-link written (e.g. an interrupted `git worktree add`).
+        std::fs::create_dir_all(repo.join(".git").join("worktrees").join("half-done")).unwrap();
+        let common = common_git_dir(&repo).unwrap();
+
+        let vouched = vouched_worktrees(&common);
+        assert_eq!(
+            vouched.len(),
+            2,
+            "the malformed entry must contribute nothing, not a bogus third path: {vouched:?}"
+        );
+    }
+
+    /// The one-way trust property, proven at the primitive level with no `git`
+    /// binary and no resolver involved: `vouched_worktrees` takes only the
+    /// *trusted* common dir as input, never the candidate path, so a foreign
+    /// directory's own forged `.git` file — even one pointing at a real
+    /// registered worktree's git dir, exactly as
+    /// `tests/containment.rs::spoofed_dotgit_pointing_into_allowed_repo_is_rejected`
+    /// builds end-to-end — cannot possibly appear in the vouched set: the
+    /// function never reads it. This is what makes the spoof structurally
+    /// impossible rather than merely unlikely.
+    #[test]
+    fn vouched_worktrees_cannot_be_steered_by_a_foreign_dotgit_pointer() {
+        let base = tempdir().unwrap();
+        let (repo, wt) = write_registered_worktree(base.path(), "feature");
+        let common = common_git_dir(&repo).unwrap();
+
+        // A foreign directory, never registered under `repo/.git/worktrees/`, whose
+        // own `.git` file points at the SAME real git dir `wt` is registered under —
+        // impersonating it from the candidate side.
+        let spoof = base.path().join("spoof");
+        std::fs::create_dir_all(&spoof).unwrap();
+        let real_gitdir_folder = repo.join(".git").join("worktrees").join("feature");
+        std::fs::write(
+            spoof.join(".git"),
+            format!("gitdir: {}\n", real_gitdir_folder.display()),
+        )
+        .unwrap();
+
+        let vouched = vouched_worktrees(&common);
+        assert!(
+            vouched.contains(&std::fs::canonicalize(&wt).unwrap()),
+            "the genuine registered worktree must still be vouched for: {vouched:?}"
+        );
+        assert!(
+            !vouched.contains(&std::fs::canonicalize(&spoof).unwrap()),
+            "a foreign dir's own forged .git must never appear in the vouched set: {vouched:?}"
+        );
+        assert_eq!(
+            vouched.len(),
+            2,
+            "spoofing must add nothing to the vouched set: {vouched:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- A coordinating agent read kaibo's resident MCP `## Scope` section today, saw only the static allowed-tree list, and wrongly concluded a sibling git worktree at `~/src/wt/` was out of scope — routing around `follow_worktrees` (on by default), a capability that was already there and already well documented in `docs/config.md` and `kaibo://tools`, just not in the two places a calling agent actually reads first.
- Adds a short, config-gated clause to the `## Scope` section (dropped in the `Unconfigured`/setup-banner branch, whose 2048-char budget had far less slack) and to `ConsultInput`/`ExploreInput`/`DeliberateInput`/`RunKaishInput`'s `path` field docs.
- Adds pure-filesystem unit tests to `src/worktree.rs`: the existing worktree-follow coverage lives entirely in `tests/containment.rs` and shells out to a real `git worktree add`, silently skipping on a git-less host. The new tests hand-craft git's link-file layout directly (no `git` binary), proving the core trust logic — main/linked agreement, a malformed registration skipped rather than panicking, and a foreign directory's forged `.git` never entering the vouched set — runs unconditionally.

## Test plan

- [x] `cargo test --lib kaish_syntax::` (19 passed, including both 2048-char budget tests)
- [x] `cargo test --lib worktree::` (4 new tests, passed)
- [x] `cargo test --test containment` (19 passed, including the full worktree-follow battery against real git)
- [x] `cargo test` (full suite: 457 lib tests + all integration suites, all green)
- [x] `cargo fmt --check` / `cargo clippy --all-targets` on the touched files (no new diffs or warnings beyond pre-existing drift in unrelated files on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6HgQA2AEtFkvhTMNkviTe