### PR TITLE
Clarify sandboxed host setup in configure guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ the git log. Each later release appends a new section at the top.
 
 ## [0.2.0] — unreleased
 
+### Changed
+
+- **Configure guidance now calls out host-agent sandboxes.** `/kaibo:configure`,
+  `kaibo configure`, and the setup docs now tell agents that kaibo needs outbound network
+  to configured model APIs, writable access to its XDG state dir for persistent MCP
+  sessions/batch handles, and XDG data access for the media CAS when artifact-producing
+  tools are enabled. The guidance also names the per-client split option so Codex,
+  Claude Code, and other agents can keep session history or generated artifacts separate,
+  and notes that Codex commonly needs explicit sandbox grants where Claude Code usually
+  starts local MCP servers with ordinary home-dir access.
+
 ### Added
 
 - **Hosted OpenAI Platform backends now use the Responses API for interactive GPT calls.**

--- a/README.md
+++ b/README.md
@@ -309,6 +309,17 @@ The file is written by your **host agent** with its own permissions, the same wa
 edits any file — *not* by kaibo's sandboxed sub-agents, which remain strictly read-only
 and never touch disk. The prompt just hands your agent the knowledge to do it.
 
+If your host agent sandboxes local commands or MCP servers, give kaibo the host access
+it actually needs: outbound network to your configured model APIs, and write access to
+kaibo's own XDG state dir if you want persistent sessions/batch handles. The default
+state db is `$XDG_STATE_HOME/kaibo/state.db` (else
+`~/.local/state/kaibo/state.db`); artifact-producing tools use the media CAS under
+`$XDG_DATA_HOME/kaibo/cas` (else `~/.local/share/kaibo/cas`) when enabled. You can
+also point state/CAS at separate per-client locations so Claude Code, Codex, and other
+agents don't share history or generated artifacts. Codex commonly has a stricter
+sandbox default than Claude Code, so its setup may need explicit network and writable
+root entries where Claude Code just works.
+
 The prompt leans on two MCP resources kaibo serves, which you can also read directly:
 
 - **`kaibo://config/example`** — the fully annotated `config.toml` template, every

--- a/docs/config.md
+++ b/docs/config.md
@@ -540,6 +540,17 @@ project, and `open` **refuses a state-db path that resolves inside an allowed tr
 it can't be pointed into a repo). See the "Read-only is the product" invariant in
 AGENTS.md.
 
+**Host-agent sandboxes still matter.** kaibo's inner model-facing shell is read-only, but
+your MCP client or calling agent may also sandbox the kaibo process itself. If that host
+sandbox blocks network, model-backed tools cannot reach providers. If it blocks writes to
+the XDG state dir, a long-lived MCP server with persistence enabled fails during startup.
+Grant the host sandbox outbound network and a narrow writable root for kaibo's state dir,
+or move the db with `--state-db` / `KAIBO_STATE_DB` / `[persistence] path`. For multi-agent
+setups, a per-client state db is often cleaner than sharing one history file across Claude
+Code, Codex, and other agents. Apply the same judgment to the media CAS when an
+artifact-producing tool is enabled: the default XDG data path is convenient for sharing
+generated artifacts across agents, while a per-client CAS keeps those artifacts separated.
+
 **Loud on failure, never a silent fallback.** If the store can't open (a bad path, a db
 inside a project, a network mount — turso's multiprocess mode is 64-bit-Unix + local-fs
 only), kaibo **fails to start** with an error naming the escape hatch and leaving the db

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,26 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-07-26 — Configure names host-agent sandbox access and per-client state
+
+The first Codex MCP bring-up surfaced a setup mismatch rather than a kaibo runtime bug:
+kaibo's own model-facing shell is read-only, but the **host agent** may also sandbox the
+kaibo process. Codex commonly does; Claude Code commonly doesn't. A stdio MCP server
+launched under that stronger sandbox needs two explicit grants before kaibo is useful:
+outbound network to the configured model APIs, and a narrow writable root for kaibo's own
+XDG state db if persistence is on. The CAS follows the same operator choice when
+artifact-producing tools are enabled: share the default XDG data path for cross-agent
+workflows, or split it if artifacts should not cross client boundaries.
+
+The important wording correction was **per-client**, not per-host. The useful split is
+Codex vs. Claude Code vs. another MCP-capable agent on the same machine, not one physical
+machine vs. another. That keeps the recommendation aligned with the trust boundary:
+opening the shared XDG state dir to a Codex session exposes that history to the outer Codex
+agent, even though kaibo's inner model team never sees it. So the configure guidance now
+asks before opening XDG paths, names Codex's `network_access` / `writable_roots` shape, and
+offers a Codex-only state db or CAS dir as a cleaner multi-agent default when sharing is not
+the goal.
+
 ## 2026-07-26 — OpenAI joins the batch lane, and batch capability stops being a kind
 
 The third batch provider, and the one that broke an assumption the other two never

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2471,8 +2471,8 @@ Work through these steps:
 and where each key is sourced from.
 ";
 
-/// Steps 2-5, channel-neutral (which provider, what roster shape, keeping secrets out
-/// of the file, and the optional read-scope widening) — the substance both the MCP
+/// Steps 2-6, channel-neutral (which provider, what roster shape, keeping secrets out
+/// of the file, optional read-scope widening, and host-agent sandbox setup) — the substance both the MCP
 /// `configure` prompt and `kaibo configure` (CLI) share verbatim, so a future edit to
 /// the roster-design guidance can't drift between the two front doors. Each caller
 /// wraps it in its own channel-specific opening (how to *read* kaibo's own config) and
@@ -2514,10 +2514,23 @@ diff, a log, a generated file you dropped somewhere — name that directory in \
 `[server] allow_paths` (`$VAR` / `${VAR}` and a leading `~` expand, resolving per machine). \
 It's a deliberate opt-in worth asking me about first, since it widens what a consult can \
 read (and can ship to a model).
+6. Host-agent sandbox. kaibo's own model-facing shell stays read-only, but the host \
+agent or MCP client that launches kaibo may sandbox the kaibo process. A useful kaibo \
+setup needs outbound network access to the model APIs I configure, and long-lived MCP \
+servers need write access to kaibo's own XDG state path \
+(`$XDG_STATE_HOME/kaibo/state.db`, else `~/.local/state/kaibo/state.db`). If a \
+media-producing tool is enabled, its content-addressed media CAS lives under the XDG \
+data dir (`$XDG_DATA_HOME/kaibo/cas`, else `~/.local/share/kaibo/cas`) and may also \
+need host-sandbox access. Ask before opening those paths. I may prefer separate \
+per-client stores — for example a Codex-only state db or CAS dir — when I don't want \
+Claude Code, Codex, and other agents sharing session history or generated artifacts. \
+Codex has a stronger sandbox default than Claude Code in common setups, so its config \
+often needs explicit `network_access` and `writable_roots`; Claude Code usually starts \
+local MCP servers with ordinary access to my home XDG dirs.
 ";
 
 const CONFIGURE_PROMPT_OUTRO_MCP: &str = "\
-6. When the file is written, remind me to reconnect the kaibo MCP server so it re-reads \
+7. When the file is written, remind me to reconnect the kaibo MCP server so it re-reads \
 the config and keys — both load once at startup.";
 
 /// The CLI-flavored opening/step-1: kaibo's own config surfaces read as plain
@@ -2536,7 +2549,7 @@ and where each key is sourced from.
 ";
 
 const CONFIGURE_PROMPT_OUTRO_CLI: &str = "\
-6. When the file is written, you're done — kaibo re-reads `config.toml` fresh on every \
+7. When the file is written, you're done — kaibo re-reads `config.toml` fresh on every \
 invocation, so the very next `kaibo consult` (or any other subcommand) picks it up. \
 Only reconnect something if you're *also* running kaibo as a long-lived MCP server \
 elsewhere — that process still loads config once at startup.";
@@ -4592,6 +4605,32 @@ mod tests {
             text.contains("don't reach for it by default"),
             "the prompt must tell the agent not to default to a chimera; body:\n{text}"
         );
+    }
+
+    /// Host-agent sandboxes are a setup concern outside kaibo's inner read-only shell.
+    /// The configure guidance must name the access kaibo actually needs and the option to
+    /// split durable state per client/host-agent, especially for Codex's stricter default.
+    #[test]
+    fn configure_prompt_covers_host_sandbox_state_and_cas_access() {
+        let result =
+            kaibo_prompt_messages(CONFIGURE_PROMPT_NAME, None).expect("configure must resolve");
+        let PromptMessageContent::Text { text } = &result.messages[0].content else {
+            panic!("configure prompt must be a text message");
+        };
+        for needle in [
+            "network_access",
+            "writable_roots",
+            "$XDG_STATE_HOME/kaibo/state.db",
+            "$XDG_DATA_HOME/kaibo/cas",
+            "per-client stores",
+            "Codex",
+            "Claude Code",
+        ] {
+            assert!(
+                text.contains(needle),
+                "configure prompt should mention host-sandbox setup fact {needle:?}; body:\n{text}"
+            );
+        }
     }
 
     /// A supplied `goal` is woven into the message so the agent tailors the roster;


### PR DESCRIPTION
## Summary

- Update `/kaibo:configure` and `kaibo configure` to mention host-agent sandbox setup:
  outbound network for model APIs, writable XDG state for persistent MCP sessions/batch
  handles, and XDG data access for the media CAS when artifact-producing tools are enabled.
- Document the same guidance in README and `docs/config.md`.
- Call the split **per-client** rather than per-host: Codex vs Claude Code vs another
  agent on the same machine may intentionally use separate state/CAS locations.
- Record the reasoning in `docs/devlog.md` and add an unreleased changelog entry.

## Validation

- `cargo test configure_prompt --lib`
- `git diff --check`

## Notes

This is guidance only; no runtime behavior changes. It reflects the Codex bring-up finding
that Codex commonly launches local tools/MCP servers under a stronger sandbox than Claude
Code, so kaibo setup should name the required host permissions explicitly.
