### PR TITLE
--allow-path is additive — it no longer evicts the launch cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,15 @@ the git log. Each later release appends a new section at the top.
 
 ### Changed
 
+- **`--allow-path` is additive now — it no longer costs you the launch cwd.** Adding a
+  tree used to *replace* the zero-config workspace: `--allow-path /extra` with no
+  `--root` dropped your project out of the allowed set entirely, so every call that
+  omitted `path` failed with "no default root". The flag widens the boundary and never
+  narrows it. Naming a `--root` is unchanged — that's you choosing the project, so the
+  cwd isn't added beside it — and the new **`--no-cwd`** (`KAIBO_NO_CWD`,
+  `[server] infer_cwd = false`) gives back the strict reading: the allowed set is exactly
+  what you named, and every call passes its own `path`. If you were relying on
+  `--allow-path` alone to *narrow* scope, add `--no-cwd`.
 - The README explains `consult` up front now — who acts, in what order — instead of
   leaving the mechanism scattered across four sections.
 - Hosted GPT examples now use the current GPT-5.6 family: a fast/tool-capable

--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ for you:
       "command": "kaibo",
       // No args needed — an MCP client launches kaibo with cwd = your workspace, and
       // it scopes its read-only access there. Common overrides (pick what you need):
-      //   "args": ["--root", "/path/to/project"]        // pin a fixed project root
-      //   "args": ["--allow-path", "/extra/tree"]        // widen read scope (repeatable)
+      //   "args": ["--root", "/path/to/project"]        // pin the project (not repeatable)
+      //   "args": ["--allow-path", "/extra/tree"]        // ADD a tree; keeps the cwd too
+      //   "args": ["--no-cwd"]                           // …unless you want only what you named
       //   "args": ["--cast", "deepseek"]                 // default cast when a call omits it
       //   "args": ["--no-run-kaish"]                     // drop a tool from the surface
       //   "args": ["--config", "/path/to/config.toml"]   // use an explicit config file

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -46,10 +46,19 @@
 # root = "/home/atobey/src/kaibo"
 
 # Additional allowed path trees beyond root. A per-call `path` must resolve to
-# at-or-under root OR one of these trees. With neither set, the server defaults
-# to the launch cwd. Also settable via --allow-path (CLI) or KAIBO_ALLOW_PATHS
-# (colon-separated env var); a non-empty CLI list replaces the env/file layer.
+# at-or-under root OR one of these trees. ADDITIVE: setting this never costs you
+# the launch cwd, which stays an allowed tree (and the default root) unless you
+# set `root` above or turn it off with `infer_cwd` below. Also settable via
+# --allow-path (CLI) or KAIBO_ALLOW_PATHS (colon-separated env var); a non-empty
+# CLI list replaces the env/file layer.
 # allow_paths = ["/home/atobey/shared-libs", "/data/shared"]
+
+# Adopt the invocation cwd as an allowed tree and the default root (default true).
+# This is what makes the zero-config case work: an MCP client launches kaibo with
+# cwd = your workspace, so kaibo scopes itself there with no configuration at all.
+# Set false when the allowed set should be exactly what you named above — every
+# call must then pass its own `path` (also: --no-cwd, KAIBO_NO_CWD).
+# infer_cwd = false
 
 # Follow git worktrees of an already-allowed repo (default true). When a call's
 # `path` misses the allowed set, kaibo admits it if it is a linked worktree of a

--- a/docs/config.md
+++ b/docs/config.md
@@ -371,6 +371,7 @@ role the cast doesn't carry). The naming rule for everything else is mechanical:
 | config file location | — | `KAIBO_CONFIG` | `--config <path>` |
 | default root | `server.root` | `KAIBO_ROOT` | `--root` |
 | additional allowed trees | `server.allow_paths` *(list)* | `KAIBO_ALLOW_PATHS` *(colon-separated)* | `--allow-path DIR` *(repeatable)* |
+| infer the cwd as an allowed tree + default root | `server.infer_cwd` *(default true)* | `KAIBO_NO_CWD` *(disables)* | `--no-cwd` *(disables)* |
 | default cast | `server.cast` | `KAIBO_CAST` | `--cast` |
 | disable a tool | `server.tools.<t> = false` | `KAIBO_NO_<T>` | `--no-<t>` |
 | log filter | `server.log` | `RUST_LOG` *(wins)* / `KAIBO_LOG` | — |
@@ -742,22 +743,27 @@ one of the allowed trees is `invalid_params`, naming the allowed trees and the t
 knobs that widen them.
 
 **The allowed set** is constructed at startup from the canonicalized `--root` plus
-every canonicalized `--allow-path`. When both are absent the allowed set defaults to
-the canonicalized launch cwd. MCP clients start stdio servers with cwd = workspace,
-so the zero-config case scopes itself to the project naturally, without any operator
-action. The default isn't silent: the resolved allowed set is reported in a startup
+every canonicalized `--allow-path`, plus the canonicalized launch cwd — unless `--root`
+named a project, or `--no-cwd` opted out. MCP clients start stdio servers with cwd =
+workspace, so the zero-config case scopes itself to the project naturally, without any
+operator action.
+
+**`--allow-path` is additive.** It widens the boundary and never narrows it: adding one
+does *not* cost you the cwd, because reaching one more tree should never evict the
+workspace your question is about. Naming a `--root` is different — that is you choosing
+the project, so the cwd is not added beside it. When you want the allowed set to be
+exactly what you named, say so with `--no-cwd` (`KAIBO_NO_CWD`, `[server] infer_cwd =
+false`); every call must then pass its own `path`. The default isn't silent: the resolved allowed set is reported in a startup
 log line and in the `## Scope` section of the server's MCP `instructions` (visible in
 every `initialize` response), and at `kaibo://config`.
 
 **The default root** is what a call resolves to when it omits `path`: an explicit
-`--root`, or — when none is set — the launch cwd, *inferred* whenever it falls inside
-the allowed set (it always does in the zero-config case, since the cwd is the whole
-allowed set). So the common single-workspace case needs no `--root`: kaibo already
-knows the workspace from its cwd and uses it for both bounding and defaulting. The
-inferred case is labelled as such in the `## Scope` handshake and at `kaibo://config`
-(`default_root_inferred`). The one gap: an `--allow-path` that *excludes* the cwd
-leaves no default root — kaibo never defaults to a path its own containment check
-would then reject, so an omitted `path` there stays an error.
+`--root`, or — when none is set — the launch cwd, *inferred*. So the common
+single-workspace case needs no `--root`: kaibo already knows the workspace from its cwd
+and uses it for both bounding and defaulting. The inferred case is labelled as such in
+the `## Scope` handshake and at `kaibo://config` (`default_root_inferred`). Only
+`--no-cwd` leaves you without a default root, and then an omitted `path` is a clear
+parameter error rather than a guess.
 
 **Widening the boundary:**
 
@@ -776,7 +782,12 @@ kaibo --allow-path ~/src --allow-path /data/fixtures
 ```
 
 A non-empty CLI `--allow-path` set replaces the env/file layer entirely (same
-precedence rule as `--root`). To lift all limits: `--allow-path /`.
+precedence rule as `--root`) — that is *layer* precedence, not narrowing: whichever
+layer wins still sits alongside the inferred cwd. To lift all limits: `--allow-path /`.
+
+`--root` is deliberately **not** repeatable — it names *the* project a path-less call
+defaults to, and there can only be one; the parser refuses a second occurrence rather
+than silently picking. `--allow-path` is the repeatable knob.
 
 **Set it once.** Putting your whole workspace tree in `allow_paths`
 (`["~/src"]`) means every project under it is in-bounds, and because the client's

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,15 +157,26 @@ pub struct CommonArgs {
     /// Default project root, and an allowed tree. A per-call `--path` must resolve to
     /// at-or-under `--root` or an `--allow-path` tree. With neither, the allowed set
     /// (and inferred default root) is the invocation cwd — so run kaibo from the
-    /// workspace and you configure nothing.
+    /// workspace and you configure nothing. Not repeatable: this names *the* project a
+    /// path-less call defaults to, and there can only be one — `--allow-path` is the
+    /// repeatable, additive knob. Setting it also means the cwd is NOT added.
     #[arg(long, value_name = "DIR", global = true)]
     pub root: Option<PathBuf>,
 
-    /// Additional allowed path tree. Repeatable. Use `--allow-path /` to lift all
-    /// limits. Also settable via KAIBO_ALLOW_PATHS (colon-separated) or
+    /// Additional allowed path tree. Repeatable, and purely ADDITIVE — it widens the
+    /// boundary and never narrows it, so without --root the invocation cwd stays
+    /// allowed alongside it (use --no-cwd to drop that). Use `--allow-path /` to lift
+    /// all limits. Also settable via KAIBO_ALLOW_PATHS (colon-separated) or
     /// [server] allow_paths; a non-empty set of flags replaces that layer.
     #[arg(long = "allow-path", value_name = "DIR", action = clap::ArgAction::Append, global = true)]
     pub allow_path: Vec<PathBuf>,
+
+    /// Don't adopt the invocation cwd as an allowed tree and default root. By default
+    /// it is one (unless --root is given), and --allow-path only ever ADDS to that.
+    /// With this, the allowed set is exactly what you named and every call must pass
+    /// its own path. Also KAIBO_NO_CWD.
+    #[arg(long = "no-cwd", global = true)]
+    pub no_cwd: bool,
 
     /// Don't follow git worktrees of an allowed repo (by default a sibling worktree is
     /// reachable without an --allow-path). Also KAIBO_NO_FOLLOW_WORKTREES.
@@ -471,6 +482,7 @@ fn load_config(common: &CommonArgs) -> anyhow::Result<Config> {
         ToolDisables::default(),
         common.allow_path.clone(),
         common.no_follow_worktrees,
+        common.no_cwd,
         common.project_context_file.clone(),
         common.user_context_file.clone(),
         common.no_persistence,

--- a/src/config.rs
+++ b/src/config.rs
@@ -719,6 +719,17 @@ pub struct Config {
     /// `--no-follow-worktrees`, `KAIBO_NO_FOLLOW_WORKTREES`, or
     /// `[server] follow_worktrees = false`) to keep the boundary strictly static.
     pub follow_worktrees: bool,
+    /// Adopt the invocation cwd as an allowed tree and the inferred default root
+    /// (default `true`) — the zero-config case, and what makes an MCP client's
+    /// "launch kaibo in the workspace" just work.
+    ///
+    /// It holds *unless* `root` is set: naming a root is the operator choosing the
+    /// project, so the cwd is not quietly added beside it. It is deliberately
+    /// independent of `allow_paths`, which is **additive** — reaching one more tree
+    /// must never cost you the workspace you started in. Set `false` (via `--no-cwd`,
+    /// `KAIBO_NO_CWD`, or `[server] infer_cwd = false`) when the allowed set should be
+    /// exactly what you named; every call must then pass `path` explicitly.
+    pub infer_cwd: bool,
     /// Default cast name when a call omits `cast`.
     pub default_cast: String,
     /// `EnvFilter` directive used when `RUST_LOG` is unset.
@@ -1329,6 +1340,7 @@ impl Config {
             .map(|s| expand_path(s))
             .collect::<anyhow::Result<Vec<_>>>()?;
         let follow_worktrees = server.follow_worktrees.unwrap_or(true);
+        let infer_cwd = server.infer_cwd.unwrap_or(true);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let persistence = merge_persistence(raw.persistence.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default())?;
@@ -1355,6 +1367,7 @@ impl Config {
             root,
             allow_paths,
             follow_worktrees,
+            infer_cwd,
             default_cast,
             log,
             tools,
@@ -1396,6 +1409,7 @@ impl Config {
         disable: ToolDisables,
         allow_paths: Vec<PathBuf>,
         disable_follow_worktrees: bool,
+        disable_infer_cwd: bool,
         project_context_files: Vec<String>,
         user_context_files: Vec<PathBuf>,
         disable_persistence: bool,
@@ -1418,6 +1432,11 @@ impl Config {
         // never force it on over a `[server] follow_worktrees = false` in the file.
         if disable_follow_worktrees {
             self.follow_worktrees = false;
+        }
+        // Same discipline for the cwd inference: `--no-cwd` narrows, and never widens
+        // over a `[server] infer_cwd = false` in the file.
+        if disable_infer_cwd {
+            self.infer_cwd = false;
         }
         if let Some(cast) = cast {
             self.default_cast = cast;
@@ -1806,6 +1825,9 @@ struct RawServer {
     /// Follow git worktrees of an already-allowed repo. Default `true`. Env:
     /// `KAIBO_NO_FOLLOW_WORKTREES`. CLI: `--no-follow-worktrees`.
     follow_worktrees: Option<bool>,
+    /// Adopt the invocation cwd as an allowed tree + default root. Default `true`.
+    /// `KAIBO_NO_CWD`. CLI: `--no-cwd`.
+    infer_cwd: Option<bool>,
     /// The default cast (was `provider` before the backends/casts split; the old
     /// key is now an unknown-field load error via `deny_unknown_fields`).
     cast: Option<String>,
@@ -2299,6 +2321,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
         if !paths.is_empty() {
             server.allow_paths = Some(paths);
         }
+    }
+    if env_flag(get, "KAIBO_NO_CWD") {
+        server.infer_cwd = Some(false);
     }
     if env_flag(get, "KAIBO_NO_FOLLOW_WORKTREES") {
         server.follow_worktrees = Some(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
         gates.tool_disables(),
         common.allow_path.clone(),
         common.no_follow_worktrees,
+        common.no_cwd,
         common.project_context_file.clone(),
         common.user_context_file.clone(),
         common.no_persistence,

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -44,14 +44,14 @@ pub struct Resolver {
     /// the handler (which keeps its own clone of the same `Arc`).
     pub(crate) config: Arc<Config>,
     /// The canonicalized allowed path trees. A per-call path must canonicalize to
-    /// at-or-under one of these. Computed once from config.root/allow_paths;
-    /// falls back to the canonicalized cwd when both are empty.
+    /// at-or-under one of these. Computed once from config.root/allow_paths, plus the
+    /// canonicalized cwd unless `--root` named a project or `--no-cwd` opted out.
     allowed_set: Arc<Vec<PathBuf>>,
     /// The effective default root a call uses when it omits `path` — the explicit
-    /// `--root`/config value, or the launch/invocation cwd inferred when it falls
-    /// inside the allowed set. Canonicalized. `None` only when no root was
-    /// configured *and* the cwd is outside the allowed set. `pub(super)` so the
-    /// split containment `impl` in `containment.rs` reads it.
+    /// `--root`/config value, else the inferred invocation cwd. Canonicalized. `None`
+    /// only when no root was configured *and* the cwd inference was turned off
+    /// (`--no-cwd`). `pub(super)` so the split containment `impl` in `containment.rs`
+    /// reads it.
     pub(super) default_root: Arc<Option<PathBuf>>,
     /// True when [`default_root`](Self::default_root) was inferred from the cwd
     /// rather than configured explicitly. Surfaced in the scope section and
@@ -65,11 +65,11 @@ impl Resolver {
     /// share. A nonexistent or non-directory entry in root / allow_paths is a loud
     /// construction error (a path that can't be canonicalized can't bound anything).
     ///
-    /// Without an explicit `--root`, the process cwd does double duty: it is both the
-    /// zero-config allowed tree *and* the inferred default root — adopted whenever it
-    /// falls inside the allowed set, so a call may omit `path` in the common
-    /// single-workspace case. A cwd the containment check would reject is never
-    /// adopted (an `--allow-path` that excludes it leaves the default root unset).
+    /// Without an explicit `--root`, the process cwd does double duty: it is both an
+    /// allowed tree *and* the inferred default root, so a call may omit `path` in the
+    /// common single-workspace case. That holds regardless of `--allow-path`, which is
+    /// purely additive — see the rationale at the resolution site below. `--no-cwd`
+    /// opts out, leaving the allowed set exactly what was named.
     pub fn from_config(config: Arc<Config>) -> Result<Self> {
         // Build the canonicalized allowed set. Each entry is canonicalized now so
         // the `starts_with` containment check is sound (symlinks resolved, `..`
@@ -96,29 +96,37 @@ impl Resolver {
             allowed.push(canon);
         }
 
-        // Resolve the default root and the allowed-set cwd fallback together. With an
-        // explicit `--root`, that is the default root and no cwd is consulted. Without
-        // one, the launch/invocation cwd is both the zero-config allowed tree and the
-        // natural default root — adopt it whenever it falls inside the allowed set. We
-        // never adopt a cwd the containment check would then reject.
+        // Resolve the default root and the cwd's place in the allowed set together.
+        //
+        // With an explicit `--root`, that is the default root and no cwd is consulted:
+        // naming a root is the operator choosing the project, so we don't quietly widen
+        // the boundary to wherever their shell happened to be.
+        //
+        // Without one, the invocation cwd is *additive* — an allowed tree in its own
+        // right and the natural default root. It is deliberately NOT conditional on
+        // `allowed` being empty: `--allow-path` says "also allow this", so reaching one
+        // more tree must never cost the caller the workspace they launched in (which is
+        // the workspace an MCP client sets as cwd, and the one their question is about).
+        // `--no-cwd` / `KAIBO_NO_CWD` / `[server] infer_cwd = false` opts out, leaving
+        // the allowed set exactly what was named and every call obliged to pass `path`.
+        //
+        // The old rule — cwd only when nothing else was allowed — meant a single
+        // `--allow-path` silently evicted the project from scope, turning every
+        // path-less call into a parameter error. See `tests/containment.rs`.
         let (default_root, default_root_inferred): (Option<PathBuf>, bool) = match explicit_root {
             Some(root) => (Some(root), false),
+            None if !config.infer_cwd => (None, false),
             None => {
                 let cwd = std::env::current_dir()
                     .context("could not determine current directory for the default root")?;
                 let cwd_canon = std::fs::canonicalize(&cwd)
                     .with_context(|| format!("canonicalizing cwd {}", cwd.display()))?;
-                if allowed.is_empty() {
-                    // Zero config: the workspace is the whole boundary. Push it here,
-                    // before the guard below, so the `starts_with` check adopts cwd as
-                    // the default root in the zero-config case.
+                // Push before the containment check so the cwd is judged against a set
+                // that includes itself — it is an allowed tree, not a guest of one.
+                if !allowed.iter().any(|tree| cwd_canon.starts_with(tree)) {
                     allowed.push(cwd_canon.clone());
                 }
-                if allowed.iter().any(|tree| cwd_canon.starts_with(tree)) {
-                    (Some(cwd_canon), true)
-                } else {
-                    (None, false)
-                }
+                (Some(cwd_canon), true)
             }
         };
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -891,6 +891,7 @@ fn cli_cast_wins_over_env_and_file() {
         },
         vec![], // no --allow-path flags
         false,  // --no-follow-worktrees not passed
+        false,  // --no-cwd not passed
         vec![], // no --project-context-file flags
         vec![], // no --user-context-file flags
         false,  // --no-persistence not passed
@@ -921,6 +922,7 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
         None,
         ToolDisables::default(),
         vec![],
+        false,
         false,
         vec![],
         vec![],
@@ -1783,6 +1785,7 @@ fn persistence_cli_wins_over_lower_layers() {
         None,
         ToolDisables::default(),
         vec![],
+        false,
         false,
         vec![],
         vec![],

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -44,6 +44,16 @@ fn handler_with_allowed(root: Option<&Path>, allow_paths: &[&Path]) -> KaiboHand
     KaiboHandler::new(config).expect("handler builds")
 }
 
+/// The same, with the cwd inference turned off (`--no-cwd` / `KAIBO_NO_CWD` /
+/// `[server] infer_cwd = false`).
+fn handler_no_cwd(root: Option<&Path>, allow_paths: &[&Path]) -> KaiboHandler {
+    let mut config = Config::builtin();
+    config.root = root.map(|p| p.to_path_buf());
+    config.allow_paths = allow_paths.iter().map(|p| p.to_path_buf()).collect();
+    config.infer_cwd = false;
+    KaiboHandler::new(config).expect("handler builds")
+}
+
 // --- (a) path outside the allowed set is rejected ----------------------------
 
 /// A call whose `path` resolves outside the allowed tree must be rejected with an
@@ -262,21 +272,52 @@ async fn omitted_path_zero_config_infers_cwd_as_default_root() {
     );
 }
 
-// --- (f2) an allow-path that excludes the cwd leaves no default root ----------
+// --- (f2) --allow-path is ADDITIVE: it never costs you the cwd ---------------
 
-/// When `--allow-path` is set to a tree that does NOT contain the launch cwd and
-/// no `--root` is given, the cwd is outside the boundary, so it must NOT be adopted
-/// as the default root. An omitted `path` then remains a parameter error — we never
-/// default to a root the containment check would reject.
+/// `--allow-path` widens the boundary; it must never *narrow* it. With no explicit
+/// `--root`, the launch cwd stays in the allowed set and stays the inferred default
+/// root even when an `--allow-path` names an unrelated tree.
+///
+/// This is the flag's whole contract, and getting it backwards was a live footgun: a
+/// user who added `--allow-path` to reach one more tree used to lose the workspace they
+/// were consulting about, and every call without an explicit `path` started erroring.
 #[tokio::test]
-async fn omitted_path_with_allow_path_excluding_cwd_still_errors() {
-    let allowed = tempdir().unwrap(); // a tempdir, never an ancestor of the crate cwd
-    let handler = handler_with_allowed(None, &[allowed.path()]);
+async fn allow_path_is_additive_and_keeps_the_cwd() {
+    let extra = tempdir().unwrap(); // a tempdir, never an ancestor of the crate cwd
+    let handler = handler_with_allowed(None, &[extra.path()]);
 
-    // No default root was inferred (cwd is outside the allow-path).
+    let cwd = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
+    assert_eq!(
+        handler.default_root().as_deref(),
+        Some(cwd.as_path()),
+        "adding an allow-path must not cost you the cwd as default root"
+    );
+    assert!(handler.default_root_inferred());
+
+    // Both trees are readable: the cwd (implicit) and the named one (explicit).
+    handler
+        .run_kaish(Parameters(RunKaishInput {
+            script: "ls".to_string(),
+            path: None,
+        }))
+        .await
+        .expect("an omitted path resolves to the still-inferred cwd");
+    try_run(&handler, extra.path().to_str().unwrap(), "ls")
+        .await
+        .expect("the explicitly allowed tree is readable too");
+}
+
+/// `--no-cwd` is how you get the strict reading: only what you named is allowed, and an
+/// omitted `path` is a parameter error rather than a silent default. (This is the
+/// behavior `--allow-path` alone used to impose on everyone.)
+#[tokio::test]
+async fn no_cwd_drops_the_inferred_root_and_the_cwd_tree() {
+    let extra = tempdir().unwrap();
+    let handler = handler_no_cwd(None, &[extra.path()]);
+
     assert!(
         handler.default_root().is_none(),
-        "cwd outside the allowed set must not be adopted as a default root"
+        "--no-cwd means no inferred default root"
     );
     assert!(!handler.default_root_inferred());
 
@@ -287,33 +328,39 @@ async fn omitted_path_with_allow_path_excluding_cwd_still_errors() {
         }))
         .await
         .expect_err("omitted path with no default root must be a parameter error");
-
     let err_str = format!("{err:?}");
     assert!(
         err_str.contains("path") || err_str.contains("root") || err_str.contains("parameter"),
         "omitted path must produce a parameter-flavored error, got: {err_str}"
     );
+
+    // …and the cwd itself is outside the boundary, not merely undefaulted.
+    let cwd = std::env::current_dir().unwrap();
+    try_run(&handler, cwd.to_str().unwrap(), "ls")
+        .await
+        .expect_err("--no-cwd removes the cwd from the allowed set entirely");
 }
 
-// --- (f3) cwd is an *ancestor* of the only allow-path: no default root --------
+// --- (f3) cwd as an *ancestor* of the allow-path is still additive ------------
 
-/// When the only `--allow-path` is a *descendant* of the launch cwd (so cwd is an
-/// ancestor of the boundary, not inside it), the cwd must NOT be adopted as the
-/// default root: `cwd.starts_with(allow_path)` is false, so cwd is above the boundary
-/// and resolving to it would escape the allowed set. This pins the ancestor-vs-
-/// descendant semantic distinctly from the sibling case in (f2).
+/// The ancestor case: the only `--allow-path` is a *descendant* of the launch cwd.
+/// `cwd.starts_with(allow_path)` is false, so before the additive rule the cwd was
+/// judged "above the boundary" and dropped. Now the cwd is a tree in its own right, so
+/// it is both allowed and the default root — and the descendant is reachable because it
+/// sits inside the cwd anyway. Pins the ancestor case distinctly from the sibling case
+/// in (f2).
 #[tokio::test]
-async fn omitted_path_with_cwd_ancestor_of_allow_path_has_no_default_root() {
-    // Create the allow-path *inside* the crate cwd so cwd is its ancestor. (tempdir's
-    // usual /tmp location would be a sibling, exercising a different branch.)
+async fn cwd_ancestor_of_allow_path_stays_the_default_root() {
     let sub = tempfile::tempdir_in(".").expect("tempdir under cwd");
     let handler = handler_with_allowed(None, &[sub.path()]);
 
-    assert!(
-        handler.default_root().is_none(),
-        "cwd as an ancestor of the allow-path is outside the boundary; no default root"
+    let cwd = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
+    assert_eq!(
+        handler.default_root().as_deref(),
+        Some(cwd.as_path()),
+        "an allow-path inside the cwd must not displace the cwd as default root"
     );
-    assert!(!handler.default_root_inferred());
+    assert!(handler.default_root_inferred());
 
     handler
         .run_kaish(Parameters(RunKaishInput {
@@ -321,7 +368,29 @@ async fn omitted_path_with_cwd_ancestor_of_allow_path_has_no_default_root() {
             path: None,
         }))
         .await
-        .expect_err("omitted path with no default root must be a parameter error");
+        .expect("an omitted path resolves to the cwd");
+}
+
+/// An explicit `--root` is the user naming *the* project, so the cwd is NOT quietly
+/// added beside it: the boundary stays exactly what was asked for. (Repeating `--root`
+/// is refused by the parser — it is the default project, and there can only be one;
+/// `--allow-path` is the repeatable, additive knob.)
+#[tokio::test]
+async fn explicit_root_does_not_pull_in_the_cwd() {
+    let root = tempdir().unwrap();
+    let handler = handler_with_allowed(Some(root.path()), &[]);
+
+    let canon_root = std::fs::canonicalize(root.path()).unwrap();
+    assert_eq!(handler.default_root().as_deref(), Some(canon_root.as_path()));
+    assert!(
+        !handler.default_root_inferred(),
+        "an explicit root is configured, not inferred"
+    );
+
+    let cwd = std::env::current_dir().unwrap();
+    try_run(&handler, cwd.to_str().unwrap(), "ls")
+        .await
+        .expect_err("naming a root must not silently allow the launch cwd as well");
 }
 
 // --- (h) empty-string path is rejected as invalid_params --------------------
@@ -519,6 +588,7 @@ fn allow_paths_cli_replaces_env_and_file() {
             std::path::PathBuf::from("/tmp/cli-a"),
             std::path::PathBuf::from("/tmp/cli-b"),
         ],
+        false,
         false,
         vec![],
         vec![],


### PR DESCRIPTION
## The bug

The README's MCP registration stanza advertises:

```jsonc
"args": ["--allow-path", "/extra/tree"]        // widen read scope (repeatable)
```

It didn't widen. `Resolver::from_config` adopted the launch cwd **only when the allowed
set was otherwise empty** (`src/server/resolver.rs:110-116` on main). So with no `--root`,
a single `--allow-path /extra` made the allowed set exactly `[/extra]`: the workspace the
user was consulting about left the boundary, `default_root` became `None`, and every call
that omitted `path` failed with *"no `path` provided and the server has no default root."*

A user reaching for one more tree lost their project instead — and the flag whose own help
text says "additional allowed path tree" was what took it away. MCP clients launch kaibo
with cwd = workspace, so this hit exactly the zero-config setup the docs recommend.

## The rule now

| flags | allowed set | default root |
|---|---|---|
| *(none)* | cwd | cwd |
| `--allow-path B` | **cwd + B** *(was: B only)* | **cwd** *(was: none)* |
| `--root A` | A | A |
| `--root A --allow-path B` | A + B | A |
| `--no-cwd --allow-path B` | B | none — calls pass `path` |

Without an explicit `--root`, the invocation cwd is an allowed tree and the inferred
default root regardless of what `--allow-path` names. Naming a `--root` is unchanged —
that's the operator choosing the project, so the cwd isn't quietly added beside it.

**`--root` stays non-repeatable**, and that's deliberate: it does double duty as an allowed
tree *and* the default project a path-less call resolves to, and "which of these three is
the default?" has no honest answer. The parser already refuses a second occurrence rather
than silently picking; both flags' help text now says which one is the additive knob.

**`--no-cwd`** (`KAIBO_NO_CWD`, `[server] infer_cwd = false`) is the new opt-out — the
honest form of what `--allow-path` alone used to impose on everyone: the allowed set is
exactly what you named, no inferred default root, every call passes its own `path`.

## Security note

This **widens** the boundary in one case, so it's loud in the CHANGELOG: anyone who used
`--allow-path` alone to *narrow* scope now needs `--no-cwd`. I think the flag name made
the narrowing reading unsupportable, but it is a real change to a security surface.

The containment invariant is untouched: a per-call path still has to canonicalize into the
allowed set, and kaibo still never adopts a default root its own check would reject. What
changed is what's *in* the set, not how it's enforced.

## Tests — proven to fail first

Reverting only the resolver hunk:

```
test allow_path_is_additive_and_keeps_the_cwd ... FAILED
test cwd_ancestor_of_allow_path_stays_the_default_root ... FAILED
test no_cwd_drops_the_inferred_root_and_the_cwd_tree ... ok
test explicit_root_does_not_pull_in_the_cwd ... ok
```

The two old tests that pinned the eviction (`omitted_path_with_allow_path_excluding_cwd_still_errors`,
`omitted_path_with_cwd_ancestor_of_allow_path_has_no_default_root`) are rewritten around
the new rule — with their original assertions preserved behind `--no-cwd`, so the strict
boundary stays covered rather than deleted.

- `cargo test` — 706 pass, 0 fail. `cargo clippy --all-targets` clean.
- Docs: README registration comment (the one that misled), `docs/config.md` (path-containment
  section + settings table row), `docs/config.example.toml` (`infer_cwd`), CHANGELOG.

## Note for a follow-up, not this PR

`cargo fmt --check` reports **84 diffs across ~24 files on clean `main`** — CI doesn't run
it. None are from this branch (I verified the hits in my touched files are main's drift,
shifted by my inserts). Worth a dedicated formatting PR plus a CI step, rather than burying
it in a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cLSYtttNJjNeAeYkemdaZ
