### PR TITLE
Add per-backend wire = "responses" | "chat" for openai-kind backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ the git log. Each later release appends a new section at the top.
 
 ### Added
 
+- **GPT-5.x is now usable behind OpenAI-compatible gateways via `wire = "responses"`.**
+  A new per-backend `[backends.<name>]` knob (`openai` kind only) picks the interactive
+  request shape explicitly: `"responses"` for rig's Responses client, `"chat"` for
+  OpenAI-compatible Chat Completions. It's optional — unset still infers the shape from
+  the endpoint, exactly as before — and exists for a gateway/proxy that implements the
+  Responses API at `/v1/responses` (verified against a real gateway) without sitting at
+  OpenAI Platform's own URL: without it, current GPT-5.x reasoning models reject Chat
+  Completions' `max_tokens` outright. `wire` never affects batch eligibility, which stays
+  Platform-only.
 - **Hosted OpenAI Platform backends now use the Responses API for interactive GPT calls.**
   A `kind = "openai"` backend pointed exactly at `https://api.openai.com/v1` can run
   current GPT-5.6 models through `oneshot` and `consult`, including image attachment and

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -289,6 +289,22 @@ base_url = "http://localhost:8080/v1"
 key_optional = true
 request_timeout_secs = 1800
 
+# An OpenAI-compatible gateway/proxy that implements OpenAI's Responses API at
+# /v1/responses (verified against a real gateway) — not OpenAI Platform's own
+# endpoint, so kaibo can't infer this from the URL. `wire = "responses"` opts it
+# into rig's Responses client for interactive calls, the shape current GPT-5.x
+# reasoning models require (they reject Chat Completions' `max_tokens` outright).
+# `wire = "chat"` is the symmetric opt-out, including on OpenAI Platform's own
+# endpoint. Either way, batch stays Platform-only: a gateway proxying /v1/responses
+# doesn't necessarily proxy /v1/batches or the Files API, so `wire` never affects
+# `batch_submit` eligibility — only `[backends.gpt]` above (Platform's exact URL)
+# can staff a batch synth.
+[backends.gateway]
+kind = "openai"
+base_url = "https://llm-gateway.example.internal/v1"
+api_key_env = "GATEWAY_API_KEY"
+wire = "responses"
+
 # ---------------------------------------------------------------------------
 # [casts.<name>] — COMPOSITIONS: role → model, freely spanning backends. This is
 # what the `cast` call param (and `server.cast` / KAIBO_CAST / --cast) selects.

--- a/docs/config.md
+++ b/docs/config.md
@@ -78,6 +78,21 @@ Connection knobs only — models never live here:
   corporate LLM gateway, say). For every *other* keyed kind rig fixes the
   endpoint, so a `base_url` there is a config error, surfaced loudly — not
   silently ignored.
+- **`wire`** (`kind = "openai"` only) picks the interactive request shape: `"responses"`
+  for rig's Responses client, `"chat"` for OpenAI-compatible Chat Completions. Optional
+  and normally unset — kaibo infers it from the endpoint (OpenAI Platform's exact URL
+  gets Responses, everything else gets Chat Completions), which is why hosted GPT and
+  local Gemma both already worked without this knob. It exists for the case the
+  heuristic can't see: an OpenAI-compatible gateway/proxy that implements the Responses
+  API at `/v1/responses` (verified against a real gateway) but doesn't sit at Platform's
+  URL. Current GPT-5.x reasoning models *require* Responses — they reject Chat
+  Completions' `max_tokens` outright (`unsupported_parameter`) — so `wire = "responses"`
+  is what makes them usable behind such a gateway. `wire = "chat"` is the symmetric
+  opt-out, including on Platform's own endpoint. Either setting is **interactive-only**:
+  it never changes batch eligibility (the batch-lane discussion under Casts below),
+  which stays keyed to the endpoint-exact check alone — a gateway proxying
+  `/v1/responses` doesn't necessarily proxy `/v1/batches` or the Files API. A `wire` on
+  any other kind is a load error, same discipline as `data_collection` below.
 - A backend resolves its key from `api_key_env` then `api_key_file` (env wins).
   **Secrets never live inline in the TOML** — only the *name* of an env var or the
   *path* to a key file. A config you can commit or paste shouldn't leak a key.
@@ -306,6 +321,10 @@ today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submi
 | `gemini` | gemini | — | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
 | `openrouter` | openrouter | — *(fixed)* | `OPENROUTER_API_KEY` / `~/.openrouter-key` | — |
 | `openai-local` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
+
+None of the built-ins set `wire` — it only matters for a new openai-kind backend
+whose endpoint isn't OpenAI Platform's own but should still take the Responses
+shape (`docs/config.example.toml`'s `[backends.gateway]`).
 
 | cast | explorer | synth | synth lane |
 |---|---|---|---|

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -480,6 +480,17 @@ in the module doc and `docs/devlog.md`. What's left:
   arm plus a hosted-ness predicate beside `is_hosted_openai`, not a refactor. Do it when the
   first such backend shows up, not before — the `anthropic` kind already permits a custom
   `base_url` (`AnthropicBatch::base_url`), so the predicate needs deciding, not discovering.
+- **Batch on a `wire = "responses"` gateway needs its own per-backend capability
+  decision.** Landed 2026-07-27 alongside the `wire` knob (`Backend::uses_responses_wire`,
+  `config.rs`): an openai-kind backend can now opt an OpenAI-compatible gateway into the
+  Responses shape for *interactive* calls without it sitting at OpenAI Platform's exact
+  URL. Deliberately kept separate from batch — `is_hosted_openai` (the
+  `batch_supported`/`require_hosted` gate) stays endpoint-exact and does not follow
+  `wire`, because a gateway proxying `/v1/responses` doesn't necessarily proxy
+  `/v1/batches` or the Files API. If a responses-wire gateway that *does* faithfully
+  proxy batch shows up, it needs its own opt-in (a `batch = true` on the backend,
+  say) rather than silently riding in on `wire = "responses"` — same "decide when the
+  backend shows up" posture as the `anthropic` note above.
 - **The many-casts fork.** `batch_submit` today is many-prompts/**one**-cast (one
   provider batch). The diverse-opinion panel — one question across **many** casts — is N
   provider batches under a composite handle; deferred. The provenance footer already

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -2152,6 +2152,7 @@ mod tests {
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         }
     }
 
@@ -3224,6 +3225,20 @@ mod tests {
         }
     }
 
+    /// An OpenAI-compatible gateway that proxies `/v1/responses` (`wire = "responses"`),
+    /// so its interactive calls take the Responses shape — but has no `/v1/batches` or
+    /// Files API behind it, so it must stay refused here regardless.
+    fn responses_wire_gateway_backend() -> Backend {
+        Backend {
+            name: "gateway".into(),
+            kind: ProviderKind::Openai,
+            base_url: Some("https://llm-gateway.example.internal/v1".into()),
+            key_optional: true,
+            wire: Some(crate::config::OpenaiWire::Responses),
+            ..anthropic_backend()
+        }
+    }
+
     /// The `openai` kind's batch verdict is a *backend* property, not a kind property:
     /// same kind, opposite answers, decided by the base URL. This is the regression that
     /// matters — a kind-keyed check would hand a local server a batch lane it can't serve.
@@ -3235,6 +3250,26 @@ mod tests {
         let mut slashed = hosted_openai_backend();
         slashed.base_url = Some(format!("{}/", crate::credentials::HOSTED_OPENAI_BASE_URL));
         assert!(batch_supported(&slashed));
+    }
+
+    /// `wire = "responses"` is an interactive-shape override, not a batch-eligibility
+    /// grant: `is_hosted_openai` — the gate `batch_supported`/`require_hosted` actually
+    /// check — stays endpoint-exact regardless of `wire`. A gateway that proxies
+    /// `/v1/responses` does not necessarily proxy `/v1/batches` or the Files API, so it
+    /// must still be refused a batch lane.
+    #[test]
+    fn responses_wire_gateway_is_not_batch_eligible() {
+        let backend = responses_wire_gateway_backend();
+        assert!(
+            backend.uses_responses_wire(),
+            "fixture must select the Responses shape for interactive calls"
+        );
+        assert!(
+            !batch_supported(&backend),
+            "wire = \"responses\" must not make a gateway batch-eligible"
+        );
+        assert!(OpenaiBatch::from_backend(&backend).is_err());
+        assert!(poller(&backend).is_err());
     }
 
     /// Refusing a local openai backend names the *fix* (Platform's URL), not just the gap —

--- a/src/config.rs
+++ b/src/config.rs
@@ -401,6 +401,38 @@ impl std::str::FromStr for DataCollection {
     }
 }
 
+/// Which request shape an `openai`-kind backend speaks for interactive calls:
+/// rig's Responses client (`/v1/responses`) or the OpenAI-compatible Chat
+/// Completions client (`/v1/chat/completions`). Optional per backend — unset
+/// falls back to the endpoint-exact heuristic
+/// ([`Backend::uses_responses_wire`]). Exists only on the `openai` kind (a load
+/// error elsewhere); see that method for the precedence rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenaiWire {
+    /// rig's Responses client. Needed behind an OpenAI-compatible gateway/proxy
+    /// that implements `/v1/responses` — current GPT-5.x reasoning models reject
+    /// Chat Completions' `max_tokens` outright (`unsupported_parameter`).
+    Responses,
+    /// The OpenAI-compatible Chat Completions client — the default shape for a
+    /// local server or a gateway that doesn't proxy `/v1/responses`.
+    Chat,
+}
+
+impl std::str::FromStr for OpenaiWire {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "responses" => Ok(Self::Responses),
+            "chat" => Ok(Self::Chat),
+            other => bail!(
+                "wire {other:?} is not a request shape — use \"responses\" (rig's \
+                 Responses client, for a backend that implements /v1/responses) or \
+                 \"chat\" (OpenAI-compatible Chat Completions)"
+            ),
+        }
+    }
+}
+
 /// A connection: how kaibo reaches one provider endpoint. The `kind` is the wire
 /// protocol (the closed [`ProviderKind`] enum — the one place "provider" still
 /// means something); everything else describes the wire: endpoint, key source,
@@ -436,6 +468,11 @@ pub struct Backend {
     /// Deny by default on every kind; only an openrouter-kind backend may set it,
     /// and only the openrouter arm reads it.
     pub data_collection: DataCollection,
+    /// `openai` kind only: an explicit override of which request shape this
+    /// backend's interactive calls use (see [`OpenaiWire`]). `None` (the common
+    /// case) defers to [`Backend::uses_responses_wire`]'s endpoint-exact
+    /// heuristic. Only an openai-kind backend may set it.
+    pub wire: Option<OpenaiWire>,
 }
 
 impl Backend {
@@ -497,13 +534,45 @@ impl Backend {
     }
 
     /// True for a generic `openai` backend that is explicitly aimed at OpenAI
-    /// Platform. This is the narrow capability seam that lets kaibo use OpenAI's
-    /// first-party Responses shape for hosted GPT models while preserving the
-    /// local/OpenAI-compatible `/chat/completions` path for `openai-local` and
-    /// gateways that do not implement `/responses`.
+    /// Platform's exact endpoint. This is the **batch/platform-lane gate**
+    /// (`batch.rs`'s `batch_supported`/`require_hosted`) — it stays endpoint-exact
+    /// and does *not* follow an explicit `wire` override, because a gateway that
+    /// faithfully proxies `/v1/responses` (see [`Backend::uses_responses_wire`])
+    /// does not thereby proxy `/v1/batches` or the Files API. The two predicates
+    /// share the same endpoint check (below) but answer different questions: this
+    /// one is "is this OpenAI Platform itself", `uses_responses_wire` is "which
+    /// interactive request shape does this backend want".
     pub fn is_hosted_openai(&self) -> bool {
-        self.kind == ProviderKind::Openai
-            && self.resolved_base_url().trim_end_matches('/') == credentials::HOSTED_OPENAI_BASE_URL
+        self.kind == ProviderKind::Openai && self.is_openai_platform_endpoint()
+    }
+
+    /// The shared endpoint-exact check both `is_hosted_openai` and
+    /// `uses_responses_wire`'s unset-`wire` fallback are built on: does this
+    /// backend's resolved base URL match OpenAI Platform's, trailing slash
+    /// normalized. Private — callers want one of the two capability questions
+    /// above it, not the raw endpoint comparison.
+    fn is_openai_platform_endpoint(&self) -> bool {
+        self.resolved_base_url().trim_end_matches('/') == credentials::HOSTED_OPENAI_BASE_URL
+    }
+
+    /// Whether this backend's interactive calls use rig's Responses client
+    /// (`/v1/responses`) rather than OpenAI-compatible Chat Completions. An
+    /// explicit `wire` wins — `"responses"` opts a gateway in, `"chat"` opts even
+    /// OpenAI Platform itself out (cheap, symmetric, no known use case blocked).
+    /// Unset falls back to the endpoint-exact heuristic: hosted OpenAI Platform
+    /// gets Responses, everything else gets Chat Completions — today's behavior,
+    /// preserved for anyone who hasn't set the knob. This is deliberately *not*
+    /// [`Backend::is_hosted_openai`]: that one gates batch eligibility and must
+    /// not follow an interactive-only override (see its doc).
+    pub fn uses_responses_wire(&self) -> bool {
+        if self.kind != ProviderKind::Openai {
+            return false;
+        }
+        match self.wire {
+            Some(OpenaiWire::Responses) => true,
+            Some(OpenaiWire::Chat) => false,
+            None => self.is_openai_platform_endpoint(),
+        }
     }
 
     /// Whether this backend has a usable credential, judged *without* committing to a
@@ -1547,6 +1616,8 @@ fn backend_template(kind: ProviderKind, defaults: &Defaults) -> Backend {
         // Deny is the only safe default: kaibo's prompts carry source code, and
         // routing them to a data-collecting host must be an explicit choice.
         data_collection: DataCollection::Deny,
+        // Unset defers to the endpoint-exact heuristic (`uses_responses_wire`).
+        wire: None,
     }
 }
 
@@ -1878,6 +1949,8 @@ struct RawBackend {
     key_optional: Option<bool>,
     request_timeout_secs: Option<u64>,
     data_collection: Option<String>,
+    /// `openai` kind only — see [`OpenaiWire`]. A load error on any other kind.
+    wire: Option<String>,
 }
 
 impl RawBackend {
@@ -1929,6 +2002,23 @@ impl RawBackend {
             b.data_collection = v.parse().with_context(|| {
                 format!("backend {:?} data_collection", b.name)
             })?;
+        }
+        if let Some(v) = &self.wire {
+            // The knob only exists on the openai kind — naming it anywhere else
+            // is a config mistake worth a loud error, same discipline as
+            // data_collection above.
+            if b.kind != ProviderKind::Openai {
+                bail!(
+                    "backend {:?} (kind {:?}) sets wire, but only the `openai` kind \
+                     has a configurable request wire (chat completions vs. responses)",
+                    b.name,
+                    b.kind
+                );
+            }
+            b.wire = Some(
+                v.parse()
+                    .with_context(|| format!("backend {:?} wire", b.name))?,
+            );
         }
         Ok(())
     }
@@ -3789,6 +3879,143 @@ mod tests {
         assert!(cfg.backends["gpt"].is_hosted_openai());
         assert!(!cfg.backends["localish"].is_hosted_openai());
         assert!(!cfg.backends["anthropic"].is_hosted_openai());
+    }
+
+    /// `wire` parses on the openai kind and sticks as the typed enum.
+    #[test]
+    fn wire_knob_parses_on_openai_kind() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [backends.gateway]
+            kind = "openai"
+            base_url = "https://llm-gateway.example.internal/v1"
+            wire = "responses"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.backends["gateway"].wire,
+            Some(OpenaiWire::Responses),
+            "the knob must parse and stick on the backend"
+        );
+    }
+
+    /// `wire` only exists on the openai kind — setting it anywhere else is a
+    /// config mistake refused at load, same discipline as `data_collection`.
+    #[test]
+    fn wire_knob_is_openai_only() {
+        for kind in ["anthropic", "deepseek"] {
+            let err = Config::from_toml_str(&format!(
+                r#"
+                [backends.{kind}]
+                wire = "responses"
+                "#
+            ))
+            .unwrap_err();
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("wire") && msg.contains("openai"),
+                "kind {kind}, got: {msg}"
+            );
+        }
+    }
+
+    /// A `wire` value outside the two-value vocabulary is a loud load error naming
+    /// both legal spellings — a typo shouldn't silently fall back to the
+    /// endpoint-exact heuristic and leave the operator wondering why GPT-5.x still
+    /// fails.
+    #[test]
+    fn wire_knob_rejects_an_unknown_value() {
+        let err = Config::from_toml_str(
+            r#"
+            [backends.gateway]
+            kind = "openai"
+            base_url = "https://llm-gateway.example.internal/v1"
+            wire = "streaming"
+            "#,
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("responses") && msg.contains("chat"),
+            "got: {msg}"
+        );
+    }
+
+    /// `uses_responses_wire`'s full precedence table: unset defers to the
+    /// endpoint-exact heuristic (trailing slash normalized either way); an
+    /// explicit `wire` overrides it in both directions — `"responses"` opts a
+    /// gateway in, `"chat"` opts even OpenAI Platform's own endpoint out; and a
+    /// non-openai kind is always false regardless of `wire` (which it can't set).
+    /// Mirrors `hosted_openai_detection_is_endpoint_exact`, but for the
+    /// interactive-wire predicate rather than the batch/platform gate.
+    #[test]
+    fn uses_responses_wire_precedence() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [backends.gpt]
+            kind = "openai"
+            base_url = "https://api.openai.com/v1"
+
+            [backends.gpt-slash]
+            kind = "openai"
+            base_url = "https://api.openai.com/v1/"
+
+            [backends.localish]
+            kind = "openai"
+            base_url = "http://localhost:13305/api/v1"
+
+            [backends.gateway]
+            kind = "openai"
+            base_url = "https://llm-gateway.example.internal/v1"
+            wire = "responses"
+
+            [backends.gpt-forced-chat]
+            kind = "openai"
+            base_url = "https://api.openai.com/v1"
+            wire = "chat"
+
+            [casts.x]
+            synth = "gpt/gpt-5.6-sol"
+            "#,
+        )
+        .unwrap();
+        assert!(
+            cfg.backends["gpt"].uses_responses_wire(),
+            "unset + api.openai.com is Responses"
+        );
+        assert!(
+            cfg.backends["gpt-slash"].uses_responses_wire(),
+            "unset + api.openai.com/ (trailing slash) is still Responses"
+        );
+        assert!(
+            !cfg.backends["localish"].uses_responses_wire(),
+            "unset + a local server is Chat Completions"
+        );
+        assert!(
+            cfg.backends["gateway"].uses_responses_wire(),
+            "wire = \"responses\" opts a gateway in even though it isn't Platform"
+        );
+        assert!(
+            !cfg.backends["gpt-forced-chat"].uses_responses_wire(),
+            "wire = \"chat\" opts OpenAI Platform's own endpoint out"
+        );
+        assert!(
+            !cfg.backends["anthropic"].uses_responses_wire(),
+            "a non-openai kind is always false"
+        );
+
+        // The batch/platform gate (`is_hosted_openai`) must NOT follow the
+        // `wire` override: a responses-wire gateway is still not OpenAI Platform,
+        // and forcing chat on Platform's own endpoint doesn't relocate it either.
+        assert!(
+            !cfg.backends["gateway"].is_hosted_openai(),
+            "wire = \"responses\" must not make a gateway batch-eligible"
+        );
+        assert!(
+            cfg.backends["gpt-forced-chat"].is_hosted_openai(),
+            "wire = \"chat\" doesn't move OpenAI Platform's own endpoint"
+        );
     }
 
     /// A backend name containing '/' is refused at load. Both the slot ref

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -262,13 +262,19 @@ impl Arm {
             Some(t.top_p),
             &t.effort,
         );
-        let hosted_openai = backend.is_hosted_openai();
-        let params = if hosted_openai {
+        // Interactive wire selection: an explicit per-backend `wire` wins; unset
+        // falls back to the endpoint-exact heuristic (today's behavior). This is
+        // deliberately `uses_responses_wire`, not the narrower `is_hosted_openai` —
+        // that one gates batch eligibility and must stay endpoint-exact (see its
+        // doc in `config.rs`), while this call site only builds the interactive
+        // request shape.
+        let responses_wire = backend.uses_responses_wire();
+        let params = if responses_wire {
             super::shaping::hosted_openai_responses_params(&slot.id, Some(t.top_p), &t.effort)
         } else {
             params
         };
-        let typed_temperature = if hosted_openai {
+        let typed_temperature = if responses_wire {
             super::shaping::hosted_openai_responses_temperature(&slot.id, t.temperature)
         } else {
             None
@@ -345,7 +351,7 @@ impl Arm {
                 // returns the configured key or a placeholder the server ignores.
                 let base_url = backend.resolved_base_url();
                 let key = backend.resolve_key()?;
-                if hosted_openai {
+                if responses_wire {
                     let client = openai::Client::builder()
                         .api_key(&key)
                         .base_url(&base_url)
@@ -3315,6 +3321,7 @@ mod tests {
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot {
             vision: Some(true),
@@ -3366,6 +3373,7 @@ mod tests {
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         assert!(
             backend.is_hosted_openai(),
@@ -3403,6 +3411,54 @@ mod tests {
         );
     }
 
+    /// An OpenAI-compatible gateway that faithfully proxies `/v1/responses` (verified
+    /// against a real gateway) is not OpenAI Platform's own endpoint, so the
+    /// endpoint-exact heuristic alone would leave it on Chat Completions — starving
+    /// current GPT-5.x reasoning models, which reject `max_tokens` outright. An
+    /// explicit `wire = "responses"` on the backend opts it into the same
+    /// Responses-shaped arm hosted OpenAI Platform gets, without the gateway needing
+    /// to sit at Platform's exact URL.
+    #[test]
+    fn responses_wire_gateway_arm_uses_responses_shape() {
+        let defaults = crate::config::Defaults::default();
+        let backend = crate::config::Backend {
+            name: "gateway".into(),
+            kind: ProviderKind::Openai,
+            base_url: Some("https://llm-gateway.example.internal/v1".into()),
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: true,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+            wire: Some(crate::config::OpenaiWire::Responses),
+        };
+        assert!(
+            !backend.is_hosted_openai(),
+            "fixture must NOT be OpenAI Platform itself — that's the whole point"
+        );
+        assert!(
+            backend.uses_responses_wire(),
+            "the explicit wire override selects the Responses shape"
+        );
+        let slot = ModelSlot {
+            effort: Some("high".into()),
+            ..ModelSlot::bare("gateway", "gpt-5.6-sol")
+        };
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a responses-wire gateway arm builds offline with a placeholder key");
+        assert_eq!(arm.model, "gpt-5.6-sol");
+        let params = arm.params.expect("responses-wire gateway sends Responses params");
+        assert_eq!(
+            params["reasoning"]["effort"], "high",
+            "reasoning effort reaches the gateway the same way it reaches Platform"
+        );
+        assert!(
+            params.get("max_tokens").is_none() && params.get("max_completion_tokens").is_none(),
+            "the Responses client maps core max_tokens to max_output_tokens, not \
+             the Chat Completions field GPT-5.x rejects"
+        );
+    }
+
     /// Older hosted GPT chat models keep sampling: the same Responses seam is used,
     /// but model-aware shaping routes temperature through rig's typed field and
     /// `top_p` through Responses additional parameters.
@@ -3418,6 +3474,7 @@ mod tests {
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot {
             temperature: Some(0.4),
@@ -3459,6 +3516,7 @@ mod tests {
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot::bare("anthropic", "claude-sonnet-4-6");
         let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
@@ -3496,6 +3554,7 @@ mod tests {
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot {
             temperature: Some(0.3),
@@ -3543,6 +3602,7 @@ mod tests {
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: crate::config::DataCollection::Allow,
+            wire: None,
         };
         let slot = ModelSlot::bare("openrouter", "~anthropic/claude-sonnet-latest");
         let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
@@ -3578,6 +3638,7 @@ mod tests {
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot {
             effort: Some("none".into()),
@@ -3655,6 +3716,7 @@ mod tests {
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot::bare("anthropic", "claude-haiku-4-5");
         let err = Arm::from_slot(&backend, &slot, ModelRole::Explorer, &defaults)
@@ -3686,6 +3748,7 @@ mod tests {
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot::bare("gemini", "gemini-3.5-flash");
         if let Err(e) = Arm::from_slot(&backend, &slot, ModelRole::Explorer, &defaults) {

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -207,6 +207,13 @@ pub(crate) fn render_config_resource(
         /// absent on every other kind.
         #[serde(skip_serializing_if = "Option::is_none")]
         data_collection: Option<&'static str>,
+        /// openai kind only: the *resolved* interactive request wire —
+        /// `"responses"` or `"chat"` (see [`crate::config::Backend::uses_responses_wire`]).
+        /// An explicit `wire` config value renders as itself; unset renders the
+        /// endpoint-exact heuristic's answer, so the effective shape is always
+        /// visible even when nothing was configured. Absent on every other kind.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        wire: Option<&'static str>,
     }
 
     /// One cast slot: the `"backend/id"` ref plus its *resolved* capabilities
@@ -262,6 +269,7 @@ pub(crate) fn render_config_resource(
                 key_optional,
                 request_timeout,
                 data_collection,
+                wire: _,
             } = b;
             let rendered_base_url = if *kind == crate::credentials::ProviderKind::Openai {
                 Some(b.resolved_base_url())
@@ -281,6 +289,16 @@ pub(crate) fn render_config_resource(
                         crate::config::DataCollection::Deny => "deny",
                         crate::config::DataCollection::Allow => "allow",
                     }),
+                // Resolved, not raw: an unset `wire` still has an effective shape
+                // (the endpoint-exact heuristic), so render what the backend will
+                // actually do, not just what was configured.
+                wire: (*kind == crate::credentials::ProviderKind::Openai).then_some(
+                    if b.uses_responses_wire() {
+                        "responses"
+                    } else {
+                        "chat"
+                    },
+                ),
             };
             (name.clone(), doc)
         })
@@ -321,12 +339,17 @@ pub(crate) fn render_config_resource(
                         &slot.id,
                         thinking_style.unwrap_or_default(),
                     );
-                    let hosted_openai = backend.is_hosted_openai();
+                    // The interactive shape a slot's arm will actually build under
+                    // (`Arm::from_slot`) follows `uses_responses_wire`, not the
+                    // narrower `is_hosted_openai` platform gate — a responses-wire
+                    // gateway shapes its inert tunables the same way hosted OpenAI
+                    // Platform does, even though it isn't batch-eligible.
+                    let responses_wire = backend.uses_responses_wire();
                     let mut inert_tunables = Vec::new();
                     let effort_sinks = shape.sinks_effort()
-                        || (hosted_openai
+                        || (responses_wire
                             && crate::consult::hosted_openai_accepts_reasoning(&slot.id));
-                    let sampling_sinks = if hosted_openai {
+                    let sampling_sinks = if responses_wire {
                         crate::consult::hosted_openai_accepts_sampling(&slot.id)
                     } else {
                         shape.sinks_sampling()
@@ -612,6 +635,59 @@ mod tests {
             inert("gpt_chat", "synth"),
             vec!["thinking_budget", "effort"],
             "hosted GPT chat sinks sampling but rejects reasoning effort and budget"
+        );
+    }
+
+    /// `kaibo://config` renders each openai-kind backend's *resolved* wire — the
+    /// answer `uses_responses_wire` gives, not the raw configured value — so an
+    /// unset `wire` still shows an effective shape. Absent on every other kind.
+    #[test]
+    fn config_render_shows_resolved_wire_for_openai_backends() {
+        let config = Config::from_toml_str(
+            r#"
+            [backends.gpt]
+            kind = "openai"
+            base_url = "https://api.openai.com/v1"
+
+            [backends.gateway]
+            kind = "openai"
+            base_url = "https://llm-gateway.example.internal/v1"
+            wire = "responses"
+
+            [backends.onprem]
+            kind = "openai"
+            base_url = "http://localhost:13399/api/v1"
+            "#,
+        )
+        .unwrap();
+        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
+        let wire = |name: &str| -> Option<String> {
+            doc.get("backends")
+                .and_then(|b| b.get(name))
+                .and_then(|b| b.get("wire"))
+                .and_then(|w| w.as_str())
+                .map(str::to_string)
+        };
+        assert_eq!(
+            wire("gpt").as_deref(),
+            Some("responses"),
+            "unset wire on OpenAI Platform's own endpoint resolves to responses"
+        );
+        assert_eq!(
+            wire("gateway").as_deref(),
+            Some("responses"),
+            "an explicit wire = \"responses\" renders as configured"
+        );
+        assert_eq!(
+            wire("onprem").as_deref(),
+            Some("chat"),
+            "unset wire on a local server resolves to chat"
+        );
+        assert_eq!(
+            wire("anthropic"),
+            None,
+            "wire is absent on every non-openai kind"
         );
     }
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1211,6 +1211,7 @@ fn local_backend(api_key_file: Option<String>, key_optional: bool) -> Backend {
         key_optional,
         request_timeout: Duration::from_secs(900),
         data_collection: Default::default(),
+        wire: None,
     }
 }
 
@@ -1248,6 +1249,7 @@ fn required_key_with_no_source_is_an_error() {
         key_optional: false,
         request_timeout: Duration::from_secs(900),
         data_collection: Default::default(),
+        wire: None,
     };
     let err = b.resolve_key().unwrap_err();
     assert!(


### PR DESCRIPTION
## Problem

kaibo only speaks OpenAI's Responses API when an `openai`-kind backend's `base_url`
is exactly `api.openai.com` (`Backend::is_hosted_openai`, `src/config.rs`). Every
other `openai`-kind backend gets rig's Chat Completions client, which sends
`max_tokens` — and current GPT-5.x reasoning models reject that outright
(`unsupported_parameter`; they want `max_completion_tokens`/Responses). So GPT-5.x
behind an OpenAI-compatible gateway/proxy that implements OpenAI's Responses API at
`/v1/responses` (verified against a real gateway) was unusable, even though nothing
about the wire protocol required that.

## Design decisions

- **New optional per-backend field**: `wire = "responses" | "chat"` on an
  `openai`-kind backend (`RawBackend`/`Backend` in `src/config.rs`). Validated in
  the existing loud style — a load error on any non-openai kind (naming the fix),
  and a load error naming both legal values on an unknown one.

- **Split the predicate in two, rather than growing `is_hosted_openai` a `wire`
  branch.** `is_hosted_openai` keeps its endpoint-exact meaning and stays the
  **batch/platform-lane gate** (`src/batch.rs`'s `batch_supported`/`require_hosted`)
  — a gateway that faithfully proxies `/v1/responses` does not necessarily proxy
  `/v1/batches` or the Files API, so `wire = "responses"` must never grant batch
  eligibility. The new `Backend::uses_responses_wire()` is the interactive-only
  question: an explicit `wire` wins in either direction (a gateway can opt in, or
  OpenAI Platform's own endpoint can opt out to Chat Completions); unset falls back
  to the same endpoint-exact heuristic `is_hosted_openai` uses, preserving today's
  behavior for anyone who hasn't set the knob. Both predicates share a private
  `is_openai_platform_endpoint` helper so the endpoint check itself isn't
  duplicated.

- **Interactive wire selection** (`Arm::from_slot` in `src/consult/engine.rs`) now
  reads `uses_responses_wire` instead of `is_hosted_openai`. `kaibo://config`'s
  rendered `wire` and its inert-tunables computation (`src/server/config_resource.rs`)
  follow the same swap, since both describe the interactive request shape, not
  batch eligibility. `src/batch.rs`'s `batch_supported`/`require_hosted` are
  untouched — still `is_hosted_openai`.

- **Docs**: `docs/config.example.toml` gets a `[backends.gateway]` example (a
  `wire = "responses"` gateway), `docs/config.md` documents the knob in prose and
  notes that none of the built-in backends set it. `CHANGELOG.md` gets one `Added`
  entry. `docs/issues.md` notes the deliberate follow-up: if a responses-wire
  gateway ever does faithfully proxy `/v1/batches`, it needs its own opt-in rather
  than riding in on `wire = "responses"`.

## Test coverage (written failing-first)

- **Config parse**: the knob is accepted on the `openai` kind and sticks as the
  typed enum; rejected loudly on `anthropic`/`deepseek` kinds naming the fix; an
  unknown value is rejected naming both legal spellings.
- **`uses_responses_wire` precedence**: unset + `api.openai.com` (with/without
  trailing slash) → true; unset + a local/other URL → false; `wire = "responses"`
  on a gateway URL → true; `wire = "chat"` on `api.openai.com` → false; a
  non-openai kind is always false. Mirrors the existing
  `hosted_openai_detection_is_endpoint_exact` test. Also proves `is_hosted_openai`
  does **not** follow the override in either direction.
- **Arm construction**: a gateway backend (`base_url =
  "https://llm-gateway.example.internal/v1"`, `wire = "responses"`) builds the
  Responses-shaped arm — mirrors `hosted_openai_arm_uses_responses_shape`.
- **Batch**: that same `wire = "responses"` gateway backend is still refused by
  `batch_supported`/`OpenaiBatch::from_backend`/`poller`.
- **Config render**: the *resolved* wire (not the raw config value) appears per
  openai-kind backend in `kaibo://config`, absent on every other kind.

## Quality gates

- `cargo test`: 465 passed in the lib suite, all integration test binaries green,
  0 failures anywhere.
- `cargo clippy --all-targets`: clean.
- `cargo tree -i aws-lc-rs` / `cargo tree -i mimalloc`: both empty (untouched, as
  expected — this change is config/consult/batch logic only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
