### PR TITLE
Allow a base_url on the gemini backend kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ the git log. Each later release appends a new section at the top.
   judged per **backend** rather than per provider kind, because only OpenAI Platform serves
   `/v1/batches` — a `lane = "batch"` synth on a local OpenAI-compatible server is refused at
   config load with the fix named, instead of 404ing at submit time.
+- **The gemini backend can now dial a Gemini-API-compatible gateway/proxy.** Setting
+  `base_url` on a `kind = "gemini"` backend used to be a load error; it now works the
+  same way it already does on the anthropic kind — unset still resolves to Google's
+  own endpoint, set it points both interactive (`consult`/`oneshot`) and batch calls
+  at your gateway instead. The value is a host root (matching rig's own client and
+  the anthropic kind's convention), not a versioned path — kaibo appends the
+  `/v1beta` version segment the batch lane needs on its own.
 - `docs/openai-api-plan.md`, a living plan for making hosted OpenAI a first-class kaibo
   backend and clarifying that kaibo's OpenAI model calls use OpenAI Platform API keys, not
   Codex subscription entitlement.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -206,10 +206,11 @@ scratch_limit_bytes = 67108864
 # Keys are referenced, never inlined: api_key_env names an env var, api_key_file a
 # path (~ ok). env wins over file. key_optional=true falls back to a placeholder
 # bearer token (keyless local servers). base_url is legal on the openai kind
-# (required for a new backend) and the anthropic kind (optional — unset still
-# dials rig's built-in api.anthropic.com; set it to point at an Anthropic-
-# Messages-API-compatible gateway/proxy instead). Every other keyed kind rejects
-# base_url at load (rig fixes those endpoints).
+# (required for a new backend) and the anthropic and gemini kinds (optional —
+# unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com;
+# set it to point at an Anthropic/Gemini-API-compatible gateway/proxy instead —
+# a HOST ROOT in both cases, since rig appends its own versioned path). Every
+# other keyed kind rejects base_url at load (rig fixes those endpoints).
 # ---------------------------------------------------------------------------
 
 # --- The five built-ins, shown with their current defaults. You only need to
@@ -236,6 +237,11 @@ api_key_file = "~/.deepseek-key"
 kind = "gemini"
 api_key_env  = "GEMINI_API_KEY"
 api_key_file = "~/.gemini-api-key"
+# Uncomment to dial a Gemini-API-compatible gateway/proxy (e.g. a corporate LLM
+# gateway) instead of generativelanguage.googleapis.com directly. Optional —
+# unset still resolves to rig's built-in endpoint. A HOST ROOT, same as the
+# anthropic base_url above: rig appends its own /v1beta path.
+# base_url = "https://llm-gateway.example.internal"
 
 # OpenRouter: one key, every major model family, through a single gateway. Fixed
 # endpoint — rig owns it, so a base_url here is a loud load error, unlike the openai

--- a/docs/config.md
+++ b/docs/config.md
@@ -72,10 +72,15 @@ Connection knobs only — models never live here:
   A *new* openai-kind backend must set it: the `OPENAI_BASE_URL`/local-default
   fallback belongs to the built-in `openai-local` backend alone, so a forgotten
   `base_url` is a load error, not a silent dial of the wrong server. It is also
-  meaningful — but *optional* — for `kind = "anthropic"`: unset still resolves to
-  rig's built-in `https://api.anthropic.com`; set, it points the Anthropic wire
-  protocol at any Anthropic-Messages-API-compatible gateway/proxy instead (a
-  corporate LLM gateway, say). For every *other* keyed kind rig fixes the
+  meaningful — but *optional* — for `kind = "anthropic"` and `kind = "gemini"`:
+  unset still resolves to rig's built-in `https://api.anthropic.com` /
+  `https://generativelanguage.googleapis.com`; set, it points that wire protocol
+  at an Anthropic/Gemini-API-compatible gateway/proxy instead (a corporate LLM
+  gateway, say). Both contracts are a HOST ROOT, not a versioned path — rig's own
+  `ClientBuilder` appends its provider-specific path (Gemini's
+  `/v1beta/models/...`) itself, and the batch lane's `GeminiBatch` versions a
+  configured host root with `/v1beta` the same way, so one address serves both
+  the interactive and batch paths. For every *other* keyed kind rig fixes the
   endpoint, so a `base_url` there is a config error, surfaced loudly — not
   silently ignored.
 - A backend resolves its key from `api_key_env` then `api_key_file` (env wins).
@@ -303,7 +308,7 @@ today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submi
 |---|---|---|---|---|
 | `anthropic` | anthropic | — *(optional)* | `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` | `claude` |
 | `deepseek` | deepseek | — | `DEEPSEEK_API_KEY` / `~/.deepseek-key` | — |
-| `gemini` | gemini | — | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
+| `gemini` | gemini | — *(optional, host root)* | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
 | `openrouter` | openrouter | — *(fixed)* | `OPENROUTER_API_KEY` / `~/.openrouter-key` | — |
 | `openai-local` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
 
@@ -886,9 +891,9 @@ operator) the full picture:
   per-slot values below read as deltas against it)
 - `backends` — each connection: its kind, `base_url` (the *resolved* value for the
   openai kind — env/local-default fallback applied; the raw configured value,
-  when set, for the anthropic kind; absent for every other kind), key source env
-  var name and key file path (never the resolved key value), `key_optional`, and
-  `request_timeout_secs`
+  when set, for the anthropic and gemini kinds; absent for every other kind), key
+  source env var name and key file path (never the resolved key value),
+  `key_optional`, and `request_timeout_secs`
 - `backend_aliases` / `cast_aliases` — alias → canonical name, built-in and
   file-declared both: every name a `cast` param, slot ref, or per-call backend
   override will resolve

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -806,9 +806,10 @@ impl BatchProvider for AnthropicBatch {
 // --- Gemini provider -------------------------------------------------------
 
 /// Gemini's default API base, used when the backend sets no `base_url` of its own.
-/// The keyed Gemini backend cannot set one today (rig fixes the endpoint), unlike the
-/// anthropic kind — but [`GeminiBatch::base_url`] already reads `backend.base_url` in
-/// case that changes, the same pattern [`AnthropicBatch::base_url`] follows now.
+/// Already versioned — the batch calls append their paths (`/models/{model}:...`,
+/// `/{batch_id}`, ...) directly onto this. See [`GeminiBatch::base_url`] for how a
+/// *configured* `base_url` (a HOST ROOT, like rig's own Gemini `ClientBuilder`) gets
+/// versioned to match.
 const GEMINI_API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
 
 /// A reqwest client carrying the backend's per-request deadline — the shared
@@ -1148,11 +1149,24 @@ impl GeminiBatch {
         Ok(())
     }
 
+    /// The batch endpoint root: [`GEMINI_API_BASE`] (already `/v1beta`-versioned) when
+    /// the backend sets no `base_url`; otherwise the configured base_url versioned
+    /// with `/v1beta` here. The config contract is a HOST ROOT — matching rig's live
+    /// Gemini `ClientBuilder` (which appends its own `/v1beta/models/...` path rather
+    /// than taking one baked into `base_url`) and the anthropic kind's style — so a
+    /// gateway/proxy address configured for the live path just works for batch too.
+    /// A trailing slash, and a base_url someone pre-versioned with `/v1beta` (with or
+    /// without a trailing slash), are both normalized first so a reasonable config
+    /// never double-versions — the spirit of rig's `normalize_anthropic_base_url`.
     fn base_url(backend: &Backend) -> String {
-        backend
-            .base_url
-            .clone()
-            .unwrap_or_else(|| GEMINI_API_BASE.to_string())
+        match backend.base_url.as_deref() {
+            Some(configured) => {
+                let trimmed = configured.trim_end_matches('/');
+                let trimmed = trimmed.strip_suffix("/v1beta").unwrap_or(trimmed);
+                format!("{trimmed}/v1beta")
+            }
+            None => GEMINI_API_BASE.to_string(),
+        }
     }
 
     /// A submit-capable client: the cast's synth slot, shaped to batch's maxed knobs.
@@ -2484,6 +2498,54 @@ mod tests {
         default_backend.key_optional = true;
         let default_client = AnthropicBatch::from_backend(&default_backend).unwrap();
         assert_eq!(default_client.base_url, ANTHROPIC_API_BASE);
+    }
+
+    /// The Gemini batch lane's base URL contract: a configured `backend.base_url` is
+    /// a HOST ROOT (mirroring rig's live Gemini `ClientBuilder`, which appends its own
+    /// `/v1beta/...` path — see the engine-arm test of the same shape), so
+    /// `GeminiBatch::base_url` must version it with `/v1beta` itself rather than use it
+    /// verbatim, unlike `AnthropicBatch::base_url` (whose `/v1/messages/batches` suffix
+    /// is appended at call time, not baked into the stored base). A trailing slash is
+    /// trimmed, and a base_url the user already versioned (with or without a trailing
+    /// slash) is not double-versioned — the spirit of rig's own
+    /// `normalize_anthropic_base_url`. The unset fallback is untouched.
+    #[test]
+    fn gemini_batch_base_url_versions_a_configured_host_root() {
+        let mut b = anthropic_backend();
+        b.kind = ProviderKind::Gemini;
+        b.key_optional = true;
+
+        b.base_url = Some("https://llm-gateway.example.internal".to_string());
+        assert_eq!(
+            GeminiBatch::base_url(&b),
+            "https://llm-gateway.example.internal/v1beta"
+        );
+
+        // Trailing slash on the configured host root.
+        b.base_url = Some("https://llm-gateway.example.internal/".to_string());
+        assert_eq!(
+            GeminiBatch::base_url(&b),
+            "https://llm-gateway.example.internal/v1beta"
+        );
+
+        // Already pre-versioned — must not become .../v1beta/v1beta.
+        b.base_url = Some("https://llm-gateway.example.internal/v1beta".to_string());
+        assert_eq!(
+            GeminiBatch::base_url(&b),
+            "https://llm-gateway.example.internal/v1beta"
+        );
+
+        // Pre-versioned with a trailing slash too.
+        b.base_url = Some("https://llm-gateway.example.internal/v1beta/".to_string());
+        assert_eq!(
+            GeminiBatch::base_url(&b),
+            "https://llm-gateway.example.internal/v1beta"
+        );
+
+        // Unset still falls back to the default, unversioned by this logic (it's
+        // already baked into GEMINI_API_BASE).
+        b.base_url = None;
+        assert_eq!(GeminiBatch::base_url(&b), GEMINI_API_BASE);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1107,17 +1107,23 @@ impl Config {
                     b.name
                 );
             }
-            // A base_url on a keyed kind: rig fixes those endpoints — except Anthropic,
-            // which also accepts one (for an Anthropic-Messages-API-compatible
+            // A base_url on a keyed kind: rig fixes those endpoints — except Anthropic
+            // and Gemini, which also accept one (for an Anthropic/Gemini-API-compatible
             // gateway/proxy in front of the real backend), optionally: unset still
-            // dials rig's built-in https://api.anthropic.com.
+            // dials rig's built-in https://api.anthropic.com /
+            // https://generativelanguage.googleapis.com. Both contracts are a HOST
+            // ROOT — rig's `ClientBuilder::base_url` appends its own versioned path
+            // (`/v1beta/models/...` for Gemini) rather than taking one baked in; see
+            // `GeminiBatch::base_url` (`batch.rs`) for the batch lane's matching
+            // reconciliation.
             if b.kind != ProviderKind::Openai
                 && b.kind != ProviderKind::Anthropic
+                && b.kind != ProviderKind::Gemini
                 && b.base_url.is_some()
             {
                 bail!(
-                    "backend {:?} (kind {:?}) sets base_url, but only the `openai` and \
-                     `anthropic` kinds have a configurable endpoint",
+                    "backend {:?} (kind {:?}) sets base_url, but only the `openai`, \
+                     `anthropic`, and `gemini` kinds have a configurable endpoint",
                     b.name,
                     b.kind
                 );
@@ -1537,8 +1543,8 @@ fn backend_template(kind: ProviderKind, defaults: &Defaults) -> Backend {
         kind,
         // No base_url baked in: `resolved_base_url` supplies the default (or
         // OPENAI_BASE_URL, for the openai kind) at use-time, keeping construction
-        // pure. Every keyed kind except anthropic rejects an explicit base_url
-        // at load (see the validation loop above); anthropic's is optional.
+        // pure. Every keyed kind except anthropic and gemini rejects an explicit
+        // base_url at load (see the validation loop above); theirs is optional.
         base_url: None,
         api_key_env: Some(kind.env_var().to_string()),
         api_key_file: Some(format!("~/{}", kind.key_file_name())),
@@ -3742,18 +3748,22 @@ mod tests {
             .to_string();
         assert!(err.contains("already exists as kind"), "got: {err}");
 
-        // A keyed kind other than anthropic still rejects base_url — rig fixes
-        // that endpoint.
-        let err = Config::from_toml_str("[backends.gemini]\nbase_url = \"http://x\"\n")
+        // A keyed kind other than anthropic/gemini still rejects base_url — rig
+        // fixes that endpoint.
+        let err = Config::from_toml_str("[backends.deepseek]\nbase_url = \"http://x\"\n")
             .unwrap_err()
             .to_string();
-        assert!(err.contains("only the `openai` and `anthropic` kinds"), "got: {err}");
+        assert!(
+            err.contains("only the `openai`, `anthropic`, and `gemini` kinds"),
+            "got: {err}"
+        );
     }
 
-    /// The anthropic kind, uniquely among the keyed kinds, may set base_url — for
-    /// an Anthropic-Messages-API-compatible gateway/proxy in front of the real
-    /// backend. Unset still resolves to rig's built-in api.anthropic.com (proven
-    /// by the builtin_anthropic_cast_and_backend-style tests having no base_url).
+    /// The anthropic kind, uniquely among the *original* keyed kinds, may set
+    /// base_url — for an Anthropic-Messages-API-compatible gateway/proxy in front
+    /// of the real backend. Unset still resolves to rig's built-in
+    /// api.anthropic.com (proven by the builtin_anthropic_cast_and_backend-style
+    /// tests having no base_url).
     #[test]
     fn anthropic_backend_accepts_a_base_url() {
         let cfg = Config::from_toml_str(
@@ -3762,6 +3772,25 @@ mod tests {
         .unwrap();
         let b = cfg.backends.get("anthropic").unwrap();
         assert_eq!(b.base_url.as_deref(), Some("http://ai.example.ts.net"));
+    }
+
+    /// The gemini kind may also set base_url — for a Gemini-API-compatible
+    /// gateway/proxy in front of the real backend (rig's Gemini `ClientBuilder`
+    /// exposes `.base_url(..)` the same as Anthropic's). Unset still resolves to
+    /// rig's built-in https://generativelanguage.googleapis.com. The contract is
+    /// a HOST ROOT, mirroring the anthropic kind and rig's own builder — not a
+    /// versioned path (see `GeminiBatch::base_url` in `batch.rs` for why).
+    #[test]
+    fn gemini_backend_accepts_a_base_url() {
+        let cfg = Config::from_toml_str(
+            "[backends.gemini]\nbase_url = \"https://llm-gateway.example.internal\"\n",
+        )
+        .unwrap();
+        let b = cfg.backends.get("gemini").unwrap();
+        assert_eq!(
+            b.base_url.as_deref(),
+            Some("https://llm-gateway.example.internal")
+        );
     }
 
     /// Hosted OpenAI is still `kind = "openai"`, but the first-party endpoint is

--- a/src/config.rs
+++ b/src/config.rs
@@ -3735,7 +3735,7 @@ mod tests {
     }
 
     /// A new backend must declare a kind; redeclaring a different kind on an
-    /// existing one is a loud error; base_url is openai/anthropic-kind only.
+    /// existing one is a loud error; base_url is openai/anthropic/gemini-kind only.
     #[test]
     fn backend_stanza_validation_is_loud() {
         let err = Config::from_toml_str("[backends.mine]\nbase_url = \"http://x\"\n")

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -316,9 +316,18 @@ impl Arm {
                 Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
             }
             ProviderKind::Gemini => {
+                // base_url is optional here (unlike the openai kind): unset dials
+                // rig's built-in https://generativelanguage.googleapis.com; set, it
+                // points at a Gemini-API-compatible gateway/proxy instead. Same
+                // pattern as the Anthropic arm above — the contract is a HOST ROOT,
+                // since rig's builder appends its own versioned path
+                // (`/v1beta/models/...`) rather than taking one baked in.
                 let key = backend.resolve_key()?;
-                let client = gemini::Client::builder()
-                    .api_key(&key)
+                let mut builder = gemini::Client::builder().api_key(&key);
+                if let Some(base_url) = backend.base_url.as_deref() {
+                    builder = builder.base_url(base_url);
+                }
+                let client = builder
                     .http_client(http)
                     .build()
                     .map_err(|e| anyhow!("gemini client init: {e}"))?;
@@ -3473,6 +3482,39 @@ mod tests {
         };
         Arm::from_slot(&default_backend, &slot, ModelRole::Synth, &defaults)
             .expect("a keyless anthropic arm with no base_url still builds offline");
+    }
+
+    /// A gemini-kind backend pointed at a custom `base_url` (a Gemini-API-compatible
+    /// gateway/proxy in front of the real backend) must build offline too — the
+    /// same conditional `.base_url(...)` pattern as the Anthropic arm above, now on
+    /// the Gemini arm of `Arm::from_slot`. The contract is a HOST ROOT (mirroring
+    /// rig's own Gemini `ClientBuilder`, which appends its own `/v1beta/...` path).
+    #[test]
+    fn arm_from_slot_builds_a_gemini_arm_with_a_custom_base_url() {
+        let defaults = crate::config::Defaults::default();
+        let backend = crate::config::Backend {
+            name: "gemini".into(),
+            kind: ProviderKind::Gemini,
+            base_url: Some("https://llm-gateway.example.internal".into()),
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: true,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+        };
+        let slot = ModelSlot::bare("gemini", "gemini-3.5-flash");
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyless gemini arm with a custom base_url builds offline");
+        assert_eq!(arm.model, "gemini-3.5-flash");
+
+        // A gemini backend with no base_url must still build (the default rig
+        // endpoint applies) — the conditional branch must not be required.
+        let default_backend = crate::config::Backend {
+            base_url: None,
+            ..backend
+        };
+        Arm::from_slot(&default_backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyless gemini arm with no base_url still builds offline");
     }
 
     /// The OpenRouter arm's full params assembly — `to_params` chained through

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -183,9 +183,9 @@ pub(crate) fn render_config_resource(
         kind: String,
         /// Resolved endpoint for openai-kind backends (explicit base_url, else
         /// OPENAI_BASE_URL, else the built-in default) — the "resolved runtime
-        /// state" promise. The raw configured value for anthropic-kind backends,
-        /// when set (an Anthropic-Messages-API-compatible gateway/proxy); absent
-        /// otherwise. Every other kind has a fixed endpoint baked into rig.
+        /// state" promise. The raw configured value for anthropic- and gemini-kind
+        /// backends, when set (an Anthropic/Gemini-API-compatible gateway/proxy);
+        /// absent otherwise. Every other kind has a fixed endpoint baked into rig.
         #[serde(skip_serializing_if = "Option::is_none")]
         base_url: Option<String>,
         /// Env var name whose value is the API key (checked first). The NAME, not

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -614,17 +614,21 @@ fn alias_collisions_are_loud_at_each_level() {
 #[test]
 fn base_url_on_a_keyed_backend_is_rejected() {
     // rig fixes most keyed kinds' endpoints; a base_url there is a config mistake.
-    // (Anthropic is the one exception — see `anthropic_backend_accepts_a_base_url`.)
+    // (Anthropic and gemini are the exceptions — see
+    // `anthropic_backend_accepts_a_base_url` / `gemini_backend_accepts_a_base_url`.)
     let err = Config::from_toml_str(
         r#"
-        [backends.gemini]
+        [backends.deepseek]
         base_url = "https://example.test/v1"
         "#,
     )
     .unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("base_url"), "got: {msg}");
-    assert!(msg.contains("only the `openai` and `anthropic` kinds"), "got: {msg}");
+    assert!(
+        msg.contains("only the `openai`, `anthropic`, and `gemini` kinds"),
+        "got: {msg}"
+    );
 }
 
 #[test]
@@ -640,6 +644,24 @@ fn anthropic_backend_accepts_a_base_url() {
     .unwrap();
     let b = cfg.backends.get("anthropic").unwrap();
     assert_eq!(b.base_url.as_deref(), Some("https://example.test/v1"));
+}
+
+#[test]
+fn gemini_backend_accepts_a_base_url() {
+    // Gemini may also point at a compatible gateway/proxy instead of
+    // generativelanguage.googleapis.com — a HOST ROOT, same contract as anthropic's.
+    let cfg = Config::from_toml_str(
+        r#"
+        [backends.gemini]
+        base_url = "https://llm-gateway.example.internal"
+        "#,
+    )
+    .unwrap();
+    let b = cfg.backends.get("gemini").unwrap();
+    assert_eq!(
+        b.base_url.as_deref(),
+        Some("https://llm-gateway.example.internal")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

kaibo's `gemini` kind rejected an explicit `base_url` at config load (`src/config.rs`: "only the `openai` and `anthropic` kinds have a configurable endpoint"), so a Gemini-API-compatible gateway/proxy in front of the real backend couldn't be dialed. rig-core 0.38's Gemini `ClientBuilder` is the same generic builder as Anthropic's and already exposes `.base_url(...)` — the restriction was entirely kaibo's own validation.

## Design decisions

1. **Relax validation.** `kind = "gemini"` now accepts `base_url`, the same way `kind = "anthropic"` already does. Error message becomes "only the `openai`, `anthropic`, and `gemini` kinds have a configurable endpoint".
2. **Plumb it into the live client.** `Arm::from_slot`'s `ProviderKind::Gemini` arm (`src/consult/engine.rs`) now conditionally calls `.base_url(...)` on rig's builder, mirroring the existing Anthropic arm.
3. **The host-root reconciliation (the one real decision).** I verified against the vendored rig-core 0.38.2 source (`providers/gemini/client.rs`) that rig's live Gemini client takes a **HOST ROOT** (`https://generativelanguage.googleapis.com`) and appends its own versioned path (`/v1beta/models/{model}:generateContent`) itself — it does not accept a pre-versioned `base_url`.

   kaibo's batch lane has its own fallback constant, `GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta"`, already carrying the version segment (the batch calls append relative paths straight onto it). Before this change, `GeminiBatch::base_url` used a configured `backend.base_url` **verbatim**, which would have been fine only because `base_url` could never actually be set on a gemini backend. Making `base_url` configurable meant that verbatim use would now dial a gateway with no `/v1beta` segment — a real bug this PR had to close, not just plumb around.

   The contract I settled on: **`base_url` is always a HOST ROOT**, matching rig's own builder and the anthropic kind's existing style, so one configured address serves both the interactive and batch paths. `GeminiBatch::base_url` versions a configured value with `/v1beta` itself — trimming a trailing slash and a pre-existing `/v1beta` suffix first (borrowing the spirit of rig's own `normalize_anthropic_base_url`, which strips a user-supplied `/v1`/`/messages` suffix), so a reasonable config never double-versions. The unset fallback (`GEMINI_API_BASE`) is untouched.

## Test coverage (written failing-first)

- `src/config.rs`: `gemini_backend_accepts_a_base_url` (mirrors `anthropic_backend_accepts_a_base_url`); flipped `backend_stanza_validation_is_loud`'s rejected example from gemini to deepseek since gemini is no longer in the rejected set, and updated the asserted message text.
- `tests/config.rs`: same flip in `base_url_on_a_keyed_backend_is_rejected`, plus a new `gemini_backend_accepts_a_base_url` integration test.
- `src/consult/engine.rs`: `arm_from_slot_builds_a_gemini_arm_with_a_custom_base_url`, mirroring the existing Anthropic-arm test — proves a keyless gemini arm with a custom `base_url` builds offline, and that an unset `base_url` still builds.
- `src/batch.rs`: `gemini_batch_base_url_versions_a_configured_host_root` — a configured host root gets `/v1beta` appended; a trailing slash is trimmed; a base_url pre-versioned with `/v1beta` (with or without a trailing slash) is not double-versioned; the unset fallback is unchanged.

All of the above were confirmed failing against the pre-change code before implementing the fix.

## Docs

`docs/config.md` (backend table + surrounding prose) and `docs/config.example.toml` (`[backends.gemini]` gains a commented `base_url` line mirroring the anthropic one) updated to describe the new, optional, host-root contract. `CHANGELOG.md` gets an Added entry under the unreleased section.

## Quality gates

- `cargo test`: all green (461 lib tests + full integration suite, 0 failed)
- `cargo clippy --all-targets`: clean
- `cargo tree -i aws-lc-rs` / `-i mimalloc`: both empty (untouched, as expected)
- Ran a cross-family review pass (kaibo's own `consult`, `anthropic` cast — the local `openai-local`/Gemma backend wasn't reachable in this environment) over the diff before opening this PR. It confirmed the host-root reconciliation is correct for all realistic inputs and found no other read-site in the codebase that assumes a gemini backend never has a `base_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
