### PR TITLE
Fix main build: add missing wire field to a gemini Arm::from_slot test

### DIFF
--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -3559,6 +3559,7 @@ mod tests {
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
+            wire: None,
         };
         let slot = ModelSlot::bare("gemini", "gemini-3.5-flash");
         let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)


### PR DESCRIPTION
## What

`main` doesn't compile. `cargo test --locked` fails with `E0063: missing field `wire` in initializer of `config::Backend`` at `src/consult/engine.rs:3553`. This one-liner adds the field.

## Why it broke

Two recently-merged PRs raced on the `config::Backend` struct:

- **#99** added `wire: Option<OpenaiWire>` to `Backend` (per-backend `wire = "responses" | "chat"` for openai-kind backends).
- **#100** added `arm_from_slot_builds_a_gemini_arm_with_a_custom_base_url`, whose `Backend { .. }` literal was authored against the pre-#99 shape.

Each PR touched disjoint lines, so git merged both without a textual conflict — but the combined tree no longer type-checks. A semantic conflict CI would have caught on either PR only if it had been rebased on the other first.

## The fix

Initialize `wire: None`, matching every sibling `Backend` literal in the module. No behavior change — the test still asserts a keyless gemini arm with a custom `base_url` builds offline.

Verified locally: `cargo test --locked --no-run` clean; `cargo test --lib arm_from_slot` → 5 passed.

Test-only change, no user-facing surface, so no `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
