### PR TITLE
Add read-only model discovery: list_models tool + kaibo models CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ the git log. Each later release appends a new section at the top.
 
 ### Added
 
+- **`list_models` (MCP tool) and `kaibo models` (CLI) — read-only model discovery.**
+  Ask kaibo what models a configured backend's provider actually serves instead of
+  hand-rolling a `curl` with the right auth header: it queries the backend's real
+  `/models` endpoint (DeepSeek, OpenRouter, Anthropic, Gemini, or any OpenAI-compatible
+  endpoint) with kaibo's already-configured auth and base URL, paginating where the
+  provider requires it. Output is normalized fields (id, display name, context window,
+  created) plus the provider's raw per-model object. Omit `backend` to sweep every
+  configured backend at once; `--json`/`--no-list-models` follow the same conventions as
+  every other tool. No cast, no model in the loop — a pure operator/config query, like
+  `kaibo://config` or `batch list`.
 - **GPT-5.x is now usable behind OpenAI-compatible gateways via `wire = "responses"`.**
   A new per-backend `[backends.<name>]` knob (`openai` kind only) picks the interactive
   request shape explicitly: `"responses"` for rig's Responses client, `"chat"` for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,13 @@ the git log. Each later release appends a new section at the top.
   `/models` endpoint (DeepSeek, OpenRouter, Anthropic, Gemini, or any OpenAI-compatible
   endpoint) with kaibo's already-configured auth and base URL, paginating where the
   provider requires it. Output is normalized fields (id, display name, context window,
-  created) plus the provider's raw per-model object. Omit `backend` to sweep every
-  configured backend at once; `--json`/`--no-list-models` follow the same conventions as
-  every other tool. No cast, no model in the loop — a pure operator/config query, like
-  `kaibo://config` or `batch list`.
+  created, and — where the provider advertises it — per-token pricing, kept as the
+  provider's own strings rather than rounded floats) plus the provider's raw per-model
+  object. Omit `backend` to sweep every configured backend at once; `--json`/
+  `--no-list-models` follow the same conventions as every other tool, and the MCP tool
+  now also returns the `--json` envelope as `structured_content` alongside the prose, so
+  a machine caller doesn't have to parse the human-readable listing. No cast, no model
+  in the loop — a pure operator/config query, like `kaibo://config` or `batch list`.
 - **GPT-5.x is now usable behind OpenAI-compatible gateways via `wire = "responses"`.**
   A new per-backend `[backends.<name>]` knob (`openai` kind only) picks the interactive
   request shape explicitly: `"responses"` for rig's Responses client, `"chat"` for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,6 +2845,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3261,6 +3262,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,12 @@ rig-core = { version = "0.38", default-features = false, features = ["reqwest", 
 # ourselves. Like the rig `image` feature, it pulled ZERO new crates (verified
 # 2026-07-25) and is crypto-free, so the aws-lc-free tree is untouched. Re-verify with
 # `cargo tree -i aws-lc-rs` (must stay empty) if either feature moves.
-reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider", "multipart"] }
+#
+# `query` is for read-only model discovery (`src/discover.rs`): Gemini's models-list
+# authenticates via a `?key=` query param, not a header, so `RequestBuilder::query` is
+# how that GET is built. It pulls in exactly one new dependency, `serde_urlencoded`
+# (pure Rust, no C/TLS), so the aws-lc-free tree stays untouched.
+reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider", "multipart", "query"] }
 # The crypto provider behind rustls, chosen explicitly: ring, not aws-lc-rs. ring
 # builds with no C toolchain or cmake, so `x86_64-unknown-linux-musl` (and friends)
 # link fully static out of the box. reqwest pins rustls `default-features = false`,

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -77,12 +77,13 @@ cast = "anthropic"
 log = "kaibo=info"
 
 # Tool gating — true advertises the tool, false drops it (the --no-<tool> flags).
-# All four default true; a config that turns all four off is refused at startup.
+# All default true; a config that turns every one off is refused at startup.
 [server.tools]
 consult        = true
 oneshot        = true
 run_kaish      = true
 batch          = true
+list_models    = true
 
 # ---------------------------------------------------------------------------
 # [defaults] — tunables every cast slot falls back to. The model-tracking knobs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,7 @@
 //! tool description, so the top-level `about` front-loads what kaibo is and every
 //! flag doc earns its line (the "Writing for models" discipline).
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -126,6 +127,9 @@ pub enum Command {
     Kaish(KaishArgs),
     /// Provider batch lanes — submit a fan-out, get results, list live/recovered handles.
     Batch(BatchArgs),
+    /// List available models a backend's provider actually serves — read-only model
+    /// discovery via the backend's real /models endpoint, no cast/model in the loop.
+    Models(ModelsArgs),
     /// Print the resolved runtime configuration (the `kaibo://config` document).
     Config,
     /// Print the guided "set up my models" walkthrough — the CLI equivalent of the
@@ -233,6 +237,9 @@ pub struct ServeGates {
     /// Don't advertise `batch_submit`. The shared job verbs stay while `consult` is on.
     #[arg(long)]
     pub no_batch: bool,
+    /// Don't advertise the `list_models` tool.
+    #[arg(long)]
+    pub no_list_models: bool,
 }
 
 impl ServeGates {
@@ -245,6 +252,7 @@ impl ServeGates {
             oneshot: self.no_oneshot,
             run_kaish: self.no_run_kaish,
             batch: self.no_batch,
+            list_models: self.no_list_models,
         }
     }
 }
@@ -463,6 +471,21 @@ pub struct BatchListArgs {
     pub all: bool,
 
     /// Emit a JSON object (entries + recovered handles + per-backend errors) instead of prose.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// `kaibo models` — read-only model discovery: ask a backend's provider "what models
+/// do you have" through kaibo's already-configured auth, instead of hand-rolling a curl.
+/// No cast, no model in the loop — a pure operator/config query.
+#[derive(Args, Debug)]
+pub struct ModelsArgs {
+    /// Which backend (name or alias) to query. Omit to sweep every configured backend.
+    #[arg(long, value_name = "BACKEND")]
+    pub backend: Option<String>,
+
+    /// Emit a JSON object (per-backend models, normalized fields + raw passthrough)
+    /// instead of prose.
     #[arg(long)]
     pub json: bool,
 }
@@ -1652,6 +1675,76 @@ async fn batch_list_inner(args: &BatchListArgs, resolver: &Resolver) -> Result<i
         }
     }
     Ok(EXIT_OK)
+}
+
+/// Run `kaibo models` — read-only model discovery, no cast/model in the loop. Returns
+/// the process exit code: 2/3 for a pre-flight config/setup rejection, 4 only when
+/// *every* queried backend's discovery call failed (a per-backend error inside an
+/// otherwise-successful sweep is reported inline and is NOT fatal — matching `batch
+/// list`'s inline-error convention), else 0.
+pub async fn run_models(common: CommonArgs, args: ModelsArgs) -> i32 {
+    init_cli_logging();
+    let config = match load_config(&common) {
+        Ok(c) => c,
+        Err(e) => {
+            return fail_preflight(
+                args.json,
+                "config",
+                format!("config error: {e:#}"),
+                EXIT_USAGE,
+            )
+        }
+    };
+    let resolver = match Resolver::from_config(Arc::new(config)) {
+        Ok(r) => r,
+        Err(e) => return fail_preflight(args.json, "setup", format!("{e:#}"), EXIT_SETUP),
+    };
+
+    // An explicit --backend scopes to that one name/alias (resolved to its canonical
+    // name so the results map keys consistently); omitted sweeps every configured
+    // backend, sorted (BTreeMap order) same as `batch list`.
+    let names: Vec<String> = match args.backend.as_deref() {
+        Some(name) => match resolver.config.resolve_backend(name) {
+            Ok(b) => vec![b.name.clone()],
+            Err(e) => return fail_preflight(args.json, "usage", e.to_string(), EXIT_USAGE),
+        },
+        None => resolver.config.backends.keys().cloned().collect(),
+    };
+    if names.is_empty() {
+        return fail_preflight(
+            args.json,
+            "setup",
+            "no backend is configured".to_string(),
+            EXIT_SETUP,
+        );
+    }
+
+    let mut results: BTreeMap<String, Result<Vec<crate::discover::DiscoveredModel>, String>> =
+        BTreeMap::new();
+    for name in &names {
+        // Each name above already resolved once; re-resolving here is cheap and
+        // avoids holding a borrow of `resolver.config` across the `.await` below.
+        let Ok(backend) = resolver.config.resolve_backend(name) else {
+            continue;
+        };
+        let fetcher = crate::discover::HttpModelListFetcher::new(backend.request_timeout);
+        let outcome = crate::discover::discover_models(backend, &fetcher)
+            .await
+            .map_err(|e| format!("{e:#}"));
+        results.insert(name.clone(), outcome);
+    }
+
+    if args.json {
+        println!("{}", crate::discover::models_json_envelope(&results));
+    } else {
+        println!("{}", crate::discover::render_models(&results));
+    }
+
+    if results.values().all(Result::is_err) {
+        EXIT_CONSULT_FAILURE
+    } else {
+        EXIT_OK
+    }
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1539,6 +1539,9 @@ impl Config {
         if disable.batch {
             self.tools.batch = false;
         }
+        if disable.list_models {
+            self.tools.list_models = false;
+        }
         // Non-empty CLI allow_paths replaces lower layers (env/file).
         if !allow_paths.is_empty() {
             self.allow_paths = allow_paths;
@@ -1567,6 +1570,7 @@ pub struct ToolDisables {
     pub oneshot: bool,
     pub run_kaish: bool,
     pub batch: bool,
+    pub list_models: bool,
 }
 
 /// Register `alias → target` at one level (backend or cast), rejecting a clash
@@ -1926,6 +1930,7 @@ struct RawTools {
     oneshot: Option<bool>,
     run_kaish: Option<bool>,
     batch: Option<bool>,
+    list_models: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -2383,6 +2388,7 @@ fn merge_tools(raw: RawTools) -> ToolGating {
         oneshot: raw.oneshot.unwrap_or(d.oneshot),
         run_kaish: raw.run_kaish.unwrap_or(d.run_kaish),
         batch: raw.batch.unwrap_or(d.batch),
+        list_models: raw.list_models.unwrap_or(d.list_models),
     }
 }
 
@@ -2453,6 +2459,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if env_flag(get, "KAIBO_NO_BATCH") {
         tools.batch = Some(false);
+    }
+    if env_flag(get, "KAIBO_NO_LIST_MODELS") {
+        tools.list_models = Some(false);
     }
 
     let defaults = raw.defaults.get_or_insert_with(Default::default);

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1,0 +1,948 @@
+//! Read-only model discovery: ask a backend's provider "what models do you have"
+//! instead of hand-rolling a curl + auth header. kaibo already knows every configured
+//! backend's base URL, key source, and wire protocol (`config.rs::Backend`), so this
+//! module turns that into one GET per backend (paginated where the provider requires
+//! it) and a normalized + raw-passthrough result.
+//!
+//! This is an **operator surface**, not a model-team capability — like `kaibo://config`
+//! or `batch list`, it's driven by the MCP tool / CLI subcommand directly, no cast, no
+//! model in the loop (see AGENTS.md's "operator surface vs. the model team" invariant).
+//! It is also pure network GETs: no filesystem write, no kaish, nothing for
+//! `tests/no_write_path.rs` to catch.
+//!
+//! The shape mirrors `batch.rs`'s provider split: a pure, offline-testable request
+//! builder ([`discovery_endpoint`]), pure per-provider parsers ([`parse_openai_models`]/
+//! [`parse_anthropic_models`]/[`parse_gemini_models`]), an injectable fetch seam
+//! ([`ModelListFetcher`], mirroring the `ScriptedClient` ethos in `test_support.rs`) so
+//! the pagination loop is testable with no network, and a real [`HttpModelListFetcher`]
+//! built on the one blessed TLS client constructor (`crate::tls::https_client`).
+
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::batch::rfc3339_to_epoch;
+use crate::config::Backend;
+use crate::credentials::ProviderKind;
+
+/// DeepSeek's models-list host. Mirrors rig's private `deepseek` provider constant —
+/// same drift-prone class as `config.rs::default_models`: if rig retargets its DeepSeek
+/// client, this needs a matching update, and nothing but a live probe will notice.
+const DEEPSEEK_BASE: &str = "https://api.deepseek.com";
+
+/// OpenRouter's unified gateway host. Mirrors rig's private `openrouter` provider
+/// constant — same drift-prone class as `DEEPSEEK_BASE` above.
+const OPENROUTER_BASE: &str = "https://openrouter.ai/api/v1";
+
+/// Anthropic's default API host — used when a backend sets no `base_url` (see
+/// `Backend::base_url`'s doc: unset falls back to rig's built-in endpoint).
+const ANTHROPIC_DEFAULT_BASE: &str = "https://api.anthropic.com";
+
+/// Gemini's default API host — used when a backend sets no `base_url`.
+const GEMINI_DEFAULT_BASE: &str = "https://generativelanguage.googleapis.com";
+
+/// Hard cap on pagination pages per backend, independent of any cursor-repeat guard —
+/// a misbehaving or adversarial endpoint that always claims "more" must not spin
+/// forever. 100 pages at Anthropic's `limit=1000` (or a Gemini default page size) is
+/// far beyond any real model catalog.
+const MAX_PAGES: usize = 100;
+
+/// One model as reported by a provider's list endpoint, normalized across the four
+/// wire shapes plus the provider's own object verbatim. Every normalized field is
+/// `Option` — a missing or wrong-typed source field is `None`, never a panic (a
+/// provider's list endpoint is out of kaibo's control).
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiscoveredModel {
+    pub id: String,
+    /// Anthropic `display_name`, Gemini `displayName`.
+    pub display_name: Option<String>,
+    /// Unix epoch seconds. OpenAI-shaped `created` (already an int) or Anthropic
+    /// `created_at` (RFC3339, parsed via [`rfc3339_to_epoch`]) — `None` if absent or
+    /// unparseable; the original value still rides in `raw` either way.
+    pub created: Option<i64>,
+    /// Anthropic `max_input_tokens`, Gemini `inputTokenLimit`.
+    pub context_window: Option<u64>,
+    /// The provider's per-model object, untouched — the passthrough half of the
+    /// contract, so a caller who needs a field we didn't normalize still has it.
+    pub raw: Value,
+}
+
+/// One page's worth of a GET: the full URL, headers, and query params, fully
+/// assertable in a test without a network call. Built by [`discovery_endpoint`] /
+/// [`discovery_endpoint_page`]; consumed by [`ModelListFetcher::get_json`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiscoveryRequest {
+    pub url: String,
+    /// `(name, value)` pairs, in the order they should be sent.
+    pub headers: Vec<(String, String)>,
+    /// `(name, value)` query params, in the order they should be sent. Empty means
+    /// no query string.
+    pub query: Vec<(String, String)>,
+}
+
+/// Build the first-page discovery request for `backend`. Pure aside from
+/// [`Backend::resolve_key`] (env/key-file read, no network) — mirrors `Arm::from_slot`'s
+/// "builds offline" contract (`consult/engine.rs`). Dispatches on `backend.kind`; see
+/// the module doc for the per-kind wire shape.
+pub fn discovery_endpoint(backend: &Backend) -> Result<DiscoveryRequest> {
+    discovery_endpoint_page(backend, None)
+}
+
+/// Like [`discovery_endpoint`], but for page N of a paginated listing: `cursor` is the
+/// provider's own continuation token (Anthropic's `after_id`, Gemini's `pageToken`).
+/// `None` builds the first page. OpenAI-shaped kinds (`Openai`/`OpenRouter`/`DeepSeek`)
+/// have no continuation — `cursor` is ignored for them, since [`discover_models`] never
+/// loops on those kinds anyway.
+pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Result<DiscoveryRequest> {
+    let key = backend.resolve_key()?;
+    match backend.kind {
+        ProviderKind::Openai => {
+            let base = backend.resolved_base_url();
+            let base = base.trim_end_matches('/');
+            Ok(DiscoveryRequest {
+                url: format!("{base}/models"),
+                headers: vec![("Authorization".to_string(), format!("Bearer {key}"))],
+                query: Vec::new(),
+            })
+        }
+        ProviderKind::OpenRouter => Ok(DiscoveryRequest {
+            url: format!("{OPENROUTER_BASE}/models"),
+            headers: vec![("Authorization".to_string(), format!("Bearer {key}"))],
+            query: Vec::new(),
+        }),
+        ProviderKind::DeepSeek => Ok(DiscoveryRequest {
+            url: format!("{DEEPSEEK_BASE}/models"),
+            headers: vec![("Authorization".to_string(), format!("Bearer {key}"))],
+            query: Vec::new(),
+        }),
+        ProviderKind::Anthropic => {
+            let base = backend
+                .base_url
+                .as_deref()
+                .unwrap_or(ANTHROPIC_DEFAULT_BASE);
+            let base = base.trim_end_matches('/');
+            let mut query = vec![("limit".to_string(), "1000".to_string())];
+            if let Some(after) = cursor {
+                query.push(("after_id".to_string(), after.to_string()));
+            }
+            Ok(DiscoveryRequest {
+                url: format!("{base}/v1/models"),
+                headers: vec![
+                    ("x-api-key".to_string(), key),
+                    (
+                        "anthropic-version".to_string(),
+                        rig_core::providers::anthropic::completion::ANTHROPIC_VERSION_LATEST
+                            .to_string(),
+                    ),
+                ],
+                query,
+            })
+        }
+        ProviderKind::Gemini => {
+            let base = backend.base_url.as_deref().unwrap_or(GEMINI_DEFAULT_BASE);
+            let base = base.trim_end_matches('/');
+            // No auth header: Gemini authenticates `?key=` as a query param. A
+            // key_optional backend's `resolve_key` already resolves to the empty
+            // string for this kind (`ProviderKind::placeholder_key`), so this emits a
+            // bare `?key=` an ambient-auth gateway accepts — the same keyless-gateway
+            // contract the live `consult`/`oneshot` arms rely on (see `#102`).
+            let mut query = vec![("key".to_string(), key)];
+            if let Some(token) = cursor {
+                query.push(("pageToken".to_string(), token.to_string()));
+            }
+            Ok(DiscoveryRequest {
+                url: format!("{base}/v1beta/models"),
+                headers: Vec::new(),
+                query,
+            })
+        }
+    }
+}
+
+/// Parse an OpenAI-shaped `{ data: [{id, created, owned_by, ...}] }` model list —
+/// shared by `Openai`, `OpenRouter`, and `DeepSeek` (all three speak the OpenAI wire).
+/// Defensive: a missing/wrong-typed field is `None`, never a panic; `.raw` keeps each
+/// item verbatim regardless of what we could normalize.
+pub fn parse_openai_models(v: &Value) -> Vec<DiscoveredModel> {
+    v.get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|item| DiscoveredModel {
+            id: item
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            display_name: None,
+            created: item.get("created").and_then(Value::as_i64),
+            context_window: None,
+            raw: item.clone(),
+        })
+        .collect()
+}
+
+/// Parse an Anthropic `{ data: [{id, display_name, created_at, max_input_tokens, ...}],
+/// has_more, last_id }` page into its models. Pagination fields (`has_more`/`last_id`)
+/// are read separately by [`discover_models`]'s loop — this is just the per-model
+/// normalization, so it's directly testable against one canned page.
+pub fn parse_anthropic_models(v: &Value) -> Vec<DiscoveredModel> {
+    v.get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|item| DiscoveredModel {
+            id: item
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            display_name: item
+                .get("display_name")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            created: item
+                .get("created_at")
+                .and_then(Value::as_str)
+                .and_then(rfc3339_to_epoch),
+            context_window: item.get("max_input_tokens").and_then(Value::as_u64),
+            raw: item.clone(),
+        })
+        .collect()
+}
+
+/// Parse a Gemini `{ models: [{name: "models/x", displayName, inputTokenLimit, ...}],
+/// nextPageToken }` page into its models. `name` is `models/{id}` — we strip the
+/// `models/` prefix into `id`, but `.raw` keeps the original `name` field untouched.
+pub fn parse_gemini_models(v: &Value) -> Vec<DiscoveredModel> {
+    v.get("models")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|item| {
+            let name = item.get("name").and_then(Value::as_str).unwrap_or_default();
+            DiscoveredModel {
+                id: name.strip_prefix("models/").unwrap_or(name).to_string(),
+                display_name: item
+                    .get("displayName")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                created: None,
+                context_window: item.get("inputTokenLimit").and_then(Value::as_u64),
+                raw: item.clone(),
+            }
+        })
+        .collect()
+}
+
+/// The fetch seam [`discover_models`] drives — injectable so the pagination loop is
+/// offline-testable, mirroring the `ScriptedClient` ethos in `test_support.rs` (a
+/// content-driven responder, not a queue-pop mock, though here the request shape is
+/// simple enough that a page-indexed script is honest: each page is requested exactly
+/// once, in order, with no concurrent fan-out).
+#[async_trait]
+pub trait ModelListFetcher: Send + Sync {
+    async fn get_json(&self, req: &DiscoveryRequest) -> Result<Value>;
+}
+
+/// The real [`ModelListFetcher`]: one GET through the blessed TLS client constructor
+/// (`crate::tls::https_client`) — the **only** reqwest-client construction site this
+/// module uses, so the rustls-ring/no-aws-lc contract stays in the one place it's
+/// supposed to live.
+pub struct HttpModelListFetcher {
+    request_timeout: Duration,
+}
+
+impl HttpModelListFetcher {
+    /// `request_timeout` should come from the backend being queried
+    /// (`Backend::request_timeout`), so a slow local server gets the same patience a
+    /// completion call would.
+    pub fn new(request_timeout: Duration) -> Self {
+        Self { request_timeout }
+    }
+}
+
+#[async_trait]
+impl ModelListFetcher for HttpModelListFetcher {
+    async fn get_json(&self, req: &DiscoveryRequest) -> Result<Value> {
+        let client = crate::tls::https_client(self.request_timeout)?;
+        let mut builder = client.get(&req.url);
+        for (name, value) in &req.headers {
+            builder = builder.header(name, value);
+        }
+        if !req.query.is_empty() {
+            builder = builder.query(&req.query);
+        }
+        let resp = builder
+            .send()
+            .await
+            .map_err(|e| anyhow!("model list request to {}: {e}", req.url))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| anyhow!("reading model list response body from {}: {e}", req.url))?;
+        if !status.is_success() {
+            return Err(anyhow!("model list {status} from {}: {text}", req.url));
+        }
+        serde_json::from_str(&text)
+            .with_context(|| format!("parsing model list JSON from {}: {text}", req.url))
+    }
+}
+
+/// Fetch every model `backend` advertises, paginating where the provider requires it:
+/// Anthropic loops on `has_more`/`last_id` (`after_id` cursor, `limit=1000`), Gemini
+/// loops on `nextPageToken` (`pageToken` query); `Openai`/`OpenRouter`/`DeepSeek` are
+/// single-page. Guarded against a misbehaving provider two ways: a hard [`MAX_PAGES`]
+/// cap, and an early stop if a cursor repeats (a provider that echoes back the same
+/// "next" token would otherwise spin forever even under the page cap).
+pub async fn discover_models(
+    backend: &Backend,
+    fetcher: &impl ModelListFetcher,
+) -> Result<Vec<DiscoveredModel>> {
+    match backend.kind {
+        ProviderKind::Anthropic => discover_paginated(
+            backend,
+            fetcher,
+            parse_anthropic_models,
+            |body| body.get("has_more").and_then(Value::as_bool).unwrap_or(false),
+            |body| {
+                body.get("last_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            },
+        )
+        .await,
+        ProviderKind::Gemini => discover_paginated(
+            backend,
+            fetcher,
+            parse_gemini_models,
+            |body| body.get("nextPageToken").and_then(Value::as_str).is_some(),
+            |body| {
+                body.get("nextPageToken")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            },
+        )
+        .await,
+        ProviderKind::Openai | ProviderKind::OpenRouter | ProviderKind::DeepSeek => {
+            let req = discovery_endpoint(backend)?;
+            let body = fetcher.get_json(&req).await?;
+            Ok(parse_openai_models(&body))
+        }
+    }
+}
+
+/// The shared pagination loop both cursor-based kinds (Anthropic, Gemini) drive, with
+/// their differing "is there another page" / "what's the cursor" reads injected —
+/// pulling the loop out once so the [`MAX_PAGES`] cap and the cursor-repeat guard live
+/// in exactly one place instead of being duplicated per kind.
+async fn discover_paginated(
+    backend: &Backend,
+    fetcher: &impl ModelListFetcher,
+    parse: fn(&Value) -> Vec<DiscoveredModel>,
+    has_more: fn(&Value) -> bool,
+    next_cursor: fn(&Value) -> Option<String>,
+) -> Result<Vec<DiscoveredModel>> {
+    let mut all = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut seen_cursors: HashSet<String> = HashSet::new();
+    for _ in 0..MAX_PAGES {
+        let req = discovery_endpoint_page(backend, cursor.as_deref())?;
+        let body = fetcher.get_json(&req).await?;
+        all.extend(parse(&body));
+        if !has_more(&body) {
+            break;
+        }
+        let Some(next) = next_cursor(&body) else {
+            break;
+        };
+        if !seen_cursors.insert(next.clone()) {
+            // The provider handed back a cursor we've already used — stop rather than
+            // spin, even though we haven't hit MAX_PAGES yet.
+            break;
+        }
+        cursor = Some(next);
+    }
+    Ok(all)
+}
+
+/// Render a multi-backend sweep as prose: one section per backend, each model's `id` +
+/// `display_name` (when present) + `context_window` (when present); a backend that
+/// errored gets an inline error line instead of a model list. Shared by the MCP tool
+/// and the CLI so the two faces can't drift on what a sweep looks like (the
+/// `render_config_resource` discipline).
+pub fn render_models(results: &BTreeMap<String, Result<Vec<DiscoveredModel>, String>>) -> String {
+    if results.is_empty() {
+        return "(no backend configured)".to_string();
+    }
+    let mut out = String::new();
+    for (name, result) in results {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!("## {name}\n"));
+        match result {
+            Ok(models) if models.is_empty() => {
+                out.push_str("(no models reported)\n");
+            }
+            Ok(models) => {
+                for m in models {
+                    let mut line = format!("- `{}`", m.id);
+                    if let Some(dn) = &m.display_name {
+                        line.push_str(&format!(" — {dn}"));
+                    }
+                    if let Some(ctx) = m.context_window {
+                        line.push_str(&format!(" (context: {ctx})"));
+                    }
+                    out.push_str(&line);
+                    out.push('\n');
+                }
+            }
+            Err(e) => {
+                out.push_str(&format!("error: {e}\n"));
+            }
+        }
+    }
+    out
+}
+
+/// The same multi-backend sweep as a structured JSON envelope — the `--json` /
+/// `structured_content` face of [`render_models`]. Per backend: `ok` + either `models`
+/// (each carrying the normalized fields plus `raw`) or `error`.
+pub fn models_json_envelope(results: &BTreeMap<String, Result<Vec<DiscoveredModel>, String>>) -> Value {
+    serde_json::json!({
+        "backends": results
+            .iter()
+            .map(|(name, result)| match result {
+                Ok(models) => serde_json::json!({
+                    "backend": name,
+                    "ok": true,
+                    "models": models
+                        .iter()
+                        .map(|m| serde_json::json!({
+                            "id": m.id,
+                            "display_name": m.display_name,
+                            "created": m.created,
+                            "context_window": m.context_window,
+                            "raw": m.raw,
+                        }))
+                        .collect::<Vec<_>>(),
+                }),
+                Err(e) => serde_json::json!({
+                    "backend": name,
+                    "ok": false,
+                    "error": e,
+                }),
+            })
+            .collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DataCollection, OpenaiWire};
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    fn backend(kind: ProviderKind) -> Backend {
+        Backend {
+            name: "test".to_string(),
+            kind,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: false,
+            request_timeout: Duration::from_secs(30),
+            data_collection: DataCollection::default(),
+            wire: None,
+        }
+    }
+
+    /// A tempdir-backed key file, so tests set a backend's credential without touching
+    /// real process environment (`env::set_var`/`remove_var` are unsafe and shared
+    /// process-wide state — a key file is the isolated, no-`unsafe` way the rest of the
+    /// suite already resolves a key; see `tests/config.rs::local_backend`). The
+    /// `TempDir` must outlive the `Backend` using its path, so callers keep the guard
+    /// alive alongside the backend.
+    fn key_file(contents: &str) -> (TempDir, String) {
+        let dir = tempfile::tempdir().expect("tempdir for a test key file");
+        let path = dir.path().join("key");
+        std::fs::write(&path, contents).expect("write test key file");
+        (dir, path.to_string_lossy().to_string())
+    }
+
+    // --- discovery_endpoint: exact URL/headers/query per kind -------------------
+
+    #[test]
+    fn openai_endpoint_is_bearer_at_base_slash_models() {
+        let mut b = backend(ProviderKind::Openai);
+        b.base_url = Some("http://localhost:9999/v1".to_string());
+        b.key_optional = true;
+        let req = discovery_endpoint(&b).expect("openai endpoint builds offline");
+        assert_eq!(req.url, "http://localhost:9999/v1/models");
+        assert_eq!(
+            req.headers,
+            vec![(
+                "Authorization".to_string(),
+                format!("Bearer {}", crate::credentials::PLACEHOLDER_OPENAI_KEY)
+            )]
+        );
+        assert!(req.query.is_empty());
+    }
+
+    #[test]
+    fn openai_endpoint_sends_bearer_even_for_the_keyless_placeholder() {
+        // Spec: for OpenAI-wire kinds, send the bearer even when it's the keyless
+        // placeholder — harmless to a local server, mirrors how rig auths.
+        let mut b = backend(ProviderKind::Openai);
+        b.base_url = Some("http://localhost:9999/v1".to_string());
+        b.key_optional = true;
+        let req = discovery_endpoint(&b).unwrap();
+        let (name, value) = &req.headers[0];
+        assert_eq!(name, "Authorization");
+        assert!(value.contains(crate::credentials::PLACEHOLDER_OPENAI_KEY));
+    }
+
+    #[test]
+    fn openrouter_endpoint_is_fixed_base_bearer() {
+        let (_dir, path) = key_file("or-key");
+        let mut b = backend(ProviderKind::OpenRouter);
+        b.api_key_file = Some(path);
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.url, format!("{OPENROUTER_BASE}/models"));
+        assert_eq!(
+            req.headers,
+            vec![("Authorization".to_string(), "Bearer or-key".to_string())]
+        );
+        assert!(req.query.is_empty());
+    }
+
+    #[test]
+    fn deepseek_endpoint_is_fixed_base_bearer() {
+        let (_dir, path) = key_file("ds-key");
+        let mut b = backend(ProviderKind::DeepSeek);
+        b.api_key_file = Some(path);
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.url, format!("{DEEPSEEK_BASE}/models"));
+        assert_eq!(
+            req.headers,
+            vec![("Authorization".to_string(), "Bearer ds-key".to_string())]
+        );
+    }
+
+    #[test]
+    fn anthropic_endpoint_defaults_base_and_carries_version_header() {
+        let (_dir, path) = key_file("anthropic-key");
+        let mut b = backend(ProviderKind::Anthropic);
+        b.api_key_file = Some(path);
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.url, format!("{ANTHROPIC_DEFAULT_BASE}/v1/models"));
+        assert!(req
+            .headers
+            .contains(&("x-api-key".to_string(), "anthropic-key".to_string())));
+        assert!(req.headers.contains(&(
+            "anthropic-version".to_string(),
+            rig_core::providers::anthropic::completion::ANTHROPIC_VERSION_LATEST.to_string()
+        )));
+        assert_eq!(
+            req.query,
+            vec![("limit".to_string(), "1000".to_string())]
+        );
+    }
+
+    #[test]
+    fn anthropic_endpoint_honors_a_base_url_gateway_override() {
+        let (_dir, path) = key_file("gw-key");
+        let mut b = backend(ProviderKind::Anthropic);
+        b.base_url = Some("https://gateway.internal/".to_string());
+        b.api_key_file = Some(path);
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.url, "https://gateway.internal/v1/models");
+    }
+
+    #[test]
+    fn anthropic_page_carries_after_id_cursor() {
+        let (_dir, path) = key_file("k");
+        let mut b = backend(ProviderKind::Anthropic);
+        b.api_key_file = Some(path);
+        let req = discovery_endpoint_page(&b, Some("model_123")).unwrap();
+        assert_eq!(
+            req.query,
+            vec![
+                ("limit".to_string(), "1000".to_string()),
+                ("after_id".to_string(), "model_123".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn gemini_endpoint_uses_query_key_no_header() {
+        let (_dir, path) = key_file("gem-key");
+        let mut b = backend(ProviderKind::Gemini);
+        b.api_key_file = Some(path);
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.url, format!("{GEMINI_DEFAULT_BASE}/v1beta/models"));
+        assert!(req.headers.is_empty(), "gemini must send no auth header");
+        assert_eq!(req.query, vec![("key".to_string(), "gem-key".to_string())]);
+    }
+
+    #[test]
+    fn gemini_endpoint_honors_a_base_url_gateway_override() {
+        let (_dir, path) = key_file("gw-key");
+        let mut b = backend(ProviderKind::Gemini);
+        b.base_url = Some("https://gateway.internal".to_string());
+        b.api_key_file = Some(path);
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.url, "https://gateway.internal/v1beta/models");
+    }
+
+    #[test]
+    fn gemini_keyless_backend_sends_an_empty_query_key() {
+        // Mirrors the #102 fix: a key_optional Gemini backend resolves to the EMPTY
+        // string, not the non-empty bearer placeholder, so kaibo emits a bare `?key=`
+        // an ambient-auth gateway accepts.
+        let mut b = backend(ProviderKind::Gemini);
+        b.key_optional = true;
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.query, vec![("key".to_string(), String::new())]);
+    }
+
+    #[test]
+    fn gemini_page_carries_page_token() {
+        let mut b = backend(ProviderKind::Gemini);
+        b.key_optional = true;
+        let req = discovery_endpoint_page(&b, Some("tok-1")).unwrap();
+        assert_eq!(
+            req.query,
+            vec![
+                ("key".to_string(), String::new()),
+                ("pageToken".to_string(), "tok-1".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_key_on_a_keyed_backend_errors_loudly() {
+        // A keyed backend with no key configured must error (loud over silent),
+        // exactly like `Arm::from_slot`/`resolve_key` for a live completion.
+        let b = backend(ProviderKind::Anthropic);
+        assert!(discovery_endpoint(&b).is_err());
+    }
+
+    #[test]
+    fn openai_wire_field_does_not_affect_discovery() {
+        // The `wire` (responses vs chat) knob shapes interactive completions only;
+        // discovery always hits the plain REST models endpoint regardless.
+        let mut b = backend(ProviderKind::Openai);
+        b.base_url = Some("http://localhost:9999/v1".to_string());
+        b.key_optional = true;
+        b.wire = Some(OpenaiWire::Responses);
+        let req = discovery_endpoint(&b).unwrap();
+        assert_eq!(req.url, "http://localhost:9999/v1/models");
+    }
+
+    // --- parse_*: canned provider bodies, normalized fields + untouched .raw ---
+
+    #[test]
+    fn parse_openai_shape() {
+        let body = serde_json::json!({
+            "data": [
+                {"id": "gpt-5", "object": "model", "created": 1_700_000_000, "owned_by": "openai"},
+                {"id": "gpt-4", "object": "model", "created": 1_600_000_000, "owned_by": "openai"},
+            ]
+        });
+        let models = parse_openai_models(&body);
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "gpt-5");
+        assert_eq!(models[0].created, Some(1_700_000_000));
+        assert_eq!(models[0].display_name, None);
+        assert_eq!(models[0].context_window, None);
+        assert_eq!(models[0].raw, body["data"][0]);
+    }
+
+    #[test]
+    fn parse_openai_shape_is_defensive_on_missing_fields() {
+        let body = serde_json::json!({ "data": [ {"object": "model"} ] });
+        let models = parse_openai_models(&body);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "");
+        assert_eq!(models[0].created, None);
+    }
+
+    #[test]
+    fn parse_openai_shape_handles_a_missing_data_array() {
+        let body = serde_json::json!({ "unexpected": "shape" });
+        assert!(parse_openai_models(&body).is_empty());
+    }
+
+    #[test]
+    fn parse_anthropic_shape() {
+        let body = serde_json::json!({
+            "data": [
+                {
+                    "id": "claude-x",
+                    "display_name": "Claude X",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "max_input_tokens": 200_000,
+                    "capabilities": ["vision"],
+                }
+            ],
+            "has_more": true,
+            "last_id": "claude-x",
+        });
+        let models = parse_anthropic_models(&body);
+        assert_eq!(models.len(), 1);
+        let m = &models[0];
+        assert_eq!(m.id, "claude-x");
+        assert_eq!(m.display_name.as_deref(), Some("Claude X"));
+        assert_eq!(m.created, Some(1_767_225_600));
+        assert_eq!(m.context_window, Some(200_000));
+        assert_eq!(m.raw, body["data"][0]);
+    }
+
+    #[test]
+    fn parse_anthropic_shape_leaves_created_none_on_an_unparseable_timestamp() {
+        let body = serde_json::json!({
+            "data": [ {"id": "x", "created_at": "not-a-timestamp"} ]
+        });
+        let models = parse_anthropic_models(&body);
+        assert_eq!(models[0].created, None);
+        // The original string still rides in .raw.
+        assert_eq!(models[0].raw["created_at"], "not-a-timestamp");
+    }
+
+    #[test]
+    fn parse_gemini_shape_strips_the_models_prefix() {
+        let body = serde_json::json!({
+            "models": [
+                {
+                    "name": "models/gemini-x",
+                    "displayName": "Gemini X",
+                    "inputTokenLimit": 1_000_000,
+                    "outputTokenLimit": 8192,
+                }
+            ],
+            "nextPageToken": "tok-2",
+        });
+        let models = parse_gemini_models(&body);
+        assert_eq!(models.len(), 1);
+        let m = &models[0];
+        assert_eq!(m.id, "gemini-x");
+        assert_eq!(m.display_name.as_deref(), Some("Gemini X"));
+        assert_eq!(m.context_window, Some(1_000_000));
+        assert_eq!(m.created, None);
+        // .raw keeps the original "models/..." name untouched.
+        assert_eq!(m.raw["name"], "models/gemini-x");
+    }
+
+    #[test]
+    fn parse_gemini_shape_handles_a_missing_models_array() {
+        let body = serde_json::json!({ "nextPageToken": null });
+        assert!(parse_gemini_models(&body).is_empty());
+    }
+
+    // --- pagination: a scripted ModelListFetcher, no network -------------------
+
+    /// A scripted fetcher returning one canned body per call, in order — content-driven
+    /// enough for this seam (one request in flight at a time, no concurrent fan-out),
+    /// unlike the real consult loop's `ScriptedClient`.
+    struct ScriptedFetcher {
+        pages: Mutex<Vec<Value>>,
+        calls: Mutex<Vec<DiscoveryRequest>>,
+    }
+
+    impl ScriptedFetcher {
+        fn new(pages: Vec<Value>) -> Self {
+            Self {
+                pages: Mutex::new(pages),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ModelListFetcher for ScriptedFetcher {
+        async fn get_json(&self, req: &DiscoveryRequest) -> Result<Value> {
+            self.calls.lock().unwrap().push(req.clone());
+            let mut pages = self.pages.lock().unwrap();
+            if pages.is_empty() {
+                return Err(anyhow!("scripted fetcher ran out of pages"));
+            }
+            Ok(pages.remove(0))
+        }
+    }
+
+    #[tokio::test]
+    async fn anthropic_pagination_follows_has_more_and_last_id() {
+        let page1 = serde_json::json!({
+            "data": [{"id": "a"}],
+            "has_more": true,
+            "last_id": "a",
+        });
+        let page2 = serde_json::json!({
+            "data": [{"id": "b"}],
+            "has_more": false,
+            "last_id": "b",
+        });
+        let fetcher = ScriptedFetcher::new(vec![page1, page2]);
+        let mut b = backend(ProviderKind::Anthropic);
+        b.key_optional = true;
+        // Anthropic doesn't tolerate a missing key in practice, but the scripted
+        // fetcher never hits a real network — key_optional here just lets
+        // discovery_endpoint build offline without configuring env/file credentials.
+        let models = discover_models(&b, &fetcher).await.unwrap();
+        assert_eq!(models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), ["a", "b"]);
+
+        let calls = fetcher.calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert!(!calls[0].query.iter().any(|(k, _)| k == "after_id"));
+        assert!(calls[1]
+            .query
+            .contains(&("after_id".to_string(), "a".to_string())));
+    }
+
+    #[tokio::test]
+    async fn gemini_pagination_follows_next_page_token() {
+        let page1 = serde_json::json!({
+            "models": [{"name": "models/a"}],
+            "nextPageToken": "tok-1",
+        });
+        let page2 = serde_json::json!({
+            "models": [{"name": "models/b"}],
+        });
+        let fetcher = ScriptedFetcher::new(vec![page1, page2]);
+        let mut b = backend(ProviderKind::Gemini);
+        b.key_optional = true;
+        let models = discover_models(&b, &fetcher).await.unwrap();
+        assert_eq!(models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), ["a", "b"]);
+
+        let calls = fetcher.calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert!(calls[1]
+            .query
+            .contains(&("pageToken".to_string(), "tok-1".to_string())));
+    }
+
+    #[tokio::test]
+    async fn openai_shaped_kinds_never_paginate() {
+        let page1 = serde_json::json!({ "data": [{"id": "only-page"}] });
+        let fetcher = ScriptedFetcher::new(vec![page1]);
+        let mut b = backend(ProviderKind::Openai);
+        b.base_url = Some("http://localhost:9999/v1".to_string());
+        b.key_optional = true;
+        let models = discover_models(&b, &fetcher).await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(fetcher.calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_repeating_cursor_stops_the_loop_instead_of_spinning() {
+        // A misbehaving provider that echoes the same "next" cursor forever must not
+        // hang discover_models — the repeat guard breaks the loop even though
+        // has_more never says stop.
+        let page = serde_json::json!({
+            "data": [{"id": "x"}],
+            "has_more": true,
+            "last_id": "same-cursor",
+        });
+        // Enough identical pages to prove we stop well short of MAX_PAGES.
+        let fetcher = ScriptedFetcher::new(vec![page.clone(), page.clone(), page]);
+        let mut b = backend(ProviderKind::Anthropic);
+        b.key_optional = true;
+        let models = discover_models(&b, &fetcher).await.unwrap();
+        // First page has no cursor set yet (cursor=None), so it's fetched; its
+        // last_id becomes the cursor for page 2, which repeats it — loop stops there.
+        assert_eq!(models.len(), 2, "expected exactly two pages before the repeat guard stops the loop");
+        assert_eq!(fetcher.calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fetch_error_propagates_out_of_discover_models() {
+        struct FailingFetcher;
+        #[async_trait]
+        impl ModelListFetcher for FailingFetcher {
+            async fn get_json(&self, _req: &DiscoveryRequest) -> Result<Value> {
+                Err(anyhow!("boom"))
+            }
+        }
+        let mut b = backend(ProviderKind::Openai);
+        b.base_url = Some("http://localhost:9999/v1".to_string());
+        b.key_optional = true;
+        let err = discover_models(&b, &FailingFetcher).await.unwrap_err();
+        assert!(err.to_string().contains("boom"));
+    }
+
+    // --- render_models / models_json_envelope -----------------------------------
+
+    #[test]
+    fn render_models_mixed_success_and_error() {
+        let mut results: BTreeMap<String, Result<Vec<DiscoveredModel>, String>> = BTreeMap::new();
+        results.insert(
+            "ok-backend".to_string(),
+            Ok(vec![DiscoveredModel {
+                id: "m1".to_string(),
+                display_name: Some("Model One".to_string()),
+                created: None,
+                context_window: Some(128_000),
+                raw: serde_json::json!({"id": "m1"}),
+            }]),
+        );
+        results.insert("broken-backend".to_string(), Err("no key".to_string()));
+
+        let text = render_models(&results);
+        assert!(text.contains("## broken-backend"));
+        assert!(text.contains("error: no key"));
+        assert!(text.contains("## ok-backend"));
+        assert!(text.contains("`m1`"));
+        assert!(text.contains("Model One"));
+        assert!(text.contains("128000") || text.contains("128,000"));
+    }
+
+    #[test]
+    fn render_models_empty_sweep() {
+        let results: BTreeMap<String, Result<Vec<DiscoveredModel>, String>> = BTreeMap::new();
+        assert_eq!(render_models(&results), "(no backend configured)");
+    }
+
+    #[test]
+    fn json_envelope_shape_mixed_success_and_error() {
+        let mut results: BTreeMap<String, Result<Vec<DiscoveredModel>, String>> = BTreeMap::new();
+        results.insert(
+            "ok-backend".to_string(),
+            Ok(vec![DiscoveredModel {
+                id: "m1".to_string(),
+                display_name: None,
+                created: Some(42),
+                context_window: None,
+                raw: serde_json::json!({"id": "m1", "extra": "field"}),
+            }]),
+        );
+        results.insert("broken-backend".to_string(), Err("no key".to_string()));
+
+        let env = models_json_envelope(&results);
+        let backends = env["backends"].as_array().unwrap();
+        assert_eq!(backends.len(), 2);
+        let ok = backends
+            .iter()
+            .find(|b| b["backend"] == "ok-backend")
+            .unwrap();
+        assert_eq!(ok["ok"], true);
+        assert_eq!(ok["models"][0]["id"], "m1");
+        assert_eq!(ok["models"][0]["created"], 42);
+        assert_eq!(ok["models"][0]["raw"]["extra"], "field");
+
+        let broken = backends
+            .iter()
+            .find(|b| b["backend"] == "broken-backend")
+            .unwrap();
+        assert_eq!(broken["ok"], false);
+        assert_eq!(broken["error"], "no key");
+    }
+
+}

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -69,6 +69,19 @@ pub struct DiscoveredModel {
     /// The provider's per-model object, untouched — the passthrough half of the
     /// contract, so a caller who needs a field we didn't normalize still has it.
     pub raw: Value,
+    /// Normalized per-token price, verbatim strings from the provider — `None` when
+    /// the endpoint doesn't advertise pricing on `/models` (only `Openai`-wire kinds
+    /// do today; see [`parse_openai_models`]).
+    pub pricing: Option<ModelPricing>,
+}
+
+/// Per-token price, kept as the provider's own string (fractional USD/token) rather
+/// than parsed to a float — this is money, and a `f64` round-trip can silently lose
+/// precision `.raw` would otherwise preserve exactly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelPricing {
+    pub input: Option<String>,
+    pub output: Option<String>,
 }
 
 /// One page's worth of a GET: the full URL, headers, and query params, fully
@@ -181,9 +194,38 @@ pub fn parse_openai_models(v: &Value) -> Vec<DiscoveredModel> {
             display_name: None,
             created: item.get("created").and_then(Value::as_i64),
             context_window: None,
+            pricing: parse_openai_pricing(item),
             raw: item.clone(),
         })
         .collect()
+}
+
+/// Extract a `pricing` object off an OpenAI-shaped model item, if present. Two field
+/// conventions in the wild: `input`/`output` (some gateways) and OpenRouter's
+/// `prompt`/`completion` — the latter is a fallback, checked only when the former is
+/// absent. String-typed only: a price is a fractional-USD-per-token string and we
+/// keep it verbatim (never parse to float — precision matters, and `.raw` already
+/// carries the original either way); a number-typed price (some providers send one)
+/// is left as `None` here rather than reformatted, since round-tripping a JSON number
+/// back to a string risks a representation that doesn't match what the provider would
+/// consider canonical — `.raw` still has it exactly as sent.
+/// `None` unless at least one of input/output is present — an all-empty pricing
+/// object would just be noise on every model line.
+fn parse_openai_pricing(item: &Value) -> Option<ModelPricing> {
+    let pricing = item.get("pricing")?;
+    let price = |primary: &str, fallback: &str| -> Option<String> {
+        pricing
+            .get(primary)
+            .or_else(|| pricing.get(fallback))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    };
+    let input = price("input", "prompt");
+    let output = price("output", "completion");
+    if input.is_none() && output.is_none() {
+        return None;
+    }
+    Some(ModelPricing { input, output })
 }
 
 /// Parse an Anthropic `{ data: [{id, display_name, created_at, max_input_tokens, ...}],
@@ -210,6 +252,8 @@ pub fn parse_anthropic_models(v: &Value) -> Vec<DiscoveredModel> {
                 .and_then(Value::as_str)
                 .and_then(rfc3339_to_epoch),
             context_window: item.get("max_input_tokens").and_then(Value::as_u64),
+            // Anthropic's `/v1/models` doesn't advertise pricing.
+            pricing: None,
             raw: item.clone(),
         })
         .collect()
@@ -233,6 +277,8 @@ pub fn parse_gemini_models(v: &Value) -> Vec<DiscoveredModel> {
                     .map(str::to_string),
                 created: None,
                 context_window: item.get("inputTokenLimit").and_then(Value::as_u64),
+                // Gemini's `/v1beta/models` doesn't advertise pricing.
+                pricing: None,
                 raw: item.clone(),
             }
         })
@@ -399,6 +445,18 @@ pub fn render_models(results: &BTreeMap<String, Result<Vec<DiscoveredModel>, Str
                     if let Some(ctx) = m.context_window {
                         line.push_str(&format!(" (context: {ctx})"));
                     }
+                    if let Some(p) = &m.pricing {
+                        let mut parts = Vec::new();
+                        if let Some(input) = &p.input {
+                            parts.push(format!("in ${input}/tok"));
+                        }
+                        if let Some(output) = &p.output {
+                            parts.push(format!("out ${output}/tok"));
+                        }
+                        if !parts.is_empty() {
+                            line.push_str(&format!(" [{}]", parts.join(", ")));
+                        }
+                    }
                     out.push_str(&line);
                     out.push('\n');
                 }
@@ -429,6 +487,10 @@ pub fn models_json_envelope(results: &BTreeMap<String, Result<Vec<DiscoveredMode
                             "display_name": m.display_name,
                             "created": m.created,
                             "context_window": m.context_window,
+                            "pricing": m.pricing.as_ref().map(|p| serde_json::json!({
+                                "input": p.input,
+                                "output": p.output,
+                            })),
                             "raw": m.raw,
                         }))
                         .collect::<Vec<_>>(),
@@ -890,6 +952,10 @@ mod tests {
                 display_name: Some("Model One".to_string()),
                 created: None,
                 context_window: Some(128_000),
+                pricing: Some(ModelPricing {
+                    input: Some("0.0000015".to_string()),
+                    output: Some("0.000006".to_string()),
+                }),
                 raw: serde_json::json!({"id": "m1"}),
             }]),
         );
@@ -902,6 +968,28 @@ mod tests {
         assert!(text.contains("`m1`"));
         assert!(text.contains("Model One"));
         assert!(text.contains("128000") || text.contains("128,000"));
+        assert!(
+            text.contains("[in $0.0000015/tok, out $0.000006/tok]"),
+            "expected a pricing suffix, got: {text}"
+        );
+    }
+
+    #[test]
+    fn render_models_omits_pricing_suffix_when_absent() {
+        let mut results: BTreeMap<String, Result<Vec<DiscoveredModel>, String>> = BTreeMap::new();
+        results.insert(
+            "ok-backend".to_string(),
+            Ok(vec![DiscoveredModel {
+                id: "m1".to_string(),
+                display_name: None,
+                created: None,
+                context_window: None,
+                pricing: None,
+                raw: serde_json::json!({"id": "m1"}),
+            }]),
+        );
+        let text = render_models(&results);
+        assert!(!text.contains('['), "no pricing means no bracketed suffix, got: {text}");
     }
 
     #[test]
@@ -920,6 +1008,10 @@ mod tests {
                 display_name: None,
                 created: Some(42),
                 context_window: None,
+                pricing: Some(ModelPricing {
+                    input: Some("0.000001".to_string()),
+                    output: None,
+                }),
                 raw: serde_json::json!({"id": "m1", "extra": "field"}),
             }]),
         );
@@ -936,6 +1028,8 @@ mod tests {
         assert_eq!(ok["models"][0]["id"], "m1");
         assert_eq!(ok["models"][0]["created"], 42);
         assert_eq!(ok["models"][0]["raw"]["extra"], "field");
+        assert_eq!(ok["models"][0]["pricing"]["input"], "0.000001");
+        assert!(ok["models"][0]["pricing"]["output"].is_null());
 
         let broken = backends
             .iter()
@@ -943,6 +1037,91 @@ mod tests {
             .unwrap();
         assert_eq!(broken["ok"], false);
         assert_eq!(broken["error"], "no key");
+    }
+
+    #[test]
+    fn json_envelope_pricing_is_null_not_an_empty_object_when_absent() {
+        let mut results: BTreeMap<String, Result<Vec<DiscoveredModel>, String>> = BTreeMap::new();
+        results.insert(
+            "ok-backend".to_string(),
+            Ok(vec![DiscoveredModel {
+                id: "m1".to_string(),
+                display_name: None,
+                created: None,
+                context_window: None,
+                pricing: None,
+                raw: serde_json::json!({"id": "m1"}),
+            }]),
+        );
+        let env = models_json_envelope(&results);
+        assert!(env["backends"][0]["models"][0]["pricing"].is_null());
+    }
+
+    // --- parse_openai_pricing: both field-name conventions, no unwrap on --------
+    // wrong-typed / missing input.
+
+    #[test]
+    fn parse_openai_shape_normalizes_input_output_pricing() {
+        let body = serde_json::json!({
+            "data": [
+                {"id": "m1", "pricing": {"input": "0.0000015", "output": "0.000006"}}
+            ]
+        });
+        let models = parse_openai_models(&body);
+        assert_eq!(
+            models[0].pricing,
+            Some(ModelPricing {
+                input: Some("0.0000015".to_string()),
+                output: Some("0.000006".to_string()),
+            })
+        );
+        // .raw keeps the original pricing object untouched.
+        assert_eq!(
+            models[0].raw["pricing"],
+            serde_json::json!({"input": "0.0000015", "output": "0.000006"})
+        );
+    }
+
+    #[test]
+    fn parse_openai_shape_falls_back_to_openrouter_prompt_completion_pricing() {
+        let body = serde_json::json!({
+            "data": [
+                {"id": "m1", "pricing": {"prompt": "0.000001", "completion": "0.000002"}}
+            ]
+        });
+        let models = parse_openai_models(&body);
+        assert_eq!(
+            models[0].pricing,
+            Some(ModelPricing {
+                input: Some("0.000001".to_string()),
+                output: Some("0.000002".to_string()),
+            })
+        );
+        assert_eq!(
+            models[0].raw["pricing"],
+            serde_json::json!({"prompt": "0.000001", "completion": "0.000002"})
+        );
+    }
+
+    #[test]
+    fn parse_openai_shape_pricing_is_none_when_the_endpoint_reports_none() {
+        let body = serde_json::json!({ "data": [ {"id": "m1"} ] });
+        let models = parse_openai_models(&body);
+        assert_eq!(models[0].pricing, None);
+        assert!(models[0].raw.get("pricing").is_none());
+    }
+
+    #[test]
+    fn parse_openai_shape_pricing_is_none_not_some_when_the_object_is_all_empty() {
+        // An all-empty pricing object (neither convention present) is noise, not
+        // a Some(ModelPricing { None, None }).
+        let body = serde_json::json!({
+            "data": [ {"id": "m1", "pricing": {}} ]
+        });
+        let models = parse_openai_models(&body);
+        assert_eq!(models[0].pricing, None);
+        // .raw still carries the (empty) pricing object verbatim.
+        assert_eq!(models[0].raw["pricing"], serde_json::json!({}));
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod config;
 pub mod consult;
 pub mod context;
 pub mod credentials;
+pub mod discover;
 pub mod explorer;
 pub mod jobs;
 pub mod kaish_syntax;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,9 @@ async fn main() -> Result<()> {
         Some(Command::Batch(args)) => {
             std::process::exit(kaibo::cli::run_batch(cli.common, args).await)
         }
+        Some(Command::Models(args)) => {
+            std::process::exit(kaibo::cli::run_models(cli.common, args).await)
+        }
         Some(Command::Config) => std::process::exit(kaibo::cli::run_config(cli.common)),
         Some(Command::Configure(args)) => std::process::exit(kaibo::cli::run_configure(args.goal)),
         Some(Command::ExampleConfig) => std::process::exit(kaibo::cli::run_example_config()),

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -89,6 +89,7 @@ pub(crate) fn render_config_resource(
         oneshot: bool,
         run_kaish: bool,
         batch: bool,
+        list_models: bool,
     }
 
     /// Runtime-computed scope state. `follow_worktrees` echoes the knob;
@@ -394,6 +395,7 @@ pub(crate) fn render_config_resource(
         oneshot,
         run_kaish,
         batch,
+        list_models,
     } = &config.tools;
     let crate::sandbox::SandboxConfig {
         exec_timeout,
@@ -448,6 +450,7 @@ pub(crate) fn render_config_resource(
             oneshot,
             run_kaish,
             batch,
+            list_models,
         },
         sandbox: SandboxDoc {
             exec_timeout_secs: exec_timeout.as_secs(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1727,7 +1727,7 @@ impl KaiboHandler {
             No cast, no model in the loop — a pure operator/config query, like \
             `kaibo://config`."
     )]
-    async fn list_models(
+    pub async fn list_models(
         &self,
         Parameters(input): Parameters<ListModelsInput>,
     ) -> Result<CallToolResult, McpError> {
@@ -1760,9 +1760,13 @@ impl KaiboHandler {
             results.insert(name, outcome);
         }
 
-        Ok(CallToolResult::success(vec![Content::text(
+        let mut result = CallToolResult::success(vec![Content::text(
             crate::discover::render_models(&results),
-        )]))
+        )]);
+        // Mirror the CLI's `--json` face: a machine caller gets the same envelope a
+        // human gets as prose, so the two never drift on what a sweep looks like.
+        result.structured_content = Some(crate::discover::models_json_envelope(&results));
+        Ok(result)
     }
 
     /// Resolve a cast's synth slot for batch: its slot + backend, plus the model's

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -146,6 +146,10 @@ pub struct ToolGating {
     /// they're one capability (you can't get or list without submit), so `--no-batch`
     /// drops them together rather than a flag apiece.
     pub batch: bool,
+    /// Read-only model discovery (`list_models`) — an operator/config surface, not a
+    /// model-driven tool: no cast, no tool loop, just a GET per backend. Its own gate,
+    /// independent of the model-backed tools above.
+    pub list_models: bool,
 }
 
 impl Default for ToolGating {
@@ -157,6 +161,7 @@ impl Default for ToolGating {
             oneshot: true,
             run_kaish: true,
             batch: true,
+            list_models: true,
         }
     }
 }
@@ -170,6 +175,7 @@ impl ToolGating {
             && !self.oneshot
             && !self.run_kaish
             && !self.batch
+            && !self.list_models
     }
 }
 
@@ -492,6 +498,18 @@ pub struct RunKaishInput {
     pub path: Option<String>,
 }
 
+/// Arguments to `list_models`: an operator/config-surface tool, not a model-driven one
+/// (no cast, no tool loop — see `discover.rs`'s module doc). Omit `backend` to sweep
+/// every configured backend.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ListModelsInput {
+    /// Which backend (name or alias) to query. Omit to sweep every configured backend.
+    /// `kaibo://config` lists the known backends.
+    #[serde(default)]
+    pub backend: Option<String>,
+}
+
 /// kaibo's MCP handler. Cheap to clone (rmcp clones it per request).
 #[derive(Clone)]
 pub struct KaiboHandler {
@@ -667,6 +685,9 @@ impl KaiboHandler {
                 gating.batch || gating.consult || gating.deliberate,
                 "job_wait",
             ),
+            // Read-only model discovery — its own gate, independent of every
+            // model-driven tool above.
+            (gating.list_models, "list_models"),
         ] {
             if !enabled {
                 assert!(
@@ -1694,6 +1715,54 @@ impl KaiboHandler {
         Ok(CallToolResult::success(vec![Content::text(format_output(
             &out,
         ))]))
+    }
+
+    #[tool(
+        description = "List available models a backend's provider actually serves — \
+            model discovery, read-only: which models can I use, what's the context \
+            window, is a new model out yet. Queries the backend's real /models \
+            endpoint (DeepSeek, OpenRouter, Anthropic, Gemini, or any OpenAI-compatible \
+            endpoint) with kaibo's already-configured auth, no `curl` + hand-rolled \
+            headers needed. Omit `backend` to sweep every configured backend at once. \
+            No cast, no model in the loop — a pure operator/config query, like \
+            `kaibo://config`."
+    )]
+    async fn list_models(
+        &self,
+        Parameters(input): Parameters<ListModelsInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let names: Vec<String> = match input.backend {
+            Some(name) => {
+                // Confirm the name resolves before spending a network call on it —
+                // an unknown backend is a usage error, not a per-backend sweep entry.
+                let backend = self
+                    .config
+                    .resolve_backend(&name)
+                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+                vec![backend.name.clone()]
+            }
+            None => self.config.backends.keys().cloned().collect(),
+        };
+
+        let mut results: std::collections::BTreeMap<String, Result<Vec<crate::discover::DiscoveredModel>, String>> =
+            std::collections::BTreeMap::new();
+        for name in names {
+            // A backend resolved above always resolves again here (nothing mutates
+            // the registry mid-call); skip defensively rather than panic if that
+            // invariant ever changes.
+            let Ok(backend) = self.config.resolve_backend(&name) else {
+                continue;
+            };
+            let fetcher = crate::discover::HttpModelListFetcher::new(backend.request_timeout);
+            let outcome = crate::discover::discover_models(backend, &fetcher)
+                .await
+                .map_err(|e| format!("{e:#}"));
+            results.insert(name, outcome);
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(
+            crate::discover::render_models(&results),
+        )]))
     }
 
     /// Resolve a cast's synth slot for batch: its slot + backend, plus the model's
@@ -3857,6 +3926,7 @@ mod tests {
                 explore: true,
                 oneshot: true,
                 run_kaish: true,
+                list_models: true,
             };
             KaiboHandler::new(config).expect("handler builds")
         };

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -12,8 +12,9 @@ use kaibo::server::{KaiboHandler, ToolGating};
 /// `batch` each carry a `*_submit` under their own flag; the collect verbs `job_get`/
 /// `job_cancel`/`job_list`/`job_wait` are *shared* — they manage both kinds of handle
 /// and stay advertised as long as either capability is on, so they belong to neither
-/// flag.
-const ALL_TOOLS: [&str; 11] = [
+/// flag. `list_models` is its own gate — a read-only operator/config tool, no model in
+/// the loop, independent of everything else here.
+const ALL_TOOLS: [&str; 12] = [
     "batch_submit",
     "consult",
     "consult_submit",
@@ -23,6 +24,7 @@ const ALL_TOOLS: [&str; 11] = [
     "job_get",
     "job_list",
     "job_wait",
+    "list_models",
     "oneshot",
     "run_kaish",
 ];
@@ -46,7 +48,7 @@ fn each_flag_removes_exactly_its_own_tools() {
     // `job_get`/`job_cancel`/`job_list` belong to neither flag alone — gating one
     // capability leaves them because the other still needs them — so they appear in no
     // row's removed-set and are covered by the "every other tool remains" check below.
-    let cases: [(&[&str], ToolGating); 6] = [
+    let cases: [(&[&str], ToolGating); 7] = [
         (
             // `--no-consult` drops the blocking `consult` and the async `consult_submit`;
             // `job_get`/`job_cancel`/`job_list` stay (batch still uses them).
@@ -94,6 +96,15 @@ fn each_flag_removes_exactly_its_own_tools() {
             &["batch_submit"],
             ToolGating {
                 batch: false,
+                ..Default::default()
+            },
+        ),
+        (
+            // `--no-list-models` drops only `list_models` — an operator/config tool
+            // with no model in the loop, independent of every other gate.
+            &["list_models"],
+            ToolGating {
+                list_models: false,
                 ..Default::default()
             },
         ),
@@ -166,6 +177,7 @@ fn all_disabled_is_detected() {
         oneshot: false,
         run_kaish: false,
         batch: false,
+        list_models: false,
     };
     assert!(none_on.all_disabled());
     // Any single tool on means it's a usable server, not the refused state.
@@ -177,6 +189,13 @@ fn all_disabled_is_detected() {
     // The batch capability alone is enough to be a usable server.
     assert!(!ToolGating {
         batch: true,
+        ..none_on
+    }
+    .all_disabled());
+    // list_models alone is a usable (if narrow) server — a read-only operator tool
+    // with no model in the loop still does something.
+    assert!(!ToolGating {
+        list_models: true,
         ..none_on
     }
     .all_disabled());
@@ -200,6 +219,7 @@ fn all_tools_disabled_refuses_to_start() {
             "--no-oneshot",
             "--no-run-kaish",
             "--no-batch",
+            "--no-list-models",
         ])
         .output()
         .expect("should be able to run the kaibo binary");

--- a/tests/list_models_tool.rs
+++ b/tests/list_models_tool.rs
@@ -1,0 +1,41 @@
+//! The caller-facing `list_models` #[tool], driven directly through `KaiboHandler` (the
+//! same pattern `tests/run_kaish_tool.rs` uses) — offline only. A handler built with
+//! zero configured backends sweeps nothing, so this never touches the network; it's
+//! here to prove `structured_content` is wired up to `models_json_envelope`, not to
+//! exercise a real provider (that needs a live backend and belongs to a manual probe,
+//! not `cargo test`).
+
+use kaibo::config::Config;
+use kaibo::server::{KaiboHandler, ListModelsInput};
+use rmcp::handler::server::wrapper::Parameters;
+
+#[tokio::test]
+async fn list_models_attaches_structured_content_mirroring_the_json_envelope() {
+    // Zero backends: the sweep loop in `list_models` iterates `config.backends.keys()`,
+    // so an empty map means zero fetches and zero network calls — offline by
+    // construction, not by mocking.
+    let mut config = Config::builtin();
+    config.backends.clear();
+    let handler = KaiboHandler::new(config).expect("handler builds with zero backends");
+
+    let result = handler
+        .list_models(Parameters(ListModelsInput { backend: None }))
+        .await
+        .expect("list_models tool call should not be an MCP-level error");
+
+    assert_eq!(
+        result.structured_content,
+        Some(serde_json::json!({ "backends": [] })),
+        "structured_content should mirror the CLI's --json envelope for an empty sweep"
+    );
+
+    // The prose face still renders too — the two outputs coexist, they don't replace
+    // each other.
+    let text = result
+        .content
+        .into_iter()
+        .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("no backend configured"), "got: {text}");
+}


### PR DESCRIPTION
## What

Adds read-only **model discovery** so a calling agent (or a human) can ask kaibo *what models a configured backend's provider actually serves*, instead of hand-rolling a `curl` against `/models` with the right auth header. Two faces over one shared core:

- **`list_models`** MCP tool
- **`kaibo models`** CLI subcommand

Omit `backend` to sweep every configured backend; scope to one by name/alias. Output is normalized fields (`id`, `display_name`, `context_window`, `created`) **plus the provider's raw per-model object**, so nothing a provider reports is lost.

## Why

kaibo already holds every backend's base URL, key source, wire protocol, and timeout. Discovery is the same **operator surface** `kaibo://config` and `batch list` already occupy — the natural way to answer "which model can I put in a cast slot" without leaving kaibo. No cast, no model in the loop.

## Shape / decisions

- **One core, two thin faces.** `src/discover.rs` owns a pure, offline-testable request builder, pure per-wire parsers, an injectable `ModelListFetcher` seam (pagination tested with no network, mirroring `test_support.rs`), and shared `render_models` / `models_json_envelope` so the tool and CLI can't drift.
- **Three wire shapes, normalized.** OpenAI-compat (`{data:[id]}`, bearer), Anthropic (`x-api-key` + `anthropic-version`, `has_more`/`last_id` paging), Gemini (`?key=` query param, `nextPageToken` paging). rig-core exposes no model-listing API, so these are raw GETs — but only through the one blessed `crate::tls::https_client` (rustls+ring). `cargo tree -i aws-lc-rs` stays empty.
- **Keyless auth mirrors the live arms.** Reuses `Backend::resolve_key`, so a keyless Gemini backend sends the empty `?key=` the #102 fix established.
- **Defensive parsing.** Missing/wrong-typed provider fields → `None`, never a panic. Pagination guarded two ways (`MAX_PAGES` cap + cursor-repeat break).
- **Independent gate.** `--no-list-models` / `[server.tools] list_models`, surfaced in `kaibo://config`. CLI exit taxonomy matches `batch list`: a per-backend failure in a sweep is inline, exit 4 only if *every* backend failed.

Server instructions left unchanged — the `instructions_*` budget tests sit at 2043/2048 and 2041/2048 chars, so the tool description carries the retrieval-index weight instead.

## Tests

- 28 new unit tests in `src/discover.rs`: endpoint shape per kind (incl. `base_url` gateway overrides + keyless-Gemini empty `?key=`), parsers against canned OpenAI/Anthropic/Gemini bodies (asserting `.raw` stays untouched), pagination via a scripted fetcher (Anthropic `has_more`/`last_id`, Gemini `nextPageToken`, cursor-repeat guard), render/JSON-envelope shape.
- `tests/gating.rs` extended: `list_models` added to `ALL_TOOLS`, a `--no-list-models` removal case, `all_disabled`, and the refuse-to-start subprocess check. Proven-failable (temporarily forced the gate on, confirmed red, reverted).
- `cargo build` / `clippy --all-targets` clean; full `cargo test` green; `cargo tree -i aws-lc-rs` and `-i mimalloc` empty.

## Review

Cross-family pass via kaibo's own `consult` (cast `deepseek`) over the diff — no defects across auth-per-kind, pagination termination, parser panic-safety, and exit-code/isolation wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
