### PR TITLE
Add Homebrew tap + bump-tap release helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,7 +311,11 @@ even for a one-line doc fix.
   After the release publishes: run the README "Verify a download" commands against a
   fresh asset (`gh attestation verify`, `cosign verify-blob` with the new tag's
   identity) — the tag-gated publish job signs releases, and signing an operator can't
-  verify is theater, so prove it the way a user would.
+  verify is theater, so prove it the way a user would. Then run `scripts/bump-tap.sh
+  vX.Y.Z` to point the Homebrew tap (`tobert/homebrew-kaibo`) at the new release — it
+  reads that release's `.sha256` sidecars and pushes with your own `gh`/git auth, so
+  there's no CI secret to rotate. Deliberately manual: releases are human-cut, so this
+  is the ritual's last step, not a workflow job.
 - **kaish pin.** Currently `kaish-kernel = "0.13.0"`. The `0.12.0 → 0.13.0` bump was
   again API-compatible — **zero** call-site changes, `cargo build`/`clippy --all-targets`/
   full `cargo test` (598 passed) all clean, `cargo tree -i aws-lc-rs` and `-i mimalloc`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ the git log. Each later release appends a new section at the top.
 
 ### Added
 
+- **Homebrew install.** `brew install tobert/kaibo/kaibo` now installs kaibo from
+  the `tobert/homebrew-kaibo` tap, pulling the prebuilt, signed release binary for
+  macOS (Apple Silicon + Intel) and Linux (arm64 + x86_64). Installing through
+  Homebrew also sidesteps the macOS Gatekeeper quarantine prompt a browser download
+  triggers — `brew` doesn't attach `com.apple.quarantine`, so the binary runs without
+  the "cannot verify the developer" dialog. A `scripts/bump-tap.sh vX.Y.Z` helper
+  refreshes the tap formula from a published release's checksums as the last step of
+  cutting a release.
+
 - **`list_models` (MCP tool) and `kaibo models` (CLI) — read-only model discovery.**
   Ask kaibo what models a configured backend's provider actually serves instead of
   hand-rolling a `curl` with the right auth header: it queries the backend's real

--- a/README.md
+++ b/README.md
@@ -105,10 +105,20 @@ the most common first-run stumble.
 
 ## Installation
 
-kaibo ships as a single self-contained binary per platform — download it, check the
-checksum, put it on your `PATH`, done. Linux builds are fully static musl and run on
-any distro; macOS (Apple silicon and Intel) and Windows binaries are self-contained
-too. Grab your platform's archive and its `.sha256` from the
+On macOS or Linux with [Homebrew](https://brew.sh):
+
+```sh
+brew install tobert/kaibo/kaibo
+```
+
+That taps [`tobert/homebrew-kaibo`](https://github.com/tobert/homebrew-kaibo) and
+installs the same signed release binary. On macOS it also avoids the Gatekeeper
+"cannot verify the developer" prompt — Homebrew's download isn't quarantined.
+
+Otherwise, kaibo ships as a single self-contained binary per platform — download it,
+check the checksum, put it on your `PATH`, done. Linux builds are fully static musl and
+run on any distro; macOS (Apple silicon and Intel) and Windows binaries are
+self-contained too. Grab your platform's archive and its `.sha256` from the
 [releases page](https://github.com/tobert/kaibo/releases):
 
 ```sh

--- a/scripts/bump-tap.sh
+++ b/scripts/bump-tap.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Bump the Homebrew tap (tobert/homebrew-kaibo) to a published kaibo release.
+#
+# Run this AFTER you push a vX.Y.Z tag and the release workflow has finished
+# publishing assets. It uses your own `gh`/git auth to read the release and push
+# the tap — no CI secret, nothing to rotate. Because you cut releases by hand,
+# this one command is the last step of that ritual.
+#
+#   scripts/bump-tap.sh v0.2.0-rc.6      # leading v optional
+#
+# It rewrites ONLY the formula's `version` line and the four per-target sha256s,
+# from the same `.sha256` sidecars the release attests — no second hashing to
+# drift. Everything else in the formula (desc/install/test) stays put.
+set -euo pipefail
+
+REPO="tobert/kaibo"
+TAP="tobert/homebrew-kaibo"
+
+TAG="${1:-}"
+[ -n "$TAG" ] || { echo "usage: $0 vX.Y.Z" >&2; exit 2; }
+case "$TAG" in v*) : ;; *) TAG="v$TAG" ;; esac
+VER="${TAG#v}"
+command -v gh >/dev/null || { echo "need the gh CLI on PATH" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+echo "==> fetching checksums for $TAG"
+gh release download "$TAG" --repo "$REPO" --dir "$work" -p '*.tar.gz.sha256'
+
+# Read a target's sha and REQUIRE exactly 64 hex chars. An empty/short value
+# would otherwise sail through a naive presence grep (grep -q "" matches every
+# line) and write sha256 "" — crash over that.
+sha() {
+  local v
+  v="$(awk '{print $1}' "$work/kaibo-${TAG}-$1.tar.gz.sha256")"
+  case "$v" in *[!0-9a-f]* | "") echo "bad sha for $1: '$v'" >&2; exit 1 ;; esac
+  [ "${#v}" -eq 64 ] || { echo "sha for $1 not 64 chars: '$v'" >&2; exit 1; }
+  printf '%s' "$v"
+}
+MAC_ARM="$(sha aarch64-apple-darwin)"
+MAC_X86="$(sha x86_64-apple-darwin)"
+LIN_ARM="$(sha aarch64-unknown-linux-musl)"
+LIN_X86="$(sha x86_64-unknown-linux-musl)"
+
+echo "==> cloning $TAP"
+gh repo clone "$TAP" "$work/tap" -- --depth 1 >/dev/null 2>&1
+f="$work/tap/Formula/kaibo.rb"
+[ -f "$f" ] || { echo "formula not found at $f" >&2; exit 1; }
+
+# Match each sha256 line by the target named on the url line just above it. A
+# sha256 line with no preceding known target is left UNTOUCHED (no silent
+# default) — the context-anchored checks below then catch any miss.
+awk -v ver="$VER" -v a="$MAC_ARM" -v b="$MAC_X86" -v c="$LIN_ARM" -v d="$LIN_X86" '
+  /^  version "/                         { sub(/"[^"]*"/, "\"" ver "\"") }
+  /aarch64-apple-darwin\.tar\.gz"/       { t="a" }
+  /x86_64-apple-darwin\.tar\.gz"/        { t="b" }
+  /aarch64-unknown-linux-musl\.tar\.gz"/ { t="c" }
+  /x86_64-unknown-linux-musl\.tar\.gz"/  { t="d" }
+  /sha256 "/ {
+    s = ""
+    if (t=="a") s=a; else if (t=="b") s=b; else if (t=="c") s=c; else if (t=="d") s=d
+    if (s != "") sub(/"[0-9a-f]*"/, "\"" s "\"")
+    t=""
+  }
+  { print }
+' "$f" > "$f.new" && mv "$f.new" "$f"
+
+# Validate by CONTEXT: each sha must sit on the line right after its own target
+# url, so a mis-assignment (not just a missing sha) fails loudly.
+grep -q "version \"${VER}\"" "$f" || { echo "version not patched" >&2; exit 1; }
+check() { # <target> <sha>
+  grep -A1 -- "-$1\.tar\.gz\"" "$f" | grep -q "\"$2\"" \
+    || { echo "sha for $1 not placed correctly" >&2; exit 1; }
+}
+check aarch64-apple-darwin       "$MAC_ARM"
+check x86_64-apple-darwin        "$MAC_X86"
+check aarch64-unknown-linux-musl "$LIN_ARM"
+check x86_64-unknown-linux-musl  "$LIN_X86"
+
+cd "$work/tap"
+if git diff --quiet -- Formula/kaibo.rb; then
+  echo "==> tap already at ${VER}; nothing to do"
+  exit 0
+fi
+git add Formula/kaibo.rb
+git commit -m "kaibo ${VER}"
+git push
+echo "==> tap bumped to ${VER}"


### PR DESCRIPTION
## What

Adds a Homebrew install path and a small helper to keep it current.

- **New tap repo** `tobert/homebrew-kaibo` (already created & pushed) serving the prebuilt, signed release binaries. Users get: `brew install tobert/kaibo/kaibo`.
- **`scripts/bump-tap.sh vX.Y.Z`** — reads a published release's `.sha256` sidecars and pushes an updated formula (version + four target shas) to the tap, using your own `gh`/git auth.
- **CHANGELOG + README + release runbook (AGENTS.md)** document the `brew` install, the macOS quarantine benefit, and the bump step.

## Why the decisions

- **Dedicated tap repo, not in-repo formula.** `brew install tobert/kaibo/kaibo` needs the `homebrew-`-prefixed repo naming; it also keeps this repo's PR/changelog trail free of formula-bump churn.
- **Local helper, not a CI job.** Cross-repo push from Actions needs a stored credential. A fine-grained PAT expires (≤90 days by policy) → a rotation treadmill; the only no-expiry options (classic PAT, deploy key, GitHub App) are all more standing secret than an occasional, human-cut release warrants. Since we tag releases by hand, `bump-tap.sh` runs as the last step of that ritual with our own auth — **no CI secret, nothing to rotate.**
- **Reuse the published `.sha256` sidecars** rather than re-hashing — the bump can't drift from the bytes the release signs/attests.
- **macOS trust:** installing via brew avoids the Gatekeeper "cannot verify the developer" prompt (brew doesn't set `com.apple.quarantine`). This is *not* code-signing/notarization — anyone downloading the tarball from a browser still hits quarantine. True Developer-ID signing is a separate, larger effort.

## Review

Cross-family review via kaibo (deepseek cast) over the awk patch + guards caught two silent-corruption paths, both fixed and covered by local tests:
1. An empty/malformed sha would pass a naive presence `grep` and write `sha256 ""` → now each sha is required to be exactly 64 hex chars before use.
2. The awk sha-assignment defaulted to the linux-x86 sha for a `sha256` line lacking a preceding target url → now unknown lines are left untouched, and validation is **context-anchored** (each sha must land on the line right after its own target's url).

## Verification (done on real hardware)

- **`brew install tobert/kaibo/kaibo` works end-to-end**: installs to the Cellar, `kaibo --version` → `kaibo 0.2.0-rc.6`, and the binary carries **no `com.apple.quarantine`** flag (the macOS-trust claim, proven).
- `brew test` passes (exit 0). A live install caught — and fixed in the tap — a real formula bug: Homebrew descends into the archive's single top dir during staging, so `bin.install "kaibo"` (not a nested glob).
- `brew audit` clean except a cosmetic "version redundant with URL" style nit; keeping the explicit `version` is deliberate (single source of truth, no prerelease mis-scan, trivial bump).
- `bump-tap.sh` tested live against `v0.2.0-rc.6`: fetched sidecars, cloned, patched, validated, and correctly no-op'd at the diff guard (nothing to push). The awk/validation logic has offline unit coverage.
- `release.yml` net change is **zero** (an earlier CI-bump draft was removed in favor of the script); YAML still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
