### PR TITLE
chore: bump turso 0.7.0 -> 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3938,9 +3938,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turso"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac8d131650c1bf6a2721202208b3dfba218be25c975f48bebda766173fbdc3b"
+checksum = "6b6c49aecd4abae3ffa88ab1e28b3de7a7497a9732be828e3a6f1855b6ea80fd"
 dependencies = [
  "thiserror",
  "tracing",
@@ -3952,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77f2106de5a3014261be18283999fde0d06c24ae5d4cb85a6eff1aaeaff453d"
+checksum = "08d19014707ed1ad4eadba5bf27394983b92697fe22b93e679e4ce9157cf8493"
 dependencies = [
  "aegis",
  "aes",
@@ -4022,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d367d863b095a9893690fc6c52bbf27edf422c135a58ba5ed2b03dbec8faac"
+checksum = "f075537ef0eef76bb25fb297cb5698e6582b42f4f4c082b88cd0dc6248d0ac53"
 dependencies = [
  "chrono",
  "getrandom 0.4.2",
@@ -4033,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a817815d9ca218cb971ed2a0a41a89a5160966b5b4bd103c82792fd2f230f1c"
+checksum = "72cf1ef8779d07a7bd8dc3d34a3e8cc6f59e929ef74aedf2bf8b2dfceda59d7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4044,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad90c0e6eea7ab131214804c70edad5372acecdcad8d4ccc75b0ded55b0df8f"
+checksum = "ae794301cc7490b2fa0af5ef2f175aaba2b69e2abbc9bbaac2c91a68a04d075f"
 dependencies = [
  "bitflags 2.12.1",
  "memchr",
@@ -4059,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1abf8f42cf5c40f9777982c8dfda776242397250eb48f99d524c383b1b641a"
+checksum = "3c4060696c394c0e38382f1757262c2e75bd7c65a139fddf8331d49f874cfe5d"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -4076,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit_macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372ce1889d2729223886f805638a4357f389756d6b64e26487af5a78b3e92e2c"
+checksum = "e3478f8f4e06133fd218ba93039765c096a7126636bca9b0893f79bcfd41adaf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4087,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_engine"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4157da3af3730e3cf5109668dc29b58b673f99fbbac3db3a682a4b87d56b9c4a"
+checksum = "341090cbeeb2866073b0a29c5279b138c8b8a67a85fbf636b26e9a11170988db"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4110,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_sdk_kit"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa3b4dee7f50c671ca757d1ac1ea7c99a7a9dec819a98bb1ad6a055e7d0234f"
+checksum = "d6f51333f96fbef3c1c9bd7831b365d21e4078785d1c7f8dbd30dd338a30eb8b"
 dependencies = [
  "bindgen",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 lru = "0.18"
 # Persistent session + batch-handle store (src/store.rs). turso is the pure-Rust
 # SQLite rewrite (ex-Limbo); the embedded `turso` crate, NOT libSQL or the cloud SDK.
-# EXACT-pinned (`=0.7.0`): the `.db-tshm` on-disk WAL format AND the API are declared
+# EXACT-pinned (`=0.7.1`): the `.db-tshm` on-disk WAL format AND the API are declared
 # unstable between releases (same discipline as the kaish-kernel pin) — a bump must be
 # a deliberate, tested port, never a silent `^` float. `default-features = false` is
 # MANDATORY: the defaults install `mimalloc` as the whole binary's global allocator via
@@ -104,7 +104,12 @@ lru = "0.18"
 # stdio-only + no-aws-lc invariants; the default `turso_sync_engine` weight carries no
 # transport without it. Verified aws-lc-rs/aws-lc-sys/openssl-sys/cmake-free via
 # `cargo tree -i` (see the store module doc-comment for the audit).
-turso = { version = "=0.7.0", default-features = false }
+# 0.7.0 -> 0.7.1: checked upstream's compare (9 commits) before pinning forward — the
+# only change touching the embedded engine (core/translate) is two query-planner
+# bugfixes (IN-LIST cost model, a missing-index-after-UPSERT case); everything else is
+# JS/serverless bindings and other-language SDKs kaibo doesn't use. No storage-format
+# or embedded-API change.
+turso = { version = "=0.7.1", default-features = false }
 # A typed store error wrapping `turso::Error` variants meaningfully (src/store.rs). The
 # rest of kaibo leans on anyhow, but a persistence library boundary wants a real error
 # enum callers can match on; thiserror is already in the tree (via kaish-kernel), so this


### PR DESCRIPTION
## Summary

- turso is exact-pinned (`.db-tshm` format + API declared unstable between
  releases), so a bump is always a deliberate, tested port — never a silent
  float. Checked upstream's `v0.7.0...v0.7.1` compare before touching the pin:
  9 commits, and the only change touching the embedded engine (`core/translate`)
  is two query-planner bugfixes (IN-LIST cost model, a missing-index-after-UPSERT
  case). Everything else is JS/serverless bindings and other-language SDK
  packages kaibo's embedded, `default-features = false`, no-`sync` build never
  touches.
- Part of the prep for cutting real v0.2.0 (turso was flagged stale during the
  release checklist pass).

## Test plan

- [x] `cargo build --all-targets` clean
- [x] `cargo test` — 502 lib + full integration suite green, including
      `tests/store.rs`'s `survives_reopen` / `reopen_does_not_re_run_migration`
      (the tests that would catch a `.db-tshm` format drift)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo tree -i aws-lc-rs` / `-i mimalloc` still empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)