### PR TITLE
chore: cut v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable, user-facing changes to kaibo are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); kaibo aims for
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-`0.2.0` is the first tracked release — the point kaibo adopts a pull-request
-workflow and a maintained changelog. It captures the feature set as kaibo goes
-public rather than reconstructing the 0.1 development line; that history lives in
-the git log. Each later release appends a new section at the top.
+`0.2.0` is kaibo's first real public release — the point it's meant for other
+people to install and run, not just us. It's also the point kaibo adopts a
+pull-request workflow and this maintained changelog. The `0.2.0` entry captures
+the feature set as kaibo goes public rather than reconstructing the 0.1
+development line; that history lives in the git log, and it's noisy enough
+(iterative, exploratory, many small commits) that we may compress it into a
+shorter retrospective note later rather than leave it as the implicit "pre-0.2.0"
+record. Each later release appends a new section at the top.
 
-## [0.2.0] — unreleased
+## [Unreleased]
+
+## [0.2.0] — 2026-07-29
 
 ### Changed
 
@@ -706,4 +712,5 @@ the git log. Each later release appends a new section at the top.
   second wrapper. The line between an attachment and the prompt stays unambiguous across
   `oneshot` and batch.
 
+[Unreleased]: https://github.com/tobert/kaibo/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/tobert/kaibo/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.2.0-rc.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
-description = "解剖 — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.2.0-rc.6"
+description = "kaibo — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -257,3 +257,29 @@ toolset has drifted from the direct one and that's the bug.
   persistence store) not re-run live this pass — unaffected by a kaish-kernel bump
   and already covered by `tests/containment.rs`/`tests/store.rs` in that same green
   run.
+- **2026-07-29** — Full battery A–E, direct via `kaibo kaish`/`kaibo --state-db`
+  (built binary, commit `ffb0bdb`, pre-release checklist pass ahead of cutting real
+  v0.2.0 — five PRs had landed since the last full run: rmcp 3.0.0-beta.5, the
+  OpenAI batch lane, `list_models`, gemini `base_url`, the Homebrew tap). All clear:
+  Battery A — every write refused `permission denied: filesystem is read-only`,
+  `leftovers` grep empty, host `ls` clean. Battery B — every external command
+  `command not found` (exit 127). Battery C — `/etc/passwd`, `..`-traversal,
+  `~/.ssh/id_rsa`, and the adjacent-secret probe all `not found`; `env`/`kaish-vars`/
+  the key-var check all empty. **Noted for the record** (not a finding): `cd / && ls`
+  lists `dev`, `home`, `v` — these are synthetic VFS scaffolding, not host content:
+  `/dev/{null,random,urandom,zero}` are virtual devices, `/v` is kaish's own builtin
+  toolbox + ephemeral blob/job scratch (confirmed empty), and `/home` is an inert,
+  unwalkable stub (`ls /home`, `/home/atobey`, `/home/atobey/src` all `not found`) —
+  only the exact `--root`-resolved absolute path mounts real content, confirmed by
+  reading `$ROOT/Cargo.toml` through it. Battery D — all five `path` containment
+  cases matched the expected table exactly (`/etc` and the root's parent refused as
+  outside the allowed set, the `..`-injected path canonicalized to `/etc` then
+  refused, a real subdir succeeded, a file path refused as "not a directory").
+  Battery E — E1 refused the in-project `--state-db` loudly with no file created;
+  E2's real on-disk state db (4 KiB, existing session data) read back `not found`
+  through kaish; E3's `no_write_path` suite (11 tests) green. Full `cargo test`
+  (502 lib + full integration) and `--test containment --test sandbox
+  --test run_kaish_tool` (34 tests) all green on the same build. Immediately
+  followed by the `turso` 0.7.0 → 0.7.1 exact-pin bump (PR #106, merged as
+  `fae7a26`) — reviewed separately (cross-family, `src/store.rs`'s WAL-reopen
+  tests) since it doesn't touch this boundary.


### PR DESCRIPTION
## Summary

- Version bump `0.2.0-rc.6` → `0.2.0` — the real, non-prerelease v0.2.0.
- CHANGELOG: retitled the accumulated `[0.2.0] — unreleased` section to
  `[0.2.0] — 2026-07-29`, opened a fresh empty `[Unreleased]` above it, and
  reworded the header note — this is kaibo's first real *public* release
  (meant for other people to install and run, not just us), and the
  pre-0.2.0 git history is noisy/iterative enough that we may compress it
  into a shorter retrospective later rather than leave it as the implicit
  record.
- Dropped the 解剖 kanji from `Cargo.toml`'s `description` (plain `kaibo` —
  the kanji reading was always a happy coincidence, not the actual name).
  Its other appearances in the tree (README, AGENTS.md, doc-comments) are a
  separate, later cleanup — not release-blocking.
- Re-ran `docs/sandbox-probes.md` in full (batteries A–E) and stamped a new
  dated entry — the last full run was 2026-07-18, and five PRs had landed
  since (rmcp 3.0 upgrade, OpenAI batch, `list_models`, gemini `base_url`,
  the Homebrew tap).

## Pre-tag release checklist (AGENTS.md "Cutting a release")

- [x] `kaish-kernel` pin (0.13.0) confirmed current against crates.io
- [x] `turso` bumped 0.7.0 → 0.7.1 in a separate, reviewed PR (#106,
      merged) after auditing upstream's compare for `.db-tshm`
      format/API drift — none found in the embedded engine path
- [x] `docs/sandbox-probes.md` re-run live, all batteries clean, stamped
- [x] `cargo tree -i aws-lc-rs` / `-i mimalloc` empty (dev *and*
      release/musl builds)
- [x] `x86_64-unknown-linux-musl` release build verified
      `statically linked` / `not a dynamic executable`, reports
      `kaibo 0.2.0`
- [x] Full suite green (502 lib + integration), clippy clean

## Test plan

- [x] `cargo build --all-targets`, `cargo test`, `cargo clippy --all-targets`
      all clean
- [x] `cargo zigbuild --release --target x86_64-unknown-linux-musl` +
      `file`/`ldd` confirm static
- [ ] After merge: tag `v0.2.0`, watch `release.yml`, verify the published
      asset (`gh attestation verify`, `cosign verify-blob`), then
      `scripts/bump-tap.sh v0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)