### PR TITLE
docs: pull the 解剖 kanji back to the README's Name section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — kaibo (解剖)
+# AGENTS.md — kaibo
 
 Kaibo is a stdio MCP server that provides an assistant agent **for other agents**.
 It augments a calling agent (Codex, Claude, Gemini, local agents, etc.) with a team of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+### Changed
+
+- **The tool is plain "kaibo" now.** The 解剖 kanji no longer rides along with the
+  name in the MCP handshake, the CLI `--help` banner, the example config, or the
+  docs — that reading is a coincidence of how the name was built (kai + aibo), not
+  the name itself, and repeating it everywhere implied otherwise. The README's
+  `## Name` section keeps the story and is now the one place it appears. No
+  behavior, flags, or tool names changed.
+
 ### Fixed
 
 - **State-db-collides-with-project-tree error now names `--root`/`--allow-path`.**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <!-- Kaile, the kaibo mascot. Brand assets + generator live in docs/brand/. -->
-  <img src="docs/brand/banner-teal.png" alt="kaibo（解剖）" width="820">
+  <img src="docs/brand/banner-teal.png" alt="kaibo" width="820">
 </p>
 
 <p align="center">
@@ -658,6 +658,9 @@ tool. kai + [aibo](https://jisho.org/word/%E7%9B%B8%E6%A3%92) sounded nice to al
 [gpal](https://github.com/tobert/gpal)/[dpal](https://github.com/tobert/dpal)/[cpal](https://github.com/tobert/cpal).
 It turns out kaibo ([解剖](https://jisho.org/word/%E8%A7%A3%E5%89%96)) means
 dissection, autopsy, or postmortem examination and that was that.
+
+That reading is a happy coincidence rather than the actual name, so this is the one
+place it appears. The tool is plain **kaibo** — kai + aibo — everywhere else.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -654,13 +654,17 @@ work, and [`docs/devlog.md`](docs/devlog.md) for the shipped-work record.
 ## Name
 
 Originally @tobert was combining 'kai' (会) with different words to find a name for this
-tool. kai + [aibo](https://jisho.org/word/%E7%9B%B8%E6%A3%92) sounded nice to align with
+tool. kai + [aibo](https://jisho.org/word/%E7%9B%B8%E6%A3%92) — overlapping the shared
+`ai` — sounded nice to align with
 [gpal](https://github.com/tobert/gpal)/[dpal](https://github.com/tobert/dpal)/[cpal](https://github.com/tobert/cpal).
 It turns out kaibo ([解剖](https://jisho.org/word/%E8%A7%A3%E5%89%96)) means
 dissection, autopsy, or postmortem examination and that was that.
 
-That reading is a happy coincidence rather than the actual name, so this is the one
-place it appears. The tool is plain **kaibo** — kai + aibo — everywhere else.
+That reading is a happy coincidence rather than the actual name, so it doesn't ride
+along with it: kaibo introduces itself as plain **kaibo** everywhere it speaks — the MCP
+handshake, `--help`, the docs. The kanji stays here, where it's the story being told,
+and in the brand wordmark, where it's deliberate lettering rather than a claim about
+what the tool is called.
 
 ## License
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,4 +1,4 @@
-# kaibo (解剖) — example configuration.
+# kaibo — example configuration.
 #
 # Copy to $XDG_CONFIG_HOME/kaibo/config.toml (default ~/.config/kaibo/config.toml),
 # or point at it with --config <path> / KAIBO_CONFIG.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,6 +1,6 @@
 # kaibo — Devlog
 
-解剖（かいぼう）'s shipped-work record: the *why* behind landed changes, newest
+kaibo's shipped-work record: the *why* behind landed changes, newest
 first. This is the curated narrative git can't carry — what we chose, what we
 rejected, what a live probe proved, how the shipped surface drifted from the plan.
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,6 +1,6 @@
 # kaibo — Known Issues & Open Work
 
-解剖（かいぼう）'s punch list. kaibo is an assistant agent for other agents — a team
+kaibo's punch list. kaibo is an assistant agent for other agents — a team
 of models offering *consultation* (read-only, cited codebase answers). This file is
 where we record what's missing, what's fragile, and what we'd improve. Evidence-first
 — name the file, the line, the *why*, and how it surfaced.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,7 +81,7 @@ EXIT CODES
 `kaibo kaish` is the one exception: it exits with kaish's own code instead of
 this table (0 ok, 126 blocked, 124 timed out).";
 
-/// kaibo (解剖) — read-only codebase consultation from a model outside your own
+/// kaibo — read-only codebase consultation from a model outside your own
 /// family. Ask a question; a capable model (DeepSeek, Gemini, Anthropic, OpenRouter,
 /// or local — pick with `--cast`) reads the project READ-ONLY and answers with
 /// `file:line` citations, never modifying anything. Bare `kaibo` is the MCP server

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -254,7 +254,7 @@ fn casts_section(config: &Config, usable: &[(String, CastUsability)]) -> String 
     )
 }
 
-/// Like [`kaibo_instructions`] but with a **scope section** appended so the calling
+/// Build the MCP server instructions, with a **scope section** appended so the calling
 /// model always knows:
 /// - the default root (or that every call must pass one),
 /// - the allowed trees a per-call `path` must be at-or-under, and
@@ -777,11 +777,17 @@ mod tests {
         );
         let casts_at = text.find("## Casts").expect("has a Casts section");
         let scope_at = text.find("## Scope").expect("has a Scope section");
-        let lead_at = text.find("kaibo").expect("opens with the lead");
+        // Assert the lead actually OPENS the text, rather than merely finding the first
+        // "kaibo" somewhere before `## Casts` — the Casts section's own `kaibo://config`
+        // reference would satisfy a bare `find`, leaving this weaker than it reads.
         assert!(
-            lead_at < casts_at && casts_at < scope_at,
-            "order must be lead → casts → scope (got lead={lead_at}, casts={casts_at}, \
-             scope={scope_at}):\n{text}"
+            text.starts_with(kaibo_lead()),
+            "the instructions must open with the lead verbatim — it is the resident pitch \
+             and the tool-search retrieval index:\n{text}"
+        );
+        assert!(
+            casts_at < scope_at,
+            "order must be lead → casts → scope (got casts={casts_at}, scope={scope_at}):\n{text}"
         );
         assert!(
             !text.contains("The shell is kaish"),

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -117,7 +117,7 @@ pub fn topics() -> Vec<(&'static str, &'static str)> {
 /// `## Scope` — the menu of teams reads before scope, and both sit above the point a
 /// truncating host (Claude Code's 2048-char cap) would cut.
 fn kaibo_lead() -> &'static str {
-    "kaibo (解剖) — grounded, cited answers about a codebase from a model outside \
+    "kaibo — grounded, cited answers about a codebase from a model outside \
      your own family. DeepSeek, Gemini, Anthropic, OpenRouter, or a local model reads the \
      project READ-ONLY and answers with file:line citations. Say in prose what you \
      did or want to know — kaibo finds and reads the current code itself; no \
@@ -777,7 +777,7 @@ mod tests {
         );
         let casts_at = text.find("## Casts").expect("has a Casts section");
         let scope_at = text.find("## Scope").expect("has a Scope section");
-        let lead_at = text.find("kaibo (解剖)").expect("opens with the lead");
+        let lead_at = text.find("kaibo").expect("opens with the lead");
         assert!(
             lead_at < casts_at && casts_at < scope_at,
             "order must be lead → casts → scope (got lead={lead_at}, casts={casts_at}, \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! kaibo (解剖) — an assistant agent *for other agents*.
+//! kaibo — an assistant agent *for other agents*.
 //!
 //! kaibo augments a calling agent (Claude, etc.) with a team of models, lending one
 //! kind of help over MCP: **consultation** — grounded, cited answers about a codebase.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! kaibo (解剖) — read-only codebase consultation, as a stdio MCP server and a CLI.
+//! kaibo — read-only codebase consultation, as a stdio MCP server and a CLI.
 //!
 //! Bare `kaibo` (and `kaibo serve`) is the MCP server: ask `consult` a question about
 //! a codebase; kaibo explores it read-only through kaish and returns a cited answer.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2360,7 +2360,7 @@ impl rmcp::ServerHandler for KaiboHandler {
         // Identify as kaibo, not rmcp (from_build_env reports the rmcp crate).
         .with_server_info(
             Implementation::new("kaibo", env!("CARGO_PKG_VERSION"))
-                .with_title("kaibo (解剖)"),
+                .with_title("kaibo"),
         )
         .with_protocol_version(ProtocolVersion::LATEST)
         // Judge provider usability from the live environment so a fresh install


### PR DESCRIPTION
## What

The 解剖 kanji comes out of the 11 *identity* positions it had accreted into, and stays in exactly one place: the README's `## Name` section.

Removed from: the MCP server instructions lead + `with_title`, the CLI `--help` banner, three crate/module doc-comments (`main.rs`, `lib.rs`, `cli.rs`), `AGENTS.md`'s title, the `docs/issues.md` and `docs/devlog.md` headers, `docs/config.example.toml`'s header, and the README banner's `alt` text.

Kept in: the README `## Name` section — plus two new sentences making the situation explicit, so the absence everywhere else reads as a decision rather than drift.

## Why

Amy's call while cutting v0.2.0: *"the kaibou kanji is more happy coincidence than actual name."* The name was built as kai + aibo, to rhyme with gpal/dpal/cpal; that it also reads as 解剖 (dissection, autopsy) was discovered afterward. Stamping `kaibo (解剖)` onto every banner and header quietly asserted the opposite — that the kanji *is* the name.

Deliberately **not** a scrub. Amy asked to de-emphasize, not erase, and the etymology is genuinely good README material.

Two small side benefits: the MCP instructions lead is the resident, 2048-char-budgeted client-facing string, so this buys back a few characters of the budget the `instructions_*` tests enforce; and `Cargo.toml`'s `description` was already done during the v0.2.0 cut, so this finishes that thread.

## Risk

Docs and display strings only — no behavior, flags, or tool names change. The one test that pinned the handshake lead string (`kaish_syntax.rs`) follows the text it pins. Full `cargo test` green.