### PR TITLE
Don't advertise a tool no configured cast can staff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,14 @@ loop. Each consultation tool is that loop wearing different clothes:
 Both model-driven tools name their cast + answering model(s) in a provenance footer
 (`with_provenance` in `server.rs`), so a cross-model study sees which model answered.
 
-Each tool is independently gated by a `--no-<tool>` flag (all on by default; the
-all-off server is refused at startup). Multi-provider over `rig-core`: a
-**`ProviderKind`** is the wire protocol (keyed Anthropic / DeepSeek / Gemini, plus
-**`openai`** for any OpenAI-compatible endpoint). A **`[backends.<name>]`**
+Seven `--no-<tool>` capability flags gate the surface (all on by default; `consult` also
+gates `consult_submit`, `batch` gates `batch_submit`, and the `job_*` verbs follow their
+live producers). A tool also needs a cast that can **staff** it, or its route is dropped;
+a server left with nothing advertised is refused at startup, by either road. See
+`CAST_ENUM_RULES` and `live_tools` in `server.rs`, and "Tool gating" in `docs/config.md`.
+Multi-provider over `rig-core`: a **`ProviderKind`** is the wire protocol (keyed
+Anthropic / DeepSeek / Gemini / OpenRouter, plus **`openai`** for any OpenAI-compatible
+endpoint). A **`[backends.<name>]`**
 (`config.rs`) is a *named connection* of a kind with its own base URL and key source —
 so two `openai` backends (hosted GPT and a local Gemma/llama.cpp server, say) can be
 live at once. A **`[casts.<name>]`** is a model team mapping each reasoning role

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,20 @@ Two audiences are optimized differently:
   of thousands to millions of tokens. Here verbosity is *licensed where it shapes
   behavior*: say it a few ways, frame positively, be explicit (see **Driving the
   models**). Verbose to install behavior, never verbose by default.
+- **Operator-facing docs** — `docs/config.example.toml`, `docs/config.md`, `README.md`.
+  The first two are **embedded in the binary** (`include_str!`) and served as
+  `kaibo://config/example` and `kaibo://config/guide`, so a model reads them as often as
+  a person does. They are shipped product, not repo notes. Write them as **technical
+  reference**: state the rule, name the default, show the shape. Declarative sentences
+  over conversational asides; a table or labelled list over a paragraph that buries three
+  facts in a clause chain. No em-dash pile-ups, no rhetorical questions, no voice.
+  Someone skimming for one key should find it without reading the prose around it, and a
+  non-native English reader should not have to parse an idiom to get a default value.
+  Split the two by job: the **template** says what to type (a knob, its default, one line
+  on what it does, a pointer for the rest); the **guide** explains semantics and
+  interactions. Detail that isn't a knob belongs in the guide — the template is read
+  start to finish by whoever is configuring kaibo, so every line there is a line they pay
+  for.
 
 ## Driving the models
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+### Changed
+
+- **kaibo no longer advertises a tool no configured cast can run.** A tool now has to
+  clear two gates to appear: its `--no-<tool>` flag, and a cast that can actually staff
+  it. The visible effect on a stock install is `deliberate`, which was advertised but
+  dead on arrival — it needs an explorer paired with an offline synth, and no built-in
+  cast has that shape, so every call failed `cast "…" has no explorer slot` while the
+  tool still cost resident tokens in every session. It now stays hidden until you
+  configure a cast that can run it (`docs/config.example.toml`'s DELIBERATE section,
+  where any of the three hosted batch providers or a big local model on the `direct`
+  lane will do). The same rule covers `explore`, `batch_submit`, `consult`/`oneshot`,
+  and the job-collect verbs, which follow whichever handle producers are live.
+
+  Because vanishing is right for the calling agent and wrong for the operator, kaibo
+  says so twice: a startup warning naming the cast *shape* that would bring each tool
+  back, and a `[runtime]` entry in `kaibo://config` — `advertised_tools` for what the
+  server really serves, `unstaffable_tools` for each tool held back plus what it wants.
+  A tool you turned off yourself is reported in `[tools]` as before and never appears
+  as unstaffable — "you disabled it" and "nothing can run it" are different answers and
+  are kept apart.
+
 ### Fixed
 
 - **State-db-collides-with-project-tree error now names `--root`/`--allow-path`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,30 @@ record. Each later release appends a new section at the top.
   list in silence. That now exits non-zero naming the cause, alongside the per-tool
   warnings that say what each tool wanted.
 
+### Added
+
+- **New MCP resource: `kaibo://config/guide`** — the full configuration manual
+  (`docs/config.md`), embedded in the binary the way the annotated template already is.
+  An agent configuring kaibo over MCP has no access to kaibo's own `docs/`, so until now
+  every explanation had to be smuggled into `config.toml`'s comments, where it cost bytes
+  on every read. The three config resources now split by job: `kaibo://config/example` is
+  the template you copy, `kaibo://config` is the resolved live state, and
+  `kaibo://config/guide` explains what any of it means. The `configure` prompt points at
+  all three.
+
+### Changed
+
+- **`docs/config.example.toml` is leaner, and `docs/config.md` reads as a reference
+  manual.** The template had been accumulating explanation that belongs in the manual —
+  a whole hand-copied table of the staffing rules above, for instance, which the running
+  server already reports for your actual config. That detail moved to the guide's new
+  "Tool gating" section and the template points at it, so the file you read while editing
+  your config is mostly the knobs you're editing. The guide itself was rewritten in
+  technical-reference style throughout: settings in tables with their defaults and
+  constraints, rules stated plainly, and the design-history essay dropped in favour of
+  `docs/casts.md`, which is the design record. No behavior changed and no rule was
+  dropped.
+
 ### Fixed
 
 - **State-db-collides-with-project-tree error now names `--root`/`--allow-path`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,33 @@ record. Each later release appends a new section at the top.
   `docs/casts.md`, which is the design record. No behavior changed and no rule was
   dropped.
 
+- **`docs/config.example.toml` documents four knobs it had been missing** —
+  `[persistence]`, `[orientation]`, `job_capacity`, and `inline_attach_budget`. The
+  resource description promised "every option with its default"; now that is true.
+
 ### Fixed
+
+- **Corrected several configuration-manual claims that did not match the code.** Found by
+  pointing kaibo's own `consult` at the rewrite (cast `or-gpt`, GPT-5.6 luna in both
+  roles) and verifying each finding against the source. The ones that would have misled
+  someone configuring kaibo:
+
+  - A synth slot's `preamble` **does** reach the offline `batch` and `deliberate` phases.
+    The manual said it did not. It is load-bearing that it does: on a batch or deliberate
+    cast the synth slot *is* the offline synth, so the opposite rule would make a slot
+    preamble do nothing on exactly the casts built for that lane.
+  - `explore` accepts a cast whose synth is on an offline lane — it runs only the
+    explorer arm. The lane rules had been generalized to "the interactive tools".
+  - A missing or broken key file, and a missing `[context] user_files` entry, are
+    **call-time** errors, not startup errors. Keys and context files both resolve lazily.
+  - Hosted OpenAI `gpt-5*` models **do** consume `effort` (as `reasoning.effort` on the
+    Responses shape). Only generic/local Chat Completions endpoints ignore it.
+  - `[context]` house rules and the `[orientation]` map reach standalone `explore` and
+    `deliberate`'s dossier explorer too, not only the `consult` driver and its sweep.
+  - The state db stores the caller's **questions** alongside the models' answers.
+  - In `kaibo://config`, `tools` is the configured flags; `runtime.advertised_tools` is
+    what the server actually serves. The distinction is new in this release, so the
+    manual now points at the right one.
 
 - **State-db-collides-with-project-tree error now names `--root`/`--allow-path`.**
   The state db's default path (`~/.local/state/kaibo/state.db`) can land inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ record. Each later release appends a new section at the top.
   as unstaffable — "you disabled it" and "nothing can run it" are different answers and
   are kept apart.
 
+- **kaibo refuses to start when nothing is left to advertise.** It already refused a
+  server with every tool switched off; staffing opened a second road to the same useless
+  state (every cast-taking tool enabled but unstaffable, with `run_kaish` and
+  `list_models` disabled), which would previously have started and served an empty tool
+  list in silence. That now exits non-zero naming the cause, alongside the per-tool
+  warnings that say what each tool wanted.
+
 ### Fixed
 
 - **State-db-collides-with-project-tree error now names `--root`/`--allow-path`.**

--- a/README.md
+++ b/README.md
@@ -362,12 +362,14 @@ agents don't share history or generated artifacts. Codex commonly has a stricter
 sandbox default than Claude Code, so its setup may need explicit network and writable
 root entries where Claude Code just works.
 
-The prompt leans on two MCP resources kaibo serves, which you can also read directly:
+The prompt leans on MCP resources kaibo serves, which you can also read directly:
 
 - **`kaibo://config/example`** — the fully annotated `config.toml` template, every
   knob with its default and a comment, embedded in the binary.
 - **`kaibo://config`** — the *resolved* runtime state: which casts and backends are
   live, what's gated, where each key is sourced from.
+- **`kaibo://config/guide`** — the full configuration reference (`docs/config.md`),
+  also embedded, for when the template's comments leave a question open.
 
 Prompts and resources are plain MCP — any client that surfaces them can use them. If
 yours doesn't render `configure` as a command, or you're driving kaibo purely through

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -34,9 +34,12 @@
 # Prefer another provider? Pass cast="<backend-or-cast>" per call, or set
 # `cast` below.
 #
-# kaibo serves two resources you can read from your MCP client, no tool turn spent:
+# kaibo serves three config resources you can read from your MCP client, no tool turn
+# spent:
 #   kaibo://config          the *resolved* runtime state (key sources, never values)
 #   kaibo://config/example  this annotated template, embedded in the binary
+#   kaibo://config/guide    the full reference manual — every key, precedence, cast
+#                           design, tool gating, containment, persistence
 
 # ---------------------------------------------------------------------------
 # [server] — process-level defaults (the things --root / --cast / --no-* set)
@@ -79,30 +82,16 @@ log = "kaibo=info"
 # Tool gating — true advertises the tool, false drops it (the --no-<tool> flags).
 # All default true; a config that turns every one off is refused at startup.
 #
-# A tool clears TWO gates to be advertised: the flag below, AND a configured cast that can
-# actually staff it. A tool nothing can staff is not advertised at all — the calling agent
-# never sees a tool whose every call would fail, and an unusable tool stops costing
-# resident tokens in every session. Which cast shape staffs which tool:
-#
-#   consult / consult_submit / oneshot   a cast with an INTERACTIVE synth (no offline lane)
-#   explore                              a cast with an `explorer` slot
-#   batch_submit                         a cast with a synth on `lane = "batch"`
-#   deliberate                           a cast with an `explorer` AND an offline synth
-#                                        (`lane = "batch"` or `lane = "direct"`)
-#   job_get / job_cancel / job_list / job_wait   live while any handle producer is
-#   run_kaish / list_models              no cast at all — always available
-#
-# Out of the box this bites exactly one tool: no BUILT-IN cast pairs an explorer with an
-# offline synth, so `deliberate` is not advertised until you configure a cast that can run
-# one — see the DELIBERATE casts near the bottom of this file. When a tool is held back
-# this way kaibo logs a warning at startup naming the cast shape it wants, and
-# `kaibo://config`'s [runtime] section lists it under `unstaffable_tools` with the same
-# explanation. (A tool YOU switched off below is reported in [tools] instead — the two
-# reasons a tool can be missing are kept apart on purpose.)
+# A tool also needs a cast that can STAFF it. One nothing can staff is not advertised at
+# all, so it costs no resident tokens and no call of it can fail. Out of the box that
+# affects `deliberate`: no built-in cast pairs an explorer with an offline synth, so it
+# stays dark until you configure one (see DELIBERATE casts below). kaibo warns at startup
+# naming the cast shape it wants, and kaibo://config's [runtime].unstaffable_tools reports
+# it live. Full table: kaibo://config/guide, "Tool gating".
 [server.tools]
 consult        = true
 explore        = true
-deliberate     = true      # ...but only advertised if a cast can staff it — see above
+deliberate     = true      # ...and needs a deliberate-shaped cast; see below
 oneshot        = true
 run_kaish      = true
 batch          = true
@@ -487,13 +476,10 @@ synth    = { backend = "gpt", id = "gpt-5.6-sol", lane = "batch" }
 #     synth-only batch casts above, these carry BOTH slots — the explorer is what makes it a
 #     deliberate cast rather than a plain batch one.
 #
-#     THIS SECTION IS WHAT TURNS `deliberate` ON. No built-in cast has this shape (the
-#     built-in offline casts, anthropic-batch and gemini-batch, are synth-only), so on a
-#     stock install the `deliberate` tool is not advertised at all — see [server.tools]
-#     near the top. Uncomment or adapt any one cast below and it appears. All three hosted
-#     batch providers work here — Anthropic (`fable`), Gemini (`gemini-deliberate`), and
-#     hosted OpenAI Platform (`gpt-deliberate`, above) — and so does a big LOCAL model on
-#     the `direct` lane (`local-direct`, below), which needs no batch API at all. ---
+#     THIS SECTION IS WHAT TURNS `deliberate` ON: no built-in cast has this shape, so the
+#     tool is dark on a stock install. Adapt any one cast below and it appears. All three
+#     hosted batch providers work, as does a big LOCAL model on `direct` (no batch API at
+#     all). ---
 
 # Fable on the batch lane, with a Sonnet explorer building the dossier.
 [casts.fable]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -79,8 +79,11 @@ cast = "anthropic"
 # tracing/EnvFilter directive used when RUST_LOG is unset.
 log = "kaibo=info"
 
-# Tool gating — true advertises the tool, false drops it (the --no-<tool> flags).
-# All default true; a config that turns every one off is refused at startup.
+# Tool gating — seven capability flags (the --no-<tool> flags), all default true. They
+# are not one-per-tool: `consult` also gates consult_submit, `batch` gates batch_submit,
+# and the job_* verbs follow whichever handle producers are live. A config that leaves
+# nothing advertised is refused at startup, whether by turning every flag off or by
+# staffing (below) removing what remains.
 #
 # A tool also needs a cast that can STAFF it. One nothing can staff is not advertised at
 # all, so it costs no resident tokens and no call of it can fail. Out of the box that
@@ -148,6 +151,37 @@ call_deadline_secs = 3600
 
 session_capacity = 128       # max multi-turn consult sessions held in memory (LRU,
                              # capacity-evicted, no TTL); must be > 0
+job_capacity     = 64        # max async-consult jobs held in memory, running plus
+                             # uncollected; evicting a running one aborts it; must be > 0
+
+# Byte budget for inlining consult text attachments into the driver prompt (greedy, in
+# caller order). Past it an attachment is DEMOTED to a read-it-whole directive, loudly,
+# never dropped. 0 inlines nothing — the escape hatch for a small-context local cast.
+inline_attach_budget = 262144   # 256 KiB
+
+# ---------------------------------------------------------------------------
+# [orientation] — a computed-once file map injected into the exploring phases, so a
+# model starts knowing the layout instead of spending turns on glob/ls/find. Built
+# from the kernel's own ignore-aware enumeration, so it can't disagree with what the
+# explorer's shell sees. Omit the stanza to keep the defaults.
+# ---------------------------------------------------------------------------
+[orientation]
+enabled = true               # false turns the map off entirely
+full_list_max_files = 256    # <= this injects the full file list; above, a directory
+                             # map; 0 is a load error (disable instead)
+tree_max_depth = 4           # how deep the fallback directory map descends; 0 is a
+                             # load error (it would render an empty map)
+
+# ---------------------------------------------------------------------------
+# [persistence] — the state db, ON by default, so consult sessions and batch handles
+# survive a restart and are shared across front doors (start over MCP, continue from
+# the CLI). Fixed XDG path, never one a model controls; refused if it resolves inside
+# an allowed tree. Failure to open is fatal, not a silent drop to memory.
+# ---------------------------------------------------------------------------
+[persistence]
+enabled = true               # false = in-memory only (--no-persistence, KAIBO_NO_PERSISTENCE)
+# Move the db (--state-db FILE, KAIBO_STATE_DB). $VAR/~-expanded like root/allow_paths.
+# path = "$XDG_STATE_HOME/kaibo/state.db"
 
 # ---------------------------------------------------------------------------
 # [sandbox] — the read-only execution limits (see src/sandbox.rs)

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -78,8 +78,31 @@ log = "kaibo=info"
 
 # Tool gating — true advertises the tool, false drops it (the --no-<tool> flags).
 # All default true; a config that turns every one off is refused at startup.
+#
+# A tool clears TWO gates to be advertised: the flag below, AND a configured cast that can
+# actually staff it. A tool nothing can staff is not advertised at all — the calling agent
+# never sees a tool whose every call would fail, and an unusable tool stops costing
+# resident tokens in every session. Which cast shape staffs which tool:
+#
+#   consult / consult_submit / oneshot   a cast with an INTERACTIVE synth (no offline lane)
+#   explore                              a cast with an `explorer` slot
+#   batch_submit                         a cast with a synth on `lane = "batch"`
+#   deliberate                           a cast with an `explorer` AND an offline synth
+#                                        (`lane = "batch"` or `lane = "direct"`)
+#   job_get / job_cancel / job_list / job_wait   live while any handle producer is
+#   run_kaish / list_models              no cast at all — always available
+#
+# Out of the box this bites exactly one tool: no BUILT-IN cast pairs an explorer with an
+# offline synth, so `deliberate` is not advertised until you configure a cast that can run
+# one — see the DELIBERATE casts near the bottom of this file. When a tool is held back
+# this way kaibo logs a warning at startup naming the cast shape it wants, and
+# `kaibo://config`'s [runtime] section lists it under `unstaffable_tools` with the same
+# explanation. (A tool YOU switched off below is reported in [tools] instead — the two
+# reasons a tool can be missing are kept apart on purpose.)
 [server.tools]
 consult        = true
+explore        = true
+deliberate     = true      # ...but only advertised if a cast can staff it — see above
 oneshot        = true
 run_kaish      = true
 batch          = true
@@ -462,7 +485,15 @@ synth    = { backend = "gpt", id = "gpt-5.6-sol", lane = "batch" }
 #     The synth's lane picks the offline mechanism: `batch` (a provider batch, half price,
 #     durable handle) below, or `direct` (one long LOCAL completion) further down. Unlike the
 #     synth-only batch casts above, these carry BOTH slots — the explorer is what makes it a
-#     deliberate cast rather than a plain batch one. ---
+#     deliberate cast rather than a plain batch one.
+#
+#     THIS SECTION IS WHAT TURNS `deliberate` ON. No built-in cast has this shape (the
+#     built-in offline casts, anthropic-batch and gemini-batch, are synth-only), so on a
+#     stock install the `deliberate` tool is not advertised at all — see [server.tools]
+#     near the top. Uncomment or adapt any one cast below and it appears. All three hosted
+#     batch providers work here — Anthropic (`fable`), Gemini (`gemini-deliberate`), and
+#     hosted OpenAI Platform (`gpt-deliberate`, above) — and so does a big LOCAL model on
+#     the `direct` lane (`local-direct`, below), which needs no batch API at all. ---
 
 # Fable on the batch lane, with a Sonnet explorer building the dossier.
 [casts.fable]

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,35 +1,20 @@
 # kaibo configuration
 
-Status: **implemented** (`src/config.rs`, tested in `tests/config.rs`). This doc is
-the rationale and reference; the code is ground truth. The design record for the
-backends/casts split is `docs/casts.md`.
+The reference manual for kaibo's configuration surface: every key, its default, and
+what it does. Implemented in `src/config.rs`, tested in `tests/config.rs`. The code is
+ground truth where this document and the code disagree.
 
-## Why
+**Related material**
 
-The config surface was carved in two passes, each splitting a fused selector.
+| where | what |
+|---|---|
+| `docs/config.example.toml` | the copyable annotated template (also `kaibo://config/example`, `kaibo example-config`) |
+| `kaibo://config` | the *resolved* runtime state of a running server (also `kaibo config`) |
+| `kaibo://config/guide` | this document, embedded in the binary |
+| `docs/casts.md` | the design record for the backends/casts split |
 
-**Pass one** (kinds and profiles) was driven by three things:
-
-1. **One `openai` endpoint per process.** The original `Provider` enum fused *which
-   wire protocol* with *which endpoint, key, and models* — so "openai" resolved a
-   single `OPENAI_BASE_URL` + key, and hosted GPT **and** local Gemma couldn't both
-   be selectable in one run.
-2. **Model ids drift and live in code.** Hardcoded explorer/synth ids rot (we ate a
-   `claude-3-5-haiku-latest` 404). They want to live in data.
-3. **Three config surfaces don't line up.** CLI flags, env vars, and a pile of
-   hardcoded constants each grew independently. A folk who prefers a file had
-   nowhere to put anything.
-
-The fix was to split the enum: a *kind* is the wire protocol, a *profile* a named
-instance of one.
-
-**Pass two** found the same disease one floor up. A profile still fused two
-selectors — *which connection* and *which model serves which role*. A profile is
-one `kind`, so a team was locked to one family: a chimera (a cheap local deepseek
-explorer feeding a claude synth) was inexpressible, and "profile" meant
-*connection* in one position and *team* in another. So the profile split too —
-into **backends** and **casts** — and `[profiles]` is deleted, not deprecated. The
-full rationale is `docs/casts.md`.
+**Configuration is optional.** With no config file, kaibo runs on a built-in registry
+of backends and casts. A missing file at the default path is not an error.
 
 ## The model: backends, roles, casts
 
@@ -40,284 +25,310 @@ Cast         = { name, role → ModelSlot }                  (freely spans backe
 ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
 ```
 
-Three concepts, each owning exactly one idea:
+Each concept owns one idea:
 
-- **backend** — a *connection*: `kind` (the closed `ProviderKind` enum — the one
-  place "provider" still means something; it picks the rig client and the request
-  shape), `base_url`, key source, `request_timeout`. "How do I reach Gemini."
-- **role** — a *job* a model serves: `explorer` and `synth`, the two agent
-  phases (there are no output/production roles — kaibo reasons over code and
-  renders nothing). A slot that reads images carries a `vision` pin; perception
-  is a slot capability, not a role.
-- **cast** — a *composition*: a named assignment of models to roles. This is what
-  the `cast` call param selects.
+- **backend** — a *connection*. Carries `kind` (the closed `ProviderKind` enum; it
+  selects the rig client and the request shape), `base_url`, a key source, and
+  `request_timeout`. Answers "how do I reach Gemini".
+- **role** — a *job* a model serves. Two exist: `explorer` and `synth`, the two agent
+  phases. There are no output or production roles, because kaibo reasons over code and
+  renders nothing. Image input is a slot capability (the `vision` pin), not a role.
+- **cast** — a *composition*. A named assignment of models to roles. This is what the
+  `cast` call parameter selects.
 
-**Selection rule:** calls pick casts; backends are reachable *only through* a
-cast's slots. Calls choose a composition, compositions choose connections. A slot
-ref borrows the backend's connection only — it never follows another cast — so
-chains and cycles are structurally impossible.
+**Selection rule.** Calls pick casts. Backends are reachable only through a cast's
+slots: calls choose a composition, compositions choose connections. A slot reference
+borrows its backend's connection and never resolves another cast, so reference chains
+and cycles cannot be expressed.
 
 ### Backends: `[backends.<name>]`
 
-Connection knobs only — models never live here:
+Connection settings only. Models are never declared here.
 
-- **`kind`** selects the rig client and request shaping. It is closed — adding a
-  kind means adding a client arm in code, not a config line. A *new* backend must
-  declare its kind (it seeds that kind's default key sources); re-listing an
-  existing backend with a *different* kind is a loud error — you don't change a
-  connection's protocol by re-declaring it.
-- **`base_url`** is meaningful for `kind = "openai"` (the generic OpenAI-compatible
-  path) — this is what lets any number of openai-kind backends (hosted GPT, two
-  local llama.cpp servers, an Ollama box) be live at once, each its own name.
-  A *new* openai-kind backend must set it: the `OPENAI_BASE_URL`/local-default
-  fallback belongs to the built-in `openai-local` backend alone, so a forgotten
-  `base_url` is a load error, not a silent dial of the wrong server. It is also
-  meaningful — but *optional* — for `kind = "anthropic"` and `kind = "gemini"`:
-  unset still resolves to rig's built-in `https://api.anthropic.com` /
-  `https://generativelanguage.googleapis.com`; set, it points that wire protocol
-  at an Anthropic/Gemini-API-compatible gateway/proxy instead (a corporate LLM
-  gateway, say). Both contracts are a HOST ROOT, not a versioned path — rig's own
-  `ClientBuilder` appends its provider-specific path (Gemini's
-  `/v1beta/models/...`) itself, and the batch lane's `GeminiBatch` versions a
-  configured host root with `/v1beta` the same way, so one address serves both
-  the interactive and batch paths. For every *other* keyed kind rig fixes the
-  endpoint, so a `base_url` there is a config error, surfaced loudly — not
-  silently ignored.
-- **`wire`** (`kind = "openai"` only) picks the interactive request shape: `"responses"`
-  for rig's Responses client, `"chat"` for OpenAI-compatible Chat Completions. Optional
-  and normally unset — kaibo infers it from the endpoint (OpenAI Platform's exact URL
-  gets Responses, everything else gets Chat Completions), which is why hosted GPT and
-  local Gemma both already worked without this knob. It exists for the case the
-  heuristic can't see: an OpenAI-compatible gateway/proxy that implements the Responses
-  API at `/v1/responses` (verified against a real gateway) but doesn't sit at Platform's
-  URL. Current GPT-5.x reasoning models *require* Responses — they reject Chat
-  Completions' `max_tokens` outright (`unsupported_parameter`) — so `wire = "responses"`
-  is what makes them usable behind such a gateway. `wire = "chat"` is the symmetric
-  opt-out, including on Platform's own endpoint. Either setting is **interactive-only**:
-  it never changes batch eligibility (the batch-lane discussion under Casts below),
-  which stays keyed to the endpoint-exact check alone — a gateway proxying
-  `/v1/responses` doesn't necessarily proxy `/v1/batches` or the Files API. A `wire` on
-  any other kind is a load error, same discipline as `data_collection` below.
-- A backend resolves its key from `api_key_env` then `api_key_file` (env wins).
-  **Secrets never live inline in the TOML** — only the *name* of an env var or the
-  *path* to a key file. A config you can commit or paste shouldn't leak a key.
-- `key_optional = true` falls back to a placeholder bearer token when no key is
-  found (the keyless local-server case). Defaults to `true` for `kind = "openai"`,
-  `false` otherwise. A key file that's *present but broken* (empty, unreadable) is
-  a loud error even for a keyless backend — there-but-wrong is a mistake, not
-  "keyless".
-- **`kind = "openrouter"`** is a keyed gateway, not a wire protocol of its own: one
-  `OPENROUTER_API_KEY` reaches every upstream model family through a fixed endpoint
-  (`base_url` there is the same loud load error as on the other keyed kinds).
-  Reasoning is **on by default on every slot** — OpenRouter's unified
-  `{"reasoning":{"effort":…}}` request field, which the gateway translates into
-  each upstream provider's native knob and drops silently where the pinned model
-  has none, so emitting it unconditionally never breaks a non-reasoning model. The
-  per-role `effort` (see [defaults] below) passes through verbatim, reaching
-  OpenRouter-only rungs (`xhigh`, `max`) deeper than the other kinds expose. No
-  `batch` lane. One slug routes across competing upstream *hosts* whose data
-  policies differ, so every request pins **no-collection routing by default**
-  (`provider.data_collection = "deny"` — kaibo's prompts carry your source, and
-  shipping it to a host that retains or trains on prompts must be a choice, never
-  a default). A model whose only hosts collect (most `:free` variants) fails
-  loudly instead of leaking quietly. `data_collection = "allow"` on the backend
-  is the explicit opt-in — kaibo then emits no restriction and your OpenRouter
-  account settings govern. The knob exists only on this kind (a load error
-  elsewhere), and `kaibo://config` renders the active policy per openrouter
-  backend so the posture is always visible.
-- **`request_timeout_secs`** (default from `[defaults]`, 900 = 15 min) is the
-  wall-clock ceiling on a *single* completion call. rig's prompt loop is
-  non-streaming and has no native timeout, so a provider that connects but never
-  responds would otherwise hang the whole tool call (it once waited ~29 min on a
-  wedged local server). It's per-backend because a slow local model legitimately
-  wants a longer leash than a hosted API. **Caveat:** a non-streaming call can't
-  tell *wedged* from *slow-but-working* — keep it above your slowest legitimate
-  single completion. `0` is rejected at load (it would time out every call
-  instantly).
+| key | type | default | notes |
+|---|---|---|---|
+| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` | required on a new backend | closed enum; selects client + request shape |
+| `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini`; load error elsewhere |
+| `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
+| `api_key_env` | env var *name* | seeded from `kind` | env source, checked first |
+| `api_key_file` | path | seeded from `kind` | file source, checked second |
+| `key_optional` | bool | `true` for `openai`, else `false` | allows a placeholder token |
+| `data_collection` | `deny` \| `allow` | `deny` | `kind = "openrouter"` only; load error elsewhere |
+| `request_timeout_secs` | integer > 0 | `[defaults]` value (900) | per-single-completion ceiling |
 
-  **Failure policy (no retry, by design).** kaibo does not retry a failed provider
-  call — there is no backoff and no `max_retries` knob. A 429/503/529 overload, a
-  connection reset, a partial stream, or a wedged backend that hits `request_timeout`
-  all fail the single completion, and `consult`/`oneshot` surface that as a **clean
-  tool-result error** (`is_error`) naming the cast and the underlying detail. The
-  rationale: a consult is an *optional* augmentation, so the calling agent should read
-  the failure and proceed without the second opinion (or call again) rather than have
-  its own tool call fail at the protocol layer. The message is classified so the agent
-  can drive the right next step: a *transient* condition (overload / rate-limit /
-  timeout / reset) invites a manual retry, a non-transient one (auth / bad request) does
-  not, and a kaibo-side failure is named as such. (Classification is a heuristic on the
-  provider's error *vocabulary*, not the HTTP status — rig surfaces the response body,
-  not the code.) Retrying is the caller's decision; for a reliably-slow backend, raise
-  its `request_timeout_secs` rather than expecting kaibo to paper over it. Automatic retry/backoff belongs in the shared HTTP layer (rig already
-  ships an `ExponentialBackoff`, wired only into its streaming path today) — landing it
-  for the non-streaming completion path is tracked as an upstream contribution in
-  `docs/issues.md`, not hand-rolled here.
+#### `kind`
+
+Closed: adding a kind requires a client arm in code, not a config line. A new backend
+must declare one, which seeds that kind's default key sources. Re-declaring an existing
+backend with a *different* kind is a load error; a connection's protocol is not changed
+by re-declaration.
+
+#### `base_url`
+
+- **`kind = "openai"`** — required on a new backend. This is what allows several
+  openai-kind backends (hosted GPT, two local llama.cpp servers, an Ollama box) to be
+  live at once under different names. The `OPENAI_BASE_URL` / local-default fallback
+  belongs to the built-in `openai-local` backend alone, so a missing `base_url` is a
+  load error rather than a silent dial of the wrong server.
+- **`kind = "anthropic"` / `kind = "gemini"`** — optional. Unset resolves to rig's
+  built-in `https://api.anthropic.com` / `https://generativelanguage.googleapis.com`.
+  Set, it points that wire protocol at a compatible gateway or proxy.
+- **Every other kind** — a load error. rig fixes those endpoints.
+
+The value is a **host root**, not a versioned path. rig's `ClientBuilder` appends the
+provider-specific path (Gemini's `/v1beta/models/...`), and the batch lane's
+`GeminiBatch` versions a configured host root with `/v1beta` the same way, so one
+address serves both the interactive and batch paths.
+
+#### `wire`
+
+Picks the interactive request shape: `"responses"` for rig's Responses client, `"chat"`
+for OpenAI-compatible Chat Completions. Normally unset — kaibo infers it from the
+endpoint, giving OpenAI Platform's exact URL the Responses shape and everything else
+Chat Completions. Hosted GPT and local Gemma both work without this knob.
+
+Set it when the heuristic cannot see the truth: an OpenAI-compatible gateway that
+implements the Responses API at `/v1/responses` but does not sit at Platform's URL.
+Current GPT-5.x reasoning models require Responses — they reject Chat Completions'
+`max_tokens` with `unsupported_parameter` — so `wire = "responses"` is what makes them
+usable behind such a gateway. `wire = "chat"` is the symmetric opt-out, including on
+Platform's own endpoint.
+
+**Interactive-only.** `wire` never changes batch eligibility, which stays keyed to the
+endpoint-exact check alone. A gateway proxying `/v1/responses` does not necessarily
+proxy `/v1/batches` or the Files API.
+
+#### Key resolution
+
+A backend resolves its key from `api_key_env`, then `api_key_file`. Env wins.
+
+**Secrets never appear inline in the TOML** — only the *name* of an env var or the
+*path* to a key file. A config file should be safe to commit or paste.
+
+`key_optional = true` substitutes a placeholder bearer token when no key is found,
+which is the keyless local-server case. A key file that is *present but broken* (empty,
+unreadable) is a load error even on a keyless backend: present-but-wrong is a mistake,
+not "keyless".
+
+#### `kind = "openrouter"` specifics
+
+OpenRouter is a keyed gateway rather than a wire protocol of its own. One
+`OPENROUTER_API_KEY` reaches every upstream model family through a fixed endpoint.
+
+- **Reasoning is on for every slot.** kaibo emits OpenRouter's unified
+  `{"reasoning":{"effort":…}}` field. The gateway translates it into each upstream
+  provider's native knob and drops it where the pinned model has none, so emitting it
+  unconditionally is safe for non-reasoning models. The per-role `effort` passes
+  through verbatim, which is where the deeper `xhigh` and `max` rungs are reachable.
+- **No `batch` lane.**
+- **`data_collection` defaults to `deny`.** One slug routes across competing upstream
+  hosts whose data policies differ, and kaibo's prompts carry your source, so
+  no-collection routing is pinned on every request. A model whose only hosts collect
+  (most `:free` variants) fails loudly instead of leaking quietly. `data_collection =
+  "allow"` is the explicit opt-in: kaibo then emits no restriction and your OpenRouter
+  account settings govern. `kaibo://config` renders the active policy per backend.
+
+#### `request_timeout_secs`
+
+Wall-clock ceiling on a *single* completion call. Default 900 (15 min), from
+`[defaults]`. `0` is rejected at load, since it would time out every call instantly.
+
+rig's prompt loop is non-streaming and has no native timeout, so without this a provider
+that connects but never responds hangs the whole tool call. The setting is per-backend
+because a slow local model legitimately wants a longer leash than a hosted API.
+
+A non-streaming call cannot distinguish *wedged* from *slow but working*, so keep the
+value above your slowest legitimate single completion.
+
+#### Failure policy: no retry
+
+kaibo does not retry a failed provider call. There is no backoff and no `max_retries`
+knob. A 429/503/529 overload, a connection reset, a partial stream, or a backend that
+hits `request_timeout` all fail the single completion, and `consult`/`oneshot` surface
+that as a clean tool-result error (`is_error`) naming the cast and the underlying
+detail.
+
+The reasoning: a consult is an *optional* augmentation. The calling agent should read
+the failure and proceed without the second opinion, or call again, rather than have its
+own tool call fail at the protocol layer.
+
+Failures are classified so the caller can pick a next step:
+
+| class | examples | retry advice |
+|---|---|---|
+| transient | overload, rate limit, timeout, connection reset | a manual retry may succeed |
+| non-transient | auth failure, bad request | fix the config or the call |
+| kaibo-side | named as such | not a provider problem |
+
+Classification is a heuristic over the provider's error *vocabulary*, not the HTTP
+status, because rig surfaces the response body rather than the code. For a reliably slow
+backend, raise its `request_timeout_secs`. Automatic retry and backoff belong in the
+shared HTTP layer — rig ships an `ExponentialBackoff` wired only into its streaming path
+today — and landing it for the non-streaming completion path is tracked as an upstream
+contribution in `docs/issues.md`.
 
 ### Casts: `[casts.<name>]`
 
-A role table. Each slot is a `"backend/model-id"` string (the common case — the
-*first* `/` splits, so HuggingFace-style `org/model` ids keep their inner slash)
-or a table when the slot needs pins or tunables:
+A role table. Each slot takes one of two forms:
+
+- **String** — `"backend/model-id"`, the common case. The *first* `/` splits, so
+  HuggingFace-style `org/model` ids keep their inner slash.
+- **Table** — when the slot needs capability pins or per-slot tunables.
 
 ```toml
 [casts.chimera]
-explorer = "deepseek/deepseek-v4-flash"     # cheap fast sweeps — local/cheap family
-synth    = "claude/claude-sonnet-4-6"       # the voice that answers — hosted family
+explorer = "deepseek/deepseek-v4-flash"     # cheap fast sweeps
+synth    = "claude/claude-sonnet-4-6"       # the model that answers
 
 # table form: id + capability pins + per-slot tunables
 # synth = { backend = "claude", id = "claude-opus-4-8", effort = "max" }
-# explorer = { backend = "openai-local", id = "Gemma-4-E4B-it", preamble = "..." }  # per-model prompt
+# explorer = { backend = "openai-local", id = "Gemma-4-E4B-it", preamble = "..." }
 ```
 
-- **Known roles:** `explorer`, `synth`. A typo'd role (or a typo'd per-slot knob)
-  is a loud load error, not a silent no-op. A cast may omit roles — the four
-  interactive built-ins carry explorer+synth, the batch built-ins carry synth
-  only; a user cast that omits a role is valid config, and the tool that needs the
-  missing role fails loudly *at call time*, naming the gap ("cast `lite` has no
-  synth slot"). Absent = capability absent. (There are no output/production roles:
-  kaibo reasons over a codebase and renders nothing, so image/tts-style "make an
-  artifact" roles don't exist. Perception — image input, audio-in later — is a
-  slot's `vision`/`ModelCaps` capability, below, not a role.)
-- **An unknown backend in a slot is a load error** naming the known backends; an
-  empty model id is rejected at load (it would surface as a baffling provider 404
-  mid-call otherwise).
-- **`vision` pins the slot's vision capability** (accepts image parts in model
-  context), overriding the built-in classifier. The classifier runs against the
-  *slot's backend kind*: Anthropic and Gemini completion models are multimodal-in;
-  DeepSeek chat/reasoner are text-only; a generic `openai` endpoint is vision-off
-  until its config says otherwise (kaibo can't know what's behind an arbitrary id —
-  opt in, don't guess). Resolved caps (not raw config) are what `kaibo://config`
-  reports, and they will gate toolset assembly when vision-in lands.
-- Backends *and* casts both take a file-level `aliases = [...]` list. An alias
-  that collides with a real name at its level, or that two names both claim, is a
-  loud load error.
+**Roles.** `explorer` and `synth`. A misspelled role, or a misspelled per-slot key, is
+a load error rather than a silent no-op.
+
+A cast may omit a role. The interactive built-ins carry both; the batch built-ins carry
+`synth` only. A user cast that omits a role is valid config, and the tool needing the
+missing role fails at call time naming the gap (`cast "lite" has no synth slot`). Absent
+means the capability is absent.
+
+**Slot references.** An unknown backend in a slot is a load error naming the known
+backends. An empty model id is rejected at load, since it would otherwise surface as an
+unexplained provider 404 mid-call.
+
+**`vision`** pins the slot's vision capability (whether it accepts image parts in model
+context), overriding the built-in classifier. The classifier keys on the slot's backend
+kind:
+
+| kind | classifier default |
+|---|---|
+| `anthropic`, `gemini` | vision on |
+| `deepseek` | vision off (text-only models) |
+| `openai`, `openrouter` | vision off until pinned |
+
+A generic endpoint is vision-off until its config says otherwise, because kaibo cannot
+know what serves an arbitrary model id. `kaibo://config` reports the *resolved*
+capability, not the raw config.
+
+**Aliases.** Backends and casts both take a file-level `aliases = [...]` list. An alias
+that collides with a real name at its level, or that two names both claim, is a load
+error.
 
 ### Tunables: what lives where
 
-The split un-straddles the knobs. **Connection knobs ride the backend** (key
-source, `base_url`, `request_timeout_secs` — they describe the wire).
-**Model-tracking knobs ride the slot** (`max_tokens`, `thinking_budget`,
-`temperature`, `effort`, `thinking_style`, the `vision` pin, and `preamble` — they
-describe the model), each falling back to its per-role `[defaults]` value when
-omitted (`explorer` slots inherit the `explorer_*` defaults; `synth` inherits the
-`synth_*` side). A profile-level `max_tokens` awkwardly shared by
-two models no longer exists. The `preamble` knob is the per-model system prompt —
-its own fallback chain (it has no `[defaults]` entry) is documented under
-[System prompts](#system-prompts-prompts) below.
+| knob group | lives on | keys |
+|---|---|---|
+| connection | the **backend** | key source, `base_url`, `wire`, `request_timeout_secs` |
+| model-tracking | the **slot** | `max_tokens`, `thinking_budget`, `temperature`, `effort`, `thinking_style`, `vision`, `preamble` |
 
-The `[defaults]` knobs themselves:
+A slot knob falls back to its per-role `[defaults]` value when omitted: `explorer` slots
+inherit the `explorer_*` defaults, `synth` slots the `synth_*` side.
 
-- **`max_tokens` / `thinking_budget`** (16384 / 8192): output headroom and
-  reasoning budget. Reasoning eats the *completion* budget, so `max_tokens` must
-  sit well above `thinking_budget` — for a slot whose model actually *sends* a
-  budget (Anthropic's legacy `budget_tokens` tier) an inverted pair is rejected at
-  load on the slot's *resolved* values (Anthropic would 400 on it mid-call). A slot
-  with no budget sink (Gemini takes a `thinkingLevel`, Anthropic's adaptive tier an
-  effort) carries an inert `thinking_budget`, so the pair isn't checked there.
-- **`explorer_temperature` / `synth_temperature` / `top_p`** (0.1 / 0.3 / 0.95):
-  sampling per role — the explorer gathers exact citations, so it runs cold; the
-  synth composes the answer, so it gets a touch more room. Sent where a model
-  accepts them (top-level for DeepSeek/OpenAI, under `generationConfig` for
-  Gemini). **Anthropic drops sampling whenever thinking is on** (every Anthropic
-  slot, by default): the Messages API 400s on a custom `temperature` under
-  thinking, and thinking is the higher-value default, so it wins. Temperature must
-  be in `[0.0, 2.0]` and `top_p` in `(0.0, 1.0]` — at the `[defaults]` level *and*
-  per slot, an out-of-range value is rejected at load, not clamped.
-- **`explorer_effort` / `synth_effort`** (`"high"` both): reasoning depth for the
-  models that take an effort param — Anthropic's adaptive tier
-  (→ `output_config.effort`), DeepSeek (→ `reasoning_effort`), Gemini
-  (→ `thinkingLevel`: the values align, `"minimal"`/`"low"`/`"medium"`/`"high"`),
-  and OpenRouter (→ its unified `{"reasoning":{"effort":…}}`, forwarded verbatim to
-  whatever the pinned model actually supports). A passthrough string the provider
-  validates (like a model id), so a new level lands without a code change — set a synth
-  slot's `effort = "max"`/`"xhigh"` for heavier runs; OpenRouter is where those
-  deeper rungs are actually reachable today. Ignored by models with no effort
-  sink (budget-tier Anthropic, OpenAI).
-- **`thinking_style`** (`auto` | `adaptive` | `budget`, default `auto`) forces the
-  Anthropic thinking shape instead of the built-in classifier. `auto` picks
-  adaptive for Opus 4.6+/Sonnet 4.6/Fable 5 and enabled-budget for older models +
-  Haiku 4.5; set `adaptive` or `budget` when a new or misclassified model ships. A
-  no-op for non-Anthropic kinds. An unknown value is a loud load error.
-- **`request_timeout_secs`** seeds every backend (see above).
-- **`call_deadline_secs`** (default 3600 = 1 h, must be > 0) is the whole-*call*
-  wall-clock ceiling on an interactive `consult`/`explore`/`oneshot` — the backstop
-  for when the per-request `request_timeout` doesn't fire (a stalled response body, a
-  pooled keep-alive to a wedged backend). Past it the call aborts with a clean
-  tool-result error instead of hanging your session. Keep it **above the largest
-  `request_timeout` a call can reach** so it never cuts a legitimately slow single
-  completion — operators running a >30-min local model should raise it. It bounds the
-  interactive loop tools — `consult`/`explore`/`oneshot` and async `consult_submit`.
-  Two in-process paths sit outside it *by nature*: `deliberate`'s direct lane is one
-  long completion bounded instead by its synth backend's `request_timeout` (+ a small
-  margin) — so a slow local `deliberate` gets its full patience *without* forcing this
-  interactive ceiling up to hours; and the **batch** lane holds no in-process wait at
-  all (the work runs on the provider's queue, collected by polling `job_get`).
-- **`explorer_max_turns` / `synth_max_turns`** (100 / 200) stay in `[defaults]`
-  only (plus per-call): they bound the *loop*, not the model.
-- **`session_capacity`** (128, must be > 0): max multi-turn consult sessions held
-  in memory (LRU, capacity-evicted, no TTL).
-- **`job_capacity`** (64, must be > 0): max async-`consult` jobs (`consult_submit`)
-  held in memory — running plus finished-but-uncollected (LRU, capacity-evicted, no
-  TTL; evicting a still-running job aborts it). Its own knob, smaller than
-  `session_capacity` because a held job result is heavier than a session's Q&A pair.
-- **`inline_attach_budget`** (262144 = 256 KiB; `0` is legal): cumulative byte budget
-  for inlining `consult` text attachments into the driver prompt (caller order,
-  greedy). A text attachment past the remaining budget is *demoted* — named in the
-  prompt with a read-it-WHOLE directive instead of its bytes — loudly, never dropped.
-  `0` inlines nothing (every text attachment becomes a directive): the escape hatch
-  for a small-context cast, e.g. a 4K-ctx local model that chokes on inlined bytes a
-  hosted model shrugs at. Inlined bytes ride every turn of the driver loop, so this
-  bounds resident prompt cost, not just one request. The tool-less tools
-  (`oneshot`/`batch_submit`) are unaffected — with no shell to fall back on, they
-  keep their own hard per-file/per-call caps.
+`preamble` is the exception — it has no `[defaults]` entry and its own fallback chain,
+documented under [System prompts](#system-prompts-prompts).
+
+### `[defaults]`
+
+Global tunables every slot falls back to. Per-slot overrides are documented above;
+`request_timeout_secs` seeds every backend.
+
+| key | default | constraint |
+|---|---|---|
+| `max_tokens` | 16384 | must exceed `thinking_budget` on a budget-tier slot |
+| `thinking_budget` | 8192 | — |
+| `explorer_temperature` | 0.1 | `[0.0, 2.0]` |
+| `synth_temperature` | 0.3 | `[0.0, 2.0]` |
+| `top_p` | 0.95 | `(0.0, 1.0]` |
+| `explorer_effort` / `synth_effort` | `"high"` | passthrough string |
+| `thinking_style` | `"auto"` | `auto` \| `adaptive` \| `budget` |
+| `request_timeout_secs` | 900 | > 0 |
+| `call_deadline_secs` | 3600 | > 0 |
+| `explorer_max_turns` | 100 | — |
+| `synth_max_turns` | 200 | — |
+| `session_capacity` | 128 | > 0 |
+| `job_capacity` | 64 | > 0 |
+| `inline_attach_budget` | 262144 (256 KiB) | `0` is legal |
+
+Out-of-range values are rejected at load, not clamped. This applies at the `[defaults]`
+level and per slot.
+
+**`max_tokens` / `thinking_budget`.** Output headroom and reasoning budget. Reasoning
+bills against the completion budget, so `max_tokens` must sit well above
+`thinking_budget`. On a slot whose model actually *sends* a budget (Anthropic's legacy
+`budget_tokens` tier) an inverted pair is rejected at load on the slot's resolved
+values, because Anthropic would 400 on it mid-call. A slot with no budget sink (Gemini
+takes a `thinkingLevel`, Anthropic's adaptive tier an effort) carries an inert
+`thinking_budget` and the pair is not checked.
+
+**Sampling.** The explorer gathers exact citations and runs cold; the synth composes the
+answer and gets slightly more room. Sent where a model accepts them: top-level for
+DeepSeek and OpenAI, under `generationConfig` for Gemini. **Anthropic drops sampling
+whenever thinking is on**, which is every Anthropic slot by default — the Messages API
+400s on a custom `temperature` under thinking, and thinking is the higher-value default.
+
+**`effort`.** Reasoning depth for models that take an effort parameter:
+
+| kind | field |
+|---|---|
+| anthropic (adaptive tier) | `output_config.effort` |
+| deepseek | `reasoning_effort` |
+| gemini | `thinkingLevel` (values align: `minimal`/`low`/`medium`/`high`) |
+| openrouter | `{"reasoning":{"effort":…}}`, forwarded verbatim |
+
+The value is a passthrough string the provider validates, like a model id, so a new
+level lands without a code change. Set a synth slot's `effort = "max"` or `"xhigh"` for
+heavier runs; OpenRouter is where those deeper rungs are reachable today. Ignored by
+models with no effort sink (budget-tier Anthropic, OpenAI).
+
+**`thinking_style`.** Forces the Anthropic thinking shape instead of the built-in
+classifier. `auto` picks adaptive for Opus 4.6+, Sonnet 4.6, and Fable 5, and
+enabled-budget for older models plus Haiku 4.5. Set `adaptive` or `budget` when a new or
+misclassified model ships. A no-op for non-Anthropic kinds; an unknown value is a load
+error.
+
+**`call_deadline_secs`.** Whole-call wall-clock ceiling on an interactive
+`consult`/`explore`/`oneshot`, and the backstop for when the per-request
+`request_timeout` does not fire (a stalled response body, a pooled keep-alive to a
+wedged backend). Past it the call aborts with a clean tool-result error. Keep it above
+the largest `request_timeout` a call can reach so it never cuts a legitimately slow
+single completion; operators running a >30-minute local model should raise it.
+
+It bounds `consult`, `explore`, `oneshot`, and async `consult_submit`. Two in-process
+paths sit outside it by nature:
+
+- **`deliberate`'s direct lane** is one long completion, bounded instead by its synth
+  backend's `request_timeout` plus a small margin. A slow local `deliberate` gets its
+  full patience without forcing the interactive ceiling up to hours.
+- **The batch lane** holds no in-process wait at all. The work runs on the provider's
+  queue and is collected by polling `job_get`.
+
+**`explorer_max_turns` / `synth_max_turns`.** Available in `[defaults]` and per call
+only. They bound the loop, not the model.
+
+**`session_capacity` / `job_capacity`.** Both LRU, capacity-evicted, no TTL.
+`session_capacity` caps multi-turn consult sessions held in memory. `job_capacity` caps
+async-`consult` jobs (`consult_submit`), running plus finished-but-uncollected; evicting
+a still-running job aborts it. It is smaller because a held job result is heavier than a
+session's question/answer pair.
+
+**`inline_attach_budget`.** Cumulative byte budget for inlining `consult` text
+attachments into the driver prompt, consumed greedily in caller order. A text attachment
+past the remaining budget is *demoted*: named in the prompt with a read-it-whole
+directive instead of its bytes. Demotion is loud; nothing is dropped.
+
+`0` inlines nothing, turning every text attachment into a directive. That is the escape
+hatch for a small-context cast, such as a 4K-context local model that chokes on inlined
+bytes a hosted model absorbs without trouble.
+
+Inlined bytes ride every turn of the driver loop, so this bounds resident prompt cost,
+not just one request. The toolless tools (`oneshot`, `batch_submit`) are unaffected;
+with no shell to fall back on, they keep their own per-file and per-call caps.
 
 ### Built-in registry (the defaults)
 
-Five backends and five same-named single-backend casts ship **in code** and
-reproduce kaibo's historical behavior exactly, so a **missing config file is not
-an error**. The `openrouter` built-in defaults to **Qwen** — a family kaibo can't
-reach directly (DeepSeek, Gemini, and Anthropic each have their own keyed backend),
-so the gateway earns its keep with a distinct lineage for a genuine cross-family
-read. OpenRouter serves no `~qwen/*-latest` router alias (only anthropic / google /
-moonshotai / openai / x-ai get those), so the built-in pins the **undated** family
-ids — the most rot-resistant Qwen ids available, each tracking the newest
-point-release until the next `.x` bump. Explorer is the cheap multimodal
-`qwen/qwen3.6-flash`, with `vision` pinned on (the classifier defaults an
-`openrouter` slot to vision-off, since the gateway fronts blind and sighted models
-alike, but the flash is multimodal-in per OpenRouter's own catalog); synth is the
-flagship reasoner `qwen/qwen3.7-max`, which is **text-only**, so its slot takes no
-vision pin. (To keep vision on the synth, swap in the multimodal plus tier
-`qwen/qwen3.7-plus` and pin its vision on — a weaker reasoner, ~4.5× cheaper.) Two
-extra built-in casts ship for the
-offline batch lane —
-`gemini-batch` (synth Gemini Pro) and `anthropic-batch` (synth Claude Opus). Lane is
-a **per-slot** property, not a cast-level one: each carries a synth slot whose
-`lane = "batch"`, which staffs `batch_submit` *only*: the interactive tools
-(`consult`/`oneshot`) refuse a cast whose synth is on an offline lane, and
-`batch_submit` refuses a cast whose synth isn't specifically `lane = "batch"`, so a
-big offline-tuned model is never run interactively by accident (and vice versa). A
-`batch`-lane synth must sit on a batch-capable backend (Anthropic, Gemini, or a
-hosted OpenAI Platform backend — a local OpenAI-compatible server has no Batch API) —
-declaring `lane = "batch"` on a slot elsewhere is a loud load error, and so is a
-lane on an *explorer* slot (the explorer always runs interactively). Because lane
-lives on the slot, a cast MAY pair an interactive explorer with an offline synth —
-the built-in batch casts stay synth-only by choice (batch is toolless, so an
-explorer would be dead weight), not by a rule. `batch = true` at the cast level is
-backward-compat sugar: it sets the synth slot's `lane = "batch"`, nothing more —
-there's exactly one internal representation of lane (the slot field). The TOML
-*merges over* this registry by name: set one field on a built-in to retarget it (a
-slot's `lane` is sticky across a bare re-declaration of its model — retuning
-`gemini-batch`'s id leaves it batch), or add brand-new backends and casts. The
-built-in alias names register at **both** levels — as cast aliases (so
-`cast = "claude"` resolves) and backend aliases (so a slot ref `claude/<id>`
-resolves) — and are reserved: naming a new backend or cast after one is a loud
-collision error.
-
-A second offline lane, `lane = "direct"`, is also validated and rendered: one long
-completion kaibo drives itself against a big *local* model — no async provider API,
-just a slower plain call. It's reserved for offline deliberation over a model too
-slow for a live tool loop; no tool routes to a `direct` synth yet, so declaring one
-today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submit`.
+Five backends and five same-named single-backend casts ship in code, plus two batch
+casts. This is why a missing config file is not an error.
 
 | backend | kind | base_url | key env / file | aliases |
 |---|---|---|---|---|
@@ -327,9 +338,9 @@ today is forward-looking, not yet callable from `consult`/`oneshot`/`batch_submi
 | `openrouter` | openrouter | — *(fixed)* | `OPENROUTER_API_KEY` / `~/.openrouter-key` | — |
 | `openai-local` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
 
-None of the built-ins set `wire` — it only matters for a new openai-kind backend
-whose endpoint isn't OpenAI Platform's own but should still take the Responses
-shape (`docs/config.example.toml`'s `[backends.gateway]`).
+No built-in sets `wire`. It matters only for a new openai-kind backend whose endpoint is
+not OpenAI Platform's own but should still take the Responses shape; see
+`[backends.gateway]` in `docs/config.example.toml`.
 
 | cast | explorer | synth | synth lane |
 |---|---|---|---|
@@ -341,10 +352,61 @@ shape (`docs/config.example.toml`'s `[backends.gateway]`).
 | `gemini-batch` | — | `gemini/gemini-pro-latest` | `batch` |
 | `anthropic-batch` | — | `anthropic/claude-opus-4-8` | `batch` |
 
-### The chimera payoff
+**Why the `openrouter` built-in points at Qwen.** DeepSeek, Gemini, and Anthropic each
+have their own keyed backend, so the gateway earns its place by reaching a family kaibo
+cannot reach directly. OpenRouter serves no `~qwen/*-latest` router alias — only
+anthropic, google, moonshotai, openai, and x-ai get those — so the built-in pins undated
+family ids, which are the most rot-resistant Qwen ids available and track the newest
+point release until the next `.x` bump.
 
-The thing the fused profile couldn't say: each role on the backend that serves it
-best, selected as one name. Two extra openai-kind connections, one composed cast:
+The explorer `qwen/qwen3.6-flash` has `vision` pinned on: the classifier defaults an
+`openrouter` slot to vision-off because the gateway fronts blind and sighted models
+alike, but the flash is multimodal-in per OpenRouter's catalog. The synth
+`qwen/qwen3.7-max` is text-only and takes no vision pin. To keep vision on the synth,
+swap in `qwen/qwen3.7-plus` and pin its vision on — a weaker reasoner, roughly 4.5×
+cheaper.
+
+**Merging.** The TOML merges over this registry by name. Set one field on a built-in to
+retarget it, or add new backends and casts. A slot's `lane` is sticky across a bare
+re-declaration of its model, so retuning `gemini-batch`'s id leaves it on the batch lane.
+
+**Reserved aliases.** Built-in alias names register at both levels — as cast aliases, so
+`cast = "claude"` resolves, and as backend aliases, so a slot reference `claude/<id>`
+resolves. Naming a new backend or cast after one is a collision error.
+
+### Lanes
+
+`lane` is a **per-slot** property, not a cast-level one.
+
+| lane | meaning | staffs |
+|---|---|---|
+| *(unset)* | interactive | `consult`, `explore`, `oneshot`, `consult_submit` |
+| `batch` | a provider batch API job | `batch_submit`, `deliberate` |
+| `direct` | one long completion kaibo drives itself | `deliberate` |
+
+Rules:
+
+- The interactive tools refuse a cast whose synth is on an offline lane, and
+  `batch_submit` refuses a cast whose synth is not specifically `lane = "batch"`. A big
+  offline-tuned model is never run interactively by accident, and the reverse.
+- A `batch`-lane synth must sit on a batch-capable backend: Anthropic, Gemini, or a
+  hosted OpenAI Platform backend. A local OpenAI-compatible server has no Batch API, so
+  declaring `lane = "batch"` on a slot elsewhere is a load error.
+- A lane on an `explorer` slot is a load error. The explorer always runs interactively.
+- Because lane lives on the slot, a cast may pair an interactive explorer with an
+  offline synth. That shape is what staffs `deliberate`. The built-in batch casts stay
+  synth-only by choice, since batch is toolless and an explorer would be dead weight.
+- `batch = true` at the cast level is backward-compatible sugar. It sets the synth
+  slot's `lane = "batch"` and nothing else; there is one internal representation of lane.
+
+`lane = "direct"` runs one long completion against a big local model with no async
+provider API involved, for offline deliberation over a model too slow for a live tool
+loop.
+
+### Cross-backend casts
+
+Each role on the backend that serves it best, selected under one name. Two extra
+openai-kind connections and one composed cast:
 
 ```toml
 [backends.gpt]
@@ -363,30 +425,33 @@ explorer = "llama/qwen2.5-coder-7b"     # sweeps stay local and free
 synth    = { backend = "gpt", id = "gpt-5.6-sol", vision = true, effort = "high" }
 ```
 
-`cast = "mixed"`, `cast = "gpt"` (if you define it), and the built-in
-`cast = "anthropic"` all walk the same resolution: each slot becomes an *arm* —
-client on the slot's backend, request shape fit to the slot's model and tunables —
-so a cast whose explorer and synth straddle any capability line (different kinds,
-even) is fit per-arm by construction.
+Every cast resolves the same way: each slot becomes an *arm*, with a client on the
+slot's backend and a request shape fit to the slot's model and tunables. A cast whose
+explorer and synth straddle a capability line, or sit on different kinds entirely, is fit
+per arm by construction.
 
-## Three surfaces that line up
+## Precedence and the three surfaces
 
-Precedence, highest wins:
+Highest wins:
 
 ```
 MCP per-call input  >  CLI flag  >  env var  >  config file  >  built-in default
 ```
 
-Per-call input is the `cast` / `*_model` / `*_backend` / `*_max_turns` tool args —
-the config supplies the *defaults those override*. A per-call model override is a
-model id sent *verbatim* (an id containing `/`, HuggingFace-style, is still one
-id — it is never parsed for a backend, so an org prefix matching a backend alias
-can't silently retarget the call); it swaps the id within the configured slot,
-dropping its pins and per-slot tunables — they described the configured model;
-the new id classifies fresh. The matching backend arg (`explorer_backend` /
-`synth_backend` on consult, `backend` on oneshot) retargets the slot
-to another backend (a call-time chimera: aliases resolve, and it works even on a
-role the cast doesn't carry). The naming rule for everything else is mechanical:
+**Per-call input** is the `cast`, `*_model`, `*_backend`, and `*_max_turns` tool
+arguments. The config supplies the defaults those override.
+
+**A per-call model override** sends the model id verbatim. An id containing `/`
+(HuggingFace style) is still one id: it is never parsed for a backend, so an org prefix
+matching a backend alias cannot silently retarget the call. The override swaps the id
+within the configured slot and drops that slot's pins and tunables, which described the
+configured model; the new id classifies fresh.
+
+**A per-call backend override** (`explorer_backend` / `synth_backend` on consult,
+`backend` on oneshot) retargets the slot to another backend. Aliases resolve, and it
+works even on a role the cast does not carry.
+
+Everything else follows one naming rule:
 
 > config key `foo_bar`  ⇄  env `KAIBO_FOO_BAR`  ⇄  CLI `--foo-bar`
 
@@ -436,22 +501,21 @@ role the cast doesn't carry). The naming rule for everything else is mechanical:
 | consult system prompt | `prompts.consult` *(file-only — full replace)* | — | — |
 | oneshot system prompt | `prompts.oneshot` *(file-only — full replace)* | — | — |
 
-**Two deliberate exceptions to the rule:**
+**Two exceptions to the naming rule:**
 
 - **Provider key vars stay native.** `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
-  `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` are *not* renamed to
-  `KAIBO_*` — people and CI expect those names. A backend points at one via
+  `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, and `OPENAI_API_KEY` are not renamed to
+  `KAIBO_*`, because people and CI expect those names. A backend points at one via
   `api_key_env`.
-- **`OPENAI_BASE_URL` is kept** as a back-compat override for any openai-kind
-  backend that doesn't set an explicit `base_url` (it's what's wired today). New
-  backends use the `base_url` config key instead.
+- **`OPENAI_BASE_URL` is kept** as a backward-compatible override for any openai-kind
+  backend with no explicit `base_url`. New backends use the `base_url` config key.
 
-`RUST_LOG` is kept (tracing's own convention) and takes precedence; `KAIBO_LOG` and
-the `server.log` config key are the lower-precedence ways to set the same filter.
+`RUST_LOG` follows tracing's own convention and takes precedence. `KAIBO_LOG` and the
+`server.log` config key set the same filter at lower precedence.
 
 ### Tombstones (the `provider` spellings)
 
-The rename map ships as loud errors, never silent reinterpretation:
+The rename map ships as load errors, never silent reinterpretation:
 
 | old spelling | what happens now |
 |---|---|
@@ -461,11 +525,54 @@ The rename map ships as loud errors, never silent reinterpretation:
 | `--provider` | rejected by clap (unknown flag) |
 | call arg `provider` | unknown-field error (`deny_unknown_fields`) — the alias is gone |
 
-The call-arg `provider` alias was the one survivor for a single cycle after the
-rename: serde drops unknown fields, so without it a client still sending
-`provider` would have been *silently ignored* into the default cast — a textbook
-silent fallback. That cycle is over; the alias is removed and a stale `provider`
-is now a loud invalid-params error like every other tombstone above.
+The call-argument `provider` alias survived one cycle after the rename. serde drops
+unknown fields, so without the alias a client still sending `provider` would have been
+silently ignored into the default cast. That cycle is over: the alias is removed, and a
+stale `provider` is now an invalid-params error like every other tombstone above.
+
+## Tool gating
+
+A tool clears **two** gates to be advertised: the `[server.tools]` flag (equivalently
+`--no-<tool>` or `KAIBO_NO_<TOOL>`), and a configured cast that can **staff** it.
+
+A tool nothing can staff has its route removed rather than shipping unusable. The calling
+agent never sees a tool whose every call would fail, and an unusable tool stops costing
+resident tokens in every session.
+
+Which cast shape staffs which tool:
+
+| tool | needs |
+|---|---|
+| `consult`, `consult_submit`, `oneshot` | a cast whose synth answers **interactively** (no offline lane) |
+| `explore` | a cast with an `explorer` slot |
+| `batch_submit` | a cast whose synth runs on `lane = "batch"` (or the `batch = true` sugar) |
+| `deliberate` | a cast with an `explorer` **and** an offline synth (`lane = "batch"` or `lane = "direct"`) |
+| `job_get`, `job_cancel`, `job_list`, `job_wait` | at least one live handle *producer*; they follow whatever survives above |
+| `run_kaish`, `list_models` | no cast at all; always advertised |
+
+**Default installs.** This affects one tool. No built-in cast pairs an explorer with an
+offline synth — the two built-in offline casts, `anthropic-batch` and `gemini-batch`, are
+synth-only — so `deliberate` is not advertised until you configure a cast carrying both
+slots. The DELIBERATE casts section of `docs/config.example.toml` is the worked example.
+Any of the three hosted batch providers serves, as does a big local model on the `direct`
+lane, which needs no batch API.
+
+The eligibility predicates live in one table in `src/server/mod.rs` (`CAST_ENUM_RULES`),
+which also feeds each surviving tool's `cast` enum. The tools advertised and the casts they
+offer are one computation, so they cannot disagree.
+
+### Finding out why a tool is missing
+
+Removing the route is right for the model's tool list and wrong for the operator, so the
+reason is reported twice:
+
+- **A startup warning** names the cast shape that would bring the tool back.
+- **`kaibo://config`'s `[runtime]` section** lists `advertised_tools` (what the server
+  serves) and `unstaffable_tools` (each held-back tool mapped to the same requirement
+  text).
+
+`unstaffable_tools` omits tools the operator switched off. "You disabled it" and "nothing
+can run it" are different answers, and `[tools]` already reports the first.
 
 ## File location & loading
 
@@ -478,30 +585,32 @@ $XDG_CONFIG_HOME/kaibo/config.toml      # default
 ~/.config/kaibo/config.toml             # when XDG_CONFIG_HOME unset
 ```
 
-Loading rules, in the spirit of "crashing beats silent corruption":
+Loading rules follow "crash rather than corrupt":
 
-- **Missing file → built-in defaults, no error.** kaibo works out of the box.
-- **Malformed TOML, an unknown key (including a typo'd role or per-slot knob), a
-  `base_url` on a keyed kind, an unknown backend in a slot, an empty model id, an
-  out-of-range sampling value, an inverted `thinking_budget`/`max_tokens` pair on
-  a thinking-kind slot, an alias collision, or an unresolvable `server.cast` →
-  hard error at startup**, non-zero exit, before `serve()`. We do not silently
-  drop a setting the user clearly meant — a typo'd knob that quietly does nothing
-  is the failure mode we refuse.
-- **An explicit `--config`/`KAIBO_CONFIG` path that doesn't exist → hard error.**
-  Only the *default* XDG path is allowed to be absent.
-- Keys are still resolved **lazily at call time** (a missing key for an unused
-  backend isn't fatal at startup). Startup validation of *which backends are
-  usable* is tracked separately in `docs/issues.md`.
+| condition | result |
+|---|---|
+| default XDG path absent | built-in defaults, no error |
+| explicit `--config` / `KAIBO_CONFIG` path absent | hard error at startup |
+| malformed TOML, or any validation failure below | hard error at startup, non-zero exit, before `serve()` |
+| missing key for an unused backend | not fatal; keys resolve lazily at call time |
 
-Project-local layering (a repo-root `.kaibo.toml` merged over the user config) is a
-plausible later layer — noted, not in this cut.
+Validation failures that abort startup: an unknown key, including a misspelled role or
+per-slot knob; a `base_url` on a keyed kind; an unknown backend in a slot; an empty
+model id; an out-of-range sampling value; an inverted `thinking_budget`/`max_tokens`
+pair on a thinking-kind slot; an alias collision; an unresolvable `server.cast`.
+
+A setting the operator clearly meant is never silently dropped. A misspelled knob that
+quietly does nothing is the failure mode these rules exist to prevent.
+
+Startup validation of *which backends are usable* is tracked separately in
+`docs/issues.md`. Project-local layering (a repo-root `.kaibo.toml` merged over the user
+config) is a plausible later addition, not implemented.
 
 ## Telemetry (OpenTelemetry traces)
 
-**Off by default, and that default is load-bearing.** kaibo reads a private
-codebase, and the spans `rig-core` emits carry prompts, completions, and source
-snippets. A default run must ship *nothing* off-box, so `[telemetry]` is opt-in:
+**Off by default.** kaibo reads a private codebase, and the spans `rig-core` emits carry
+prompts, completions, and source snippets. A default run ships nothing off-box, so
+`[telemetry]` is opt-in.
 
 ```toml
 [telemetry]
@@ -512,33 +621,37 @@ service_name = "kaibo"                             # service.name on the trace R
 headers = { authorization = "Bearer <token>" }     # file-only; values are secrets
 ```
 
-What you get is the GenAI trace tree rig already produces — a tool call →
-`run_phase` per phase → `invoke_agent` → a `chat` span per model turn (with
-`gen_ai.request.model` and every `gen_ai.usage.*` token count). On top of that,
-kaibo adds the named parent spans (`consult` / `oneshot` /
-`run_kaish`) that root each trace, **and a `tool` span per tool invocation**
-(`tool_span.rs`) carrying `gen_ai.tool.name` and an ok/err `outcome` — so you can
-query *which* tool the model actually called (`run_kaish`, `view_image`, the nested
-`explore′`), not just that a turn happened. rig's own per-tool instrumentation
-isn't reliably queryable across backends, so this is kaibo's, on kaibo's tools. The
-exporter ships the rest. Transport is OTLP/HTTP + protobuf (the `/v1/traces` path),
-reusing kaibo's `reqwest` — no gRPC, no second HTTP stack.
+**What you get.** The GenAI trace tree rig produces — a tool call → `run_phase` per
+phase → `invoke_agent` → a `chat` span per model turn, carrying `gen_ai.request.model`
+and every `gen_ai.usage.*` token count. kaibo adds:
 
-**The boundary this draws.** Enabling opens an **outbound** OTLP connection to
-`endpoint`. That's allowed under kaibo's stdio-only invariant — kaibo can read a
-filesystem, so it must never *bind* a socket, but reaching *out* to a collector is
-not binding. Keep `endpoint` local (the default `localhost:4318`) unless you mean
-to send traces — with full content — to a remote. Header **values** are secrets and
-never appear in the `kaibo://config` render (only the header *names* do, like an
-API-key env-var name). Logs continue to ride the `tracing` → stderr + MCP
-`notifications/message` path regardless; telemetry adds the *traces* signal only.
+- The named parent spans (`consult`, `oneshot`, `run_kaish`) that root each trace.
+- A `tool` span per tool invocation (`tool_span.rs`) carrying `gen_ai.tool.name` and an
+  ok/err `outcome`, so a query can name *which* tool the model called (`run_kaish`,
+  `view_image`, the nested `explore′`), not just that a turn happened. rig's own
+  per-tool instrumentation is not reliably queryable across backends.
+
+Transport is OTLP/HTTP with protobuf on the `/v1/traces` path, reusing kaibo's
+`reqwest`. No gRPC and no second HTTP stack.
+
+**Boundary.** Enabling opens an **outbound** OTLP connection to `endpoint`. This is
+allowed under kaibo's stdio-only invariant: kaibo can read a filesystem, so it must never
+*bind* a socket, but reaching out to a collector is not binding. Keep `endpoint` local
+(the default `localhost:4318`) unless you intend to send traces, with full content, to a
+remote.
+
+Header **values** are secrets and never appear in the `kaibo://config` render; only the
+header *names* do, like an API-key env-var name.
+
+Logs continue to ride the `tracing` → stderr + MCP `notifications/message` path
+regardless. Telemetry adds the traces signal only.
 
 ## Persistence: `[persistence]`
 
-**On by default.** kaibo keeps a small state db so a `consult` session thread and the
-provider batch handles you launch **survive a server restart** and are shared across
-front doors (start a session over MCP, continue it from the CLI). It lives at a fixed
-XDG state path, never a path a model controls:
+**On by default.** kaibo keeps a small state db so `consult` session threads and
+provider batch handles survive a server restart and are shared across front doors — a
+session started over MCP continues from the CLI. It lives at a fixed XDG state path,
+never a path a model controls.
 
 ```toml
 [persistence]
@@ -550,57 +663,60 @@ CLI/env: `--no-persistence` / `KAIBO_NO_PERSISTENCE` disable it (in-memory, like
 `--state-db <FILE>` / `KAIBO_STATE_DB` move the db. `path` is `$VAR`/`~`-expanded like
 `root`/`allow_paths`.
 
-**What persists:** the lean `(question, answer)` turns of each session (capacity-evicted,
-no TTL — same as the in-memory store), and the `{backend, provider-id, label}` of each
-batch you submit (so `job_list` can re-surface a handle after a restart). **What never
-persists:** background *consult/deliberate* job handles (`job-N` — in-memory, session-only
-by design) and exploration reports (ephemeral by design — they'd be stale bloat). Its
-content is model output, never anything the calling model steers onto disk — and because
-that output is **what you paid for**, kaibo treats the db as your data: it never removes
-the file, under any error, so moving it aside is always your decision.
+**Contents.**
 
-**Read-only toward your project is unchanged.** The store is handler-side, at the XDG
-path — kaish's read-only sandbox never sees it, kaibo still writes nothing into any
-project, and `open` **refuses a state-db path that resolves inside an allowed tree** (so
-it can't be pointed into a repo). See the "Read-only is the product" invariant in
-AGENTS.md.
+| persists | never persists |
+|---|---|
+| the `(question, answer)` turns of each session (capacity-evicted, no TTL, same as the in-memory store) | background consult/deliberate job handles (`job-N`), which are in-memory and session-only by design |
+| the `{backend, provider-id, label}` of each submitted batch, so `job_list` can re-surface a handle after a restart | exploration reports, which would be stale bloat |
 
-**Host-agent sandboxes still matter.** kaibo's inner model-facing shell is read-only, but
-your MCP client or calling agent may also sandbox the kaibo process itself. If that host
-sandbox blocks network, model-backed tools cannot reach providers. If it blocks writes to
-the XDG state dir, a long-lived MCP server with persistence enabled fails during startup.
+Everything stored is model output. Nothing the calling model steers reaches disk. Because
+that output is what you paid for, kaibo treats the db as your data and never removes the
+file under any error; moving it aside is your decision.
+
+**Read-only toward your project is unchanged.** The store is handler-side at the XDG
+path. kaish's read-only sandbox never sees it, kaibo writes nothing into any project, and
+`open` refuses a state-db path that resolves inside an allowed tree, so it cannot be
+pointed into a repo. See the "Read-only is the product" invariant in AGENTS.md.
+
+**Host-agent sandboxes.** kaibo's inner model-facing shell is read-only, but your MCP
+client or calling agent may also sandbox the kaibo process itself.
+
+- A host sandbox that blocks network prevents model-backed tools from reaching providers.
+- A host sandbox that blocks writes to the XDG state dir fails a long-lived MCP server
+  during startup when persistence is enabled.
+
 Grant the host sandbox outbound network and a narrow writable root for kaibo's state dir,
-or move the db with `--state-db` / `KAIBO_STATE_DB` / `[persistence] path`. For multi-agent
-setups, a per-client state db is often cleaner than sharing one history file across Claude
-Code, Codex, and other agents. Apply the same judgment to the media CAS when an
-artifact-producing tool is enabled: the default XDG data path is convenient for sharing
-generated artifacts across agents, while a per-client CAS keeps those artifacts separated.
+or move the db with `--state-db` / `KAIBO_STATE_DB` / `[persistence] path`. In
+multi-agent setups a per-client state db is often cleaner than sharing one history file
+across Claude Code, Codex, and other agents. The same judgment applies to the media CAS
+when an artifact-producing tool is enabled: the default XDG data path is convenient for
+sharing generated artifacts across agents, while a per-client CAS keeps them separated.
 
-**Loud on failure, never a silent fallback.** If the store can't open (a bad path, a db
-inside a project, a network mount — turso's multiprocess mode is 64-bit-Unix + local-fs
-only), kaibo **fails to start** with an error naming the escape hatch and leaving the db
-untouched — rather than quietly dropping to memory and losing your sessions on the next
-restart.
+**Failure is loud.** If the store cannot open — a bad path, a db inside a project, a
+network mount (turso's multiprocess mode is 64-bit Unix plus local filesystem only) —
+kaibo fails to start with an error naming the escape hatch, leaving the db untouched. It
+does not drop to memory and lose your sessions at the next restart.
 
-**One exception, Windows only.** On Windows (and other non-64-bit-Unix targets) the store
-is single-process. A *second* kaibo opening the same db — a second editor window — would,
-under an MCP client that auto-restarts its servers, crash-loop if this were fatal. So that
-one case (`SingleProcessLocked`) is the deliberate carve-out: kaibo **warns loudly and
-serves with in-memory sessions** for that run instead of crashing. It's not silent — the
-startup log says so, and `kaibo://config` shows `persistence.active = false` (with
-`enabled = true`) so the calling model can see durability is off. Close the other kaibo,
-point `--state-db` elsewhere, or `--no-persistence` to make it explicit. Every *other*
-open failure stays fatal.
+**One exception, Windows only.** On Windows and other non-64-bit-Unix targets the store is
+single-process. A second kaibo opening the same db, such as a second editor window, would
+crash-loop under an MCP client that auto-restarts its servers. So `SingleProcessLocked` is
+the one carve-out: kaibo warns and serves with in-memory sessions for that run.
+
+It is not silent. The startup log says so, and `kaibo://config` shows `persistence.active
+= false` alongside `enabled = true`, so the calling model can see that durability is off.
+Close the other kaibo, point `--state-db` elsewhere, or pass `--no-persistence` to make it
+explicit. Every other open failure stays fatal.
 
 ## House rules: `[context]`
 
-kaibo's models are *for other agents*, so it helps when they inherit the calling
-agent's conventions. `[context]` names files whose contents are spliced into each
-consultation tool's preamble (the system prompt) as standing guidance — an
-`AGENTS.md`, a shared user guidance file, whatever you call yours. **Vendor-
-neutral:** no filename is hardcoded in the product; the only default is the
-emerging cross-tool `AGENTS.md` convention, and that's just a config default you
-can change or turn off.
+kaibo's models work for other agents, so they benefit from inheriting the calling agent's
+conventions. `[context]` names files whose contents are spliced into each consultation
+tool's preamble (the system prompt) as standing guidance: an `AGENTS.md`, a shared user
+guidance file, or whatever your project uses.
+
+No filename is hardcoded in the product. The only default is the cross-tool `AGENTS.md`
+convention, and that is a config default you can change or turn off.
 
 ```toml
 [context]
@@ -613,37 +729,42 @@ project_files = ["AGENTS.md", "docs/CONVENTIONS.md"]
 user_files = ["~/.config/kaibo/agent-guidance.md"]
 ```
 
-Two lists, two deliberately different failure semantics:
+Two lists with different failure semantics:
 
-- **`project_files`** are root-relative and **read-if-present**: a repo with no
-  `AGENTS.md` is the normal case, not an error. Each is joined to the resolved
-  project root and canonicalize-checked to stay *within* it — a configured `../`
-  or an out-of-tree symlink is refused, so the same containment that bounds the
-  read-only shell bounds what gets injected.
-- **`user_files`** are **read-required**: you named the file on purpose, so a
-  missing one is a loud error rather than a silent skip that ships an answer
-  missing the guidance you were counting on.
+| list | paths | missing file |
+|---|---|---|
+| `project_files` | root-relative | normal; read if present |
+| `user_files` | absolute or `~` | startup-visible error |
 
-**The trust boundary** (why `user_files` may sit outside the allowed set): these
-files are read in trusted server-side Rust at the tool handler — the same trust
-level as `config.toml` itself — and only their *contents* reach the model, never
-the path. The read-only kaish shell still cannot reach the user guidance path; the model's
-read scope is *not* widened. That's the distinction from `[server] allow_paths`
-below: `allow_paths` widens what the *model* can explore, `[context]` injects
-fixed operator text the model never navigates to.
+`project_files` are joined to the resolved project root and canonicalize-checked to stay
+within it. A configured `../` or an out-of-tree symlink is refused, so the containment
+that bounds the read-only shell also bounds what gets injected. A repo with no `AGENTS.md`
+is the normal case.
 
-Injected into the codebase-reading phases — the `consult` driver *and* its nested
-`explore′` sweep — so the cheap explorer orients on the same `AGENTS.md`/user guidance
-while it searches, not just at answer time (the block names where things live and
-what matters). Precedence is the usual per-call > CLI > env > file > built-in: a
-CLI `--project-context-file` replaces lower layers additively (the CLI can't
-express "empty"; opt out with an empty `[context] project_files = []` or
-`KAIBO_PROJECT_FILES=`).
+`user_files` are read-required: you named the file on purpose, so a missing one is an
+error rather than a silent skip that ships an answer without the guidance you counted on.
+
+**Trust boundary.** `user_files` may sit outside the allowed set because these files are
+read in trusted server-side Rust at the tool handler, at the same trust level as
+`config.toml` itself, and only their *contents* reach the model, never the path. The
+read-only kaish shell still cannot reach the user guidance path; the model's read scope is
+not widened.
+
+This is the distinction from `[server] allow_paths` below. `allow_paths` widens what the
+*model* can explore; `[context]` injects fixed operator text the model never navigates to.
+
+**Where it lands.** The codebase-reading phases — the `consult` driver and its nested
+`explore′` sweep — so the cheap explorer orients on the same guidance while it searches,
+not only at answer time.
+
+**Precedence** is the usual per-call > CLI > env > file > built-in. A CLI
+`--project-context-file` replaces lower layers additively. The CLI cannot express "empty";
+opt out with `[context] project_files = []` or `KAIBO_PROJECT_FILES=`.
 
 ## System prompts: `[prompts]`
 
-Where `[context]` *adds* project guidance, `[prompts]` *replaces* the built-in
-role framing — the system prompt each phase runs under. One override per phase:
+`[context]` *adds* project guidance. `[prompts]` *replaces* the built-in role framing,
+which is the system prompt each phase runs under. One override per phase:
 
 ```toml
 [prompts]
@@ -663,34 +784,34 @@ Prefer architectural answers; name the file:line that carries each claim.
 | `oneshot` | `oneshot_preamble` | the thin, toolless `oneshot` |
 | `batch` | `batch_preamble` | the offline, max-thinking `batch_submit` |
 
-**Full replace, by decision.** An override *is* the role framing, verbatim — kaibo
-does not re-wrap it. That's safe because the kaish operating contract (how to drive
-the read-only shell, the exit-code meanings, the `cat -n`/`grep -rn` idioms) rides the
-`run_kaish` *tool description* independently, so the model keeps the shell contract
-even when you rewrite the prose. What an override *does* drop is the tuned role
-framing kaibo ships — the explorer's "report, don't conclude", the synth's "trust a
-grounded citation, reach for more", the positive-framing discipline weak/local
-models lean on. That's yours to own when you override.
+**Full replace.** An override *is* the role framing, verbatim; kaibo does not re-wrap it.
+This is safe because the kaish operating contract — how to drive the read-only shell, the
+exit-code meanings, the `cat -n` and `grep -rn` idioms — rides the `run_kaish` tool
+description independently, so the model keeps the shell contract even when you rewrite the
+prose.
 
-**Orthogonal to `[context]`.** House rules still append on top of an override:
-`[prompts]` sets the *role*, `[context]` adds the *project's* conventions, and both
-land in the final system prompt. Layering order is `override-or-built-in` →
-`+ house rules`.
+An override does drop the tuned role framing kaibo ships: the explorer's "report, don't
+conclude", the synth's "trust a grounded citation, reach for more", and the
+positive-framing discipline that weaker and local models depend on. That becomes yours to
+own.
 
-**File-only, and operator-only.** Multiline prose has no clean env/CLI form (the
-same call `telemetry.headers` makes), so overrides live only in `config.toml`. They
-are *not* a per-call tool argument — a calling agent can't inject a system prompt;
-only the operator who owns the config can. An empty or whitespace-only override is
-a **loud load error** (a blank system prompt is never intended) — remove the key to
-fall back to the built-in.
+**Orthogonal to `[context]`.** House rules still append on top of an override.
+`[prompts]` sets the role, `[context]` adds the project's conventions, and both land in
+the final system prompt. Layering order is `override-or-built-in` → `+ house rules`.
+
+**File-only and operator-only.** Multiline prose has no clean env or CLI form, the same
+constraint `telemetry.headers` has, so overrides live only in `config.toml`. They are not
+a per-call tool argument: a calling agent cannot inject a system prompt, only the operator
+who owns the config can. An empty or whitespace-only override is a load error, since a
+blank system prompt is never intended. Remove the key to fall back to the built-in.
 
 ### Per-model overrides (the slot `preamble`)
 
-`[prompts]` is keyed by *phase* (the job). A prompt can also be keyed by *model*,
-because the same phase may run different models — a local Gemma explorer wants
-different framing than a Claude Haiku one (kaibo's request shaping is already
-model-aware; the prose is too). The per-model knob is `preamble` on the cast's
-**slot**, beside `effort`/`thinking_style`:
+`[prompts]` is keyed by *phase*, meaning the job. A prompt can also be keyed by *model*,
+because the same phase may run different models: a local Gemma explorer wants different
+framing than a Claude Haiku one. kaibo's request shaping is already model-aware, and the
+prose can be too. The per-model knob is `preamble` on the cast's **slot**, beside
+`effort` and `thinking_style`:
 
 ```toml
 [casts.local]
@@ -698,31 +819,32 @@ explorer = { backend = "openai-local", id = "Gemma-4-E4B-it", preamble = "You ar
 synth    = "anthropic/claude-sonnet-4-6"   # no per-model prompt; uses [prompts] or built-in
 ```
 
-**Precedence, per phase:** `slot.preamble` → `[prompts].<phase>` → built-in. The
-slot (most specific — *this* model in *this* cast) wins, the same way `effort`
-overrides the `[defaults]` effort. Set neither and the built-in runs.
+**Precedence, per phase:** `slot.preamble` → `[prompts].<phase>` → built-in. The slot is
+most specific (this model in this cast) and wins, the same way a slot `effort` overrides
+the `[defaults]` effort. Set neither and the built-in runs.
 
-**One model, two synth jobs.** The synth slot's model plays *both* the `consult`
-driver and the toolless `oneshot`, so its `preamble` feeds both — but each phase
-resolves under its own key, so they stay **independently overridable**: a copy today
-(both the synth slot's voice), free to diverge by setting `[prompts].consult` and
-`[prompts].oneshot` separately. `slot.preamble` = "this model's voice"; the phase
-keys = "this job's framing." The explorer has one job, so no ambiguity. A per-call
-model override (a bare slot) carries no `preamble` — overriding the model doesn't
-drag the configured slot's framing along. Same loud-on-empty rule as `[prompts]`.
+**One model, two synth jobs.** The synth slot's model runs both the `consult` driver and
+the toolless `oneshot`, so its `preamble` feeds both. Each phase resolves under its own
+key, so they remain independently overridable: identical by default, free to diverge by
+setting `[prompts].consult` and `[prompts].oneshot` separately. Read `slot.preamble` as
+"this model's voice" and the phase keys as "this job's framing". The explorer has one job,
+so no ambiguity arises.
 
-`batch_submit` runs the synth model too, but deliberately does **not** inherit the
-synth slot's `preamble`: its lane has a distinct behavioral contract (one offline
-response, no follow-up, spend on depth) that a slot preamble written for interactive
-synth would silently replace. Tune batch through `[prompts].batch` (or accept the
-built-in `batch_preamble`); the slot preamble stays scoped to the interactive phases.
+A per-call model override (a bare slot) carries no `preamble`. Overriding the model does
+not drag the configured slot's framing along. The empty-value load error applies here too.
+
+**`batch_submit` does not inherit the slot `preamble`.** It runs the synth model, but its
+lane has a distinct behavioral contract — one offline response, no follow-up, spend on
+depth — that a slot preamble written for interactive synth would silently replace. Tune
+batch through `[prompts].batch`, or accept the built-in `batch_preamble`. The slot
+preamble stays scoped to the interactive phases.
 
 ## Repo orientation: `[orientation]`
 
-A static, computed-once **file map** injected into the exploring preamble, so a
-model starts *knowing* the project's files instead of spending its first turns on
-`glob`/`ls`/`find` to discover the layout (the structure-first lesson from
-Agentless/Aider, made free — no model in the loop).
+A static, computed-once file map injected into the exploring preamble, so a model starts
+knowing the project's files instead of spending its first turns on `glob`, `ls`, and
+`find` to discover the layout. This is the structure-first approach from Agentless and
+Aider, with no model in the loop.
 
 ```toml
 [orientation]
@@ -731,63 +853,68 @@ full_list_max_files = 256    # ≤ this → inject the full file list; above →
 tree_max_depth = 4           # how deep the fallback directory map descends
 ```
 
-How it works: the server runs the kernel's **own** `glob -a --json '**/*'` server-side
-per `explore`/`consult` call — the *same* ignore-aware enumeration the model's shell
-would get (same VFS, same ignore rules), so the map can't disagree with what the
-explorer's own `glob`/`grep` sees. `-a` includes hidden config (`.github/`, `.cargo/`);
-the ignore filter still drops `.git`/`target`.
+**How it is built.** The server runs the kernel's own `glob -a --json '**/*'`
+server-side per `explore` and `consult` call. This is the same ignore-aware enumeration
+the model's shell would get, on the same VFS under the same ignore rules, so the map
+cannot disagree with what the explorer's own `glob` and `grep` see. `-a` includes hidden
+config such as `.github/` and `.cargo/`; the ignore filter still drops `.git` and
+`target`.
 
-Size-gated, with a graceful descent — orientation is an *enhancement* (the model always
-has `glob`/`grep`/`explore′`), so its absence is never fatal and the call is never refused
-for being large:
-- **≤ `full_list_max_files`** → the complete file list is spliced in.
-- **above it** → a **directory map**: the same files folded into a depth-limited tree of
-  `dir/  N files` lines, descending `tree_max_depth` levels (deeper files stay counted at
-  the deepest shown directory). The names are traded for structure; the model recovers them
-  with `glob 'DIR/**/*'` / `grep -rn`.
-- **above it *and* the directory map would itself exceed `full_list_max_files` lines** (a very
-  large or very wide repo) → a short **discover-as-you-go note** naming the discovery tools.
-  Skipped maps are logged (`tracing::warn`), not silent.
+**Size gating.** Orientation is an enhancement — the model always has `glob`, `grep`, and
+`explore′` — so its absence is never fatal and no call is refused for being large.
 
-`full_list_max_files = 0` is a load error (it would refuse every repo — disable instead), as is
-`tree_max_depth = 0` (it would render an empty map).
+| repo size | injected |
+|---|---|
+| ≤ `full_list_max_files` | the complete file list |
+| above it | a directory map: the same files folded into a depth-limited tree of `dir/  N files` lines, descending `tree_max_depth` levels |
+| above it, and the directory map would itself exceed `full_list_max_files` lines | a short discover-as-you-go note naming the discovery tools |
 
-It rides the **exploring** phases only — the `consult` driver and its nested
-`explore′` sweep. The toolless `oneshot` reads no project, so it gets no map. Like
-`[context]`, the block re-sends each turn, which the size gate
-keeps bounded. Whether it actually erases the discovery turns is measurable via the
-per-tool `tool` spans (see Telemetry).
+In the directory map, files deeper than `tree_max_depth` stay counted at the deepest shown
+directory. Names are traded for structure, and the model recovers them with `glob
+'DIR/**/*'` or `grep -rn`. A skipped map is logged at `warn`, not silent.
+
+`full_list_max_files = 0` is a load error, since it would refuse every repo; disable the
+block instead. `tree_max_depth = 0` is a load error, since it would render an empty map.
+
+**Scope.** The exploring phases only: the `consult` driver and its nested `explore′`
+sweep. The toolless `oneshot` reads no project and gets no map. Like `[context]`, the
+block re-sends each turn, which the size gate keeps bounded. Whether it erases discovery
+turns in practice is measurable through the per-tool `tool` spans (see Telemetry).
 
 ## Path containment
 
-**Always on.** Every tool call's `path` argument (or the default root when `path`
-is omitted) is resolved — `std::fs::canonicalize` expands symlinks and collapses `..`
-— and then checked against the **allowed set**. A path that doesn't fall at-or-under
-one of the allowed trees is `invalid_params`, naming the allowed trees and the three
-knobs that widen them.
+**Always on.** Every tool call's `path` argument, or the default root when `path` is
+omitted, is resolved with `std::fs::canonicalize` (expanding symlinks and collapsing
+`..`) and then checked against the **allowed set**. A path that does not fall at or under
+one of the allowed trees is `invalid_params`, naming the allowed trees and the three knobs
+that widen them.
 
-**The allowed set** is constructed at startup from the canonicalized `--root` plus
-every canonicalized `--allow-path`, plus the canonicalized launch cwd — unless `--root`
-named a project, or `--no-cwd` opted out. MCP clients start stdio servers with cwd =
-workspace, so the zero-config case scopes itself to the project naturally, without any
-operator action.
+**The allowed set** is constructed at startup from the canonicalized `--root`, every
+canonicalized `--allow-path`, and the canonicalized launch cwd — the last unless `--root`
+named a project or `--no-cwd` opted out. MCP clients start stdio servers with cwd set to
+the workspace, so the zero-config case scopes itself to the project with no operator
+action.
 
-**`--allow-path` is additive.** It widens the boundary and never narrows it: adding one
-does *not* cost you the cwd, because reaching one more tree should never evict the
-workspace your question is about. Naming a `--root` is different — that is you choosing
-the project, so the cwd is not added beside it. When you want the allowed set to be
-exactly what you named, say so with `--no-cwd` (`KAIBO_NO_CWD`, `[server] infer_cwd =
-false`); every call must then pass its own `path`. The default isn't silent: the resolved allowed set is reported in a startup
-log line and in the `## Scope` section of the server's MCP `instructions` (visible in
-every `initialize` response), and at `kaibo://config`.
+**`--allow-path` is additive.** It widens the boundary and never narrows it. Adding one
+does not cost you the cwd, because reaching one more tree should not evict the workspace
+the question is about. `--root` behaves differently: naming it is choosing the project, so
+the cwd is not added beside it.
 
-**The default root** is what a call resolves to when it omits `path`: an explicit
-`--root`, or — when none is set — the launch cwd, *inferred*. So the common
-single-workspace case needs no `--root`: kaibo already knows the workspace from its cwd
-and uses it for both bounding and defaulting. The inferred case is labelled as such in
-the `## Scope` handshake and at `kaibo://config` (`default_root_inferred`). Only
-`--no-cwd` leaves you without a default root, and then an omitted `path` is a clear
-parameter error rather than a guess.
+To make the allowed set exactly what you named, use `--no-cwd` (`KAIBO_NO_CWD`, `[server]
+infer_cwd = false`). Every call must then pass its own `path`.
+
+The resolved allowed set is reported in three places: a startup log line, the `## Scope`
+section of the server's MCP `instructions` (visible in every `initialize` response), and
+`kaibo://config`.
+
+**The default root** is what a call resolves to when it omits `path`. It is an explicit
+`--root`, or, when none is set, the launch cwd, inferred. The common single-workspace case
+therefore needs no `--root`: kaibo knows the workspace from its cwd and uses it for both
+bounding and defaulting. The inferred case is labelled as such in the `## Scope` handshake
+and at `kaibo://config` (`default_root_inferred`).
+
+Only `--no-cwd` leaves you with no default root, and an omitted `path` is then a parameter
+error rather than a guess.
 
 **Widening the boundary:**
 
@@ -805,32 +932,35 @@ KAIBO_ALLOW_PATHS=~/src:/data/fixtures kaibo
 kaibo --allow-path ~/src --allow-path /data/fixtures
 ```
 
-A non-empty CLI `--allow-path` set replaces the env/file layer entirely (same
-precedence rule as `--root`) — that is *layer* precedence, not narrowing: whichever
-layer wins still sits alongside the inferred cwd. To lift all limits: `--allow-path /`.
+A non-empty CLI `--allow-path` set replaces the env and file layers entirely, the same
+precedence rule as `--root`. That is layer precedence, not narrowing: whichever layer wins
+still sits alongside the inferred cwd. `--allow-path /` lifts all limits.
 
-`--root` is deliberately **not** repeatable — it names *the* project a path-less call
-defaults to, and there can only be one; the parser refuses a second occurrence rather
-than silently picking. `--allow-path` is the repeatable knob.
+`--root` is not repeatable. It names *the* project a path-less call defaults to, and there
+can be only one, so the parser refuses a second occurrence rather than picking silently.
+`--allow-path` is the repeatable knob.
 
-**Set it once.** Putting your whole workspace tree in `allow_paths`
-(`["~/src"]`) means every project under it is in-bounds, and because the client's
-cwd/workspace lands inside that tree, kaibo infers it as the [default root](#path-containment)
-automatically — so you configure access once and never pass `path` per call.
+**Configure access once.** Putting your whole workspace tree in `allow_paths` (`["~/src"]`)
+puts every project under it in bounds, and because the client's workspace cwd lands inside
+that tree, kaibo infers it as the default root automatically. You then never pass `path`
+per call.
 
-**Path expansion.** In `root` / `allow_paths`, the file and env layers expand a leading
-`~` to `$HOME` *and* `$VAR` / `${VAR}` from the environment; the CLI relies on your shell's
-own expansion instead. Paths with no `~`/`$` are taken as written. A variable that is unset,
-**set but empty**, or non-UTF-8 is a loud load error rather than a silent gap that would
-misplace the boundary — an empty value matters because `$EMPTY/scratch` would collapse to
-`/scratch` and `$EMPTY/` to `/` (the whole filesystem). Write `$$` for a literal `$`; a
-stray `$` that begins no reference is itself an error, so a typo can't slip through as a
-literal segment. (A directory literally named `$foo` is written `$$foo`.)
+**Path expansion.** In `root` and `allow_paths`, the file and env layers expand a leading
+`~` to `$HOME`, and `$VAR` / `${VAR}` from the environment. The CLI relies on your shell's
+expansion instead. Paths with no `~` or `$` are taken as written.
 
-**Reading a scratch / temp space.** kaibo reads only what's in the allowed set and never
-writes anywhere — so to let it read artifacts a workflow drops in a temp dir (a diff, a
-generated file, a log), add that dir to `allow_paths`. Write it portably with the env var
-rather than a host-specific literal, so it resolves on whatever machine kaibo runs on:
+A variable that is unset, set but empty, or non-UTF-8 is a load error rather than a silent
+gap that would misplace the boundary. The empty case matters because `$EMPTY/scratch`
+collapses to `/scratch` and `$EMPTY/` to `/`, the whole filesystem.
+
+Write `$$` for a literal `$`; a directory literally named `$foo` is written `$$foo`. A
+stray `$` that begins no reference is an error, so a typo cannot slip through as a literal
+segment.
+
+**Reading a scratch or temp space.** kaibo reads only what is in the allowed set and never
+writes anywhere, so to let it read artifacts a workflow drops in a temp dir (a diff, a
+generated file, a log), add that dir to `allow_paths`. Use the env var rather than a
+host-specific literal so it resolves on whatever machine kaibo runs on:
 
 ```toml
 [server]
@@ -838,37 +968,40 @@ allow_paths = ["~/src", "$TMPDIR", "$XDG_RUNTIME_DIR/kaibo"]
 ```
 
 `$TMPDIR` (POSIX) and `$XDG_RUNTIME_DIR` (XDG) land on the per-user scratch dir on macOS
-and sandboxed Linux respectively, where a bare `/tmp` would be wrong. This is an opt-in:
-widening to a shared, world-writable space like `/tmp` is a real (read-only) boundary
-move, so kaibo never adds it for you.
+and sandboxed Linux respectively, where a bare `/tmp` would be wrong. This is opt-in:
+widening to a shared, world-writable space like `/tmp` is a real boundary move, even a
+read-only one, so kaibo never adds it for you.
 
-**When defaulting does *not* happen.** If `--allow-path` is set to a tree that does
-not contain the launch cwd and no `--root` is given, there is no default root: the
-cwd is outside the boundary, so adopting it would point the default at a path
-containment rejects. An omitted `path` then errors ("no `path` provided and the
-server has no default root …") — `invalid_params`, surfaced where the caller can read
-it. Pass an explicit `--root` (inside an allowed tree) to restore a default.
+**When no default root exists.** If `--allow-path` names a tree that does not contain the
+launch cwd and no `--root` is given, there is no default root. The cwd is outside the
+boundary, so adopting it would point the default at a path containment rejects. An omitted
+`path` then returns `invalid_params` ("no `path` provided and the server has no default
+root …"). Pass an explicit `--root` inside an allowed tree to restore a default.
 
-**Resolution.** `resolve_root` (`src/server.rs`) returns the *canonicalized* path,
-so the kaish VFS mount target is always resolved. A nonexistent or non-directory
-entry in `--root` / `--allow-path` is a loud construction error at startup.
+**Resolution.** `resolve_root` (`src/server.rs`) returns the canonicalized path, so the
+kaish VFS mount target is always resolved. A nonexistent or non-directory entry in
+`--root` or `--allow-path` is a construction error at startup.
 
-**Following git worktrees (on by default).** When a call's `path` misses the allowed
-set, kaibo doesn't reject it outright if it's a *linked git worktree of a repo
-already in the set* — it admits it. So a feature branch you check out in a sibling
-directory (`git worktree add ../proj-feature …`), even one created mid-session, is
-reachable without touching `allow_paths`. This is *narrower* than widening to the
-parent (`--allow-path ~/src` would grant read of everything under it); follow admits
-exactly the worktrees of an already-allowed repo and nothing else.
+### Following git worktrees
 
-kaibo resolves this by **reading git's own link files** — a worktree's `.git` file,
-the repo's `.git/worktrees/<name>/{gitdir,commondir}` — never by running `git` (the
-binary isn't in the build; see [the sandbox probe runbook](sandbox-probes.md)). Trust flows only
-outward from the allowed repo: kaibo enumerates the worktrees the *allowed* repo's
-common git dir vouches for and admits a candidate only if it falls inside one. It
-never consults the candidate's own `.git`, so a foreign directory with a forged
-`gitdir:` pointer can't admit itself. The check runs only on the (rare)
-containment-miss path — the normal in-bounds call is untouched.
+On by default. When a call's `path` misses the allowed set, kaibo admits it if it is a
+linked git worktree of a repo already in the set. A feature branch checked out in a
+sibling directory (`git worktree add ../proj-feature …`), including one created
+mid-session, is reachable without touching `allow_paths`.
+
+This is narrower than widening to the parent: `--allow-path ~/src` would grant read of
+everything under it, while follow admits exactly the worktrees of an already-allowed repo
+and nothing else.
+
+kaibo resolves this by reading git's own link files — a worktree's `.git` file and the
+repo's `.git/worktrees/<name>/{gitdir,commondir}` — never by running `git`, which is not
+in the build (see [the sandbox probe runbook](sandbox-probes.md)).
+
+Trust flows outward from the allowed repo only. kaibo enumerates the worktrees the
+*allowed* repo's common git dir vouches for and admits a candidate only if it falls inside
+one. It never consults the candidate's own `.git`, so a foreign directory with a forged
+`gitdir:` pointer cannot admit itself. The check runs only on the containment-miss path;
+a normal in-bounds call is untouched.
 
 Turn it off to keep the boundary strictly static:
 
@@ -888,53 +1021,53 @@ reconnect.
 
 ## kaibo://config
 
-An MCP resource at the URI `kaibo://config` (`application/toml`) exposes the server's
-resolved runtime state. Reading it before making calls tells the calling model (or an
-operator) the full picture:
+An MCP resource at `kaibo://config` (`application/toml`) exposing the server's resolved
+runtime state. Read it before making calls to see the full picture.
 
-- `allowed_paths` — the canonicalized trees a per-call path must be at-or-under
-- `default_root` — the `--root` value, if set
-- `default_cast` — which cast is used when a call omits `cast`
-- `runtime` — state *computed at read time*, kept distinct from the configured
-  knobs above so a reader can tell "what kaibo discovered" from "what the operator
-  set". Currently `follow_worktrees` (the knob's effective value) and
-  `followed_worktrees` (the git worktrees admitted beyond `allowed_paths` right
-  now; recomputed each read, so a worktree added mid-session appears without a
-  reconnect)
-- `tools` — which tools are currently advertised (`consult`, `oneshot`,
-  `run_kaish`)
-- `sandbox` — exec timeout, output cap, scratch (`/` MemoryFs) cap, and any extra disabled builtins
-- `kaish.ignore` — the resolved ignore policy the file-walking builtins honor:
-  `files`, `defaults`, `auto_gitignore`, `global_gitignore`, `scope`
-- `defaults` — the global tunables every slot falls back to (rendered so the
-  per-slot values below read as deltas against it)
-- `backends` — each connection: its kind, `base_url` (the *resolved* value for the
-  openai kind — env/local-default fallback applied; the raw configured value,
-  when set, for the anthropic and gemini kinds; absent for every other kind), key
-  source env var name and key file path (never the resolved key value),
-  `key_optional`, and `request_timeout_secs`
-- `backend_aliases` / `cast_aliases` — alias → canonical name, built-in and
-  file-declared both: every name a `cast` param, slot ref, or per-call backend
-  override will resolve
-- `casts` — each composition's slots as `model = "backend/id"` (canonical backend
-  name) with the *resolved* `vision` capability (slot pin applied, else the
-  classifier) and only the per-slot tunables actually set
+| section | contents |
+|---|---|
+| `allowed_paths` | the canonicalized trees a per-call path must be at or under |
+| `default_root` | the `--root` value, if set |
+| `default_cast` | the cast used when a call omits `cast` |
+| `runtime` | state computed at read time (see below) |
+| `tools` | which tools are currently advertised |
+| `sandbox` | exec timeout, output cap, scratch (`/` MemoryFs) cap, any extra disabled builtins |
+| `kaish.ignore` | the resolved ignore policy the file-walking builtins honor: `files`, `defaults`, `auto_gitignore`, `global_gitignore`, `scope` |
+| `defaults` | the global tunables every slot falls back to, rendered so per-slot values read as deltas |
+| `backends` | each connection: kind, `base_url`, key source names, `key_optional`, `request_timeout_secs` |
+| `backend_aliases` / `cast_aliases` | alias → canonical name, built-in and file-declared, covering every name a `cast` param, slot reference, or per-call backend override resolves |
+| `casts` | each composition's slots as `model = "backend/id"`, with the resolved `vision` capability and only the per-slot tunables actually set |
 
-**Secret-safety contract:** `kaibo://config` includes key *source metadata* — the
-env var name and file path an operator configured — but never the resolved key value.
-Keys are resolved lazily at call time and never cached in the `Config` struct, so the
-render function has no field that holds a secret. The render destructures `Backend`,
-`ModelSlot`, `Defaults`, `ToolGating`, and `SandboxConfig` exhaustively, so a new
-field is a compile error at the render site — an explicit render-or-skip (and
-secret-review) decision, not a silent omission. The
-`api_key_env` and `api_key_file` names are included deliberately: an operator
-debugging a missing-key error needs to see what source the backend is pointing at.
+**`runtime`** is kept distinct from the configured knobs so a reader can tell what kaibo
+discovered from what the operator set. It carries `follow_worktrees` (the knob's effective
+value), `followed_worktrees` (the git worktrees admitted beyond `allowed_paths` right now,
+recomputed each read so a mid-session worktree appears without a reconnect), and the
+`advertised_tools` / `unstaffable_tools` pair described under [Tool gating](#tool-gating).
 
-See `docs/config.example.toml` for the full, commented surface, and `docs/casts.md`
-for the design record of the backends/casts split (including how a cast resolves
-into per-phase arms).
+**`backends.base_url`** renders the *resolved* value for the openai kind, with the env and
+local-default fallback applied; the raw configured value, when set, for the anthropic and
+gemini kinds; and nothing for every other kind.
 
-All three "help me set up models" surfaces have a CLI mirror, for a caller with no MCP
-client at all: `kaibo config` prints this resolved state, `kaibo example-config`
-prints the annotated template, and `kaibo configure [goal]` prints the same guided
-walkthrough as the `configure` MCP prompt.
+**Secret-safety contract.** `kaibo://config` includes key *source metadata* — the env var
+name and file path an operator configured — and never the resolved key value. Keys resolve
+lazily at call time and are never cached in the `Config` struct, so the render function has
+no field holding a secret.
+
+The render destructures `Backend`, `ModelSlot`, `Defaults`, `ToolGating`, and
+`SandboxConfig` exhaustively, so a new field is a compile error at the render site. That
+makes rendering a field an explicit decision, subject to secret review, rather than a
+silent omission.
+
+`api_key_env` and `api_key_file` are included on purpose: an operator debugging a
+missing-key error needs to see which source the backend points at.
+
+## CLI mirrors
+
+Every "help me set up models" surface has a CLI equivalent, for a caller with no MCP
+client:
+
+| MCP | CLI |
+|---|---|
+| `kaibo://config` | `kaibo config` |
+| `kaibo://config/example` | `kaibo example-config` |
+| `configure` prompt | `kaibo configure [goal]` |

--- a/docs/config.md
+++ b/docs/config.md
@@ -105,10 +105,16 @@ A backend resolves its key from `api_key_env`, then `api_key_file`. Env wins.
 **Secrets never appear inline in the TOML** — only the *name* of an env var or the
 *path* to a key file. A config file should be safe to commit or paste.
 
-`key_optional = true` substitutes a placeholder bearer token when no key is found,
-which is the keyless local-server case. A key file that is *present but broken* (empty,
-unreadable) is a load error even on a keyless backend: present-but-wrong is a mistake,
-not "keyless".
+`key_optional = true` substitutes a placeholder when no key is found, which is the
+keyless local-server case. The placeholder fits the auth style: an empty query key for
+Gemini, a non-empty bearer for header-auth backends (`src/credentials.rs`).
+
+A key file that is *present but broken* (empty, unreadable, a directory) is a loud error
+even on a keyless backend, because present-but-wrong is a mistake rather than "keyless".
+Only a genuinely absent file falls back.
+
+**Timing.** Keys resolve lazily, when the backend is first used to build a client, not at
+config load. A missing or broken key on a backend no call touches never surfaces.
 
 #### `kind = "openrouter"` specifics
 
@@ -276,10 +282,13 @@ whenever thinking is on**, which is every Anthropic slot by default — the Mess
 | gemini | `thinkingLevel` (values align: `minimal`/`low`/`medium`/`high`) |
 | openrouter | `{"reasoning":{"effort":…}}`, forwarded verbatim |
 
-The value is a passthrough string the provider validates, like a model id, so a new
-level lands without a code change. Set a synth slot's `effort = "max"` or `"xhigh"` for
-heavier runs; OpenRouter is where those deeper rungs are reachable today. Ignored by
-models with no effort sink (budget-tier Anthropic, OpenAI).
+Hosted OpenAI Platform reasoning models (`gpt-5*`) also take it, as `reasoning.effort` on
+the Responses shape. Generic and local OpenAI-compatible endpoints on Chat Completions do
+not, and neither does budget-tier Anthropic, which uses `thinking_budget` instead.
+
+The value is a passthrough string the provider validates, like a model id, so a new level
+lands without a code change. Set a synth slot's `effort = "max"` or `"xhigh"` for heavier
+runs; OpenRouter is where those deeper rungs are reachable today.
 
 **`thinking_style`.** Forces the Anthropic thinking shape instead of the built-in
 classifier. `auto` picks adaptive for Opus 4.6+, Sonnet 4.6, and Fable 5, and
@@ -386,9 +395,13 @@ resolves. Naming a new backend or cast after one is a collision error.
 
 Rules:
 
-- The interactive tools refuse a cast whose synth is on an offline lane, and
-  `batch_submit` refuses a cast whose synth is not specifically `lane = "batch"`. A big
-  offline-tuned model is never run interactively by accident, and the reverse.
+- The interactive *answering* tools — `consult`, `consult_submit`, `oneshot` — refuse a
+  cast whose synth is on an offline lane, and `batch_submit` refuses a cast whose synth
+  is not specifically `lane = "batch"`. A big offline-tuned model is never run
+  interactively by accident, and the reverse.
+- `explore` is exempt: it runs only the explorer arm, which is always interactive, so a
+  deliberate or direct cast's explorer is valid there. It needs an `explorer` slot and
+  nothing more.
 - A `batch`-lane synth must sit on a batch-capable backend: Anthropic, Gemini, or a
   hosted OpenAI Platform backend. A local OpenAI-compatible server has no Batch API, so
   declaring `lane = "batch"` on a slot elsewhere is a load error.
@@ -399,9 +412,10 @@ Rules:
 - `batch = true` at the cast level is backward-compatible sugar. It sets the synth
   slot's `lane = "batch"` and nothing else; there is one internal representation of lane.
 
-`lane = "direct"` runs one long completion against a big local model with no async
-provider API involved, for offline deliberation over a model too slow for a live tool
-loop.
+`lane = "direct"` runs one long completion kaibo drives itself, with no async provider API
+involved, for offline deliberation over a model too slow for a live tool loop. A big local
+model is the intended case, but this is not enforced: unlike `batch`, the `direct` lane
+applies no backend capability check, so any backend that resolves may carry one.
 
 ### Cross-backend casts
 
@@ -500,6 +514,7 @@ Everything else follows one naming rule:
 | explorer system prompt | `prompts.explorer` *(file-only — full replace)* | — | — |
 | consult system prompt | `prompts.consult` *(file-only — full replace)* | — | — |
 | oneshot system prompt | `prompts.oneshot` *(file-only — full replace)* | — | — |
+| batch system prompt | `prompts.batch` *(file-only — full replace)* | — | — |
 
 **Two exceptions to the naming rule:**
 
@@ -535,6 +550,10 @@ stale `provider` is now an invalid-params error like every other tombstone above
 A tool clears **two** gates to be advertised: the `[server.tools]` flag (equivalently
 `--no-<tool>` or `KAIBO_NO_<TOOL>`), and a configured cast that can **staff** it.
 
+The seven flags are *capability* switches, not one per MCP tool. `consult` gates both
+`consult` and `consult_submit`; `batch` gates `batch_submit`; the `job_*` verbs have no
+flag of their own and follow whichever handle producers are live.
+
 A tool nothing can staff has its route removed rather than shipping unusable. The calling
 agent never sees a tool whose every call would fail, and an unusable tool stops costing
 resident tokens in every session.
@@ -548,7 +567,7 @@ Which cast shape staffs which tool:
 | `batch_submit` | a cast whose synth runs on `lane = "batch"` (or the `batch = true` sugar) |
 | `deliberate` | a cast with an `explorer` **and** an offline synth (`lane = "batch"` or `lane = "direct"`) |
 | `job_get`, `job_cancel`, `job_list`, `job_wait` | at least one live handle *producer*; they follow whatever survives above |
-| `run_kaish`, `list_models` | no cast at all; always advertised |
+| `run_kaish`, `list_models` | no cast at all; advertised whenever their flag is on |
 
 **Default installs.** This affects one tool. No built-in cast pairs an explorer with an
 offline synth — the two built-in offline casts, `anthropic-batch` and `gemini-batch`, are
@@ -667,12 +686,13 @@ CLI/env: `--no-persistence` / `KAIBO_NO_PERSISTENCE` disable it (in-memory, like
 
 | persists | never persists |
 |---|---|
-| the `(question, answer)` turns of each session (capacity-evicted, no TTL, same as the in-memory store) | background consult/deliberate job handles (`job-N`), which are in-memory and session-only by design |
+| the `(question, answer)` turns of each session, caller question included (capacity-evicted, no TTL, same as the in-memory store) | background consult/deliberate job handles (`job-N`), which are in-memory and session-only by design |
 | the `{backend, provider-id, label}` of each submitted batch, so `job_list` can re-surface a handle after a restart | exploration reports, which would be stale bloat |
 
-Everything stored is model output. Nothing the calling model steers reaches disk. Because
-that output is what you paid for, kaibo treats the db as your data and never removes the
-file under any error; moving it aside is your decision.
+Stored content is the caller's questions, the models' answers, and batch-handle metadata.
+Nothing the *inner model team* steers reaches disk: the store is handler-side, and kaish
+has no write path to it. Because those answers are what you paid for, kaibo treats the db
+as your data and never removes the file under any error; moving it aside is your decision.
 
 **Read-only toward your project is unchanged.** The store is handler-side at the XDG
 path. kaish's read-only sandbox never sees it, kaibo writes nothing into any project, and
@@ -734,14 +754,17 @@ Two lists with different failure semantics:
 | list | paths | missing file |
 |---|---|---|
 | `project_files` | root-relative | normal; read if present |
-| `user_files` | absolute or `~` | startup-visible error |
+| `user_files` | absolute or `~` | error when a call assembles its prompt |
+
+Both are read when a consultation phase builds its preamble, not at config load, so a
+broken `user_files` entry surfaces on the first call that needs it rather than at startup.
 
 `project_files` are joined to the resolved project root and canonicalize-checked to stay
 within it. A configured `../` or an out-of-tree symlink is refused, so the containment
 that bounds the read-only shell also bounds what gets injected. A repo with no `AGENTS.md`
 is the normal case.
 
-`user_files` are read-required: you named the file on purpose, so a missing one is an
+`user_files` are read-required: you named the file on purpose, so a missing one is a loud
 error rather than a silent skip that ships an answer without the guidance you counted on.
 
 **Trust boundary.** `user_files` may sit outside the allowed set because these files are
@@ -753,9 +776,10 @@ not widened.
 This is the distinction from `[server] allow_paths` below. `allow_paths` widens what the
 *model* can explore; `[context]` injects fixed operator text the model never navigates to.
 
-**Where it lands.** The codebase-reading phases — the `consult` driver and its nested
-`explore′` sweep — so the cheap explorer orients on the same guidance while it searches,
-not only at answer time.
+**Where it lands.** Every codebase-reading phase: the `consult` driver and its nested
+`explore′` sweep, standalone `explore`, and `deliberate`'s dossier explorer. The cheap
+explorer therefore orients on the same guidance while it searches, not only at answer
+time. The toolless `oneshot` and the offline batch synth read no project and get none.
 
 **Precedence** is the usual per-call > CLI > env > file > built-in. A CLI
 `--project-context-file` replaces lower layers additively. The CLI cannot express "empty";
@@ -833,11 +857,15 @@ so no ambiguity arises.
 A per-call model override (a bare slot) carries no `preamble`. Overriding the model does
 not drag the configured slot's framing along. The empty-value load error applies here too.
 
-**`batch_submit` does not inherit the slot `preamble`.** It runs the synth model, but its
-lane has a distinct behavioral contract — one offline response, no follow-up, spend on
-depth — that a slot preamble written for interactive synth would silently replace. Tune
-batch through `[prompts].batch`, or accept the built-in `batch_preamble`. The slot
-preamble stays scoped to the interactive phases.
+**The offline synth phases inherit it too.** A synth slot's `preamble` feeds `batch` and
+`deliberate` alongside `consult` and `oneshot` (`Cast::resolved_prompts` in
+`src/config.rs`). This is load-bearing rather than incidental: on a batch or deliberate
+cast, the synth slot *is* the offline synth, so its voice has to reach the offline phase
+or the slot preamble would do nothing on exactly the casts built for that lane.
+
+Each phase still resolves under its own key, so `[prompts].batch` overrides the built-in
+`batch_preamble` for the batch phase alone. To give the offline lane a different voice
+from the interactive one on the same cast, set the phase key rather than the slot.
 
 ## Repo orientation: `[orientation]`
 
@@ -871,14 +899,16 @@ config such as `.github/` and `.cargo/`; the ignore filter still drops `.git` an
 
 In the directory map, files deeper than `tree_max_depth` stay counted at the deepest shown
 directory. Names are traded for structure, and the model recovers them with `glob
-'DIR/**/*'` or `grep -rn`. A skipped map is logged at `warn`, not silent.
+'DIR/**/*'` or `grep -rn`. An oversized directory map that gets skipped is logged at
+`warn`; an enumeration failure or an empty result degrades to no map without one.
 
 `full_list_max_files = 0` is a load error, since it would refuse every repo; disable the
 block instead. `tree_max_depth = 0` is a load error, since it would render an empty map.
 
-**Scope.** The exploring phases only: the `consult` driver and its nested `explore′`
-sweep. The toolless `oneshot` reads no project and gets no map. Like `[context]`, the
-block re-sends each turn, which the size gate keeps bounded. Whether it erases discovery
+**Scope.** The exploring phases: the `consult` driver and its nested `explore′` sweep,
+standalone `explore`, and `deliberate`'s dossier explorer. The toolless `oneshot` reads no
+project and gets no map. Like `[context]`, the block re-sends each turn, which the size
+gate keeps bounded. Whether it erases discovery
 turns in practice is measurable through the per-tool `tool` spans (see Telemetry).
 
 ## Path containment
@@ -1027,10 +1057,10 @@ runtime state. Read it before making calls to see the full picture.
 | section | contents |
 |---|---|
 | `allowed_paths` | the canonicalized trees a per-call path must be at or under |
-| `default_root` | the `--root` value, if set |
+| `default_root` | the effective default root, explicit or inferred; `default_root_inferred` distinguishes them |
 | `default_cast` | the cast used when a call omits `cast` |
 | `runtime` | state computed at read time (see below) |
-| `tools` | which tools are currently advertised |
+| `tools` | the **configured** flags — what the operator enabled, not what is served; see `runtime.advertised_tools` for the live surface |
 | `sandbox` | exec timeout, output cap, scratch (`/` MemoryFs) cap, any extra disabled builtins |
 | `kaish.ignore` | the resolved ignore policy the file-walking builtins honor: `files`, `defaults`, `auto_gitignore`, `global_gitignore`, `scope` |
 | `defaults` | the global tunables every slot falls back to, rendered so per-slot values read as deltas |

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -334,6 +334,32 @@ DeepSeek CLI-subcommands review (2026-07-17).
 
 ## P3 — Infra, perf, polish
 
+### Stale code comments + test assertions that predate the 5th backend / the direct lane
+Surfaced by a kaibo `or-gpt` (gpt-5.6-luna) review of PR #110, verified against the code.
+Three spots still describe a world with four built-ins and no tool routing to `direct`.
+None affects behavior; all three are places a reader (or a future us) would be misled, and
+the test one could let a real regression pass:
+
+- **`tests/config.rs`** (~:35) — "Four built-in backends + four single-backend casts", and
+  the loop below it iterates only Anthropic/DeepSeek/Gemini/Openai. `openrouter` is a real
+  built-in (`config.rs::builtin_registry`), so removing it would keep this test green.
+  Same undercount in a `src/server/config_resource.rs` test (~:831).
+- **`src/config.rs`** (~:225) — a doc-comment still says the `direct` lane has no tool
+  route. `deliberate` routes to it now (`config.rs::cast_can_deliberate`,
+  `server/mod.rs::CAST_ENUM_RULES`).
+
+Fix is mechanical; kept out of PR #110 because that one is a docs PR and this touches
+tests. Do it with the next change that lands in `tests/config.rs`.
+
+### Shipped config template omits four knobs its own resource description promises
+`kaibo://config/example`'s description said "every option with its default"; the template
+was missing `[persistence]`, `[orientation]`, `job_capacity`, and `inline_attach_budget`.
+Added in PR #110, so the claim is true again — **the open work is the guard**: nothing
+tests that the template covers the config surface, so the next new knob can silently
+reintroduce the gap. A test walking `RawConfig`'s field names against
+`CONFIG_EXAMPLE_TOML` would close it, in the spirit of the `no_write_path.rs` pinned-count
+guard. (The example's *parse* test exists already; coverage is the missing half.)
+
 ### Release pipeline — harden native matrix + GitHub-native signing (plan in `docs/releases.md`)
 The full plan and its decisions live in **`docs/releases.md`** (living doc); this is the
 tracker pointer. Direction settled 2026-06-25 (w/ Amy): **stay OSS / GitHub-native** —

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -22,18 +22,6 @@ the model-facing surface pass + the full consultation ladder (arc closeout, #37�
 
 ## P1 — High-leverage features & robustness
 
-### `deliberate` cannot be staffed by any built-in cast — advertised but DOA
-`cast_can_deliberate` (`config.rs:846`) needs an **offline synth lane plus an explorer
-slot**. Of the built-in casts, only `anthropic-batch` and `gemini-batch` carry an offline
-lane, and both are **synth-only** — so every `deliberate` call on a stock install fails
-`cast "…" has no explorer slot`. The tool's own description points at `fable` /
-`gemini-deliberate` / `local-direct`, which live in `docs/config.example.toml` and are
-**not** built in, so the guidance names casts the user does not have. Either ship a
-deliberate-capable built-in (a Flash-Lite explorer beside the Pro batch synth is one line)
-or have the refusal say "no built-in cast can staff this; copy `gemini-deliberate` from
-`docs/config.example.toml`". Surfaced 2026-07-25 trying to run a `deliberate` design pass
-on the media CAS; worked around locally by adding the cast to the XDG config.
-
 ### Media spine — perception in, production REOPENED (2026-07-25)
 
 **Superseded in part.** The 2026-06-28 direction below removed `generate_image` and made
@@ -53,13 +41,36 @@ must land *together* with the first tool, because each is unsafe or dishonest al
   mounted will accept the prompt, **spend the user's provider credits**, verify and write
   the artifact, then destroy it on exit. Silently evaporating paid artifacts is exactly what
   a store that refuses to ever delete exists to prevent. Ranked the top remaining risk by
-  the Gemini design pass. Detect overlay/tmpfs backing and warn severely, or require an
-  explicit acknowledgement — never proceed quietly.
+  the Gemini design pass. **Decided (Amy, 2026-07-30): detect overlay/tmpfs backing and warn
+  severely, then proceed** — not a refusal gated on an acknowledgement flag. The container
+  path stays frictionless for someone who genuinely doesn't want persistence; what must not
+  happen is proceeding *quietly*.
 - **`AGENTS.md`'s opening paragraph** still says kaibo "produces no output artifacts." That
   is *true today* (nothing reachable produces anything) and becomes false the moment a tool
   lands. Rewrite it in that same change.
-- **The tool must be gated and auto-disabled** — see the next entry, which this shares a
-  mechanism with.
+- **Gating is done** — the staffing gate shipped 2026-07-30 (a tool no configured cast can
+  staff is not advertised, with the reason in the startup log and `kaibo://config`'s
+  `[runtime].unstaffable_tools`). An image tool inherits it by adding a `CAST_ENUM_RULES`
+  entry with an `cast_can_generate_image` predicate, so a user who configures no image cast
+  pays zero resident tokens for it. Nothing further to build here — just wire the rule.
+
+**Decided with Amy, 2026-07-30 — the shape of the first image tool:**
+- **The image model is a cast SLOT, not a separate config concept.** Revive
+  `ModelRole::Image` (undoing that part of `986806f`) so a cast reads
+  `[casts.artist] explorer = … / synth = … / image = "stability/core"`. Considered and
+  rejected: a standalone `[image]`/backend-only concept divorced from casts, on the argument
+  that a cast is a *reasoning* team. Amy's call went the other way, and it buys a real
+  simplification — the staffing gate, the `cast` enum, and the per-call `cast` argument all
+  keep working unchanged, with `cast_can_generate_image` sitting beside
+  `cast_can_deliberate` in exactly the same shape.
+- **The tool returns the digest and the path — not the bytes.** No inline image content
+  block: a multi-megabyte artifact should not land in the calling agent's context unless it
+  asks, and the caller may not even share kaibo's filesystem. A by-digest read verb can come
+  later if wanted (and see the egress-gateway note below, which already argues a by-digest
+  fetch leaks nothing).
+- Still open, not yet decided: whether `ProviderKind::Stability` is the right home for the
+  image backend (it is not a rig `CompletionModel`, so it does not slot into the existing
+  arm machinery), and the `[cas]` config surface (dir override, `max_bytes` cap).
 
 **Decided, so it isn't re-litigated:** audio and 3D are *not* refused on principle. The
 account-fleet argument that justifies image generation extends to them; the real constraint
@@ -108,30 +119,6 @@ file" — is the general escape hatch the invariant exists to refuse.
 
 **What must not weaken:** kaibo never touches the *project* — that is the user promise and
 egress-to-CAS does not touch it. And the model team still must not enumerate.
-
-### Never advertise a tool no configured cast can staff
-A single rule that fixes an existing bug and pre-empts a coming one. Tools are gated at
-startup by dropping routes from the `ToolRouter` (`server/mod.rs`, the `remove_route` loop),
-and `CAST_ENUM_RULES` already computes per-tool cast eligibility from live config
-(`cast_can_explore`, `cast_can_deliberate`, …). But eligibility currently only shapes the
-`cast` *enum* — it never removes the tool. `inject_cast_enum` even documents the near-miss:
-when no cast qualifies it *skips* injecting the enum, because an empty enum reads as "no
-valid value." So the tool ships advertised with no usable cast, which is precisely the
-`deliberate` DOA bug above.
-
-Fix: when a tool's eligible-cast list is empty, **remove the route** instead of skipping its
-enum. That repairs `deliberate` on stock installs, and gives image tools zero resident cost
-for the many users who configure no image cast — answering the resident-cost objection from
-the direction review with a mechanism rather than a caveat. It generalizes to `explore` and
-`batch_submit`, which have the same latent shape.
-
-Pair it with a **startup log line naming what was dropped and why** ("deliberate disabled:
-no configured cast pairs an explorer with an offline synth — see
-`docs/config.example.toml`"). Vanishing is right for the model's tool list and wrong for
-operator discoverability; the log plus `kaibo://config`'s roster keeps the operator informed
-without spending resident characters on the model. Amy agreed 2026-07-25; deliberately kept
-out of the media-CAS PR since it changes `deliberate`'s live behavior and deserves its own
-review.
 
 Direction settled 2026-06-28 (w/ Amy): `generate_image` removed and read-only becomes
 *unconditional* — no out-dir, no handler-side write, no write path of any kind. Image

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,23 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
     let session_capacity = config.defaults.session_capacity;
     let handler = KaiboHandler::new(config)?.with_notifications(notifications);
 
+    // The other road to a zero-tool server. `all_disabled()` above catches the operator
+    // switching everything off, but it runs before the handler exists and reads only the
+    // `--no-<tool>` flags — so it cannot see the second way the surface empties out: every
+    // cast-taking tool left ON but unstaffable, with `run_kaish` and `list_models` (the two
+    // tools no cast can affect) disabled. That server starts, advertises nothing, and is
+    // exactly as useless as the state we already refuse, so refuse it the same way and for
+    // the same reason: crashing beats running silently useless. The per-tool warnings above
+    // have already named what each tool wanted; this says the surface came out empty.
+    anyhow::ensure!(
+        !handler.advertised_tools().is_empty(),
+        "no tools left to advertise — every tool is either disabled by a --no-<tool> flag \
+         or has no configured cast that can staff it (the warnings above name what each one \
+         needs). Fix by configuring a cast with a working provider key, or by re-enabling a \
+         tool that needs no cast at all (`run_kaish`, `list_models`). `kaibo config` shows \
+         the resolved casts and the per-tool verdict."
+    );
+
     // Stand up the durable session/batch store when persistence is enabled. Opening it is
     // fallible (a bad path, a locked db, a network mount). A failure is a LOUD startup error
     // naming the escape hatch — never a silent fallback to memory (crash over silent

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -33,6 +33,28 @@ pub(crate) fn render_config_resource(
     use serde::Serialize;
     use std::collections::BTreeMap;
 
+    // Which cast-taking tools nothing can staff right now, and the cast shape each one
+    // wants. Computed through the same `eligible_casts_by_tool` the router gated on, so
+    // the explanation can't drift from the decision. A tool the OPERATOR turned off is
+    // deliberately absent here — `[tools]` already reports that, and conflating "you
+    // disabled it" with "nothing can run it" is exactly the confusion this section exists
+    // to remove.
+    let usable: Vec<String> = config
+        .usable_casts(|k| std::env::var(k).ok())
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    let unstaffable: BTreeMap<String, String> = super::eligible_casts_by_tool(config, &usable)
+        .into_iter()
+        .filter(|(tool, casts)| casts.is_empty() && config.tools.enabled(tool))
+        .map(|(tool, _)| {
+            let requirement = super::cast_requirement_for(tool)
+                .expect("a tool in the eligibility map has a rule")
+                .to_string();
+            (tool.to_string(), requirement)
+        })
+        .collect();
+
     // Dedicated render-only shapes — plain Serialize structs that carry exactly what
     // the resource must expose and nothing more. Keeps the contract explicit.
 
@@ -97,10 +119,22 @@ pub(crate) fn render_config_resource(
     /// `allowed_paths` right now — git worktrees of an already-allowed repo,
     /// resolved by reading git's link files. Recomputed on each read, so a worktree
     /// added mid-session shows up here without a reconnect.
+    ///
+    /// `advertised_tools` and `unstaffable_tools` are the observed answer to "why can't I
+    /// see that tool?" — the question the staffing gate would otherwise leave an operator
+    /// guessing at, since a tool no configured cast can staff is removed from the router
+    /// outright rather than shipped with an empty `cast` enum. `[tools]` above says what
+    /// the operator *asked for* (the `--no-<tool>` flags); these say what the server
+    /// actually ended up advertising and, for each tool held back by its cast roster
+    /// rather than by a flag, the cast shape that would bring it back. Keeping the two
+    /// apart is the same `[runtime]` rule the worktree fields follow: what kaibo
+    /// *discovered*, never what the operator *chose*.
     #[derive(Serialize)]
     struct RuntimeDoc {
         follow_worktrees: bool,
         followed_worktrees: Vec<String>,
+        advertised_tools: Vec<String>,
+        unstaffable_tools: BTreeMap<String, String>,
     }
 
     #[derive(Serialize)]
@@ -442,6 +476,11 @@ pub(crate) fn render_config_resource(
                 .iter()
                 .map(|p| p.display().to_string())
                 .collect(),
+            advertised_tools: super::live_tools(config, &usable)
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            unstaffable_tools: unstaffable,
         },
         tools: ToolsDoc {
             consult,
@@ -550,6 +589,70 @@ mod tests {
         assert!(
             body.contains("/tmp/the-repo-feature"),
             "runtime section must list the followed worktree:\n{body}"
+        );
+    }
+
+    /// The body of TOML section `header` — up to the next `[` at column 0. A
+    /// `BTreeMap` field renders as its own nested table (`[runtime.unstaffable_tools]`)
+    /// rather than inline, so a test that wants one has to ask for it by name.
+    fn section<'a>(body: &'a str, header: &str) -> &'a str {
+        body.split(&format!("\n{header}\n"))
+            .nth(1)
+            .unwrap_or_else(|| panic!("no `{header}` section in:\n{body}"))
+            .split("\n[")
+            .next()
+            .expect("the section's own body")
+    }
+
+    /// `[runtime]` answers "why can't I see that tool?" for the case an operator cannot
+    /// otherwise diagnose: the tool is gone because nothing can staff it, not because
+    /// they turned it off. On the built-in config that's `deliberate` — no built-in cast
+    /// pairs an explorer with an offline synth — so it must be absent from
+    /// `advertised_tools` AND named in `[runtime.unstaffable_tools]` with the cast shape
+    /// that would fix it. Without both halves the tool just vanishes, which is the
+    /// confusing failure this reporting exists to prevent.
+    #[test]
+    fn config_resource_runtime_explains_a_tool_no_cast_can_staff() {
+        let body = render_config_resource(&Config::builtin(), &[], None, false, vec![], false);
+        let runtime = section(&body, "[runtime]");
+        assert!(
+            !runtime.contains("\"deliberate\""),
+            "deliberate can't be staffed by any built-in cast, so it must not appear in \
+             advertised_tools:\n{runtime}"
+        );
+        // A targeted drop, not a shutdown — the staffable surface is still advertised.
+        assert!(
+            runtime.contains("\"consult\"") && runtime.contains("\"run_kaish\""),
+            "advertised_tools must list the surviving surface:\n{runtime}"
+        );
+
+        let unstaffable = section(&body, "[runtime.unstaffable_tools]");
+        assert!(
+            unstaffable.contains("deliberate = "),
+            "unstaffable_tools must name deliberate:\n{unstaffable}"
+        );
+        assert!(
+            unstaffable.to_lowercase().contains("offline synth"),
+            "the entry must say what shape of cast would bring the tool back, not just \
+             that it is missing:\n{unstaffable}"
+        );
+    }
+
+    /// The other half: a tool the OPERATOR disabled is not reported as unstaffable.
+    /// Conflating "you switched it off" with "nothing can run it" would send an operator
+    /// hunting for a cast to fix a flag they set themselves.
+    #[test]
+    fn config_resource_does_not_blame_casts_for_an_operator_disabled_tool() {
+        let mut config = Config::builtin();
+        config.tools.deliberate = false;
+        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        assert!(
+            !section(&body, "[runtime.unstaffable_tools]").contains("deliberate"),
+            "a flag-disabled tool belongs to [tools], not unstaffable_tools:\n{body}"
+        );
+        assert!(
+            section(&body, "[tools]").contains("deliberate = false"),
+            "[tools] must still report the operator's own choice:\n{body}"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -89,6 +89,14 @@ const CONFIG_URI: &str = "kaibo://config";
 /// user copies to `~/.config/kaibo/config.toml`. Most useful on a fresh install,
 /// where the setup guidance points at it.
 const CONFIG_EXAMPLE_URI: &str = "kaibo://config/example";
+/// The full configuration reference manual (`docs/config.md`). The third config
+/// resource: `kaibo://config` is the resolved state, `kaibo://config/example` the
+/// copyable template, and this the explanatory prose behind both — precedence,
+/// backend/cast design, tool gating, containment, persistence. It exists so the
+/// template can stay a *template*: an agent configuring kaibo over MCP has no access to
+/// this repo's `docs/`, so without it every explanation had to be smuggled into the
+/// example's comments, where it costs bytes on every read and drifts from the code.
+const CONFIG_GUIDE_URI: &str = "kaibo://config/guide";
 /// Long-form "how to wield the tools well" guidance — attachments, cast/model
 /// selection, the sync↔async pairs and their handles, and the read-only shell's
 /// idioms. The tool schemas stay terse and point here, so the repetition and positive
@@ -114,6 +122,11 @@ const PROMPTS_CAST_URI_TEMPLATE: &str = "kaibo://prompts/{cast}";
 /// `pub(crate)` so `kaibo example-config` (`cli.rs`) can print the exact same string
 /// the `kaibo://config/example` resource serves — one source, no drift.
 pub(crate) const CONFIG_EXAMPLE_TOML: &str = include_str!("../../docs/config.example.toml");
+
+/// `docs/config.md`, embedded for the same reason as the template above: `cargo install
+/// kaibo` lays down no docs, so a runtime file read would 404 exactly when someone is
+/// trying to configure the thing.
+const CONFIG_GUIDE_MD: &str = include_str!("../../docs/config.md");
 
 /// Slack added above a `deliberate`-direct job's synth `request_timeout` when sizing
 /// its wall-clock backstop: the per-request reqwest deadline should fire first (a
@@ -2669,6 +2682,15 @@ fn kaibo_resources() -> Vec<rmcp::model::Resource> {
                  ~/.config/kaibo/config.toml and edit. Pairs with kaibo://config, which \
                  shows the *resolved* runtime state.",
             ),
+        // The reference manual behind the other two: what each knob means and why.
+        markdown_resource(
+            CONFIG_GUIDE_URI,
+            "kaibo: configuration guide",
+            "The full configuration reference: precedence across call/CLI/env/file, the \
+             backend + cast model, tool gating (why a tool may not be advertised), path \
+             containment, persistence, telemetry, house rules, and prompt overrides. Read \
+             this when kaibo://config/example's comments leave a question open.",
+        ),
         markdown_resource(
             SANDBOX_URI,
             "kaibo read-only sandbox",
@@ -2714,10 +2736,11 @@ models it uses.
 
 Work through these steps:
 
-1. Read kaibo's two config resources first (they're MCP resources — no tool turn spent):
+1. Read kaibo's config resources first (they're MCP resources — no tool turn spent):
    • `kaibo://config/example` — the annotated config.toml template, every knob explained.
    • `kaibo://config` — the resolved live state: the casts and backends that exist now, \
 and where each key is sourced from.
+   • `kaibo://config/guide` — the full reference manual, if a question stays open.
 ";
 
 /// Steps 2-6, channel-neutral (which provider, what roster shape, keeping secrets out
@@ -3102,6 +3125,10 @@ with the `[prompts]` table, or per cast with a slot's `preamble` (the two axes a
 fn render_resource(uri: &str, schemas: &[ToolSchema]) -> Option<String> {
     if uri == SANDBOX_URI {
         return Some(kaibo_sandbox_doc());
+    }
+    if uri == CONFIG_GUIDE_URI {
+        // Static and config-independent — the embedded manual verbatim.
+        return Some(CONFIG_GUIDE_MD.to_string());
     }
     if uri == TOOLS_URI {
         return Some(TOOLS_DOC.to_string());
@@ -5513,6 +5540,51 @@ mod tests {
         );
         crate::config::Config::from_toml_str(&body)
             .expect("the embedded config example must parse as a valid Config");
+    }
+
+    // --- kaibo://config/guide resource tests ----------------------------------
+
+    /// The embedded configuration manual is listed and readable. It carries the detail
+    /// the template deliberately no longer inlines, so an agent configuring kaibo over
+    /// MCP (no access to this repo's `docs/`) can still reach it.
+    #[test]
+    fn config_guide_resource_is_listed_and_readable() {
+        let uris: Vec<String> = kaibo_resources().into_iter().map(|r| r.uri).collect();
+        assert!(
+            uris.iter().any(|u| u == CONFIG_GUIDE_URI),
+            "kaibo_resources() must list kaibo://config/guide, got {uris:?}"
+        );
+
+        let body = render_resource(CONFIG_GUIDE_URI, &[]).expect("guide must render");
+        assert!(
+            body.starts_with("# kaibo configuration"),
+            "guide must be docs/config.md verbatim:\n{}",
+            &body[..body.len().min(200)]
+        );
+    }
+
+    /// The pointer the trimmed template makes — "full table: kaibo://config/guide,
+    /// 'Tool gating'" — must actually land somewhere. This is the drift guard for
+    /// moving that content out of the example: delete or rename the section and the
+    /// template becomes a dead reference, so fail here instead.
+    #[test]
+    fn config_guide_carries_the_tool_gating_section_the_template_points_at() {
+        let guide = render_resource(CONFIG_GUIDE_URI, &[]).expect("guide must render");
+        assert!(
+            guide.contains("## Tool gating"),
+            "docs/config.md must keep the section config.example.toml points at"
+        );
+        assert!(
+            CONFIG_EXAMPLE_TOML.contains(CONFIG_GUIDE_URI),
+            "the template must point at the guide it defers its detail to"
+        );
+        // Each cast-gated tool is named where an operator would look up why it vanished.
+        for tool in ["consult", "explore", "batch_submit", "deliberate"] {
+            assert!(
+                guide.contains(tool),
+                "the gating section must account for `{tool}`"
+            );
+        }
     }
 
     // --- kaibo://config resource tests ---------------------------------------

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -174,6 +174,26 @@ impl Default for ToolGating {
 }
 
 impl ToolGating {
+    /// Whether the operator left tool `name` enabled — the raw `--no-<tool>` answer,
+    /// *before* the staffing gate in [`KaiboHandler::new`] has its say. Used to tell the
+    /// two reasons a tool can vanish apart: a flag-off tool is the operator's own choice
+    /// and needs no explanation, while a flag-ON tool no cast can staff earns a startup
+    /// warning. `consult_submit` shares `consult`'s flag (one capability, two shapes).
+    /// A name with no flag of its own reads as enabled — the castless tools
+    /// (`run_kaish`, `list_models`) are gated directly, never through this.
+    pub fn enabled(&self, name: &str) -> bool {
+        match name {
+            "consult" | "consult_submit" => self.consult,
+            "explore" => self.explore,
+            "deliberate" => self.deliberate,
+            "oneshot" => self.oneshot,
+            "run_kaish" => self.run_kaish,
+            "batch_submit" => self.batch,
+            "list_models" => self.list_models,
+            _ => true,
+        }
+    }
+
     /// True iff every tool is disabled — the zero-tool server we refuse to start.
     pub fn all_disabled(&self) -> bool {
         !self.consult
@@ -566,9 +586,21 @@ pub struct KaiboHandler {
     batch_providers: Arc<dyn crate::batch::BatchProviderFactory>,
 }
 
-/// One `CAST_ENUM_RULES` entry: the tools sharing a cast eligibility, and the predicate
-/// (a `Config::cast_is_*`/`cast_can_*`) that decides which usable casts they advertise.
-type CastEnumRule = (&'static [&'static str], fn(&Config, &str) -> bool);
+/// One `CAST_ENUM_RULES` entry: the tools sharing a cast eligibility, the predicate
+/// (a `Config::cast_is_*`/`cast_can_*`) that decides which usable casts they advertise,
+/// and a plain-language statement of the cast *shape* the predicate wants.
+///
+/// That third field is operator-facing text, not decoration: when a rule matches nothing
+/// the tools are dropped entirely (see [`KaiboHandler::new`]), and vanishing silently is
+/// right for the model's tool list but wrong for the operator — so the startup warning
+/// says what a cast would have to look like to bring the tool back. Keeping it in this
+/// table rather than at the log site is what stops the message from drifting away from
+/// the predicate it describes.
+type CastEnumRule = (
+    &'static [&'static str],
+    fn(&Config, &str) -> bool,
+    &'static str,
+);
 
 /// The single source mapping each cast-taking tool to the predicate that decides which
 /// *usable* casts its `cast` enum advertises — keyed on the cast's shape (synth lane +
@@ -576,6 +608,11 @@ type CastEnumRule = (&'static [&'static str], fn(&Config, &str) -> bool);
 /// injects the enums straight from this table. A cast may match more than one rule (a
 /// deliberate-shaped batch cast like `fable` serves both `batch_submit` and `deliberate`);
 /// the rules are independent filters, not a partition.
+///
+/// This table also decides whether a tool is advertised **at all**: a rule matching no
+/// usable cast means nothing can staff its tools, so [`KaiboHandler::new`] removes their
+/// routes instead of shipping a tool whose every call would fail. See that function for
+/// why removal beats an empty enum.
 ///
 /// Two tests guard it: `cast_enum_never_advertises_a_gated_cast` (no enum offers a cast its
 /// tool's gate — `reject_offline_cast`/`require_batch_cast`/`require_deliberate_cast` —
@@ -588,13 +625,28 @@ const CAST_ENUM_RULES: &[CastEnumRule] = &[
     (
         &["consult", "consult_submit", "oneshot"],
         Config::cast_is_interactive,
+        "a cast whose synth answers interactively (any cast without an offline synth lane)",
     ),
     // `explore` runs only the explorer, so it advertises *any* cast with one — including
     // `deliberate`/`direct` casts, whose (often smarter) explorers are useful standalone.
     // Its own rule, broader than the interactive tools' (which also need an interactive synth).
-    (&["explore"], Config::cast_can_explore),
-    (&["batch_submit"], Config::cast_is_batch),
-    (&["deliberate"], Config::cast_can_deliberate),
+    (
+        &["explore"],
+        Config::cast_can_explore,
+        "a cast with an `explorer` slot",
+    ),
+    (
+        &["batch_submit"],
+        Config::cast_is_batch,
+        "a cast whose synth runs on the batch lane (`lane = \"batch\"`, or the `batch = true` \
+         sugar) — Anthropic, Gemini, or a hosted OpenAI Platform backend",
+    ),
+    (
+        &["deliberate"],
+        Config::cast_can_deliberate,
+        "a cast pairing an `explorer` slot with an OFFLINE synth (`lane = \"batch\"` or \
+         `lane = \"direct\"`) — see the DELIBERATE casts in docs/config.example.toml",
+    ),
 ];
 
 /// Inject `casts` as a JSON-Schema `enum` on the `cast` parameter of every
@@ -609,6 +661,115 @@ const CAST_ENUM_RULES: &[CastEnumRule] = &[
 /// reach a model), because an empty `enum` reads as "no valid value" to a strict
 /// client and would wrongly forbid the field, which is optional. A gated-off tool
 /// is already absent from `router`, so the lookups simply skip it.
+/// Which of `usable` can staff each cast-taking tool, keyed by tool name — the one
+/// computation behind both the staffing gate (an empty list ⇒ the route is dropped) and
+/// the `cast` enum each surviving tool advertises.
+///
+/// A tool absent from the returned map takes no `cast` at all (`run_kaish`,
+/// `list_models`, the collect verbs), so no roster can make it unusable. Shared with
+/// `kaibo://config`'s `[runtime]` section so the resource explains the *same* verdict the
+/// router acted on, rather than a second implementation that could drift from it.
+pub(crate) fn eligible_casts_by_tool(
+    config: &Config,
+    usable: &[String],
+) -> std::collections::HashMap<&'static str, Vec<String>> {
+    CAST_ENUM_RULES
+        .iter()
+        .flat_map(|(tools, is_eligible, _)| {
+            let casts: Vec<String> = usable
+                .iter()
+                .filter(|n| is_eligible(config, n))
+                .cloned()
+                .collect();
+            tools.iter().map(move |&t| (t, casts.clone()))
+        })
+        .collect()
+}
+
+/// The plain-language cast shape tool `name` needs, from its `CAST_ENUM_RULES` entry.
+/// `None` for a tool that takes no cast. The operator-facing half of the staffing gate:
+/// both the startup warning and `kaibo://config` explain a missing tool with this text.
+pub(crate) fn cast_requirement_for(name: &str) -> Option<&'static str> {
+    CAST_ENUM_RULES
+        .iter()
+        .find(|(tools, _, _)| tools.contains(&name))
+        .map(|(_, _, requirement)| *requirement)
+}
+
+/// Every `#[tool]` route name kaibo can advertise — the fixed universe [`live_tools`]
+/// filters. `KaiboHandler::new` asserts each really exists on the router, so a renamed
+/// tool method fails the build rather than leaving a gate quietly inert.
+pub(crate) const ALL_TOOL_NAMES: [&str; 12] = [
+    "consult",
+    "consult_submit",
+    "explore",
+    "deliberate",
+    "oneshot",
+    "run_kaish",
+    "batch_submit",
+    "job_get",
+    "job_cancel",
+    "job_list",
+    "job_wait",
+    "list_models",
+];
+
+/// Which tools this config actually advertises: the operator's `--no-<tool>` flags AND
+/// a cast that can staff each one.
+///
+/// The single source for that decision. `KaiboHandler::new` filters the router through
+/// it, and `kaibo://config` reports it — including from the CLI, which renders the
+/// resource with no router in existence. Deriving the answer twice is how the resource
+/// would come to describe a surface the server doesn't actually serve, so it is derived
+/// once, here.
+///
+/// Two tools don't take a `cast` and so can't be unstaffable: `run_kaish` (the shell, no
+/// model at all) and `list_models` (an operator query). The four collect verbs are a
+/// third shape — castless too, but they exist only to collect handles, so they follow
+/// their *producers*: live while any of `consult_submit`, `batch_submit`, or
+/// `deliberate` is live, dropped once none is.
+pub(crate) fn live_tools(config: &Config, usable: &[String]) -> Vec<&'static str> {
+    let eligible = eligible_casts_by_tool(config, usable);
+    let can_staff = |name: &str| eligible.get(name).is_none_or(|c| !c.is_empty());
+    let gating = &config.tools;
+
+    let consult_live = gating.consult && can_staff("consult");
+    let explore_live = gating.explore && can_staff("explore");
+    let deliberate_live = gating.deliberate && can_staff("deliberate");
+    let oneshot_live = gating.oneshot && can_staff("oneshot");
+    let batch_live = gating.batch && can_staff("batch_submit");
+    let jobs_live = consult_live || batch_live || deliberate_live;
+
+    [
+        (consult_live, "consult"),
+        // `consult_submit` is the async sibling of `consult` — same capability, a
+        // submit/collect surface rather than a blocking one — so it shares the `consult`
+        // flag and the same interactive-cast requirement. (docs/issues.md tracks a
+        // dedicated flag if anyone needs only one shape.)
+        (consult_live, "consult_submit"),
+        // The single-phase explorer sweep — its own gate, and the broadest cast rule
+        // (any cast with an explorer, interactive or not).
+        (explore_live, "explore"),
+        (deliberate_live, "deliberate"),
+        (oneshot_live, "oneshot"),
+        // No cast, no model: the read-only shell is always staffable.
+        (gating.run_kaish, "run_kaish"),
+        (batch_live, "batch_submit"),
+        // The collect verbs follow their producers — see the fn doc. "Live" folds the
+        // flag AND staffing together, so a producer nothing can staff keeps them no more
+        // than a producer the operator switched off does: neither mints a handle.
+        (jobs_live, "job_get"),
+        (jobs_live, "job_cancel"),
+        (jobs_live, "job_list"),
+        (jobs_live, "job_wait"),
+        // Read-only model discovery — an operator/config query, no cast in sight.
+        (gating.list_models, "list_models"),
+    ]
+    .into_iter()
+    .filter_map(|(live, name)| live.then_some(name))
+    .collect()
+}
+
 fn inject_cast_enum(router: &mut ToolRouter<KaiboHandler>, tools: &[&str], casts: &[String]) {
     if casts.is_empty() {
         return;
@@ -645,91 +806,111 @@ impl KaiboHandler {
     /// or non-directory entry in root / allow_paths is a loud construction error —
     /// a path that can't be canonicalized can't bound anything.
     pub fn new(config: Config) -> Result<Self> {
+        Self::new_with_env(config, |k| std::env::var(k).ok())
+    }
+
+    /// [`new`](Self::new) with the credential lookup injected — the seam that makes the
+    /// staffing gate testable.
+    ///
+    /// Which casts are *usable* depends on which keys resolve, and the built-in cast
+    /// registry merges under every config, so a test that built a handler from a fixture
+    /// TOML was really testing "my fixture **plus** whatever keys happen to be in the
+    /// developer's environment." That passes on CI and fails on the maintainer's laptop
+    /// (or the reverse) — the flakiest kind of test, and it hid real behavior here: the
+    /// gate correctly dropped `deliberate` everywhere, but `explore`/`batch_submit`
+    /// looked ungated because ambient keys made a built-in cast usable. Tests pass a
+    /// closure that answers for exactly the keys the fixture means to have; production
+    /// passes the real environment. Deliberately a closure rather than `set_var`, which
+    /// is unsafe and process-global — the same reasoning `stability.rs` and
+    /// `config_resource.rs` already record.
+    pub fn new_with_env(config: Config, get_env: impl Fn(&str) -> Option<String>) -> Result<Self> {
         let gating = config.tools;
         // `#[tool_router]` gathers every #[tool] method at compile time; gating is a
         // runtime choice, so build the full router and drop the disabled routes by
         // name. (The methods stay compiled — no dead code — they're just not
         // advertised or callable.)
         let mut tool_router = Self::tool_router();
-        // `remove_route` silently no-ops on an unknown name, so a renamed #[tool]
-        // method would leave its --no-<tool> flag quietly inert. Assert the route
-        // exists before dropping it — a stale name is a build-time bug we want loud.
-        for (enabled, name) in [
-            (gating.consult, "consult"),
-            // `consult_submit` is the async sibling of `consult` — same capability, a
-            // submit/collect surface rather than a blocking one — so it shares the
-            // `consult` gate. (docs/issues.md tracks a dedicated flag if anyone needs
-            // only one shape.) The verbs that *collect* its handles (`job_get`/
-            // `job_cancel`/`job_list`) are shared with batch and gated below.
-            (gating.consult, "consult_submit"),
-            // The single-phase explorer sweep — its own gate.
-            (gating.explore, "explore"),
-            // `deliberate` starts an offline deliberation; its own gate. The collect
-            // verbs it hands off to (batch or job) live below, gated by their capability.
-            (gating.deliberate, "deliberate"),
-            (gating.oneshot, "oneshot"),
-            (gating.run_kaish, "run_kaish"),
-            // `--no-batch` drops `batch_submit`; the shared collect verbs live below.
-            (gating.batch, "batch_submit"),
-            // `job_get`/`job_cancel`/`job_list`/`job_wait` manage *both* batch and
-            // consult handles — and now `deliberate` handles too (batch on its batch
-            // lane, `job-N` on its direct lane) — so they stay as long as *any* of the
-            // three producers is on, and drop only when all are gated off. Routing by
-            // handle shape inside each verb refuses a handle whose producer is disabled.
-            (
-                gating.batch || gating.consult || gating.deliberate,
-                "job_get",
-            ),
-            (
-                gating.batch || gating.consult || gating.deliberate,
-                "job_cancel",
-            ),
-            (
-                gating.batch || gating.consult || gating.deliberate,
-                "job_list",
-            ),
-            (
-                gating.batch || gating.consult || gating.deliberate,
-                "job_wait",
-            ),
-            // Read-only model discovery — its own gate, independent of every
-            // model-driven tool above.
-            (gating.list_models, "list_models"),
-        ] {
-            if !enabled {
-                assert!(
-                    tool_router.has_route(name),
-                    "gating: no tool route named {name:?} — did a #[tool] method get renamed?"
-                );
-                tool_router.remove_route(name);
+
+        // The live cast roster, resolved once here (the same startup moment the handshake
+        // resolves its list; a reconnect re-reads it). It feeds BOTH the staffing gate
+        // just below and the `cast` enum injection further down.
+        let usable: Vec<String> = config
+            .usable_casts(&get_env)
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+
+        // Per-tool eligible casts, straight from `CAST_ENUM_RULES`.
+        let eligible = eligible_casts_by_tool(&config, &usable);
+        // A tool nothing can staff is not advertised. `inject_cast_enum` documents the
+        // near-miss this closes: faced with an empty roster it *skipped* injecting the
+        // enum (an empty `enum` reads as "no valid value" to a strict client), so the tool
+        // shipped looking usable while every call would fail its own gate — exactly the
+        // `deliberate`-on-a-stock-install bug. Dropping the route is the honest answer:
+        // the model never sees a tool it cannot use, and an unusable tool stops billing
+        // resident tokens against every session. Tools take no `cast` are unaffected.
+
+        // Vanishing is right for the model's tool list and wrong for operator
+        // discoverability — so say so, once per rule, naming the cast shape that would
+        // bring the tool back. Only for tools the operator left ON: a `--no-<tool>` drop
+        // is already the operator's own choice and needs no explanation.
+        for (tools, _, requirement) in CAST_ENUM_RULES {
+            if !eligible.get(tools[0]).is_some_and(Vec::is_empty) {
+                continue;
             }
+            let on: Vec<&str> = tools
+                .iter()
+                .copied()
+                .filter(|t| gating.enabled(t))
+                .collect();
+            if on.is_empty() {
+                continue;
+            }
+            tracing::warn!(
+                tools = on.join(", "),
+                "disabled: no configured cast can staff it — needs {requirement}. \
+                 Configured casts are listed at kaibo://config."
+            );
+        }
+
+        // Which tools actually survive: the operator's flags AND a cast that can staff
+        // each. `live_tools` is the single source — `kaibo://config` reports the same
+        // decision, so the resource can never describe a surface this router doesn't serve.
+        let live = live_tools(&config, &usable);
+        // `remove_route` silently no-ops on an unknown name, so a renamed #[tool] method
+        // would leave its gate quietly inert. Assert the route exists before dropping it —
+        // a stale name is a build-time bug we want loud.
+        for name in ALL_TOOL_NAMES {
+            if live.contains(&name) {
+                continue;
+            }
+            assert!(
+                tool_router.has_route(name),
+                "gating: no tool route named {name:?} — did a #[tool] method get renamed?"
+            );
+            tool_router.remove_route(name);
         }
 
         // Stamp the live cast roster onto the consultation tools' `cast` param as a
         // JSON-Schema `enum`, so an agent choosing a team reads the menu off the tool
         // schema it already fills arguments from — not only the handshake prose, which
-        // a host may truncate (the failure that motivated this). Env is read once here,
-        // the same startup moment the handshake resolves its list; reconnect re-reads.
-        let usable: Vec<String> = config
-            .usable_casts(|k| std::env::var(k).ok())
-            .into_iter()
-            .map(|(name, _)| name)
-            .collect();
-        // Advertise each tool's `cast` enum from the one `CAST_ENUM_RULES` table: a cast's
-        // shape (synth lane + explorer) decides which tools it serves, and each rule is an
-        // independent filter (the batch and deliberate views OVERLAP — a deliberate-shaped
-        // batch cast like `fable` serves both). Routing every enum through this table (and
-        // cross-checking it against the gates in the consistency test) is what keeps the
-        // advertised menu and the call-time gate from drifting apart. The `cast` enum is the
-        // one authoritative per-lane roster — the resident-prose roster this used to also
+        // a host may truncate (the failure that motivated this).
+        //
+        // Same `eligible` map the staffing gate above used — a cast's shape (synth lane +
+        // explorer) decides which tools it serves, and each rule is an independent filter
+        // (the batch and deliberate views OVERLAP — a deliberate-shaped batch cast like
+        // `fable` serves both). Routing every enum through this table (and cross-checking
+        // it against the gates in the consistency test) is what keeps the advertised menu
+        // and the call-time gate from drifting apart. The `cast` enum is the one
+        // authoritative per-lane roster — the resident-prose roster this used to also
         // append (`append_cast_roster`) was dropped as redundant; see `docs/devlog.md`.
-        for (tools, eligible) in CAST_ENUM_RULES {
-            let casts: Vec<String> = usable
-                .iter()
-                .filter(|n| eligible(&config, n))
-                .cloned()
-                .collect();
-            inject_cast_enum(&mut tool_router, tools, &casts);
+        //
+        // Every empty roster here now belongs to a route the gate already removed, so
+        // `inject_cast_enum`'s empty-list skip is a belt-and-braces guard rather than the
+        // load-bearing behavior it used to be.
+        for (tools, _, _) in CAST_ENUM_RULES {
+            let casts = eligible.get(tools[0]).expect("every rule seeded the map");
+            inject_cast_enum(&mut tool_router, tools, casts);
         }
 
         // Pin `consult` resident under Claude Code's tool-schema deferral: a host may
@@ -3475,6 +3656,21 @@ mod tests {
             .expect("handler builds")
     }
 
+    /// `handler_from_toml` with an EMPTY credential environment, so the usable-cast
+    /// roster is exactly what the fixture declares. The built-in cast registry merges
+    /// under every config, so without this a fixture's roster silently includes every
+    /// built-in cast whose key happens to be set in the developer's shell — which is how
+    /// a staffing test can pass on CI and fail on a maintainer's laptop. Fixtures that
+    /// want a usable cast declare a `key_optional = true` backend (no credential needed);
+    /// everything else resolves to `Unconfigured` and drops out.
+    fn hermetic_handler_from_toml(toml: &str) -> KaiboHandler {
+        KaiboHandler::new_with_env(
+            Config::from_toml_str(toml).expect("config parses"),
+            |_| None,
+        )
+        .expect("handler builds")
+    }
+
     /// The joined text of a successful `CallToolResult` — for asserting on a handler's
     /// reply message.
     fn result_text(r: CallToolResult) -> String {
@@ -3745,7 +3941,7 @@ mod tests {
         };
 
         let mut checked = 0;
-        for &(tools, _) in CAST_ENUM_RULES {
+        for &(tools, _, _) in CAST_ENUM_RULES {
             for &tool in tools {
                 let advertised = enum_of(tool);
                 assert!(
@@ -3769,6 +3965,210 @@ mod tests {
         assert!(checked > 0, "the guard checked nothing");
     }
 
+    /// Renders every BUILT-IN cast unusable, so a staffing fixture's roster is exactly
+    /// the casts it declares.
+    ///
+    /// The built-in registry merges under every config, and a built-in cast counts as
+    /// usable the moment its backend resolves a credential — from the environment *or*
+    /// from a key file on disk. So the keyed backends get an `api_key_file` that cannot
+    /// exist (mirroring `config.rs`'s `NO_KEY_FILES`, whose comment records why: Amy
+    /// keeps real key files, so a naive fixture passes on her box and fails in CI). The
+    /// keyless `openai-local` needs the extra `key_optional = false`: without a required
+    /// credential it resolves to a *placeholder* and stays `LocalUnverified`, which counts
+    /// as usable — and that is what kept `explore` looking ungated even under an empty
+    /// environment, since the built-in local casts all carry explorer slots.
+    const NO_BUILTIN_CASTS: &str = r#"
+        [backends.anthropic]
+        api_key_file = "/nonexistent-kaibo-test/anthropic"
+        [backends.deepseek]
+        api_key_file = "/nonexistent-kaibo-test/deepseek"
+        [backends.gemini]
+        api_key_file = "/nonexistent-kaibo-test/gemini"
+        [backends.openrouter]
+        api_key_file = "/nonexistent-kaibo-test/openrouter"
+        [backends.openai-local]
+        key_optional = false
+        api_key_file = "/nonexistent-kaibo-test/openai"
+    "#;
+
+    /// A cast fixture with an interactive team and nothing else — so `explore` has an
+    /// explorer, `consult`/`oneshot` have an interactive synth, and NOTHING can staff
+    /// `batch_submit` or `deliberate` (both need an offline synth lane).
+    /// `NO_BUILTIN_CASTS` followed by `rest`. A plain concatenation rather than
+    /// `format!`, because these fixtures contain TOML inline tables — every `{` and `}`
+    /// in a slot like `synth = { backend = "gem", ... }` would have to be doubled to
+    /// survive a format string, which is a silent trap for the next fixture.
+    fn with_no_builtin_casts(rest: &str) -> String {
+        format!("{NO_BUILTIN_CASTS}\n{rest}")
+    }
+
+    fn only_interactive() -> String {
+        with_no_builtin_casts(
+            r#"
+        [backends.gem]
+        kind = "gemini"
+        key_optional = true
+
+        [casts.inter]
+        explorer = "gem/lite"
+        synth    = "gem/flash"
+
+        [server]
+        cast = "inter"
+    "#,
+        )
+    }
+
+    /// The staffing gate, `deliberate`'s case — the bug this whole mechanism exists to
+    /// fix. `deliberate` needs an offline synth PLUS an explorer; a config carrying only
+    /// interactive casts can't staff one, so the tool must not be advertised at all
+    /// rather than shipping with an empty `cast` enum and failing at call time.
+    #[test]
+    fn deliberate_is_not_advertised_when_no_cast_can_staff_it() {
+        let h = hermetic_handler_from_toml(&only_interactive());
+        assert!(
+            !h.advertised_tools().iter().any(|t| t == "deliberate"),
+            "deliberate must be dropped when no configured cast pairs an explorer with an \
+             offline synth — advertising it costs resident tokens for a tool that can only \
+             fail. Advertised: {:?}",
+            h.advertised_tools()
+        );
+    }
+
+    /// The other half: a cast that CAN staff it keeps the tool. Without this, "drop the
+    /// route" could be satisfied by dropping it unconditionally.
+    #[test]
+    fn deliberate_is_advertised_when_a_cast_can_staff_it() {
+        let h = hermetic_handler_from_toml(&with_no_builtin_casts(
+            r#"
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.inter]
+            explorer = "gem/lite"
+            synth    = "gem/flash"
+
+            [casts.deep]                                   # explorer + OFFLINE synth
+            explorer = "gem/lite"
+            synth    = { backend = "gem", id = "pro", lane = "batch" }
+
+            [server]
+            cast = "inter"
+        "#,
+        ));
+        assert!(
+            h.advertised_tools().iter().any(|t| t == "deliberate"),
+            "deliberate must survive when a cast pairs an explorer with an offline synth. \
+             Advertised: {:?}",
+            h.advertised_tools()
+        );
+    }
+
+    /// Generalized: the same rule covers `batch_submit`. A config with no batch-lane cast
+    /// must not advertise the batch submit verb.
+    #[test]
+    fn batch_submit_is_not_advertised_without_a_batch_cast() {
+        let h = hermetic_handler_from_toml(&only_interactive());
+        assert!(
+            !h.advertised_tools().iter().any(|t| t == "batch_submit"),
+            "batch_submit must be dropped when no cast runs a synth on the batch lane. \
+             Advertised: {:?}",
+            h.advertised_tools()
+        );
+    }
+
+    /// And `explore`: a synth-only fixture has no explorer slot anywhere, so the sweep
+    /// tool cannot run.
+    #[test]
+    fn explore_is_not_advertised_without_an_explorer_slot() {
+        let h = hermetic_handler_from_toml(&with_no_builtin_casts(
+            r#"
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.synth_only]
+            synth = "gem/flash"
+
+            [server]
+            cast = "synth_only"
+        "#,
+        ));
+        let tools = h.advertised_tools();
+        assert!(
+            !tools.iter().any(|t| t == "explore"),
+            "explore must be dropped when no cast carries an explorer slot. Advertised: {tools:?}"
+        );
+        assert!(
+            tools.iter().any(|t| t == "consult"),
+            "consult must SURVIVE here — its interactive synth can staff it, and the driver \
+             carries its own explorer. Advertised: {tools:?}"
+        );
+    }
+
+    /// The collect verbs are shared by three producers (`consult_submit`, `batch_submit`,
+    /// `deliberate`), so they must key off *effective* liveness, not the raw `--no-*`
+    /// flags: with batch and deliberate unstaffable but consult live, the job verbs stay
+    /// (consult_submit still mints `job-N` handles).
+    #[test]
+    fn job_verbs_survive_on_the_one_staffed_producer() {
+        let h = hermetic_handler_from_toml(&only_interactive());
+        let tools = h.advertised_tools();
+        for verb in ["job_get", "job_cancel", "job_list", "job_wait"] {
+            assert!(
+                tools.iter().any(|t| t == verb),
+                "{verb} must survive while consult_submit can still produce handles. \
+                 Advertised: {tools:?}"
+            );
+        }
+    }
+
+    /// ...and drop when NO producer can be staffed. A synth-only cast with `--no-consult`
+    /// leaves nothing that can mint a handle, so the collect verbs are dead weight.
+    #[test]
+    fn job_verbs_drop_when_no_producer_can_be_staffed() {
+        let h = hermetic_handler_from_toml(&with_no_builtin_casts(
+            r#"
+            [backends.gem]
+            kind = "gemini"
+            key_optional = true
+
+            [casts.synth_only]
+            synth = "gem/flash"
+
+            [server]
+            cast = "synth_only"
+
+            [server.tools]
+            consult = false
+        "#,
+        ));
+        let tools = h.advertised_tools();
+        for verb in ["job_get", "job_cancel", "job_list", "job_wait"] {
+            assert!(
+                !tools.iter().any(|t| t == verb),
+                "{verb} must drop when no producer is live: consult is flag-off, and neither \
+                 batch_submit nor deliberate can be staffed. Advertised: {tools:?}"
+            );
+        }
+    }
+
+    /// A tool that takes NO cast is never touched by the staffing gate — `run_kaish` runs
+    /// the shell with no model at all, so no cast roster can make it unusable.
+    #[test]
+    fn castless_tools_are_untouched_by_the_staffing_gate() {
+        let h = hermetic_handler_from_toml(&only_interactive());
+        let tools = h.advertised_tools();
+        for tool in ["run_kaish", "list_models"] {
+            assert!(
+                tools.iter().any(|t| t == tool),
+                "{tool} takes no cast — the staffing gate must not reach it. \
+                 Advertised: {tools:?}"
+            );
+        }
+    }
+
     /// The completeness half of the single source: every advertised tool that TAKES a
     /// `cast` argument must be covered by a `CAST_ENUM_RULES` entry — otherwise a future
     /// cast-taking tool would ship with a silently-empty `cast` enum (never advertising its
@@ -3780,7 +4180,7 @@ mod tests {
         let h = handler();
         let ruled: std::collections::HashSet<&str> = CAST_ENUM_RULES
             .iter()
-            .flat_map(|(tools, _)| tools.iter().copied())
+            .flat_map(|(tools, _, _)| tools.iter().copied())
             .collect();
         let mut cast_taking = 0;
         for tool in h.advertised_tools() {

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -274,6 +274,79 @@ fn all_disabled_is_detected() {
     .all_disabled());
 }
 
+/// The zero-tool guard has to cover STAFFING, not just the flags.
+///
+/// `ToolGating::all_disabled()` runs before the handler is built and only reads the
+/// `--no-<tool>` flags, so it cannot see the other way the surface can empty out: every
+/// cast-taking tool flag-ON but unstaffable, with both castless tools (`run_kaish`,
+/// `list_models`) switched off. That server starts, advertises nothing, and says nothing
+/// — the silently-useless state the flag guard exists to refuse, reached by a different
+/// road. Narrow to arrive at (the keyless `openai-local` cast survives by default, so it
+/// takes an explicit `key_optional = false` plus an unreachable key file to kill it) but
+/// a real hole in a "crash rather than run useless" posture. Found by the DeepSeek
+/// cross-family review of this change.
+#[test]
+fn a_server_left_with_no_staffable_tools_refuses_to_start() {
+    let dir = tempfile::tempdir().expect("tempdir for an isolated XDG_CONFIG_HOME");
+    let config_dir = dir.path().join("kaibo");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    // Every built-in backend unreachable — including the keyless one, which otherwise
+    // keeps a usable local cast alive and staffs consult/explore/oneshot.
+    std::fs::write(
+        config_dir.join("config.toml"),
+        r#"
+        [backends.anthropic]
+        api_key_file = "/nonexistent-kaibo-test/anthropic"
+        [backends.deepseek]
+        api_key_file = "/nonexistent-kaibo-test/deepseek"
+        [backends.gemini]
+        api_key_file = "/nonexistent-kaibo-test/gemini"
+        [backends.openrouter]
+        api_key_file = "/nonexistent-kaibo-test/openrouter"
+        [backends.openai-local]
+        key_optional = false
+        api_key_file = "/nonexistent-kaibo-test/openai"
+        "#,
+    )
+    .expect("write config");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_kaibo"))
+        .env("XDG_CONFIG_HOME", dir.path())
+        // Clear every provider key so the fixture's unreachable key files are the whole
+        // story — otherwise a developer's own environment re-staffs the casts.
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("DEEPSEEK_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("OPENAI_API_KEY")
+        // The two tools no cast can affect — off, so staffing decides everything.
+        .args(["--no-run-kaish", "--no-list-models"])
+        .output()
+        .expect("should be able to run the kaibo binary");
+
+    assert!(
+        !out.status.success(),
+        "a server whose every tool is unstaffable must exit non-zero, got {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // Assert on the guard's OWN message, not merely a non-zero exit. This test is run
+    // with stdin closed, and a kaibo that got as far as serving exits non-zero anyway
+    // ("connection closed: initialize request") — so a bare status check passes whether
+    // or not the guard exists, which is exactly how it passed before the guard was
+    // written. Pinning the message is what makes this test able to fail.
+    assert!(
+        stderr.contains("no tools left to advertise"),
+        "must refuse with the empty-surface guard, not merely fail later at the \
+         transport; stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("cast"),
+        "the refusal must point at the CAST configuration — an operator who disabled \
+         almost nothing needs to know why the surface is empty; stderr was: {stderr}"
+    );
+}
+
 /// The startup guard, end to end: launching with every `--no-*` flag must exit
 /// non-zero with a clear message, before binding the stdio transport. A supervisor
 /// has to be able to catch a zero-tool misconfiguration.

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -29,17 +29,90 @@ const ALL_TOOLS: [&str; 12] = [
     "run_kaish",
 ];
 
+/// A config where every tool is *staffable*, so these tests measure the `--no-<tool>`
+/// flags and nothing else.
+///
+/// Since a tool no configured cast can staff is now dropped from the router entirely,
+/// flag-gating and cast-staffing both decide whether a route survives — and this file is
+/// about the flags. So the fixture supplies both cast shapes on one keyless backend (an
+/// interactive team, and an explorer paired with an offline synth, which covers
+/// `batch_submit` and `deliberate` at once) and neutralizes the built-in casts, whose
+/// usability would otherwise depend on which API keys the machine running the tests
+/// happens to have. `default_advertises_all_tools` guards the premise.
+const FULLY_STAFFED: &str = r#"
+    [backends.anthropic]
+    api_key_file = "/nonexistent-kaibo-test/anthropic"
+    [backends.deepseek]
+    api_key_file = "/nonexistent-kaibo-test/deepseek"
+    [backends.gemini]
+    api_key_file = "/nonexistent-kaibo-test/gemini"
+    [backends.openrouter]
+    api_key_file = "/nonexistent-kaibo-test/openrouter"
+    [backends.openai-local]
+    key_optional = false
+    api_key_file = "/nonexistent-kaibo-test/openai"
+
+    [backends.gem]
+    kind = "gemini"
+    key_optional = true
+
+    [casts.inter]
+    explorer = "gem/lite"
+    synth    = "gem/flash"
+
+    [casts.deep]
+    explorer = "gem/lite"
+    synth    = { backend = "gem", id = "pro", lane = "batch" }
+
+    [server]
+    cast = "inter"
+"#;
+
 fn advertised(gating: ToolGating) -> Vec<String> {
-    let mut config = Config::builtin();
+    let mut config = Config::from_toml_str(FULLY_STAFFED).expect("fixture config parses");
     config.tools = gating;
-    KaiboHandler::new(config)
+    // Empty credential environment: paired with the fixture's unreachable key files, the
+    // usable-cast roster is exactly `inter` + `deep`, on any machine.
+    KaiboHandler::new_with_env(config, |_| None)
         .expect("handler builds")
         .advertised_tools()
 }
 
+/// All flags on and every tool staffable ⇒ the full surface.
+///
+/// This is also the premise every other test in this file rests on. If a future tool
+/// arrives with a cast requirement `FULLY_STAFFED` can't meet, that tool vanishes from
+/// the router and the flag assertions below would quietly stop covering it — the
+/// `assert_eq!` against the complete list fails instead of silently narrowing.
 #[test]
 fn default_advertises_all_tools() {
     assert_eq!(advertised(ToolGating::default()), ALL_TOOLS);
+}
+
+/// The DOA bug, pinned at the integration level: kaibo's BUILT-IN casts cannot staff
+/// `deliberate` (it needs an explorer beside an offline synth, and the built-in offline
+/// casts are synth-only), so a stock install must not advertise the tool at all. It used
+/// to ship advertised-but-unusable — every call failed `cast "…" has no explorer slot`,
+/// while still costing resident tokens in every session.
+///
+/// Robust to the developer's own keys: adding credentials makes MORE built-in casts
+/// usable, but none of them gains an explorer beside an offline synth, so the verdict
+/// holds with a full keyring or an empty one.
+#[test]
+fn a_stock_install_does_not_advertise_deliberate() {
+    let tools = KaiboHandler::new(Config::builtin())
+        .expect("handler builds")
+        .advertised_tools();
+    assert!(
+        !tools.contains(&"deliberate".to_string()),
+        "no built-in cast pairs an explorer with an offline synth, so `deliberate` must \
+         not be advertised on a stock install; got {tools:?}"
+    );
+    assert!(
+        tools.contains(&"consult".to_string()),
+        "the rest of the surface must survive — this is a targeted drop, not a shutdown; \
+         got {tools:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

A tool now clears **two** gates to be advertised: its `--no-<tool>` flag, and a configured cast that can actually staff it. A tool nothing can staff has its route removed rather than shipping unusable.

## Why

`deliberate` was **dead on arrival** for anyone running stock kaibo. It needs an explorer paired with an offline synth; the two built-in offline casts (`anthropic-batch`, `gemini-batch`) are synth-only, so `cast_can_deliberate` matched nothing — every call failed `cast "…" has no explorer slot`, while the tool still billed resident tokens every session and its own description pointed at casts that exist only in `docs/config.example.toml`.

The machinery was already there, pointed one step short. `CAST_ENUM_RULES` computed per-tool cast eligibility from live config, but only fed the `cast` *enum*. `inject_cast_enum` documented the near-miss itself: given an empty roster it **skipped** injecting, because an empty `enum` reads as "no valid value" to a strict client — leaving the tool advertised and broken. Making an empty roster remove the route generalizes for free to `explore`, `batch_submit`, `consult`/`oneshot`, and the collect verbs.

Amy: *"deliberate should be disabled without a configured cast, so it doesn't take up tool space. Tools should not be presented if they are not usable as a default policy."*

## Decisions

- **One source, not two.** `live_tools()` folds flags + staffing into the surviving set; the router filters through it and `kaibo://config` reports it. The CLI renders that resource with no router in existence, so a second derivation is precisely how the resource would come to describe a surface the server doesn't serve.
- **Collect verbs follow *effective* liveness.** A producer nothing can staff mints no handles, so it can't justify keeping `job_*` resident any more than a flag-disabled one can.
- **The reason is said twice.** Vanishing is right for the model's tool list and wrong for the operator: a startup warning names the cast *shape* that would bring the tool back, and `[runtime]` gains `advertised_tools` + `unstaffable_tools`. That requirement text lives in the `CAST_ENUM_RULES` row beside the predicate it describes, so it can't drift.
- **"You disabled it" ≠ "nothing can run it."** `unstaffable_tools` deliberately omits flag-disabled tools; `[tools]` already reports those.

## A test-hygiene problem this surfaced

Handler tests built from a fixture TOML were really testing *"my fixture plus whatever API keys are on this machine"* — the built-in cast registry merges under every config, and a built-in cast counts as usable the moment its backend resolves a credential from env **or a key file on disk**. That's why the first cut appeared to gate `deliberate` but not `explore`/`batch_submit`.

Fixed with `new_with_env` (injecting the credential lookup — the closure pattern `config.rs` already uses, deliberately not `set_var`) plus fixtures that neutralize the built-in roster explicitly. `tests/gating.rs` now separates concerns: a `FULLY_STAFFED` fixture so the flag tests measure flags, and one test pinning the DOA bug itself.

## Docs

`[server.tools]` gains the two-gates explanation (it was also missing `explore` and `deliberate` entirely), and the DELIBERATE casts section says plainly that it's what turns the tool on — all three hosted batch providers work there, as does a big local model on the `direct` lane.

## Note for the media CAS

An image tool inherits this gate by adding one `CAST_ENUM_RULES` row, so a user who configures no image cast pays zero resident tokens for it. Amy's CAS shape decisions (image as a cast slot; warn-don't-refuse on ephemeral storage; return digest+path, not bytes) are recorded in `docs/issues.md`.

## Testing

Full `cargo test` green, `clippy --all-targets` clean. Seven new staffing tests plus two `kaibo://config` tests; the shipped example config still parses.