### PR TITLE
fix: make reasoning-effort honest end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,57 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+### Changed
+
+- **Batch treats `effort` as a floor, not an override.** Every other batch knob
+  already worked this way: `max_tokens` and the thinking budget rise to a batch
+  minimum but never undercut a slot that asked for more. `effort` alone was
+  clobbered in both directions, so a cast deliberately tuned to `xhigh`/`max` for the
+  offline lane was quietly demoted to `high`. Now a slot asking deeper than the batch
+  floor keeps its rung, a shallower one is still lifted (batch is the lane that
+  spends), and a rung kaibo doesn't recognize passes through untouched rather than
+  being replaced.
+
 ### Fixed
+
+- **A reasoning `effort` your provider client can't accept now fails with a message
+  you can act on.** Two request shapes — Gemini and OpenAI's Responses API — go
+  through a typed builder in the underlying `rig` client whose reasoning levels are a
+  closed set: Gemini takes only `minimal`/`low`/`medium`/`high`, and Responses stops
+  at `xhigh` even though OpenAI's own API accepts `max`. A rung outside those used to
+  die mid-call with a bare ``unknown variant `max` `` naming neither the cast nor the
+  slot that asked for it. kaibo now checks the same builder up front and refuses with
+  the cast, the role, the backend, the model, whose ceiling it is, and the rungs that
+  path *does* take. kaibo still keeps **no allowlist of its own** — that list is read
+  back out of the client, so a rung a provider (or a client upgrade) makes available
+  works immediately, with no kaibo release.
+
+- **`[defaults] synth_effort = "xhigh"` no longer quietly breaks every Gemini cast.**
+  The shipped example config invited exactly that value; on Gemini it produced a
+  failed call with an opaque message. The docs now carry the real per-provider
+  ladders — including that OpenAI's rungs differ **per model** (`gpt-5.6` reaches
+  `max`, `gpt-5.2` stops at `xhigh`, `gpt-5.1` at `high`) — instead of implying one
+  universal ladder.
+
+- **`effort = "none"` on a DeepSeek slot now actually turns reasoning off.** kaibo
+  was sending "reasoning enabled" alongside "zero effort"; the enable won, so the
+  opt-out did nothing and still billed reasoning tokens (160–253 on a probe). It now
+  sends DeepSeek's structural disable, matching how the same setting already worked
+  on OpenRouter.
+
+- **An `effort` that lands nowhere is now said out loud.** Anthropic's budget-tier
+  models and any OpenAI-compatible chat endpoint (local llama.cpp/Ollama, most
+  gateways) have no reasoning parameter at all, so the setting was dropped in
+  silence. If you *wrote* one — on a slot, in `[defaults]`, or via `KAIBO_*_EFFORT` —
+  kaibo now warns at startup naming the cast and slot, and `kaibo://config` lists it
+  under that slot's `inert_tunables`. The inherited built-in default stays quiet, so
+  an ordinary local cast doesn't nag.
+
+- **`kaibo://config` reports inert tunables the way the request is actually built.**
+  It previously ignored a `[defaults].thinking_style` (mislabelling whether a
+  `thinking_budget` was live), ignored `[defaults]`-sourced effort entirely, and was
+  blind to `lane = "batch"` — rendering a batch slot's `effort` and `temperature` as
+  effective when batch sends no sampling at all and floors the effort.
 
 - **State-db-collides-with-project-tree error now names `--root`/`--allow-path`.**
   The state db's default path (`~/.local/state/kaibo/state.db`) can land inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ record. Each later release appends a new section at the top.
   spends), and a rung kaibo doesn't recognize passes through untouched rather than
   being replaced.
 
+- **`effort = "none"` survives the batch lane.** The floor raises reasoning *depth*,
+  and "off" isn't a depth — so a `batch_submit` fan-out you turned reasoning off for
+  stays off, instead of being lifted to `high` and billing thinking on every item. That
+  matters most exactly where batch is cheapest: bulk extraction and classification over
+  many prompts.
+
 ### Fixed
 
 - **A reasoning `effort` your provider client can't accept now fails with a message
@@ -66,6 +72,12 @@ record. Each later release appends a new section at the top.
   `thinking_budget` was live), ignored `[defaults]`-sourced effort entirely, and was
   blind to `lane = "batch"` — rendering a batch slot's `effort` and `temperature` as
   effective when batch sends no sampling at all and floors the effort.
+
+- **The startup warning and `kaibo://config` can no longer disagree about an effort.**
+  They answer from one shared rule now, so a value the batch lane lifts is reported by
+  both (it used to be flagged in the resource and stay silent at startup), and the
+  warning says *which* thing happened — dropped by a wire with no reasoning parameter,
+  or raised to the batch floor — since those want different fixes.
 
 - **State-db-collides-with-project-tree error now names `--root`/`--allow-path`.**
   The state db's default path (`~/.local/state/kaibo/state.db`) can land inside

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "clap",
  "kaish-kernel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,3 +158,7 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+# Request-body capture in `tests/effort_wire.rs`: rig's `HttpClientExt` trait is
+# typed in `bytes::Bytes`, so implementing a fake transport needs the type by name.
+# Already in the tree via reqwest/rig-core — zero new crates.
+bytes = "1"

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -478,7 +478,9 @@ synth    = { backend = "gpt", id = "gpt-5.6-sol", lane = "batch" }
 # output floor (it never skimps on the cheap async lane), and a slot that asks for MORE keeps
 # it — `effort = "xhigh"` on a batch synth reaches the provider as written, which also means
 # the provider's ladder applies (a Gemini batch slot still takes only minimal/low/medium/high,
-# so `xhigh` there is now the provider's error rather than a silent demotion). Reasoning bills
+# so `xhigh` there is now the provider's error rather than a silent demotion). The floor is on
+# DEPTH, so `effort = "none"` survives it: a cheap bulk-extraction fan-out stays reasoning-off
+# rather than being lifted to "high" and billing thinking on every item. Reasoning bills
 # against that same output budget, so a big attached-file review at max thinking can spend the
 # budget thinking and truncate the answer — kaibo flags such a result INCOMPLETE with its
 # finishReason rather than passing off the cut-off fragment as a clean answer. Give batch more

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -105,8 +105,31 @@ synth_temperature    = 0.3
 top_p                = 0.95
 
 # Reasoning depth, per role, for the models that take an effort param (Anthropic
-# adaptive tier, DeepSeek, Gemini's thinkingLevel, OpenRouter). A passthrough string
-# the provider validates — bump synth_effort to "max"/"xhigh" for heavier runs.
+# adaptive tier, DeepSeek, Gemini's thinkingLevel, OpenRouter, hosted GPT-5.x).
+# A passthrough string — kaibo keeps no allowlist, so a rung a provider ships
+# tomorrow works today.
+#
+# THE LADDER IS PER-PROVIDER, and often per-MODEL. There is no universal rung set,
+# so a value here lands on every cast at once and can be wrong for some of them:
+#   Gemini      minimal | low | medium | high — four, and that is Google's own
+#               schema, not a kaibo limit. "minimal" is the off-switch, itself
+#               model-dependent (gemini-3.5-flash takes it; gemini-pro-latest
+#               refuses it). "none"/"xhigh"/"max" are rejected outright.
+#   DeepSeek    all seven (none…max), strictly validated.
+#   OpenRouter  all seven; the gateway maps each onto the upstream's native knob,
+#               so deep rungs reach models that refuse them on their direct API.
+#   OpenAI      per MODEL, at both ends: gpt-5.6 reaches "max", gpt-5.2 stops at
+#               "xhigh", gpt-5.1 at "high"; gpt-5's bottom rung is "minimal" while
+#               5.1+ use "none". kaibo sends yours and OpenAI names its supported
+#               values if it disagrees.
+#   Anthropic   the adaptive tier takes an effort; the budget tier (Haiku 4.5 and
+#               older) has no effort field at all and drops it.
+#
+# So prefer a deep rung on the SLOT that can use it (see the casts below) over a
+# server-wide default here. kaibo tells you when a value can't land: one this
+# slot's client refuses is a call-time error naming the cast, the slot and the
+# rungs that wire takes; one with nowhere to go is a startup warning and shows up
+# as `inert_tunables` in kaibo://config.
 explorer_effort = "high"
 synth_effort    = "high"
 
@@ -379,11 +402,13 @@ synth    = { backend = "claude", id = "claude-opus-4-8", effort = "max", max_tok
 # --- The built-in `openrouter` backend already has a key source, so a custom cast on
 #     it needs only slots. `~author/family-latest` aliases (OpenRouter serves them for
 #     anthropic/google/openai/x-ai/moonshotai — not every family) track the newest
-#     release instead of rotting; `effort = "xhigh"` here pushes
-#     the synth slot past [defaults] synth_effort ("high") into a rung only OpenRouter's
-#     unified reasoning param reaches. The same knob is the opt-out: reasoning is on by
-#     default for everything kaibo calls, and `effort = "none"` on a slot turns it off
-#     when the cost/latency isn't wanted (reasoning bills as output tokens). ---
+#     release instead of rotting; `effort = "xhigh"` here pushes the synth slot past
+#     [defaults] synth_effort ("high"). OpenRouter takes all seven rungs on every model
+#     and maps each onto the upstream's native knob — it will carry a rung to a model
+#     that refuses it on that vendor's direct API. The same knob is the opt-out:
+#     reasoning is on by default for everything kaibo calls, and `effort = "none"` on a
+#     slot turns it off (structurally, not by asking for zero) when the cost/latency
+#     isn't wanted — reasoning bills as output tokens. ---
 
 [casts.or-deep]
 explorer = "openrouter/~google/gemini-flash-latest"
@@ -400,8 +425,12 @@ synth    = "claude/claude-sonnet-4-6"        # no per-model prompt → [prompts]
 # --- Hosted GPT end to end, both roles on the keyed backend above.
 #     Sol is the flagship synth; Luna is the fast/tool-capable explorer. Both slots
 #     pin vision because generic openai endpoints default blind until you say otherwise.
-#     Use `effort = "none"` / "low" / "medium" / "high" / "xhigh" / "max" per slot
-#     to trade latency/cost against reasoning depth on the GPT-5.6 family. ---
+#     Per-slot `effort` trades latency/cost against reasoning depth. The rungs are a
+#     property of the MODEL, not the family: gpt-5.6 goes up to "max", gpt-5.2 stops at
+#     "xhigh", gpt-5.1 at "high", and gpt-5's bottom rung is "minimal" where 5.1+ use
+#     "none". kaibo passes yours through; OpenAI names its supported values if it
+#     disagrees. Note rig's own Responses client caps at "xhigh" — kaibo refuses "max"
+#     up front, naming the cast and slot, rather than letting it die mid-call. ---
 
 [casts.gpt]
 explorer = { backend = "gpt", id = "gpt-5.6-luna", vision = true, effort = "low" }
@@ -445,15 +474,18 @@ synth    = { backend = "gpt", id = "gpt-5.6-sol", lane = "batch" }
 explorer = { backend = "gpt", id = "gpt-5.6-luna", vision = true, effort = "low" }
 synth    = { backend = "gpt", id = "gpt-5.6-sol", lane = "batch" }
 #
-# OUTPUT BUDGET. Batch maxes the knobs: high effort + a 32768-token output-token FLOOR (it
-# never skimps on the cheap async lane). Reasoning bills against that same output budget, so a
-# big attached-file review at max thinking can spend the budget thinking and truncate the
-# answer — kaibo flags such a result INCOMPLETE with its finishReason rather than passing off
-# the cut-off fragment as a clean answer. Give batch more answer headroom by raising
-# `max_tokens` on the synth slot; it's a floor, so a higher value wins, and mind each model's
-# output ceiling (Gemini Pro is generous; some backends cap lower). Batch forces effort to
-# high and ignores a per-slot `thinking_budget` (Gemini takes a level; Anthropic floors it),
-# so `max_tokens` is the knob worth setting here:
+# OUTPUT BUDGET. Batch FLOORS the knobs, never caps them: "high" effort and a 32768-token
+# output floor (it never skimps on the cheap async lane), and a slot that asks for MORE keeps
+# it — `effort = "xhigh"` on a batch synth reaches the provider as written, which also means
+# the provider's ladder applies (a Gemini batch slot still takes only minimal/low/medium/high,
+# so `xhigh` there is now the provider's error rather than a silent demotion). Reasoning bills
+# against that same output budget, so a big attached-file review at max thinking can spend the
+# budget thinking and truncate the answer — kaibo flags such a result INCOMPLETE with its
+# finishReason rather than passing off the cut-off fragment as a clean answer. Give batch more
+# answer headroom by raising `max_tokens` on the synth slot; it's a floor too, so a higher
+# value wins, and mind each model's output ceiling (Gemini Pro is generous; some backends cap
+# lower). A per-slot `thinking_budget` is ignored here (Gemini takes a level; Anthropic floors
+# it), so `max_tokens` is the knob worth setting:
 #   synth = { backend = "gemini", id = "gemini-pro-latest", lane = "batch", max_tokens = 65536 }
 
 # --- DELIBERATE casts: an interactive explorer PLUS an offline synth. `deliberate` runs

--- a/docs/config.md
+++ b/docs/config.md
@@ -113,8 +113,9 @@ Connection knobs only — models never live here:
   `{"reasoning":{"effort":…}}` request field, which the gateway translates into
   each upstream provider's native knob and drops silently where the pinned model
   has none, so emitting it unconditionally never breaks a non-reasoning model. The
-  per-role `effort` (see [defaults] below) passes through verbatim, reaching
-  OpenRouter-only rungs (`xhigh`, `max`) deeper than the other kinds expose. No
+  per-role `effort` (see [defaults] below) reaches the gateway verbatim; OpenRouter
+  accepts all seven rungs on every model and normalizes each onto the upstream's own
+  knob, so `xhigh`/`max` land here even on models that refuse them direct. No
   `batch` lane. One slug routes across competing upstream *hosts* whose data
   policies differ, so every request pins **no-collection routing by default**
   (`provider.data_collection = "deny"` — kaibo's prompts carry your source, and
@@ -226,13 +227,39 @@ The `[defaults]` knobs themselves:
 - **`explorer_effort` / `synth_effort`** (`"high"` both): reasoning depth for the
   models that take an effort param — Anthropic's adaptive tier
   (→ `output_config.effort`), DeepSeek (→ `reasoning_effort`), Gemini
-  (→ `thinkingLevel`: the values align, `"minimal"`/`"low"`/`"medium"`/`"high"`),
-  and OpenRouter (→ its unified `{"reasoning":{"effort":…}}`, forwarded verbatim to
-  whatever the pinned model actually supports). A passthrough string the provider
-  validates (like a model id), so a new level lands without a code change — set a synth
-  slot's `effort = "max"`/`"xhigh"` for heavier runs; OpenRouter is where those
-  deeper rungs are actually reachable today. Ignored by models with no effort
-  sink (budget-tier Anthropic, OpenAI).
+  (→ `thinkingLevel`), OpenRouter (→ its unified `{"reasoning":{"effort":…}}`), and
+  hosted GPT-5.x (→ `reasoning.effort`). A passthrough string, like a model id:
+  **kaibo keeps no allowlist**, so a rung a provider ships tomorrow works today.
+
+  **There is no universal ladder.** A `[defaults]` effort lands on every cast at once,
+  so a rung that suits one provider can be invalid on another — prefer a deep rung on
+  the *slot* that can use it. Measured 2026-08-01:
+
+  | provider | rungs |
+  | --- | --- |
+  | Gemini | `minimal` `low` `medium` `high` — Google's own schema rejects `none`/`xhigh`/`max`. `minimal` is the off-switch, itself model-dependent (`gemini-3.5-flash` takes it, `gemini-pro-latest` refuses it). |
+  | DeepSeek | all seven (`none` … `max`), strictly validated. `none` emits the structural `thinking:{"type":"disabled"}` — asking for zero effort while thinking stays enabled bills reasoning tokens anyway. |
+  | OpenRouter | all seven on everything; the gateway normalizes each onto the upstream's native knob, so a rung can reach a model that refuses it on that vendor's direct API. `none` emits the gateway's structural disable. |
+  | OpenAI (hosted) | **per model**, at both ends: `gpt-5.6` → `max`, `gpt-5.2` → `xhigh`, `gpt-5.1` → `high`; `gpt-5`'s bottom rung is `minimal` where 5.1+ use `none`. |
+  | Anthropic | the adaptive tier takes an effort; the budget tier (Haiku 4.5 and older) expresses depth as `budget_tokens` and has no effort field at all. |
+
+  **rig's client is a second, lower ceiling on two wires**, independent of the provider:
+  rig 0.38 parses kaibo's params into a typed struct for Gemini and for OpenAI's
+  Responses API, and those enums stop at `high` and `xhigh` respectively — so `max`
+  fails for a hosted GPT slot even though OpenAI's own API accepts it. kaibo asks rig's
+  converter before each call and refuses with a message naming the cast, the slot, the
+  backend and the rungs that wire *does* take, rather than letting a bare
+  ``unknown variant `max` `` surface mid-consult. That list is read back out of rig, so
+  a rig upgrade widens it with no kaibo change.
+
+  **An effort with nowhere to land is said out loud.** Budget-tier Anthropic and the
+  generic OpenAI `/chat/completions` wire (every local llama.cpp / Ollama / gateway
+  backend) have no reasoning field, so the value is dropped. When *you wrote* the effort
+  — on a slot, in `[defaults]`, or via `KAIBO_*_EFFORT` — kaibo logs a startup warning
+  naming the cast and slot, and `kaibo://config` lists `effort` under that slot's
+  `inert_tunables`. The inherited built-in `"high"` stays quiet: every local cast
+  inherits it onto a toggle-less wire, so warning there would be noise on every ordinary
+  setup.
 - **`thinking_style`** (`auto` | `adaptive` | `budget`, default `auto`) forces the
   Anthropic thinking shape instead of the built-in classifier. `auto` picks
   adaptive for Opus 4.6+/Sonnet 4.6/Fable 5 and enabled-budget for older models +

--- a/docs/config.md
+++ b/docs/config.md
@@ -241,7 +241,11 @@ The `[defaults]` knobs themselves:
   | DeepSeek | all seven (`none` … `max`), strictly validated. `none` emits the structural `thinking:{"type":"disabled"}` — asking for zero effort while thinking stays enabled bills reasoning tokens anyway (probed: 160–253). |
   | OpenRouter | all seven on everything; the gateway normalizes each onto the upstream's native knob, so a rung can reach a model that refuses it on that vendor's direct API. `none` emits the gateway's structural disable. |
   | OpenAI (hosted) | **per model**, at both ends: `gpt-5.6` → `max`, `gpt-5.2` → `xhigh`, `gpt-5.1` → `high`; `gpt-5`'s bottom rung is `minimal` where 5.1+ use `none`. |
-  | Anthropic | the adaptive tier takes an effort; the budget tier (Haiku 4.5 and older) expresses depth as `budget_tokens` and has no effort field at all. |
+  | Anthropic | the adaptive tier takes an effort; the budget tier (Haiku 4.5 and older) expresses depth as `budget_tokens` and has no effort field at all. **Which rungs the adaptive tier takes is still unmeasured** — see `docs/issues.md`. |
+
+  Every row above except the Anthropic one was measured against the live endpoint, and
+  each is re-checkable: `tests/consult.rs` carries an `#[ignore]`d probe per provider
+  that fails if a ladder moves, rather than letting this table quietly rot.
 
   **rig's client is a second, lower ceiling on two wires**, independent of the provider:
   rig 0.38 parses kaibo's params into a typed struct for Gemini and for OpenAI's

--- a/docs/config.md
+++ b/docs/config.md
@@ -238,7 +238,7 @@ The `[defaults]` knobs themselves:
   | provider | rungs |
   | --- | --- |
   | Gemini | `minimal` `low` `medium` `high` — Google's own schema rejects `none`/`xhigh`/`max`. `minimal` is the off-switch, itself model-dependent (`gemini-3.5-flash` takes it, `gemini-pro-latest` refuses it). |
-  | DeepSeek | all seven (`none` … `max`), strictly validated. `none` emits the structural `thinking:{"type":"disabled"}` — asking for zero effort while thinking stays enabled bills reasoning tokens anyway. |
+  | DeepSeek | all seven (`none` … `max`), strictly validated. `none` emits the structural `thinking:{"type":"disabled"}` — asking for zero effort while thinking stays enabled bills reasoning tokens anyway (probed: 160–253). |
   | OpenRouter | all seven on everything; the gateway normalizes each onto the upstream's native knob, so a rung can reach a model that refuses it on that vendor's direct API. `none` emits the gateway's structural disable. |
   | OpenAI (hosted) | **per model**, at both ends: `gpt-5.6` → `max`, `gpt-5.2` → `xhigh`, `gpt-5.1` → `high`; `gpt-5`'s bottom rung is `minimal` where 5.1+ use `none`. |
   | Anthropic | the adaptive tier takes an effort; the budget tier (Haiku 4.5 and older) expresses depth as `budget_tokens` and has no effort field at all. |
@@ -251,6 +251,13 @@ The `[defaults]` knobs themselves:
   backend and the rungs that wire *does* take, rather than letting a bare
   ``unknown variant `max` `` surface mid-consult. That list is read back out of rig, so
   a rig upgrade widens it with no kaibo change.
+
+  **`"none"` is an off-switch, not the shallowest rung.** kaibo treats it as a sentinel
+  beside the ladder rather than a depth: where a provider ships a structural disable
+  (DeepSeek, OpenRouter) the request carries that rather than a zero-effort string, and
+  the batch lane's depth *floor* leaves it alone — a cheap bulk fan-out you turned
+  reasoning off for stays off instead of being lifted to `high` and billing thinking on
+  every item.
 
   **An effort with nowhere to land is said out loud.** Budget-tier Anthropic and the
   generic OpenAI `/chat/completions` wire (every local llama.cpp / Ollama / gateway

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -645,7 +645,7 @@ global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
   for OpenAI-compatible reasoners, OpenRouter's unified `reasoning` param when the
   backend is OpenRouter — landing with the first-class OpenRouter work. No longer
   *silent*, at least: an `effort` the operator wrote onto this wire is now a startup
-  warning plus an `inert_tunables` entry (`Config::inert_efforts`), and
+  warning plus an `inert_tunables` entry (`Config::effort_diagnostics`), and
   `tests/effort_wire.rs` pins the drop against a real serialized request body. Audible
   is not fixed — reasoning is still off on that wire.
 - **`thinking_style` is missing from the `inert_tunables` render** (GLM review,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -495,10 +495,18 @@ in the module doc and `docs/devlog.md`. What's left:
   provider batch). The diverse-opinion panel — one question across **many** casts — is N
   provider batches under a composite handle; deferred. The provenance footer already
   makes each result self-labelling, so the rendering is mostly there.
-- **Effort tier.** Batch forces `BATCH_EFFORT = "high"` (== `DEFAULT_EFFORT`, the
-  proven-accepted top for the Anthropic adaptive tier). If a higher tier (`xhigh`/`max`)
-  is ever confirmed by probe for a batch backend, lift it there — the constant is the
-  one knob to change.
+- **Anthropic's effort ladder is still unknown, and two of our own documents disagree
+  about it.** `docs/config.example.toml` ships `effort = "max"` on an Opus slot;
+  `BATCH_EFFORT`'s doc treats `high` as the top. The probe that settles it is written and
+  in the tree — `anthropic_adaptive_effort_ladder_live` (`tests/consult.rs`) — but cannot
+  run on an unfunded key: Anthropic's billing check precedes body validation, so every
+  rung returns the same credit-balance 400 and a rejection proves nothing about the rung.
+  The test fails loudly on that message rather than skipping, so an unfunded run can't be
+  mistaken for a result. Run it with a funded key, then fix whichever document is wrong.
+  Every other provider's ladder is now measured (see the sibling live probes and the
+  table in `docs/config.md`); this is the one empty cell. Lower stakes than it was, since
+  batch's `effort` is a floor rather than a force — a cast that pins a deeper rung already
+  reaches the provider, so only kaibo's *default* rides on the answer.
 - **`FileRef` / Gemini File API for *batch* is bigger than "a variant beside `Image`"
   — and may be the wrong shape.** Re-scoped after checking gpal + Google's docs (2026-06-22):
   - **gpal's batch is inline-only** (`create_batch` → `InlinedRequest(contents=prompt)`,

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -547,12 +547,6 @@ failures and a truncated page are surfaced, not hidden). Still open:
   progress string to know whether it's looking at a status or its answers. A structured
   status token (or distinct content shape) would let the caller branch without reading
   prose.
-- **Forced effort vs. a floor.** `max_tokens` is already a floor (never undercuts a
-  richer slot), but effort is *force-clobbered* to `BATCH_EFFORT` — lossy for legitimate
-  bulk-classification / short-extraction batches where high effort is wasted spend.
-  Consider making effort a default-on floor the cast/caller can lower, the way
-  `max_tokens` already is. (Distinct from the "lift the tier" bullet above — that's the
-  ceiling, this is the override.)
 - **Shared `attach` duplicates per item — bounded by the inlined-batch payload cap.**
   Attachments are shared across the batch but inlined *per item*: `anthropic_content`/
   `gemini_parts` (`batch.rs`) re-encode every attachment into every item's request, so a
@@ -649,27 +643,16 @@ global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
   thinking maximized by default**, opt-*out* per slot, never silently absent. The
   fix wants model-aware shaping on the openai wire — e.g. emit `reasoning_effort`
   for OpenAI-compatible reasoners, OpenRouter's unified `reasoning` param when the
-  backend is OpenRouter — landing with the first-class OpenRouter work.
+  backend is OpenRouter — landing with the first-class OpenRouter work. No longer
+  *silent*, at least: an `effort` the operator wrote onto this wire is now a startup
+  warning plus an `inert_tunables` entry (`Config::inert_efforts`), and
+  `tests/effort_wire.rs` pins the drop against a real serialized request body. Audible
+  is not fixed — reasoning is still off on that wire.
 - **`thinking_style` is missing from the `inert_tunables` render** (GLM review,
   2026-07-03): `kaibo://config` flags an inert `thinking_budget`/`effort`/
   `temperature` per slot (`config_resource.rs`), but a `thinking_style` set on a
   slot whose kind ignores the override (anything non-Anthropic) renders as if
   effective. Display accuracy only; add it to the inert check alongside the others.
-- **The `inert_tunables` render is lane-blind** (or-gpt review, 2026-07-18): it
-  resolves only the model *shape*, not the slot's `lane`, so a **batch** slot renders
-  `effort` and `temperature` as effective even though `batch_shaping` forces
-  `BATCH_EFFORT` (ignoring the slot's `effort`) and passes `None` sampling. A configured
-  `effort = "low"` on a `lane = "batch"` slot is a silent no-op the render doesn't flag.
-  Same display-accuracy class as the `thinking_style` gap above; make the inert check
-  lane-aware — mark batch `effort` as overridden and batch sampling as inert.
-- **The `inert_tunables` render resolves the shape differently from validation**
-  (deepseek review, 2026-07-18): the render resolves `thinking_style` via
-  `unwrap_or_default()` (→ `Auto`), while the validation/`slot.tunables` path uses the
-  `defaults.thinking_style` fallback — so a `[defaults].thinking_style = "adaptive"` set
-  without a per-slot override is missed by the render, which can mislabel a
-  `thinking_budget`'s inertness on an actually-adaptive Anthropic slot. Display-only,
-  no wire effect. The clean fix for this whole render-accuracy cluster: resolve the
-  slot's shape in the render exactly as `slot.tunables` does.
 
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -60,9 +60,15 @@ use crate::credentials::ProviderKind;
 const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com";
 
 /// The reasoning depth batch *floors* every item at. Equal to
-/// [`crate::consult::DEFAULT_EFFORT`] today (the proven-accepted top for the Anthropic
-/// adaptive tier); kept a separate constant so batch's "spend, it's async" intent
-/// survives a change to the interactive default.
+/// [`crate::consult::DEFAULT_EFFORT`] today — `high` is *observed-accepted* on the
+/// Anthropic adaptive tier (every live consult rides it); whether it is that tier's
+/// **top** is genuinely unknown, since the probe that would settle it
+/// (`anthropic_adaptive_effort_ladder_live`, `tests/consult.rs`) cannot run on an
+/// unfunded key: Anthropic's billing check precedes body validation, so a 400 there
+/// says nothing about the rung. `docs/config.example.toml` ships `effort = "max"` on an
+/// Opus slot on the other assumption; exactly one of these is right, and both stay put
+/// until the probe answers. Kept a separate constant either way, so batch's
+/// "spend, it's async" intent survives a change to the interactive default.
 ///
 /// A floor, matching every other batch knob — see [`batch_effort`] for why the direction
 /// matters and how an unrankable rung is handled.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -69,26 +69,46 @@ const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com";
 pub const BATCH_EFFORT: &str = "high";
 
 /// The reasoning depth one batch item runs at: the deeper of the slot's `effort` and
-/// [`BATCH_EFFORT`], with an unrankable rung deferring to the slot.
+/// [`BATCH_EFFORT`] — a floor on **depth**, which is why the reasoning off-switch is the
+/// first thing it asks about.
 ///
 /// Batch floors its knobs rather than fixing them, and effort was the one exception —
 /// force-clobbered in *both* directions. Lifting a thin slot is the intent ("a cast tuned
 /// down for flaky interactive use still batches hot"); demoting a slot that deliberately
-/// asked for `xhigh`/`max` was collateral, and silent. So:
+/// asked for `xhigh`/`max` was collateral, and silent. So, in order:
 ///
-/// - the slot ranks **deeper** than the floor → the slot wins (never cap a richer slot,
-///   the same promise `max_tokens` and the thinking budget already make);
-/// - the slot ranks **shallower** → the floor wins (the deliberate lift, unchanged);
-/// - either rung is **outside** [`EFFORT_LADDER`] → the slot wins. kaibo keeps no effort
+/// - the slot is [`EFFORT_OFF`](crate::consult::EFFORT_OFF) → the slot wins and reasoning
+///   stays off. **A depth floor has no business switching reasoning on.** `none` is a
+///   sentinel, not the shallowest rung of
+///   [`EFFORT_LADDER`](crate::consult::EFFORT_LADDER) — it used to sit there, and this
+///   function lifted it to `BATCH_EFFORT`, billing reasoning on every item of a fan-out.
+///   A cheap bulk-extraction batch is exactly where an operator turns reasoning off, and
+///   exactly where the per-item cost multiplies.
+/// - the slot ranks **shallower** than the floor → the floor wins (the deliberate lift).
+/// - the slot ranks **deeper** → the slot wins (never cap a richer slot, the same promise
+///   `max_tokens` and the thinking budget already make).
+/// - either value sits **outside** the ladder → the slot wins. kaibo keeps no effort
 ///   allowlist, so a rung it can't order is an operator reaching for something newer than
-///   this table — trusting it is what keeps that passthrough real, and silently replacing
-///   it with "high" would be exactly the override this function exists to retire.
+///   this table; trusting it is what keeps that passthrough real, and quietly replacing it
+///   with "high" would be exactly the override this function exists to retire.
+///
+/// Equal depths return the slot's own string, spelling included — kaibo never normalizes
+/// an operator's value on its way to a provider. A caller deciding whether the configured
+/// value "ships as written" must therefore compare by
+/// [`effort_rank`](crate::consult::effort_rank), not by string; see
+/// [`Config::effort_disposition`](crate::config::Config::effort_disposition), which is
+/// the single place that judgement lives.
 pub fn batch_effort(slot_effort: &str) -> &str {
+    // Off first, and before any ranking: `is_effort_off` answers the question
+    // `effort_rank` structurally cannot, which is the whole reason it is public.
+    if crate::consult::is_effort_off(slot_effort) {
+        return slot_effort;
+    }
     match (
         crate::consult::effort_rank(slot_effort),
         crate::consult::effort_rank(BATCH_EFFORT),
     ) {
-        (Some(slot), Some(floor)) if slot <= floor => BATCH_EFFORT,
+        (Some(slot), Some(floor)) if slot < floor => BATCH_EFFORT,
         _ => slot_effort,
     }
 }
@@ -2273,11 +2293,70 @@ mod tests {
         );
     }
 
+    /// The reasoning **off-switch** survives the batch depth floor. `none` is not the
+    /// shallowest rung — it is a different kind of answer — and a floor that raises
+    /// *depth* has no business switching reasoning back on.
+    ///
+    /// It used to. `EFFORT_LADDER` carried `"none"` at index 0, so `batch_effort` ranked
+    /// it below `BATCH_EFFORT` and lifted it to `"high"`, quietly billing reasoning on
+    /// every item of a fan-out the operator had turned it off for — and a fan-out is
+    /// exactly where a bulk-extraction batch turns reasoning off, and exactly where the
+    /// per-item cost multiplies. Two reviewers read the same code and reached opposite
+    /// conclusions about this, because `effort_rank` and `is_effort_off` each acted as
+    /// though the other didn't exist.
+    #[test]
+    fn batch_effort_floor_leaves_the_reasoning_off_switch_alone() {
+        assert_eq!(
+            batch_effort(crate::consult::EFFORT_OFF),
+            crate::consult::EFFORT_OFF,
+            "a DEPTH floor must not turn reasoning on — off is not a shallow depth"
+        );
+        assert_eq!(batch_effort("NONE"), "NONE", "however it was spelled");
+        assert_eq!(batch_effort(" none "), " none ", "however it was spaced");
+        assert!(
+            crate::consult::effort_rank(crate::consult::EFFORT_OFF).is_none(),
+            "the off-switch must not be rankable — ranking it is what let a floor lift it"
+        );
+
+        // And it reaches the wire as the structural disable, not as a lifted depth: the
+        // shaping half of the same contract.
+        let (_max, params) = batch_shaping(
+            ProviderKind::DeepSeek,
+            "deepseek-v4-pro",
+            &tunables("none", 100),
+        );
+        let params = params.expect("deepseek carries a thinking block");
+        assert_eq!(
+            params["thinking"]["type"], "disabled",
+            "a batch item with reasoning off must actually run with it off: {params}"
+        );
+        assert!(params.get("reasoning_effort").is_none(), "{params}");
+    }
+
+    /// `batch_effort`'s floor only exists if `BATCH_EFFORT` is rankable. Set it to
+    /// anything absent from `EFFORT_LADDER` — a typo, a provider's newer rung, or the
+    /// off-switch — and the wildcard arm returns the slot's value for *every* input,
+    /// silently disabling the floor with no test noticing. This is the guard: the
+    /// constant has to be a depth kaibo can order, and it must not be the off-switch.
+    #[test]
+    fn batch_effort_floor_constant_is_a_rankable_depth() {
+        assert!(
+            crate::consult::effort_rank(BATCH_EFFORT).is_some(),
+            "BATCH_EFFORT {BATCH_EFFORT:?} is not on EFFORT_LADDER {:?} — the batch floor \
+             would silently do nothing at all",
+            crate::consult::EFFORT_LADDER
+        );
+        assert!(
+            !crate::consult::is_effort_off(BATCH_EFFORT),
+            "BATCH_EFFORT is a floor on depth; the off-switch is not a depth"
+        );
+    }
+
     /// The floor rule itself, isolated from any provider shape — every direction in one
     /// place so a future edit to `batch_effort` can't quietly flip one of them.
     #[test]
     fn batch_effort_is_a_floor_not_an_override() {
-        assert_eq!(batch_effort("none"), BATCH_EFFORT, "lifted");
+        assert_eq!(batch_effort("minimal"), BATCH_EFFORT, "lifted");
         assert_eq!(batch_effort("low"), BATCH_EFFORT, "lifted");
         assert_eq!(
             batch_effort(BATCH_EFFORT),
@@ -2287,6 +2366,8 @@ mod tests {
         assert_eq!(batch_effort("xhigh"), "xhigh", "deeper wins");
         assert_eq!(batch_effort("max"), "max", "deeper wins");
         assert_eq!(batch_effort("ludicrous"), "ludicrous", "unranked defers");
+        // The off-switch is not a rung and is not lifted — its own test above owns why.
+        assert_eq!(batch_effort("none"), "none", "off stays off");
         // Ranking is case/whitespace tolerant, but the slot's own spelling is what ships —
         // kaibo never normalizes an operator's string on its way to a provider.
         assert_eq!(

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -13,12 +13,13 @@
 //! tool loop. So batch is built on the `oneshot` *shape* (a single capable model
 //! answering from what it was handed), never `consult`.
 //!
-//! **Max the knobs by default.** Batch is the cheap/async lane, so it spends: it
-//! floors `max_tokens` at [`BATCH_MAX_TOKENS_FLOOR`] and forces thinking on at
-//! [`BATCH_EFFORT`] regardless of how the cast's synth slot was tuned for interactive
-//! use. The latency that makes max-thinking painful synchronously is free here — the
-//! caller already accepted "come back later." This is the lane for asking the best
-//! model the hard question and waiting.
+//! **Floor the knobs by default.** Batch is the cheap/async lane, so it spends: every
+//! knob rises to a batch minimum — `max_tokens` to [`BATCH_MAX_TOKENS_FLOOR`], the
+//! thinking budget to [`BATCH_THINKING_BUDGET`], reasoning depth to [`BATCH_EFFORT`] —
+//! and none of them is ever *capped*. A slot tuned thin for flaky interactive use still
+//! batches hot; a slot that already asks for more keeps it. The latency that makes deep
+//! thinking painful synchronously is free here — the caller already accepted "come back
+//! later." This is the lane for asking the best model the hard question and waiting.
 //!
 //! **Per-provider HTTP seam.** rig-core has no batch path, so each provider is
 //! hand-rolled behind the [`BatchProvider`] trait (one trait, per-provider impls, honest
@@ -58,12 +59,39 @@ use crate::credentials::ProviderKind;
 /// see [`AnthropicBatch::base_url`]).
 const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com";
 
-/// The effort batch runs every item at — the maxed knob. Equal to
+/// The reasoning depth batch *floors* every item at. Equal to
 /// [`crate::consult::DEFAULT_EFFORT`] today (the proven-accepted top for the Anthropic
 /// adaptive tier); kept a separate constant so batch's "spend, it's async" intent
-/// survives a change to the interactive default. Forced regardless of the slot's
-/// configured `effort` — a cast tuned down for flaky interactive use still batches hot.
+/// survives a change to the interactive default.
+///
+/// A floor, matching every other batch knob — see [`batch_effort`] for why the direction
+/// matters and how an unrankable rung is handled.
 pub const BATCH_EFFORT: &str = "high";
+
+/// The reasoning depth one batch item runs at: the deeper of the slot's `effort` and
+/// [`BATCH_EFFORT`], with an unrankable rung deferring to the slot.
+///
+/// Batch floors its knobs rather than fixing them, and effort was the one exception —
+/// force-clobbered in *both* directions. Lifting a thin slot is the intent ("a cast tuned
+/// down for flaky interactive use still batches hot"); demoting a slot that deliberately
+/// asked for `xhigh`/`max` was collateral, and silent. So:
+///
+/// - the slot ranks **deeper** than the floor → the slot wins (never cap a richer slot,
+///   the same promise `max_tokens` and the thinking budget already make);
+/// - the slot ranks **shallower** → the floor wins (the deliberate lift, unchanged);
+/// - either rung is **outside** [`EFFORT_LADDER`] → the slot wins. kaibo keeps no effort
+///   allowlist, so a rung it can't order is an operator reaching for something newer than
+///   this table — trusting it is what keeps that passthrough real, and silently replacing
+///   it with "high" would be exactly the override this function exists to retire.
+pub fn batch_effort(slot_effort: &str) -> &str {
+    match (
+        crate::consult::effort_rank(slot_effort),
+        crate::consult::effort_rank(BATCH_EFFORT),
+    ) {
+        (Some(slot), Some(floor)) if slot <= floor => BATCH_EFFORT,
+        _ => slot_effort,
+    }
+}
 
 /// Floor for a batch item's completion budget. Thinking eats the completion budget, so
 /// a thin `max_tokens` starves the answer; batch is async and cheap, so it never skimps.
@@ -154,21 +182,21 @@ pub trait BatchProvider: Send + Sync {
 
 // --- Request shaping (pure, offline-testable) ------------------------------
 
-/// Batch's maxed request shape for one (kind, model): the floored completion budget and
-/// the forced thinking block, at [`BATCH_EFFORT`]. Threads `BATCH_EFFORT` *explicitly*
+/// Batch's request shape for one (kind, model): the floored completion budget and the
+/// forced-on thinking block at the floored effort. Threads the effort *explicitly*
 /// through [`ModelShape::to_params`](crate::consult::ModelShape::to_params) rather than
 /// the public [`thinking_params`](crate::consult::thinking_params) helper (which would
-/// bake in `consult`'s interactive `DEFAULT_EFFORT`) — so batch's effort stays decoupled
+/// bake in `consult`'s interactive `DEFAULT_EFFORT`) — so batch's depth stays decoupled
 /// from the interactive default, the way the [`BATCH_EFFORT`] doc promises.
 ///
-/// Every knob is *floored*, never capped: `max_tokens` and the thinking budget both rise
-/// to the batch floor but keep a slot's already-higher value — that's the "max the knobs"
-/// promise (batch spends even when the cast was tuned thin for interactive use), and it
-/// can't *undercut* a slot that already asks for more. The budget is held strictly under
-/// `max_tokens` (Anthropic requires `budget_tokens < max_tokens`; the adaptive tier
-/// ignores the budget and expresses depth as `output_config.effort`). Sampling is left
-/// to the provider default — `None`/`None` here — since batch maxes thinking, and the
-/// adaptive tier rejects sampling under thinking anyway.
+/// Every knob is a *floor*, never a cap: `max_tokens`, the thinking budget, and the
+/// effort ([`batch_effort`]) each rise to the batch minimum but keep a slot's
+/// already-higher value — the "spend, it's async" promise in the direction that helps,
+/// without undercutting a cast that deliberately asked for more. The budget is held
+/// strictly under `max_tokens` (Anthropic requires `budget_tokens < max_tokens`; the
+/// adaptive tier ignores the budget and expresses depth as `output_config.effort`).
+/// Sampling is left to the provider default — `None`/`None` here — since batch runs
+/// thinking deep, and the adaptive tier rejects sampling under thinking anyway.
 pub fn batch_shaping(
     kind: ProviderKind,
     model: &str,
@@ -182,7 +210,7 @@ pub fn batch_shaping(
         .max(BATCH_THINKING_BUDGET)
         .min(max_tokens.saturating_sub(1));
     let params = crate::consult::ModelShape::resolve(kind, model, tunables.thinking_style)
-        .to_params(budget, None, None, BATCH_EFFORT);
+        .to_params(budget, None, None, batch_effort(&tunables.effort));
     (max_tokens, params)
 }
 
@@ -1291,19 +1319,22 @@ const OPENAI_COMPLETION_WINDOW: &str = "24h";
 /// so it says who made it.
 const OPENAI_INPUT_FILENAME: &str = "kaibo-batch-input.jsonl";
 
-/// Batch's maxed request shape for a *hosted* OpenAI slot — the Responses-flavored sibling
-/// of [`batch_shaping`]. It can't go through [`ModelShape`](crate::consult::ModelShape):
+/// Batch's request shape for a *hosted* OpenAI slot — the Responses-flavored sibling of
+/// [`batch_shaping`]. It can't go through [`ModelShape`](crate::consult::ModelShape):
 /// that classifier maps the whole `openai` kind to [`ThinkingStyle::None`] on purpose
 /// (a local llama.cpp/Ollama server takes no reasoning params), and hosted-ness is a
 /// property of the *backend*, not the kind. So this reuses the same model-aware classifier
-/// the interactive hosted arm uses, at [`BATCH_EFFORT`] instead of the interactive default.
+/// the interactive hosted arm uses, at the batch-floored effort instead of the interactive
+/// default.
 ///
-/// `max_tokens` is floored exactly like [`batch_shaping`] (never undercut a slot that asks
-/// for more). Sampling is left to the provider default — `top_p = None` — matching the
-/// other providers' batch shape; only the reasoning knob is forced.
+/// `max_tokens` and the effort are floored exactly like [`batch_shaping`] — same
+/// [`batch_effort`] rule, so the two lanes can't drift apart on which direction wins.
+/// Sampling is left to the provider default — `top_p = None` — matching the other
+/// providers' batch shape.
 pub fn openai_batch_shaping(model: &str, tunables: &SlotTunables) -> (u64, Option<Value>) {
     let max_tokens = tunables.max_tokens.max(BATCH_MAX_TOKENS_FLOOR);
-    let params = crate::consult::hosted_openai_responses_params(model, None, BATCH_EFFORT);
+    let params =
+        crate::consult::hosted_openai_responses_params(model, None, batch_effort(&tunables.effort));
     (max_tokens, params)
 }
 
@@ -2177,15 +2208,18 @@ mod tests {
             temperature: 1.0,
             top_p: 1.0,
             effort: effort.to_string(),
+            effort_explicit: true,
             thinking_style: crate::consult::ThinkingStyleOverride::Auto,
         }
     }
 
-    /// Batch maxes the knobs: even a slot tuned thin for interactive use (tiny
-    /// max_tokens, low effort) is floored and forced to the batch effort. The adaptive
-    /// tier expresses that as `output_config.effort: "high"`.
+    /// Batch floors the knobs: a slot tuned thin for interactive use (tiny max_tokens,
+    /// `low` effort) is lifted to the batch budget and the batch effort. The adaptive
+    /// tier expresses that as `output_config.effort: "high"`. This is the direction that
+    /// was always the intent — a cast tuned down for flaky interactive use still batches
+    /// hot — and it must survive effort becoming a floor rather than an override.
     #[test]
-    fn shaping_floors_tokens_and_forces_high_effort_adaptive() {
+    fn shaping_floors_tokens_and_lifts_thin_effort_adaptive() {
         let (max_tokens, params) = batch_shaping(
             ProviderKind::Anthropic,
             "claude-sonnet-4-6",
@@ -2202,8 +2236,65 @@ mod tests {
         // dead-constant bug the cross-family review caught).
         assert_eq!(
             params["output_config"]["effort"], BATCH_EFFORT,
-            "batch must force BATCH_EFFORT regardless of the slot's configured effort: {params}"
+            "a shallower slot effort must be lifted to the batch floor: {params}"
         );
+    }
+
+    /// The other two directions of the effort floor, which the old force-in-both-directions
+    /// shaping got wrong: a slot asking **deeper** than `BATCH_EFFORT` keeps its value (the
+    /// same never-cap-a-richer-slot promise `max_tokens` and the thinking budget already
+    /// make — a cast pinned to `xhigh` for the offline lane was being silently demoted),
+    /// and a rung kaibo can't rank defers to the operator (effort is a passthrough string;
+    /// quietly replacing an unrecognized rung with "high" is the override this retires).
+    #[test]
+    fn shaping_effort_floor_keeps_a_deeper_slot_and_defers_to_an_unranked_rung() {
+        let (_max, params) = batch_shaping(
+            ProviderKind::Anthropic,
+            "claude-sonnet-4-6",
+            &tunables("xhigh", 100),
+        );
+        let params = params.expect("an adaptive Anthropic model carries a thinking block");
+        assert_eq!(
+            params["output_config"]["effort"], "xhigh",
+            "a slot deeper than the batch floor must keep its effort: {params}"
+        );
+
+        // A rung outside EFFORT_LADDER — a provider's newer name, or a typo; from here
+        // they look identical, and trusting the operator is what keeps passthrough real.
+        let (_max, params) = batch_shaping(
+            ProviderKind::Anthropic,
+            "claude-sonnet-4-6",
+            &tunables("ludicrous", 100),
+        );
+        let params = params.expect("an adaptive Anthropic model carries a thinking block");
+        assert_eq!(
+            params["output_config"]["effort"], "ludicrous",
+            "an unrankable rung passes through untouched: {params}"
+        );
+    }
+
+    /// The floor rule itself, isolated from any provider shape — every direction in one
+    /// place so a future edit to `batch_effort` can't quietly flip one of them.
+    #[test]
+    fn batch_effort_is_a_floor_not_an_override() {
+        assert_eq!(batch_effort("none"), BATCH_EFFORT, "lifted");
+        assert_eq!(batch_effort("low"), BATCH_EFFORT, "lifted");
+        assert_eq!(
+            batch_effort(BATCH_EFFORT),
+            BATCH_EFFORT,
+            "equal stays equal"
+        );
+        assert_eq!(batch_effort("xhigh"), "xhigh", "deeper wins");
+        assert_eq!(batch_effort("max"), "max", "deeper wins");
+        assert_eq!(batch_effort("ludicrous"), "ludicrous", "unranked defers");
+        // Ranking is case/whitespace tolerant, but the slot's own spelling is what ships —
+        // kaibo never normalizes an operator's string on its way to a provider.
+        assert_eq!(
+            batch_effort(" LOW "),
+            BATCH_EFFORT,
+            "ranked case-insensitively"
+        );
+        assert_eq!(batch_effort("XHIGH"), "XHIGH", "deeper keeps its spelling");
     }
 
     /// The thinking budget is a *floor*, not a cap: a budget-tier slot already asking
@@ -2692,11 +2783,14 @@ mod tests {
         );
     }
 
-    /// A 3-line id takes `thinkingLevel`, forced to BATCH_EFFORT — the per-role effort
-    /// lever, not a token budget — even when the slot asked for a shallower "low". (The
+    /// A 3-line id takes `thinkingLevel` — the per-role effort lever, not a token budget —
+    /// lifted to BATCH_EFFORT when the slot asked for a shallower "low". (The
     /// `gemini-batch` cast synths `gemini-pro-latest`, also a level-tier id now that the
     /// whole Gemini 3-line takes a level; every Gemini id runs this one path through
-    /// `batch_shaping`.)
+    /// `batch_shaping`.) Note the ladder above `high` is Google's to answer for on this
+    /// wire: batch POSTs its own JSON (no rig converter in the path), so a slot pinned
+    /// deeper than `high` reaches Google verbatim and Google decides — the passthrough
+    /// contract, applied honestly rather than quietly clamped back to `high`.
     #[test]
     fn gemini_3_line_uses_thinking_level_at_batch_effort() {
         let (_max, params) = batch_shaping(
@@ -3349,10 +3443,12 @@ mod tests {
         );
     }
 
-    /// Batch maxes the knobs on hosted OpenAI too: a slot tuned thin and low-effort for
-    /// interactive use is floored to the batch budget and forced to `BATCH_EFFORT`.
+    /// Batch floors the knobs on hosted OpenAI too, and by the *same* rule as every other
+    /// provider — the two shaping functions can't drift on which direction wins. A thin,
+    /// `low`-effort slot is lifted to the batch budget and `BATCH_EFFORT`; a slot that
+    /// asked deeper keeps its rung; an unrankable rung defers to the operator.
     #[test]
-    fn openai_shaping_floors_tokens_and_forces_high_effort() {
+    fn openai_shaping_floors_tokens_and_treats_effort_as_a_floor() {
         let (max_tokens, params) = openai_batch_shaping("gpt-5.6-sol", &tunables("low", 100));
         assert!(
             max_tokens >= BATCH_MAX_TOKENS_FLOOR,
@@ -3361,7 +3457,7 @@ mod tests {
         assert_eq!(
             params.as_ref().unwrap()["reasoning"]["effort"],
             json!(BATCH_EFFORT),
-            "the slot's `low` is overridden by the batch effort"
+            "the slot's shallower `low` is lifted to the batch effort"
         );
         assert!(
             params.as_ref().unwrap().get("top_p").is_none(),
@@ -3370,6 +3466,20 @@ mod tests {
         // A slot already asking for more keeps it — floored, never capped.
         let (bigger, _) = openai_batch_shaping("gpt-5.6-sol", &tunables("low", 1 << 20));
         assert_eq!(bigger, 1 << 20);
+
+        let (_, params) = openai_batch_shaping("gpt-5.6-sol", &tunables("xhigh", 100));
+        assert_eq!(
+            params.as_ref().unwrap()["reasoning"]["effort"],
+            json!("xhigh"),
+            "a deeper slot effort survives the batch lane instead of being demoted"
+        );
+
+        let (_, params) = openai_batch_shaping("gpt-5.6-sol", &tunables("ludicrous", 100));
+        assert_eq!(
+            params.as_ref().unwrap()["reasoning"]["effort"],
+            json!("ludicrous"),
+            "an unrankable rung passes through — kaibo holds no effort allowlist"
+        );
     }
 
     /// The model-aware half: an older chat family takes no `reasoning` block at all, so

--- a/src/config.rs
+++ b/src/config.rs
@@ -395,10 +395,17 @@ pub enum EffortFate {
     /// Ships exactly as configured: an orderable depth this wire carries.
     Sent,
     /// Ships as configured, and it is the reasoning **off-switch**
-    /// ([`crate::consult::EFFORT_OFF`]) — the request structurally disables thinking.
-    /// Called out separately because "off" is not a depth: the batch depth floor
-    /// deliberately leaves it alone, and a reader who sees `none` shipped should know
-    /// that was a decision rather than an oversight.
+    /// ([`crate::consult::EFFORT_OFF`]). Called out separately because "off" is not a
+    /// depth: the batch depth floor deliberately leaves it alone, and a reader who sees
+    /// `none` shipped should know that was a decision rather than an oversight.
+    ///
+    /// "Ships" means kaibo puts it in the params blob — it does *not* promise the wire
+    /// takes it. On DeepSeek and OpenRouter it becomes a structural disable
+    /// (`thinking:{"type":"disabled"}` / `reasoning:{"enabled":false}`); on Gemini,
+    /// whose `thinkingLevel` has no off variant at all, it is refused by the preflight
+    /// (`consult::preflight_params`) before a request is built, naming the slot and the
+    /// rungs that wire does take. This fate answers "what did kaibo do with the value",
+    /// and the preflight answers "will this wire accept it" — two questions on purpose.
     SentAsOff,
     /// Ships as configured, but kaibo can't rank it — a rung newer than
     /// [`crate::consult::EFFORT_LADDER`], or a typo. Passed through on purpose (kaibo
@@ -1236,6 +1243,12 @@ impl Config {
         } else {
             t.effort.clone()
         };
+        // Order is load-bearing, and two of these arms shadow each other if swapped:
+        // `EFFORT_OFF` and an unrankable rung BOTH answer `None` to `effort_rank`, so
+        // `SentAsOff` has to be asked before `SentUnranked` or every reasoning-off would
+        // be reported as "a rung kaibo can't order". `is_effort_off` is the only thing
+        // that tells them apart — the same reason it exists beside `effort_rank` rather
+        // than inside it. The fate-table test pins each arm against a real cast.
         let fate = if !sinks {
             EffortFate::NoSink
         } else if crate::consult::effort_rank(&shipped) != crate::consult::effort_rank(&t.effort) {
@@ -4123,6 +4136,9 @@ mod tests {
             [casts.lifted]
             synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "low" }
 
+            [casts.batch-off]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "none" }
+
             [casts.dropped]
             synth = { backend = "lab", id = "gemma", effort = "xhigh" }
             "#,
@@ -4148,6 +4164,16 @@ mod tests {
             "kaibo keeps no allowlist: a rung it can't order still goes to the provider"
         );
         assert_eq!(fate("lifted"), EffortFate::LiftedToBatchFloor);
+        // The combination that broke before: `none` on a BATCH slot. The depth floor
+        // lifts a shallow rung, and `none` used to be the shallowest rung, so an
+        // operator's reasoning-off silently became `high` and billed on every item.
+        // Regressing `EFFORT_OFF` back onto `EFFORT_LADDER` makes this read
+        // `LiftedToBatchFloor` and fails here.
+        assert_eq!(
+            fate("batch-off"),
+            EffortFate::SentAsOff,
+            "a DEPTH floor must leave an explicit reasoning-off alone on the batch lane too"
+        );
         assert_eq!(fate("dropped"), EffortFate::NoSink);
 
         // Only the last two are things the operator needs to hear about.
@@ -4155,7 +4181,9 @@ mod tests {
             .effort_diagnostics()
             .into_iter()
             .map(|d| d.cast)
-            .filter(|c| ["plain", "off", "newer", "lifted", "dropped"].contains(&c.as_str()))
+            .filter(|c| {
+                ["plain", "off", "newer", "lifted", "dropped", "batch-off"].contains(&c.as_str())
+            })
             .collect();
         assert_eq!(
             diagnosed,

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,10 +66,23 @@ pub struct Defaults {
     /// Per-role reasoning effort for the models that take one as a request param
     /// (Anthropic adaptive's `output_config.effort`, DeepSeek's `reasoning_effort`,
     /// Gemini's `thinkingLevel`, OpenRouter's unified `reasoning.effort`). A passthrough
-    /// string — the provider validates it. Default `"high"` both roles; bump a synth
-    /// slot's `effort` to `"max"`/`"xhigh"` for heavier synth runs.
+    /// string — kaibo keeps no allowlist. Default `"high"` both roles; bump a synth
+    /// slot's `effort` for heavier synth runs. **The ladder is per-provider**, not
+    /// universal — see `docs/config.md` and [`crate::consult::EffortWire`].
     pub explorer_effort: String,
     pub synth_effort: String,
+    /// Did the operator *write* the per-role effort (config file, `KAIBO_*_EFFORT`), or
+    /// is it the inherited built-in [`crate::consult::DEFAULT_EFFORT`]?
+    ///
+    /// The distinction is what lets kaibo be loud about an effort that lands nowhere
+    /// without crying wolf: two wires have no reasoning knob at all (Anthropic's budget
+    /// tier, the generic OpenAI `/chat/completions` shape) and drop it silently, and
+    /// *every* local cast inherits `high` onto one of them. Warning about the inherited
+    /// default would fire on every ordinary local setup; warning about a value the
+    /// operator typed is the signal they actually asked for. See
+    /// [`Config::inert_efforts`].
+    pub explorer_effort_explicit: bool,
+    pub synth_effort_explicit: bool,
     /// Force the Anthropic thinking style (`auto`/`adaptive`/`budget`) instead of the
     /// built-in classifier — the escape hatch for a new or misclassified model.
     /// Server-wide default; overridable per slot. A no-op for non-Anthropic kinds.
@@ -139,6 +152,9 @@ impl Default for Defaults {
             // run is unchanged. `Auto` classifies the thinking style from the model id.
             explorer_effort: crate::consult::DEFAULT_EFFORT.to_string(),
             synth_effort: crate::consult::DEFAULT_EFFORT.to_string(),
+            // Inherited, not asked for — see the field docs.
+            explorer_effort_explicit: false,
+            synth_effort_explicit: false,
             thinking_style: ThinkingStyleOverride::Auto,
             // 15 min. A single completion that takes longer is pathological for a
             // hosted API and a generous ceiling for a slow local model. It's the
@@ -319,14 +335,19 @@ impl ModelSlot {
     /// wins, else the per-role `[defaults]` value. The single fallback point — the
     /// per-arm request shaping in `consult.rs` reads only the result.
     pub fn tunables(&self, role: ModelRole, defaults: &Defaults) -> SlotTunables {
-        let (default_temperature, default_effort) = match role {
+        let (default_temperature, default_effort, default_effort_explicit) = match role {
             ModelRole::Explorer => (
                 defaults.explorer_temperature,
                 defaults.explorer_effort.as_str(),
+                defaults.explorer_effort_explicit,
             ),
             // Synth and (future) media roles take the synth-side defaults: the
             // answer-composing posture is the general-purpose one.
-            _ => (defaults.synth_temperature, defaults.synth_effort.as_str()),
+            _ => (
+                defaults.synth_temperature,
+                defaults.synth_effort.as_str(),
+                defaults.synth_effort_explicit,
+            ),
         };
         SlotTunables {
             max_tokens: self.max_tokens.unwrap_or(defaults.max_tokens),
@@ -337,9 +358,43 @@ impl ModelSlot {
                 .effort
                 .clone()
                 .unwrap_or_else(|| default_effort.to_string()),
+            // Explicit either way an operator can write it: on the slot, or in the
+            // `[defaults]`/env layer this slot inherits from.
+            effort_explicit: self.effort.is_some() || default_effort_explicit,
             thinking_style: self.thinking_style.unwrap_or(defaults.thinking_style),
         }
     }
+}
+
+/// Where an operator wrote the `effort` that turned out to be inert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffortSource {
+    /// On the cast slot itself (`effort = "…"` in the role table).
+    Slot,
+    /// In `[defaults].explorer_effort` / `synth_effort`, or the matching `KAIBO_*_EFFORT`.
+    Defaults,
+}
+
+impl EffortSource {
+    /// Where to go edit it — a short token, since this rides a structured log field.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Slot => "slot",
+            Self::Defaults => "[defaults]/env",
+        }
+    }
+}
+
+/// One configured slot whose written `effort` has no sink on its wire — see
+/// [`Config::inert_efforts`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InertEffort {
+    pub cast: String,
+    pub role: &'static str,
+    /// The slot's `"backend/model-id"` ref, so the message names both halves.
+    pub model: String,
+    pub effort: String,
+    pub source: EffortSource,
 }
 
 /// A slot's effective request-shaping knobs after the per-role fallback (see
@@ -351,6 +406,10 @@ pub struct SlotTunables {
     pub temperature: f64,
     pub top_p: f64,
     pub effort: String,
+    /// True when `effort` came from something the operator wrote (a slot `effort =`, the
+    /// `[defaults]` table, a `KAIBO_*_EFFORT` env) rather than the built-in
+    /// [`crate::consult::DEFAULT_EFFORT`]. See [`Defaults::explorer_effort_explicit`].
+    pub effort_explicit: bool,
     pub thinking_style: ThinkingStyleOverride,
 }
 
@@ -1074,6 +1133,72 @@ impl Config {
     pub fn slot_caps(&self, slot: &ModelSlot) -> Result<ModelCaps> {
         let backend = self.resolve_backend(&slot.backend)?;
         Ok(ModelCaps::resolve(backend.kind, &slot.id, slot.vision))
+    }
+
+    /// Does this slot's `effort` reach the wire? The one answer the render, the startup
+    /// scan, and (through [`crate::consult::effort_sinks`]) the arm all read — resolving
+    /// the shape exactly as [`ModelSlot::tunables`] does, `[defaults].thinking_style`
+    /// fallback included, so display can't disagree with what actually ships.
+    ///
+    /// Lane-aware: a `lane = "batch"` slot never touches the interactive wire, and batch's
+    /// hosted-OpenAI shape is gated on the endpoint-exact `is_hosted_openai` rather than
+    /// the configurable `uses_responses_wire`.
+    pub fn slot_effort_sinks(&self, slot: &ModelSlot, role: ModelRole) -> Result<bool> {
+        let backend = self.resolve_backend(&slot.backend)?;
+        let t = slot.tunables(role, &self.defaults);
+        let responses = match slot.lane {
+            Some(Lane::Batch) => backend.is_hosted_openai(),
+            _ => backend.uses_responses_wire(),
+        };
+        Ok(crate::consult::effort_sinks(
+            backend.kind,
+            &slot.id,
+            t.thinking_style,
+            responses,
+        ))
+    }
+
+    /// Every configured cast slot where the operator *wrote* an `effort` that this
+    /// slot's wire has no place to put — the silent drop, made loud.
+    ///
+    /// Two wires carry no reasoning knob at all: Anthropic's legacy budget tier (Haiku
+    /// 4.5 and older, which express depth as `budget_tokens`) and the generic OpenAI
+    /// `/chat/completions` shape every local llama.cpp/Ollama/gateway backend speaks. An
+    /// `effort` aimed at either evaporates in `to_params`, and nothing downstream fails —
+    /// exactly the silent fallback kaibo refuses everywhere else.
+    ///
+    /// Only *explicit* efforts are reported (see [`Defaults::explorer_effort_explicit`]):
+    /// every local cast inherits the built-in `high` onto a toggle-less wire, so a warning
+    /// there would be noise on every ordinary setup and would train operators to ignore
+    /// the one that matters. Returned rather than logged so the rule is unit-testable and
+    /// both front doors (and the `kaibo://config` render) share one answer; the caller
+    /// decides how to say it. Slots whose backend doesn't resolve are skipped — a broken
+    /// ref is someone else's louder error.
+    pub fn inert_efforts(&self) -> Vec<InertEffort> {
+        let mut out = Vec::new();
+        for (cast_name, cast) in &self.casts {
+            for (role, slot) in &cast.slots {
+                let t = slot.tunables(*role, &self.defaults);
+                if !t.effort_explicit {
+                    continue;
+                }
+                if self.slot_effort_sinks(slot, *role).unwrap_or(true) {
+                    continue;
+                }
+                out.push(InertEffort {
+                    cast: cast_name.clone(),
+                    role: role.key(),
+                    model: slot.qualified(),
+                    effort: t.effort,
+                    source: if slot.effort.is_some() {
+                        EffortSource::Slot
+                    } else {
+                        EffortSource::Defaults
+                    },
+                });
+            }
+        }
+        out
     }
 
     /// Validate `[sandbox].disable_builtins` against the set of builtins actually
@@ -2200,6 +2325,10 @@ fn merge_defaults(raw: RawDefaults) -> Result<Defaults> {
         explorer_temperature: raw.explorer_temperature.unwrap_or(d.explorer_temperature),
         synth_temperature: raw.synth_temperature.unwrap_or(d.synth_temperature),
         top_p: raw.top_p.unwrap_or(d.top_p),
+        // `raw` already carries the env layer folded in (`apply_env`), so `is_some` is
+        // "the operator wrote this" for both the config file and `KAIBO_*_EFFORT`.
+        explorer_effort_explicit: raw.explorer_effort.is_some(),
+        synth_effort_explicit: raw.synth_effort.is_some(),
         explorer_effort: raw.explorer_effort.unwrap_or(d.explorer_effort),
         synth_effort: raw.synth_effort.unwrap_or(d.synth_effort),
         thinking_style: match raw.thinking_style {
@@ -3681,6 +3810,145 @@ mod tests {
             ..ModelSlot::bare("openai-local", "llava")
         };
         assert!(cfg.slot_caps(&pinned).unwrap().vision);
+    }
+
+    // --- inert effort -----------------------------------------------------------
+
+    /// An `effort` the operator WROTE onto a wire with no reasoning knob is reported;
+    /// the inherited built-in default on the same wire is not.
+    ///
+    /// This is the whole explicit-vs-inherited distinction. Anthropic's budget tier and
+    /// the generic OpenAI chat shape drop the effort in `to_params` and nothing fails —
+    /// but *every* local cast inherits `high` onto that second wire, so flagging the
+    /// inherited value would fire on every ordinary setup and teach operators to tune the
+    /// warning out. Flagging what they typed is the signal they asked for.
+    #[test]
+    fn inert_efforts_reports_a_written_effort_and_stays_quiet_about_the_inherited_one() {
+        // A local (openai-chat) cast with no effort written anywhere: the built-in `high`
+        // lands nowhere, and that is normal — silence.
+        let cfg = Config::from_toml_str(
+            r#"
+            [backends.lab]
+            kind = "openai"
+            base_url = "http://127.0.0.1:8080/v1"
+            key_optional = true
+
+            [casts.zorak]
+            synth = "lab/gemma"
+            "#,
+        )
+        .unwrap();
+        assert!(
+            cfg.inert_efforts().is_empty(),
+            "an inherited default on a toggle-less wire is ordinary, not a warning: {:?}",
+            cfg.inert_efforts()
+        );
+
+        // The same cast, with the effort written on the slot: now it is a claim the
+        // operator made, and it goes nowhere.
+        let cfg = Config::from_toml_str(
+            r#"
+            [backends.lab]
+            kind = "openai"
+            base_url = "http://127.0.0.1:8080/v1"
+            key_optional = true
+
+            [casts.zorak]
+            synth = { backend = "lab", id = "gemma", effort = "xhigh" }
+            "#,
+        )
+        .unwrap();
+        let inert = cfg.inert_efforts();
+        assert_eq!(inert.len(), 1, "one slot, one report: {inert:?}");
+        assert_eq!(inert[0].cast, "zorak");
+        assert_eq!(inert[0].role, "synth");
+        assert_eq!(inert[0].model, "lab/gemma");
+        assert_eq!(inert[0].effort, "xhigh");
+        assert_eq!(
+            inert[0].source,
+            EffortSource::Slot,
+            "the message must point at the line to edit"
+        );
+
+        // And via `[defaults]` — the case a per-slot-only check missed entirely, since a
+        // defaults effort lands on every cast at once.
+        let cfg = Config::from_toml_str(
+            r#"
+            [defaults]
+            synth_effort = "low"
+
+            [backends.lab]
+            kind = "openai"
+            base_url = "http://127.0.0.1:8080/v1"
+            key_optional = true
+
+            [casts.zorak]
+            synth = "lab/gemma"
+            "#,
+        )
+        .unwrap();
+        let inert = cfg.inert_efforts();
+        let zorak: Vec<_> = inert.iter().filter(|i| i.cast == "zorak").collect();
+        assert_eq!(
+            zorak.len(),
+            1,
+            "the defaults effort is reported too: {inert:?}"
+        );
+        assert_eq!(zorak[0].effort, "low");
+        assert_eq!(zorak[0].source, EffortSource::Defaults);
+    }
+
+    /// A written effort on a wire that *does* carry one is never reported — the flag has
+    /// to discriminate, or it is noise. One slot per effort-carrying wire kaibo ships.
+    #[test]
+    fn inert_efforts_stays_quiet_where_the_effort_actually_lands() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.spread]
+            explorer = { backend = "deepseek", id = "deepseek-v4-pro", effort = "low" }
+            synth = { backend = "anthropic", id = "claude-sonnet-4-6", effort = "xhigh" }
+            "#,
+        )
+        .unwrap();
+        assert!(
+            cfg.inert_efforts().iter().all(|i| i.cast != "spread"),
+            "DeepSeek's reasoning_effort and Anthropic adaptive's output_config.effort \
+             both carry the value: {:?}",
+            cfg.inert_efforts()
+        );
+
+        // The budget tier is the Anthropic half that does NOT: depth there is
+        // `budget_tokens`, so an effort beside it evaporates.
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.haiku]
+            synth = { backend = "anthropic", id = "claude-haiku-4-5", effort = "xhigh" }
+            "#,
+        )
+        .unwrap();
+        let inert = cfg.inert_efforts();
+        assert!(
+            inert.iter().any(|i| i.cast == "haiku"),
+            "the budget tier has no effort sink: {inert:?}"
+        );
+
+        // ...and the `thinking_style` escape hatch moves the answer, resolved through the
+        // same `slot.tunables` fallback the wire uses — a `[defaults]` style must count.
+        let cfg = Config::from_toml_str(
+            r#"
+            [defaults]
+            thinking_style = "adaptive"
+
+            [casts.haiku]
+            synth = { backend = "anthropic", id = "claude-haiku-4-5", effort = "xhigh" }
+            "#,
+        )
+        .unwrap();
+        assert!(
+            cfg.inert_efforts().iter().all(|i| i.cast != "haiku"),
+            "forced adaptive gives the effort a sink: {:?}",
+            cfg.inert_efforts()
+        );
     }
 
     /// A model id with an inner slash (HuggingFace style) survives the string

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ pub struct Defaults {
     /// *every* local cast inherits `high` onto one of them. Warning about the inherited
     /// default would fire on every ordinary local setup; warning about a value the
     /// operator typed is the signal they actually asked for. See
-    /// [`Config::inert_efforts`].
+    /// [`Config::effort_diagnostics`].
     pub explorer_effort_explicit: bool,
     pub synth_effort_explicit: bool,
     /// Force the Anthropic thinking style (`auto`/`adaptive`/`budget`) instead of the
@@ -385,16 +385,72 @@ impl EffortSource {
     }
 }
 
-/// One configured slot whose written `effort` has no sink on its wire — see
-/// [`Config::inert_efforts`].
+/// Why a slot's configured `effort` does or doesn't ship as written. The "why" half of
+/// [`EffortDisposition`] — every outcome kaibo's effort plumbing can produce, named, so a
+/// caller explains the same thing everywhere.
+// `Ord` so a caller can group diagnostics by fate deterministically (see the startup
+// warning in `server::resolver`); the order itself carries no meaning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EffortFate {
+    /// Ships exactly as configured: an orderable depth this wire carries.
+    Sent,
+    /// Ships as configured, and it is the reasoning **off-switch**
+    /// ([`crate::consult::EFFORT_OFF`]) — the request structurally disables thinking.
+    /// Called out separately because "off" is not a depth: the batch depth floor
+    /// deliberately leaves it alone, and a reader who sees `none` shipped should know
+    /// that was a decision rather than an oversight.
+    SentAsOff,
+    /// Ships as configured, but kaibo can't rank it — a rung newer than
+    /// [`crate::consult::EFFORT_LADDER`], or a typo. Passed through on purpose (kaibo
+    /// keeps no allowlist); the provider is the one that answers for it.
+    SentUnranked,
+    /// The batch lane floored a shallower depth up to
+    /// [`crate::batch::BATCH_EFFORT`], so the configured value is not what runs.
+    LiftedToBatchFloor,
+    /// This wire has no reasoning field at all, so the value is dropped before the
+    /// request is built and nothing downstream fails.
+    NoSink,
+}
+
+/// What actually happens to one slot's `effort`: what the operator wrote, what the
+/// request carries, and why those differ. Produced by
+/// [`Config::effort_disposition`](Config::effort_disposition) — the single implementation
+/// of that policy, shared by the `kaibo://config` render and the startup scan.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InertEffort {
+pub struct EffortDisposition {
+    /// The effective value after the slot → `[defaults]` fallback.
+    pub configured: String,
+    /// What the request actually carries — `None` when this wire sends no effort at all.
+    pub sent: Option<String>,
+    pub fate: EffortFate,
+    /// Did a human write this, or is it the inherited built-in
+    /// [`crate::consult::DEFAULT_EFFORT`]? See [`Defaults::explorer_effort_explicit`].
+    pub explicit: bool,
+    /// Where they wrote it. Meaningful only when `explicit`.
+    pub source: EffortSource,
+}
+
+impl EffortDisposition {
+    /// Does the configured value reach the provider as written? False exactly when the
+    /// knob reads as effective and isn't — the condition both the `inert_tunables` render
+    /// and the startup warning key on, so they cannot disagree.
+    pub fn ships_as_configured(&self) -> bool {
+        matches!(
+            self.fate,
+            EffortFate::Sent | EffortFate::SentAsOff | EffortFate::SentUnranked
+        )
+    }
+}
+
+/// One configured slot whose *written* `effort` doesn't ship as written — see
+/// [`Config::effort_diagnostics`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffortDiagnostic {
     pub cast: String,
     pub role: &'static str,
     /// The slot's `"backend/model-id"` ref, so the message names both halves.
     pub model: String,
-    pub effort: String,
-    pub source: EffortSource,
+    pub disposition: EffortDisposition,
 }
 
 /// A slot's effective request-shaping knobs after the per-role fallback (see
@@ -1135,66 +1191,103 @@ impl Config {
         Ok(ModelCaps::resolve(backend.kind, &slot.id, slot.vision))
     }
 
-    /// Does this slot's `effort` reach the wire? The one answer the render, the startup
-    /// scan, and (through [`crate::consult::effort_sinks`]) the arm all read — resolving
-    /// the shape exactly as [`ModelSlot::tunables`] does, `[defaults].thinking_style`
-    /// fallback included, so display can't disagree with what actually ships.
+    /// What actually happens to this slot's `effort` on the way to the provider — the
+    /// **one** implementation of that policy. `kaibo://config`'s `inert_tunables`, the
+    /// startup warning, and anything else that wants to explain an effort all consume
+    /// this; there is deliberately no second copy of the rule to drift from. (There was
+    /// one, briefly, and it drifted inside a single commit: the render already knew a
+    /// batch lift meant the configured value didn't ship, and the startup scan didn't.)
     ///
-    /// Lane-aware: a `lane = "batch"` slot never touches the interactive wire, and batch's
-    /// hosted-OpenAI shape is gated on the endpoint-exact `is_hosted_openai` rather than
-    /// the configurable `uses_responses_wire`.
-    pub fn slot_effort_sinks(&self, slot: &ModelSlot, role: ModelRole) -> Result<bool> {
+    /// The shape is resolved exactly as [`ModelSlot::tunables`] resolves it —
+    /// `[defaults].thinking_style` fallback included — so what is displayed can't disagree
+    /// with what ships. Lane-aware: a `lane = "batch"` slot never builds an interactive
+    /// arm, and batch's hosted-OpenAI shape is gated on the endpoint-exact
+    /// `is_hosted_openai` rather than the configurable `uses_responses_wire`.
+    pub fn effort_disposition(
+        &self,
+        slot: &ModelSlot,
+        role: ModelRole,
+    ) -> Result<EffortDisposition> {
         let backend = self.resolve_backend(&slot.backend)?;
         let t = slot.tunables(role, &self.defaults);
-        let responses = match slot.lane {
-            Some(Lane::Batch) => backend.is_hosted_openai(),
-            _ => backend.uses_responses_wire(),
+        let batch_lane = slot.lane == Some(Lane::Batch);
+        let responses = if batch_lane {
+            backend.is_hosted_openai()
+        } else {
+            backend.uses_responses_wire()
         };
-        Ok(crate::consult::effort_sinks(
-            backend.kind,
-            &slot.id,
-            t.thinking_style,
-            responses,
-        ))
+        let sinks =
+            crate::consult::effort_sinks(backend.kind, &slot.id, t.thinking_style, responses);
+        let source = if slot.effort.is_some() {
+            EffortSource::Slot
+        } else {
+            EffortSource::Defaults
+        };
+        // The batch lane floors DEPTH; `batch_effort` is the authority on what that does
+        // to this value (including leaving the off-switch alone). Judge the outcome by
+        // RANK, not by string. Today `batch_effort` returns the operator's own spelling
+        // whenever the depths match, so the two agree — but they are separate decisions,
+        // and the string comparison was wrong the moment the floor normalized a tie: a
+        // `" HIGH "` came back as `"high"` and got reported as not-shipping when it ships
+        // untouched. Comparing depth to depth means "did the floor change what runs?" is
+        // answered independently of how `batch_effort` resolves ties.
+        let shipped = if batch_lane {
+            crate::batch::batch_effort(&t.effort).to_string()
+        } else {
+            t.effort.clone()
+        };
+        let fate = if !sinks {
+            EffortFate::NoSink
+        } else if crate::consult::effort_rank(&shipped) != crate::consult::effort_rank(&t.effort) {
+            EffortFate::LiftedToBatchFloor
+        } else if crate::consult::is_effort_off(&t.effort) {
+            EffortFate::SentAsOff
+        } else if crate::consult::effort_rank(&t.effort).is_none() {
+            EffortFate::SentUnranked
+        } else {
+            EffortFate::Sent
+        };
+        Ok(EffortDisposition {
+            configured: t.effort,
+            sent: sinks.then_some(shipped),
+            fate,
+            explicit: t.effort_explicit,
+            source,
+        })
     }
 
-    /// Every configured cast slot where the operator *wrote* an `effort` that this
-    /// slot's wire has no place to put — the silent drop, made loud.
+    /// Every configured cast slot where the operator *wrote* an `effort` that doesn't ship
+    /// as written — the silent divergences, made loud.
     ///
-    /// Two wires carry no reasoning knob at all: Anthropic's legacy budget tier (Haiku
-    /// 4.5 and older, which express depth as `budget_tokens`) and the generic OpenAI
-    /// `/chat/completions` shape every local llama.cpp/Ollama/gateway backend speaks. An
-    /// `effort` aimed at either evaporates in `to_params`, and nothing downstream fails —
-    /// exactly the silent fallback kaibo refuses everywhere else.
+    /// Two kinds, both from [`effort_disposition`](Self::effort_disposition) so this can't
+    /// disagree with the `kaibo://config` render: a wire with no reasoning field at all
+    /// (Anthropic's legacy budget tier; the generic OpenAI `/chat/completions` shape every
+    /// local llama.cpp/Ollama/gateway backend speaks) drops the value in `to_params` with
+    /// nothing downstream failing, and the batch lane lifts a below-floor depth. Either
+    /// way the knob reads as effective and isn't — exactly the silent fallback kaibo
+    /// refuses everywhere else.
     ///
     /// Only *explicit* efforts are reported (see [`Defaults::explorer_effort_explicit`]):
     /// every local cast inherits the built-in `high` onto a toggle-less wire, so a warning
     /// there would be noise on every ordinary setup and would train operators to ignore
     /// the one that matters. Returned rather than logged so the rule is unit-testable and
-    /// both front doors (and the `kaibo://config` render) share one answer; the caller
-    /// decides how to say it. Slots whose backend doesn't resolve are skipped — a broken
-    /// ref is someone else's louder error.
-    pub fn inert_efforts(&self) -> Vec<InertEffort> {
+    /// the caller decides how to say it. Slots whose backend doesn't resolve are skipped —
+    /// a broken ref is someone else's louder error.
+    pub fn effort_diagnostics(&self) -> Vec<EffortDiagnostic> {
         let mut out = Vec::new();
         for (cast_name, cast) in &self.casts {
             for (role, slot) in &cast.slots {
-                let t = slot.tunables(*role, &self.defaults);
-                if !t.effort_explicit {
+                let Ok(disposition) = self.effort_disposition(slot, *role) else {
+                    continue;
+                };
+                if !disposition.explicit || disposition.ships_as_configured() {
                     continue;
                 }
-                if self.slot_effort_sinks(slot, *role).unwrap_or(true) {
-                    continue;
-                }
-                out.push(InertEffort {
+                out.push(EffortDiagnostic {
                     cast: cast_name.clone(),
                     role: role.key(),
                     model: slot.qualified(),
-                    effort: t.effort,
-                    source: if slot.effort.is_some() {
-                        EffortSource::Slot
-                    } else {
-                        EffortSource::Defaults
-                    },
+                    disposition,
                 });
             }
         }
@@ -3823,7 +3916,7 @@ mod tests {
     /// inherited value would fire on every ordinary setup and teach operators to tune the
     /// warning out. Flagging what they typed is the signal they asked for.
     #[test]
-    fn inert_efforts_reports_a_written_effort_and_stays_quiet_about_the_inherited_one() {
+    fn effort_diagnostics_report_a_written_effort_and_stay_quiet_about_the_inherited_one() {
         // A local (openai-chat) cast with no effort written anywhere: the built-in `high`
         // lands nowhere, and that is normal — silence.
         let cfg = Config::from_toml_str(
@@ -3839,9 +3932,9 @@ mod tests {
         )
         .unwrap();
         assert!(
-            cfg.inert_efforts().is_empty(),
+            cfg.effort_diagnostics().is_empty(),
             "an inherited default on a toggle-less wire is ordinary, not a warning: {:?}",
-            cfg.inert_efforts()
+            cfg.effort_diagnostics()
         );
 
         // The same cast, with the effort written on the slot: now it is a claim the
@@ -3858,14 +3951,19 @@ mod tests {
             "#,
         )
         .unwrap();
-        let inert = cfg.inert_efforts();
+        let inert = cfg.effort_diagnostics();
         assert_eq!(inert.len(), 1, "one slot, one report: {inert:?}");
         assert_eq!(inert[0].cast, "zorak");
         assert_eq!(inert[0].role, "synth");
         assert_eq!(inert[0].model, "lab/gemma");
-        assert_eq!(inert[0].effort, "xhigh");
+        assert_eq!(inert[0].disposition.configured, "xhigh");
+        assert_eq!(inert[0].disposition.fate, EffortFate::NoSink);
+        assert!(
+            inert[0].disposition.sent.is_none(),
+            "nothing reaches the wire"
+        );
         assert_eq!(
-            inert[0].source,
+            inert[0].disposition.source,
             EffortSource::Slot,
             "the message must point at the line to edit"
         );
@@ -3887,21 +3985,21 @@ mod tests {
             "#,
         )
         .unwrap();
-        let inert = cfg.inert_efforts();
+        let inert = cfg.effort_diagnostics();
         let zorak: Vec<_> = inert.iter().filter(|i| i.cast == "zorak").collect();
         assert_eq!(
             zorak.len(),
             1,
             "the defaults effort is reported too: {inert:?}"
         );
-        assert_eq!(zorak[0].effort, "low");
-        assert_eq!(zorak[0].source, EffortSource::Defaults);
+        assert_eq!(zorak[0].disposition.configured, "low");
+        assert_eq!(zorak[0].disposition.source, EffortSource::Defaults);
     }
 
     /// A written effort on a wire that *does* carry one is never reported — the flag has
     /// to discriminate, or it is noise. One slot per effort-carrying wire kaibo ships.
     #[test]
-    fn inert_efforts_stays_quiet_where_the_effort_actually_lands() {
+    fn effort_diagnostics_stay_quiet_where_the_effort_actually_lands() {
         let cfg = Config::from_toml_str(
             r#"
             [casts.spread]
@@ -3911,10 +4009,10 @@ mod tests {
         )
         .unwrap();
         assert!(
-            cfg.inert_efforts().iter().all(|i| i.cast != "spread"),
+            cfg.effort_diagnostics().iter().all(|i| i.cast != "spread"),
             "DeepSeek's reasoning_effort and Anthropic adaptive's output_config.effort \
              both carry the value: {:?}",
-            cfg.inert_efforts()
+            cfg.effort_diagnostics()
         );
 
         // The budget tier is the Anthropic half that does NOT: depth there is
@@ -3926,7 +4024,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let inert = cfg.inert_efforts();
+        let inert = cfg.effort_diagnostics();
         assert!(
             inert.iter().any(|i| i.cast == "haiku"),
             "the budget tier has no effort sink: {inert:?}"
@@ -3945,9 +4043,124 @@ mod tests {
         )
         .unwrap();
         assert!(
-            cfg.inert_efforts().iter().all(|i| i.cast != "haiku"),
+            cfg.effort_diagnostics().iter().all(|i| i.cast != "haiku"),
             "forced adaptive gives the effort a sink: {:?}",
-            cfg.inert_efforts()
+            cfg.effort_diagnostics()
+        );
+    }
+
+    /// Whether the configured value "ships as written" is a question about **depth**, not
+    /// about spelling. `batch_effort` returns the operator's own string when the depths
+    /// match — kaibo never normalizes a value on its way to a provider — so a padded or
+    /// upper-cased `" HIGH "` compares unequal to `"high"` while meaning exactly the same
+    /// thing. Comparing by string reported that slot as not-shipping and told the operator
+    /// to go fix a setting that was already correct.
+    #[test]
+    fn effort_disposition_compares_depth_by_rank_not_by_spelling() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [casts.padded]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = " HIGH " }
+
+            [casts.padded_low]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = " LoW " }
+            "#,
+        )
+        .unwrap();
+        let slot = |cast: &str| {
+            cfg.resolve_cast(cast)
+                .unwrap()
+                .require_slot(ModelRole::Synth)
+                .unwrap()
+                .clone()
+        };
+
+        // Same depth as the batch floor, different spelling: it ships, untouched.
+        let d = cfg
+            .effort_disposition(&slot("padded"), ModelRole::Synth)
+            .unwrap();
+        assert_eq!(d.fate, EffortFate::Sent, "same depth as the floor: {d:?}");
+        assert!(
+            d.ships_as_configured(),
+            "a spelling difference is not a lift: {d:?}"
+        );
+        assert_eq!(
+            d.sent.as_deref(),
+            Some(" HIGH "),
+            "and the operator's own string is what goes out — kaibo doesn't normalize"
+        );
+
+        // Genuinely shallower, however it was spelled: that IS a lift.
+        let d = cfg
+            .effort_disposition(&slot("padded_low"), ModelRole::Synth)
+            .unwrap();
+        assert_eq!(d.fate, EffortFate::LiftedToBatchFloor, "{d:?}");
+        assert!(!d.ships_as_configured(), "{d:?}");
+        assert_eq!(d.sent.as_deref(), Some(crate::batch::BATCH_EFFORT));
+    }
+
+    /// The whole fate table on one wire, so a reader can see what kaibo can say about an
+    /// effort — and so the two "it ships, but you should know why" cases don't quietly
+    /// collapse into plain `Sent`.
+    #[test]
+    fn effort_disposition_names_why_a_value_ships_or_does_not() {
+        let cfg = Config::from_toml_str(
+            r#"
+            [backends.lab]
+            kind = "openai"
+            base_url = "http://127.0.0.1:8080/v1"
+            key_optional = true
+
+            [casts.plain]
+            synth = { backend = "deepseek", id = "deepseek-v4-pro", effort = "xhigh" }
+
+            [casts.off]
+            synth = { backend = "deepseek", id = "deepseek-v4-pro", effort = "none" }
+
+            [casts.newer]
+            synth = { backend = "deepseek", id = "deepseek-v4-pro", effort = "ludicrous" }
+
+            [casts.lifted]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "low" }
+
+            [casts.dropped]
+            synth = { backend = "lab", id = "gemma", effort = "xhigh" }
+            "#,
+        )
+        .unwrap();
+        let fate = |cast: &str| {
+            let slot = cfg
+                .resolve_cast(cast)
+                .unwrap()
+                .require_slot(ModelRole::Synth)
+                .unwrap();
+            cfg.effort_disposition(slot, ModelRole::Synth).unwrap().fate
+        };
+        assert_eq!(fate("plain"), EffortFate::Sent);
+        assert_eq!(
+            fate("off"),
+            EffortFate::SentAsOff,
+            "off ships, and a reader must be told it was a decision, not an oversight"
+        );
+        assert_eq!(
+            fate("newer"),
+            EffortFate::SentUnranked,
+            "kaibo keeps no allowlist: a rung it can't order still goes to the provider"
+        );
+        assert_eq!(fate("lifted"), EffortFate::LiftedToBatchFloor);
+        assert_eq!(fate("dropped"), EffortFate::NoSink);
+
+        // Only the last two are things the operator needs to hear about.
+        let diagnosed: Vec<String> = cfg
+            .effort_diagnostics()
+            .into_iter()
+            .map(|d| d.cast)
+            .filter(|c| ["plain", "off", "newer", "lifted", "dropped"].contains(&c.as_str()))
+            .collect();
+        assert_eq!(
+            diagnosed,
+            vec!["dropped".to_string(), "lifted".to_string()],
+            "only the two that don't ship as written are diagnostics (BTreeMap cast order)"
         );
     }
 

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -288,6 +288,31 @@ impl Arm {
         // config opt-in. A no-op for every other kind.
         let params =
             super::shaping::inject_provider_prefs(backend.kind, params, backend.data_collection);
+        // Preflight the blob through rig's OWN request builder for this wire. Two of the
+        // six wires parse it into a typed struct whose reasoning rungs are a closed enum,
+        // so an effort rig can't name dies *inside rig* at call time with a bare serde
+        // line ("unknown variant `max`") that says nothing about which slot of which cast
+        // asked for it. Asking here — the single live construction point — turns that into
+        // a boundary error naming the slot and the rungs that wire does take. It stays a
+        // preflight, not a policy: the accepted list is read back out of rig, so a rig bump
+        // that adds a rung needs no kaibo change, and effort stays a passthrough string
+        // everywhere rig lets it be one.
+        let wire = super::shaping::EffortWire::resolve(backend.kind, responses_wire);
+        if let Err(detail) = super::shaping::preflight_params(wire, params.as_ref()) {
+            return Err(anyhow!(
+                "model {:?} (backend {:?}, {} slot): effort {:?} is refused by rig's {} \
+                 request builder before the request leaves kaibo. That ceiling is \
+                 rig-core's typed client, not the provider's API — this wire accepts {}. \
+                 Set the slot's `effort` (or `[defaults]`) to one of those, or point the \
+                 slot at a backend whose wire passes effort through. (rig: {detail})",
+                slot.id,
+                backend.name,
+                role.key(),
+                t.effort,
+                wire.label(),
+                super::shaping::accepted_efforts(wire).join(" | "),
+            ));
+        }
         let caps = ModelCaps::resolve(backend.kind, &slot.id, slot.vision);
 
         // One HTTP backend carrying the per-request deadline, built by the shared
@@ -3417,6 +3442,88 @@ mod tests {
         assert!(
             arm.caps.vision,
             "the vision pin survives into the hosted arm"
+        );
+    }
+
+    /// An effort rig's typed request builder can't name fails **here**, at arm
+    /// construction, with a message an operator can act on — not mid-consult as a bare
+    /// `unknown variant \`max\``.
+    ///
+    /// Two wires parse kaibo's blob into a typed struct with a closed rung set (rig's
+    /// Gemini `ThinkingLevel`, its Responses `ReasoningEffort`), and that ceiling is
+    /// rig's client rather than the provider's API — OpenAI's own endpoint takes `"max"`.
+    /// kaibo keeps no allowlist of its own, so the refusal comes from asking rig's
+    /// converter, and the rungs it offers are read back out of rig too
+    /// (`tests/effort_wire.rs` pins both against real request bodies). What this test
+    /// owns is the *message*: the model, the backend, the role, the value that failed,
+    /// whose ceiling it is, and what to type instead.
+    #[test]
+    fn a_rig_refused_effort_fails_at_arm_construction_with_an_actionable_message() {
+        let defaults = crate::config::Defaults::default();
+        let backend = crate::config::Backend {
+            name: "google".into(),
+            kind: ProviderKind::Gemini,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: None,
+            key_optional: true,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+            wire: None,
+        };
+        // `docs/config.example.toml` used to invite exactly this, and it broke every
+        // Gemini cast the moment a call was made.
+        let slot = ModelSlot {
+            effort: Some("xhigh".into()),
+            ..ModelSlot::bare("google", "gemini-3.5-flash")
+        };
+        let err = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect_err("rig's Gemini builder refuses xhigh")
+            .to_string();
+        assert!(err.contains("gemini-3.5-flash"), "names the model: {err}");
+        assert!(err.contains("google"), "names the backend: {err}");
+        assert!(err.contains("synth"), "names the role: {err}");
+        assert!(err.contains("xhigh"), "names the value that failed: {err}");
+        assert!(
+            err.contains("rig-core"),
+            "says whose ceiling this is, so the operator doesn't go hunting in \
+             Google's docs for a limit that isn't theirs: {err}"
+        );
+        assert!(
+            err.contains("minimal | low | medium | high"),
+            "offers the rungs this wire does take: {err}"
+        );
+
+        // A rung the wire accepts builds normally — the preflight adds no ceiling of
+        // its own, it only reports rig's.
+        let slot = ModelSlot {
+            effort: Some("low".into()),
+            ..ModelSlot::bare("google", "gemini-3.5-flash")
+        };
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("an accepted rung builds offline with a placeholder key");
+        assert_eq!(
+            arm.params.expect("gemini sends a thinking block")["generationConfig"]
+                ["thinkingConfig"]["thinkingLevel"],
+            "low"
+        );
+
+        // And a passthrough wire keeps passing anything through — the preflight must not
+        // quietly become a global allowlist.
+        let backend = crate::config::Backend {
+            name: "deepseek".into(),
+            kind: ProviderKind::DeepSeek,
+            ..backend
+        };
+        let slot = ModelSlot {
+            effort: Some("ludicrous".into()),
+            ..ModelSlot::bare("deepseek", "deepseek-v4-pro")
+        };
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a passthrough wire carries an unknown rung to the provider");
+        assert_eq!(
+            arm.params.expect("deepseek sends a thinking block")["reasoning_effort"],
+            "ludicrous"
         );
     }
 

--- a/src/consult/mod.rs
+++ b/src/consult/mod.rs
@@ -41,7 +41,8 @@ pub use prompts::{
     ConsultAttachment, Phase, PromptOverrides,
 };
 pub use shaping::{
-    hosted_openai_accepts_reasoning, hosted_openai_accepts_sampling,
-    hosted_openai_responses_params, inject_provider_prefs, request_params, thinking_params,
-    ModelCaps, ModelShape, ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
+    accepted_efforts, effort_rank, effort_sinks, hosted_openai_accepts_reasoning,
+    hosted_openai_accepts_sampling, hosted_openai_responses_params, inject_provider_prefs,
+    preflight_params, request_params, thinking_params, EffortWire, ModelCaps, ModelShape,
+    ThinkingStyleOverride, DEFAULT_EFFORT, EFFORT_LADDER, THINKING_BUDGET,
 };

--- a/src/consult/mod.rs
+++ b/src/consult/mod.rs
@@ -43,6 +43,7 @@ pub use prompts::{
 pub use shaping::{
     accepted_efforts, effort_rank, effort_sinks, hosted_openai_accepts_reasoning,
     hosted_openai_accepts_sampling, hosted_openai_responses_params, inject_provider_prefs,
-    preflight_params, request_params, thinking_params, EffortWire, ModelCaps, ModelShape,
-    ThinkingStyleOverride, DEFAULT_EFFORT, EFFORT_LADDER, THINKING_BUDGET,
+    is_effort_off, known_efforts, preflight_params, request_params, thinking_params, EffortWire,
+    ModelCaps, ModelShape, ThinkingStyleOverride, DEFAULT_EFFORT, EFFORT_LADDER, EFFORT_OFF,
+    THINKING_BUDGET,
 };

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -295,9 +295,12 @@ pub fn oneshot_preamble() -> String {
 ///   next turn) but wrong here — stopping at "I'd need X" burns the caller's one shot
 ///   for nothing. The batch contract is *state the assumption, answer under it, flag
 ///   what would change* — both the answer and the diagnostic, in one pass.
-/// - **Depth is free.** The lane forces high effort + a generous token floor precisely
+/// - **Depth is free.** The lane floors reasoning depth and the token budget precisely
 ///   because the latency is already accepted. The prompt says so out loud — spend the
-///   room on depth — rather than leaving that intent only in the knobs.
+///   room on depth — rather than leaving that intent only in the knobs. It says it
+///   *without naming a rung*: effort is a floor a cast can raise (see
+///   [`batch_effort`](crate::batch::batch_effort)), so a preamble promising "high"
+///   would be quietly wrong on a slot tuned deeper.
 /// - **The written answer comes before the depth (GH #75).** Reasoning and answer draw
 ///   on one shared output budget, so a big attached-file review at max thinking can spend
 ///   the whole budget thinking and get truncated *before* the answer is written — the
@@ -319,8 +322,8 @@ pub fn batch_preamble() -> String {
      from the material it provides and your own knowledge — this call has no codebase \
      access and no tools, so the caller owns all the context you have. This is your \
      single response: there is no follow-up turn and the caller cannot clarify, so make \
-     the answer complete and self-contained. The lane gives you room and high effort — \
-     spend it on depth, but spend it on the *written* answer: lead with the conclusion \
+     the answer complete and self-contained. The lane runs offline with room to think, \
+     so depth is free — spend it on the *written* answer: lead with the conclusion \
      (the findings, the verdict, the recommendation) and write it in full, then let your \
      reasoning build under it. Your thinking and your answer draw on one shared output \
      budget, so land the deliverable the caller can act on first — don't reason at length \

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -419,9 +419,13 @@ impl ModelShape {
                 // Unlike the other effort sinks this one is NOT a passthrough string: rig
                 // 0.38 models the level as a closed enum (`minimal|low|medium|high`), so
                 // `xhigh`/`max`/`none` are refused by rig's own converter before the
-                // request leaves the process. That ceiling is rig's, not Google's —
-                // [`EffortWire::Gemini`] names it and `Arm::from_slot` turns it into a
-                // legible error instead of a mid-call surprise.
+                // request leaves the process. [`EffortWire::Gemini`] names that, and
+                // `Arm::from_slot` turns it into a legible error rather than a mid-call
+                // surprise. Here rig's enum is *correct*, not a stale cap: Google's own
+                // schema refuses those three rungs too (`gemini_thinking_level_ladder_live`,
+                // 2026-08-01, protobuf enum error). `minimal` is Google's off-switch, and
+                // is itself per-model — gemini-pro-latest refuses even that
+                // (`gemini_pro_rejects_minimal_live`).
                 obj.insert(
                     "generationConfig".into(),
                     json!({ "thinkingConfig": { "thinkingLevel": effort, "includeThoughts": true } }),
@@ -432,6 +436,8 @@ impl ModelShape {
                 // (2026-08-01): `type:"enabled"` + `reasoning_effort:"none"` bills 160–253
                 // reasoning tokens — the explicit enable wins and the opt-out is a silent
                 // no-op the operator pays for. `type:"disabled"` alone is a true zero.
+                // Re-checked live by `deepseek_effort_none_needs_the_structural_disable_live`
+                // (tests/consult.rs), which also asserts this blob bills zero on the wire.
                 if is_effort_off(effort) {
                     obj.insert("thinking".into(), json!({ "type": "disabled" }));
                 } else {
@@ -510,7 +516,10 @@ pub fn request_params(
 /// deliberately encodes none of that: an operator gets to reach a rung OpenAI shipped
 /// this morning, and a wrong one comes back as OpenAI's own error naming the model's
 /// supported values. (rig's enum is a separate, *lower* ceiling that kaibo does report
-/// up front — see [`EffortWire`].)
+/// up front — see [`EffortWire`].) Measured and re-checkable:
+/// `openai_effort_ceiling_is_per_model_live` in `tests/consult.rs`, which also pins the
+/// trap that an off-schema sentinel reports the API's superset for every model — so the
+/// table can only be re-derived by posting the real rungs.
 pub fn hosted_openai_responses_params(
     model: &str,
     top_p: Option<f64>,
@@ -589,8 +598,11 @@ pub enum EffortWire {
     /// strictly against its own seven rungs, OpenRouter accepts all seven and normalizes
     /// each onto the upstream's native knob (proven 2026-08-01: `xhigh`/`max` reach
     /// `openai/gpt-5.1` through the gateway with reasoning billed, on ids that 400 those
-    /// rungs on OpenAI's direct API), and the toggle-less chat shape has no field to put
-    /// it in at all. "Passthrough" is a statement about *rig*, not about the far end.
+    /// rungs on OpenAI's direct API — the two halves are
+    /// `openrouter_clamps_rungs_the_direct_backend_refuses_live` and
+    /// `openai_effort_ceiling_is_per_model_live`), and the toggle-less chat shape has no
+    /// field to put it in at all. "Passthrough" is a statement about *rig*, not about the
+    /// far end.
     Passthrough,
 }
 

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -15,10 +15,38 @@ pub const THINKING_BUDGET: u64 = 8192;
 
 /// The per-role thinking-depth lever for the models that expose one as a request
 /// param (Anthropic adaptive's `output_config.effort`, DeepSeek's `reasoning_effort`).
-/// A passthrough string the provider validates — like a model id — so a new level
-/// lands without a code change. Default for both roles unless a slot or the
+/// A passthrough string — like a model id — so a rung a provider ships tomorrow
+/// lands without a kaibo release. Default for both roles unless a slot or the
 /// per-role `[defaults]` tunes it.
+///
+/// **kaibo keeps no allowlist.** Two of the six wire paths *do* have a closed ladder,
+/// but it belongs to rig's typed request builder, not to the provider — see
+/// [`EffortWire`] and [`accepted_efforts`], which read that ladder back out of rig
+/// itself rather than restating it here.
 pub const DEFAULT_EFFORT: &str = "high";
+
+/// The reasoning rungs kaibo knows how to *order*, shallow → deep. Used for exactly
+/// one thing: comparing two efforts when a lane needs a floor (`batch.rs`). It is a
+/// ranking, never a gate — an effort outside this list is still shaped and sent, and
+/// a comparison against it simply defers to the operator's value.
+pub const EFFORT_LADDER: [&str; 7] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+/// Where `effort` sits on [`EFFORT_LADDER`], or `None` for a rung kaibo can't order
+/// (a provider's new name, an operator's typo — both look the same from here, and
+/// both mean "don't second-guess it"). Case- and whitespace-insensitive.
+pub fn effort_rank(effort: &str) -> Option<usize> {
+    let e = effort.trim().to_ascii_lowercase();
+    EFFORT_LADDER.iter().position(|rung| *rung == e)
+}
+
+/// Is this effort the reasoning **opt-out**? The bottom rung is special on the providers
+/// that ship a structural off-switch: DeepSeek and OpenRouter both have one, and both
+/// ignore (or bill) a "zero effort" string that rides beside an explicit enable. Asking
+/// here rather than at each call site keeps the two branches from drifting, and keeps
+/// `"None"` from quietly meaning "on".
+fn is_effort_off(effort: &str) -> bool {
+    effort.trim().eq_ignore_ascii_case("none")
+}
 
 /// Which Anthropic models want **adaptive** thinking (`{type:"adaptive"}` plus an
 /// `output_config.effort`) instead of the legacy `{type:"enabled", budget_tokens}`.
@@ -353,21 +381,36 @@ impl ModelShape {
             ThinkingStyle::GeminiLevel => {
                 // Gemini's depth lever IS the per-role effort: the values align (Google's
                 // thinking doc lists `minimal|low|medium|high` across the 3-line; the
-                // default "high" matches gemini-cli's investigator, rig deserializes it to
-                // ThinkingLevel::High), and like every effort it's a passthrough string
-                // the provider validates. Dropping it for a hardcoded "high" would
+                // default "high" deserializes to rig's `ThinkingLevel::High` and matches
+                // gemini-cli's investigator). Dropping it for a hardcoded "high" would
                 // silently ignore a slot's `effort = "low"`.
+                //
+                // Unlike the other effort sinks this one is NOT a passthrough string: rig
+                // 0.38 models the level as a closed enum (`minimal|low|medium|high`), so
+                // `xhigh`/`max`/`none` are refused by rig's own converter before the
+                // request leaves the process. That ceiling is rig's, not Google's —
+                // [`EffortWire::Gemini`] names it and `Arm::from_slot` turns it into a
+                // legible error instead of a mid-call surprise.
                 obj.insert(
                     "generationConfig".into(),
                     json!({ "thinkingConfig": { "thinkingLevel": effort, "includeThoughts": true } }),
                 );
             }
             ThinkingStyle::DeepSeekEffort => {
-                // Explicit-on (the V4 default, but stated so intent survives a default
-                // flip). rig flattens both top-level and round-trips the response
-                // `reasoning_content` so tool loops don't trip DeepSeek's echo-or-400 rule.
-                obj.insert("thinking".into(), json!({ "type": "enabled" }));
-                obj.insert("reasoning_effort".into(), json!(effort));
+                // `"none"` gets the *structural* off-switch. Measured on deepseek-v4-pro
+                // (2026-08-01): `type:"enabled"` + `reasoning_effort:"none"` bills 160–253
+                // reasoning tokens — the explicit enable wins and the opt-out is a silent
+                // no-op the operator pays for. `type:"disabled"` alone is a true zero.
+                if is_effort_off(effort) {
+                    obj.insert("thinking".into(), json!({ "type": "disabled" }));
+                } else {
+                    // Explicit-on (the V4 default, but stated so intent survives a default
+                    // flip). rig flattens both top-level and round-trips the response
+                    // `reasoning_content` so tool loops don't trip DeepSeek's echo-or-400
+                    // rule.
+                    obj.insert("thinking".into(), json!({ "type": "enabled" }));
+                    obj.insert("reasoning_effort".into(), json!(effort));
+                }
             }
             ThinkingStyle::OpenRouterEffort => {
                 // The unified reasoning knob. `effort` is the per-role depth lever, a
@@ -380,7 +423,7 @@ impl ModelShape {
                 // gateway's documented off-switch — rather than trusting the effort
                 // ladder to treat the literal string as off (a drift there would
                 // silently re-enable reasoning, billed as output tokens).
-                if effort == "none" {
+                if is_effort_off(effort) {
                     obj.insert("reasoning".into(), json!({ "enabled": false }));
                 } else {
                     obj.insert("reasoning".into(), json!({ "effort": effort }));
@@ -428,6 +471,15 @@ pub fn request_params(
 /// reasoning models (`gpt-5*`, including `gpt-5.6-sol`) take `reasoning.effort`
 /// and reject custom `temperature`; older GPT chat families (`gpt-4*`,
 /// `gpt-3.5*`, `chatgpt-*`) take sampling and reject `reasoning.effort`.
+///
+/// *Whether* a model takes reasoning is a family question; **which rungs it takes is a
+/// per-model question** — measured 2026-08-01, the ladder moves at both ends within
+/// `gpt-5*`: `gpt-5.6` reaches `max`, `gpt-5.2` stops at `xhigh`, `gpt-5.1` at `high`,
+/// and plain `gpt-5`'s bottom rung is `minimal` where 5.1+ have `none` instead. kaibo
+/// deliberately encodes none of that: an operator gets to reach a rung OpenAI shipped
+/// this morning, and a wrong one comes back as OpenAI's own error naming the model's
+/// supported values. (rig's enum is a separate, *lower* ceiling that kaibo does report
+/// up front — see [`EffortWire`].)
 pub fn hosted_openai_responses_params(
     model: &str,
     top_p: Option<f64>,
@@ -461,6 +513,134 @@ pub fn hosted_openai_accepts_sampling(model: &str) -> bool {
 
 pub fn hosted_openai_accepts_reasoning(model: &str) -> bool {
     model.trim().to_ascii_lowercase().starts_with("gpt-5")
+}
+
+/// Does this (backend, slot) actually put the per-role `effort` on the wire? The one
+/// answer both the wire path and the `kaibo://config` render read, so an operator's
+/// "is my `effort` doing anything?" is settled in exactly one place. `responses_wire`
+/// is the backend's resolved interactive wire ([`Backend::uses_responses_wire`]),
+/// which is what splits a hosted GPT-5 slot (reasoning) from the same `openai` kind
+/// pointed at a local llama.cpp server (no reasoning knob at all).
+pub fn effort_sinks(
+    kind: ProviderKind,
+    model: &str,
+    style: ThinkingStyleOverride,
+    responses_wire: bool,
+) -> bool {
+    if responses_wire {
+        return hosted_openai_accepts_reasoning(model);
+    }
+    ModelShape::resolve(kind, model, style).sinks_effort()
+}
+
+/// Which of rig's request builders this arm's `additional_params` blob has to survive.
+///
+/// kaibo hands rig a JSON blob; most providers `#[serde(flatten)]` it straight into the
+/// body, so whatever an operator writes reaches the provider and the *provider* decides.
+/// Two paths don't: rig deserializes the blob into a typed struct first, and a typed
+/// struct has a closed set of reasoning rungs. That ceiling belongs to **rig's client**,
+/// not the provider's API — OpenAI accepts `effort = "max"` on the wire (probed live
+/// 2026-08-01, 200 + echoed) while rig 0.38's `ReasoningEffort` enum stops at `xhigh`.
+///
+/// Naming the wire lets kaibo ask rig *before* the call (see [`preflight_params`]) and
+/// report the ceiling honestly instead of surfacing a bare serde message mid-consult.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffortWire {
+    /// `gemini::completion::create_request_body` parses the blob as
+    /// `gemini_api_types::AdditionalParameters`, whose `ThinkingLevel` is a closed enum.
+    Gemini,
+    /// OpenAI's Responses builder parses the blob as `responses_api::AdditionalParameters`,
+    /// whose `ReasoningEffort` is a closed enum.
+    OpenaiResponses,
+    /// rig flattens the blob into the body verbatim (Anthropic, DeepSeek, OpenRouter, and
+    /// the generic OpenAI `/chat/completions` shape). kaibo can express anything here; who
+    /// answers for it is the *provider's* business, and they differ — DeepSeek validates
+    /// strictly against its own seven rungs, OpenRouter accepts all seven and normalizes
+    /// each onto the upstream's native knob (proven 2026-08-01: `xhigh`/`max` reach
+    /// `openai/gpt-5.1` through the gateway with reasoning billed, on ids that 400 those
+    /// rungs on OpenAI's direct API), and the toggle-less chat shape has no field to put
+    /// it in at all. "Passthrough" is a statement about *rig*, not about the far end.
+    Passthrough,
+}
+
+impl EffortWire {
+    /// The wire an arm built from `kind` (with its resolved `responses_wire` flag) runs on.
+    pub fn resolve(kind: ProviderKind, responses_wire: bool) -> Self {
+        if responses_wire {
+            return Self::OpenaiResponses;
+        }
+        match kind {
+            ProviderKind::Gemini => Self::Gemini,
+            ProviderKind::Anthropic
+            | ProviderKind::DeepSeek
+            | ProviderKind::OpenRouter
+            | ProviderKind::Openai => Self::Passthrough,
+        }
+    }
+
+    /// How an operator would name this wire in a config conversation.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Gemini => "gemini",
+            Self::OpenaiResponses => "openai responses",
+            Self::Passthrough => "passthrough",
+        }
+    }
+}
+
+/// Run `params` through rig's own converter for `wire`, exactly as the live call will.
+/// `Ok(())` means the request builder accepts this blob; `Err` carries rig's own message.
+///
+/// This is a *preflight*, not a policy: it asks rig, it doesn't hold a list. A rung rig
+/// starts accepting after a version bump starts working here the same day, with no kaibo
+/// change — which is the whole reason effort stayed a passthrough string.
+pub fn preflight_params(
+    wire: EffortWire,
+    params: Option<&Value>,
+) -> std::result::Result<(), String> {
+    let Some(params) = params else {
+        return Ok(());
+    };
+    match wire {
+        EffortWire::Passthrough => Ok(()),
+        // The exact `serde_json::from_value` rig runs in `create_request_body`
+        // (gemini/completion.rs) — same type, same failure.
+        EffortWire::Gemini => serde_json::from_value::<
+            rig_core::providers::gemini::completion::gemini_api_types::AdditionalParameters,
+        >(params.clone())
+        .map(|_| ())
+        .map_err(|e| e.to_string()),
+        // The exact `serde_json::from_value` rig runs building a Responses request
+        // (openai/responses_api/mod.rs).
+        EffortWire::OpenaiResponses => serde_json::from_value::<
+            rig_core::providers::openai::responses_api::AdditionalParameters,
+        >(params.clone())
+        .map(|_| ())
+        .map_err(|e| e.to_string()),
+    }
+}
+
+/// The effort rungs `wire` accepts today, read back out of rig by probing each rung of
+/// [`EFFORT_LADDER`] through [`preflight_params`]. Derived, never declared — so the list
+/// an error message shows an operator is rig's current truth even after a rig bump, and
+/// kaibo never grows a second ladder to drift from it.
+pub fn accepted_efforts(wire: EffortWire) -> Vec<&'static str> {
+    if wire == EffortWire::Passthrough {
+        return EFFORT_LADDER.to_vec();
+    }
+    EFFORT_LADDER
+        .iter()
+        .copied()
+        .filter(|rung| {
+            let probe = match wire {
+                EffortWire::Gemini => {
+                    json!({ "generationConfig": { "thinkingConfig": { "thinkingLevel": rung } } })
+                }
+                _ => json!({ "reasoning": { "effort": rung } }),
+            };
+            preflight_params(wire, Some(&probe)).is_ok()
+        })
+        .collect()
 }
 
 /// Fold this arm's output-token budget into `params` where the provider needs it
@@ -611,6 +791,43 @@ mod tests {
             .to_params(8192, Some(0.5), None, DEFAULT_EFFORT)
             .unwrap();
         assert_eq!(params["temperature"], 0.5);
+    }
+
+    /// `effort = "none"` on DeepSeek must be the *structural* disable
+    /// (`thinking:{"type":"disabled"}`), not enabled-plus-`reasoning_effort:"none"`.
+    ///
+    /// Measured against deepseek-v4-pro (live probe, 2026-08-01), one variable at a time:
+    /// `reasoning_effort:"none"` alone → 0 reasoning tokens; `thinking:{"type":"disabled"}`
+    /// → 0 reasoning tokens; **`thinking:{"type":"enabled"}` + `reasoning_effort:"none"`
+    /// → reasoning ON, 160–253 tokens billed.** The explicit `type:"enabled"` wins, so the
+    /// old shape turned an operator's opt-out into a silent no-op they paid for — the exact
+    /// silent-fallback class kaibo refuses. Same structural-off pattern as OpenRouter below.
+    #[test]
+    fn deepseek_effort_none_disables_reasoning_structurally() {
+        let shape = ModelShape::resolve(
+            ProviderKind::DeepSeek,
+            "deepseek-v4-pro",
+            ThinkingStyleOverride::Auto,
+        );
+        let params = shape.to_params(8192, None, None, "none").unwrap();
+        assert_eq!(
+            params["thinking"]["type"], "disabled",
+            "none must turn thinking off structurally, not ask for zero effort while \
+             leaving it enabled: {params}"
+        );
+        assert!(
+            params.get("reasoning_effort").is_none(),
+            "no effort string rides alongside the disable — it is what re-enabled \
+             reasoning: {params}"
+        );
+        // Off is off however it was spelled; every other rung still rides as effort.
+        assert_eq!(
+            shape.to_params(8192, None, None, "NONE").unwrap()["thinking"]["type"],
+            "disabled"
+        );
+        let params = shape.to_params(8192, None, None, "low").unwrap();
+        assert_eq!(params["thinking"]["type"], "enabled");
+        assert_eq!(params["reasoning_effort"], "low");
     }
 
     /// `effort = "none"` is the documented reasoning opt-out, and it must be the

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -25,27 +25,58 @@ pub const THINKING_BUDGET: u64 = 8192;
 /// itself rather than restating it here.
 pub const DEFAULT_EFFORT: &str = "high";
 
-/// The reasoning rungs kaibo knows how to *order*, shallow → deep. Used for exactly
-/// one thing: comparing two efforts when a lane needs a floor (`batch.rs`). It is a
-/// ranking, never a gate — an effort outside this list is still shaped and sent, and
-/// a comparison against it simply defers to the operator's value.
-pub const EFFORT_LADDER: [&str; 7] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+/// The reasoning **depths** kaibo knows how to order, shallow → deep. Used for exactly
+/// one thing: comparing two efforts when a lane needs a floor
+/// ([`batch_effort`](crate::batch::batch_effort)). It is a ranking, never a gate — an
+/// effort outside this list is still shaped and sent, and a comparison against it simply
+/// defers to the operator's value.
+///
+/// **[`EFFORT_OFF`] is deliberately not on this ladder.** "Off" is not the shallowest
+/// depth; it is a different kind of answer. Ranking it as rung 0 let a *depth* floor
+/// silently switch reasoning back **on** — see [`EFFORT_OFF`] and [`is_effort_off`],
+/// which are the other half of this pair. Anything that ranks an effort has to decide
+/// what it does about the off-switch first.
+pub const EFFORT_LADDER: [&str; 6] = ["minimal", "low", "medium", "high", "xhigh", "max"];
 
-/// Where `effort` sits on [`EFFORT_LADDER`], or `None` for a rung kaibo can't order
-/// (a provider's new name, an operator's typo — both look the same from here, and
-/// both mean "don't second-guess it"). Case- and whitespace-insensitive.
+/// The reasoning **opt-out** — a sentinel beside [`EFFORT_LADDER`], not a rung on it.
+///
+/// Two providers ship a structural off-switch (DeepSeek's `thinking:{"type":"disabled"}`,
+/// OpenRouter's `reasoning:{"enabled":false}`) and both mishandle a "zero effort" string
+/// riding beside an explicit enable — DeepSeek bills 160–253 reasoning tokens for exactly
+/// that pairing (probed 2026-08-01). So `none` is answered by *shape*, not by value:
+/// [`ModelShape::to_params`] routes it through [`is_effort_off`].
+///
+/// Keeping it off the ladder is the same distinction one level up. A floor that raises
+/// *depth* (batch) must leave an operator's "off" alone, because turning reasoning back
+/// on isn't "more depth" — it's ignoring the setting, and billing them for it.
+pub const EFFORT_OFF: &str = "none";
+
+/// Where `effort` sits on [`EFFORT_LADDER`], or `None` for anything that isn't an
+/// orderable depth: [`EFFORT_OFF`] (ask [`is_effort_off`] instead — off is not a depth),
+/// a provider's newer rung, or an operator's typo. The last two look identical from here
+/// and both mean "don't second-guess it". Case- and whitespace-insensitive.
 pub fn effort_rank(effort: &str) -> Option<usize> {
     let e = effort.trim().to_ascii_lowercase();
     EFFORT_LADDER.iter().position(|rung| *rung == e)
 }
 
-/// Is this effort the reasoning **opt-out**? The bottom rung is special on the providers
-/// that ship a structural off-switch: DeepSeek and OpenRouter both have one, and both
-/// ignore (or bill) a "zero effort" string that rides beside an explicit enable. Asking
-/// here rather than at each call site keeps the two branches from drifting, and keeps
-/// `"None"` from quietly meaning "on".
-fn is_effort_off(effort: &str) -> bool {
-    effort.trim().eq_ignore_ascii_case("none")
+/// Is this effort the reasoning opt-out ([`EFFORT_OFF`])? The counterpart to
+/// [`effort_rank`]: that one orders depths and returns `None` here; this one answers the
+/// question ranking can't. **Public because the batch lane must ask it** — a depth floor
+/// consulting only the ladder would see `none` as unrankable, and an earlier version that
+/// ranked it as rung 0 lifted it to `BATCH_EFFORT`, quietly billing reasoning on every
+/// item of a fan-out the operator had switched off.
+///
+/// Case- and whitespace-insensitive, so `"None"` can never quietly mean "on".
+pub fn is_effort_off(effort: &str) -> bool {
+    effort.trim().eq_ignore_ascii_case(EFFORT_OFF)
+}
+
+/// Every effort spelling kaibo knows by name — the off-switch, then the depth ladder.
+/// For *probing* and *presenting* ("what does this wire accept?"), never for gating: an
+/// effort absent from this list is still shaped and sent.
+pub fn known_efforts() -> Vec<&'static str> {
+    std::iter::once(EFFORT_OFF).chain(EFFORT_LADDER).collect()
 }
 
 /// Which Anthropic models want **adaptive** thinking (`{type:"adaptive"}` plus an
@@ -620,17 +651,16 @@ pub fn preflight_params(
     }
 }
 
-/// The effort rungs `wire` accepts today, read back out of rig by probing each rung of
-/// [`EFFORT_LADDER`] through [`preflight_params`]. Derived, never declared — so the list
+/// The effort values `wire` accepts today, read back out of rig by probing each of
+/// [`known_efforts`] through [`preflight_params`]. Derived, never declared — so the list
 /// an error message shows an operator is rig's current truth even after a rig bump, and
 /// kaibo never grows a second ladder to drift from it.
 pub fn accepted_efforts(wire: EffortWire) -> Vec<&'static str> {
     if wire == EffortWire::Passthrough {
-        return EFFORT_LADDER.to_vec();
+        return known_efforts();
     }
-    EFFORT_LADDER
-        .iter()
-        .copied()
+    known_efforts()
+        .into_iter()
         .filter(|rung| {
             let probe = match wire {
                 EffortWire::Gemini => {

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -248,12 +248,12 @@ pub(crate) fn render_config_resource(
         /// an Anthropic slot drops under thinking: each load-validates and would otherwise
         /// render as if effective. Absent when every knob in play has a sink.
         ///
-        /// `effort` is judged on the **effective** value, not just a per-slot override:
-        /// a `[defaults]`/env effort lands on every cast, so a lane-blind per-slot-only
-        /// check missed the case that bites hardest. The shape is resolved through
-        /// [`Config::slot_effort_sinks`](crate::config::Config::slot_effort_sinks) — the
-        /// same fallbacks `slot.tunables` uses, lane included — so the render can't
-        /// disagree with the wire.
+        /// `effort` is judged on the **effective** value, not just a per-slot override —
+        /// a `[defaults]`/env effort lands on every cast, so a per-slot-only check missed
+        /// the case that bites hardest — and it is judged by
+        /// [`Config::effort_disposition`](crate::config::Config::effort_disposition), the
+        /// single implementation of that policy, which the startup warning reads too.
+        /// Two copies of this rule diverged once already; there is now only one.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         inert_tunables: Vec<&'static str>,
     }
@@ -360,16 +360,14 @@ pub(crate) fn render_config_resource(
                         backend.uses_responses_wire()
                     };
                     let mut inert_tunables = Vec::new();
-                    let effort_sinks = crate::consult::effort_sinks(
-                        backend.kind,
-                        &slot.id,
-                        t.thinking_style,
-                        responses_wire,
-                    );
-                    // Batch floors the effort, so a rung at or below `BATCH_EFFORT` is
-                    // lifted and the configured value never ships as written.
-                    let effort_lands = effort_sinks
-                        && (!batch_lane || crate::batch::batch_effort(&t.effort) == t.effort);
+                    // Whether the effort ships is a policy with exactly one implementation
+                    // — `Config::effort_disposition`. The render asks it rather than
+                    // re-deriving (drop? batch lift? off-switch?), which is what keeps this
+                    // and the startup warning from ever telling an operator different
+                    // stories about the same slot.
+                    let disposition = config
+                        .effort_disposition(slot, *role)
+                        .expect("a loaded cast's slot backend resolves");
                     // Batch hands the provider no sampling at all (`None`/`None`), so a
                     // `temperature` on a batch slot is inert regardless of the model.
                     let sampling_sinks = if batch_lane {
@@ -386,7 +384,7 @@ pub(crate) fn render_config_resource(
                     // `[defaults]`/env effort lands on every cast, and one that lands
                     // nowhere deserves the same flag. Inherited built-in defaults stay
                     // quiet — see `Defaults::explorer_effort_explicit`.
-                    if t.effort_explicit && !effort_lands {
+                    if disposition.explicit && !disposition.ships_as_configured() {
                         inert_tunables.push("effort");
                     }
                     if temperature.is_some() && !sampling_sinks {
@@ -758,6 +756,95 @@ mod tests {
             "a batch slot deeper than the floor keeps its effort: {:?}",
             inert("bat_deep", "synth")
         );
+    }
+
+    /// The startup warning and the `kaibo://config` render must give the same verdict on
+    /// the same slot. They are two audiences for one policy, and when they were two
+    /// implementations they diverged inside a single commit: the render already knew a
+    /// batch-lane lift meant the configured value never runs, while the startup scan only
+    /// asked "does this wire have a reasoning field?" and stayed silent — so an operator
+    /// who set `effort = "low"` on a batch slot saw it flagged in the resource and never
+    /// heard a word at startup.
+    ///
+    /// Asserting *agreement* rather than either verdict is deliberate: it fails for any
+    /// future divergence, not just this one. `Config::effort_disposition` is the single
+    /// implementation both now read.
+    #[test]
+    fn the_startup_scan_and_the_config_render_agree_slot_for_slot() {
+        let config = Config::from_toml_str(
+            r#"
+            [backends.lab]
+            kind = "openai"
+            base_url = "http://127.0.0.1:8080/v1"
+            key_optional = true
+
+            # The case that diverged: an effort-carrying wire, but the batch depth floor
+            # lifts this shallower value, so `low` never runs.
+            [casts.bat_low]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "low" }
+
+            # Deeper than the floor: ships as written, nobody should complain.
+            [casts.bat_deep]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "xhigh" }
+
+            # Reasoning off on the batch lane: a depth floor must not raise it, so it
+            # ships as configured and is NOT a diagnostic.
+            [casts.bat_off]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "none" }
+
+            # No reasoning field at all — the drop.
+            [casts.lab_cast]
+            synth = { backend = "lab", id = "gemma", effort = "xhigh" }
+
+            # Carries it fine.
+            [casts.ds]
+            synth = { backend = "deepseek", id = "deepseek-v4-pro", effort = "xhigh" }
+            "#,
+        )
+        .unwrap();
+
+        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
+        let render_flags = |cast: &str, role: &str| -> bool {
+            doc.get("casts")
+                .and_then(|c| c.get(cast))
+                .and_then(|c| c.get(role))
+                .and_then(|s| s.get("inert_tunables"))
+                .and_then(|a| a.as_array())
+                .map(|a| a.iter().any(|v| v.as_str() == Some("effort")))
+                .unwrap_or(false)
+        };
+        let warned: std::collections::BTreeSet<(String, &str)> = config
+            .effort_diagnostics()
+            .into_iter()
+            .map(|d| (d.cast, d.role))
+            .collect();
+
+        for cast in ["bat_low", "bat_deep", "bat_off", "lab_cast", "ds"] {
+            assert_eq!(
+                warned.contains(&(cast.to_string(), "synth")),
+                render_flags(cast, "synth"),
+                "cast {cast}: the startup scan and the kaibo://config render disagree \
+                 about whether this slot's effort ships"
+            );
+        }
+
+        // And the verdicts themselves, so "they agree" can't be satisfied by both being
+        // wrong in the same direction.
+        assert!(
+            render_flags("bat_low", "synth"),
+            "a lifted effort is flagged"
+        );
+        assert!(
+            render_flags("lab_cast", "synth"),
+            "a dropped effort is flagged"
+        );
+        assert!(!render_flags("bat_deep", "synth"), "a deeper effort ships");
+        assert!(
+            !render_flags("bat_off", "synth"),
+            "the off-switch survives a depth floor, so it ships as configured"
+        );
+        assert!(!render_flags("ds", "synth"), "deepseek carries the effort");
     }
 
     /// `kaibo://config` renders each openai-kind backend's *resolved* wire — the

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -242,11 +242,18 @@ pub(crate) fn render_config_resource(
         /// means interactive. Only ever set on a synth slot (load-validated).
         #[serde(skip_serializing_if = "Option::is_none")]
         lane: Option<&'static str>,
-        /// Per-slot tunables that *are* set here but this slot's resolved request shape
-        /// will never send — the honest no-op flag. A `thinking_budget` on an
-        /// effort-driven or toggle-less model, an `effort` on a budget model, a
-        /// `temperature` an Anthropic slot drops under thinking: each load-validates and
-        /// would otherwise render as if effective. Absent when every set knob has a sink.
+        /// Tunables in effect for this slot that its resolved request shape will never
+        /// send — the honest no-op flag. A `thinking_budget` on an effort-driven or
+        /// toggle-less model, an `effort` on a budget/toggle-less model, a `temperature`
+        /// an Anthropic slot drops under thinking: each load-validates and would otherwise
+        /// render as if effective. Absent when every knob in play has a sink.
+        ///
+        /// `effort` is judged on the **effective** value, not just a per-slot override:
+        /// a `[defaults]`/env effort lands on every cast, so a lane-blind per-slot-only
+        /// check missed the case that bites hardest. The shape is resolved through
+        /// [`Config::slot_effort_sinks`](crate::config::Config::slot_effort_sinks) — the
+        /// same fallbacks `slot.tunables` uses, lane included — so the render can't
+        /// disagree with the wire.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         inert_tunables: Vec<&'static str>,
     }
@@ -335,22 +342,39 @@ pub(crate) fn render_config_resource(
                     let backend = config
                         .resolve_backend(&slot.backend)
                         .expect("a loaded cast's slot backend resolves");
-                    let shape = ModelShape::resolve(
+                    // Resolve through `slot.tunables` — the same fallbacks the wire path
+                    // takes, so a `[defaults].thinking_style` (which the old
+                    // `unwrap_or_default()` here silently ignored) can't make the render
+                    // disagree with what actually ships.
+                    let t = slot.tunables(*role, &config.defaults);
+                    let shape = ModelShape::resolve(backend.kind, &slot.id, t.thinking_style);
+                    // Lane-aware: a `lane = "batch"` slot never builds an interactive arm.
+                    // Batch POSTs its own body and gates the Responses shape on the
+                    // endpoint-exact `is_hosted_openai`; the interactive arm follows the
+                    // configurable `uses_responses_wire` (a responses-wire gateway shapes
+                    // like Platform even though it isn't batch-eligible).
+                    let batch_lane = matches!(lane, Some(Lane::Batch));
+                    let responses_wire = if batch_lane {
+                        backend.is_hosted_openai()
+                    } else {
+                        backend.uses_responses_wire()
+                    };
+                    let mut inert_tunables = Vec::new();
+                    let effort_sinks = crate::consult::effort_sinks(
                         backend.kind,
                         &slot.id,
-                        thinking_style.unwrap_or_default(),
+                        t.thinking_style,
+                        responses_wire,
                     );
-                    // The interactive shape a slot's arm will actually build under
-                    // (`Arm::from_slot`) follows `uses_responses_wire`, not the
-                    // narrower `is_hosted_openai` platform gate — a responses-wire
-                    // gateway shapes its inert tunables the same way hosted OpenAI
-                    // Platform does, even though it isn't batch-eligible.
-                    let responses_wire = backend.uses_responses_wire();
-                    let mut inert_tunables = Vec::new();
-                    let effort_sinks = shape.sinks_effort()
-                        || (responses_wire
-                            && crate::consult::hosted_openai_accepts_reasoning(&slot.id));
-                    let sampling_sinks = if responses_wire {
+                    // Batch floors the effort, so a rung at or below `BATCH_EFFORT` is
+                    // lifted and the configured value never ships as written.
+                    let effort_lands = effort_sinks
+                        && (!batch_lane || crate::batch::batch_effort(&t.effort) == t.effort);
+                    // Batch hands the provider no sampling at all (`None`/`None`), so a
+                    // `temperature` on a batch slot is inert regardless of the model.
+                    let sampling_sinks = if batch_lane {
+                        false
+                    } else if responses_wire {
                         crate::consult::hosted_openai_accepts_sampling(&slot.id)
                     } else {
                         shape.sinks_sampling()
@@ -358,7 +382,11 @@ pub(crate) fn render_config_resource(
                     if thinking_budget.is_some() && !shape.sinks_thinking_budget() {
                         inert_tunables.push("thinking_budget");
                     }
-                    if effort.is_some() && !effort_sinks {
+                    // The *effective* effort, not just a per-slot override: a
+                    // `[defaults]`/env effort lands on every cast, and one that lands
+                    // nowhere deserves the same flag. Inherited built-in defaults stay
+                    // quiet — see `Defaults::explorer_effort_explicit`.
+                    if t.effort_explicit && !effort_lands {
                         inert_tunables.push("effort");
                     }
                     if temperature.is_some() && !sampling_sinks {
@@ -414,6 +442,10 @@ pub(crate) fn render_config_resource(
         top_p,
         explorer_effort,
         synth_effort,
+        // Provenance, not a knob: it decides whether an inert effort is worth flagging
+        // (below and at startup), and the render already shows the effective values.
+        explorer_effort_explicit: _,
+        synth_effort_explicit: _,
         thinking_style,
         request_timeout,
         call_deadline,
@@ -638,6 +670,93 @@ mod tests {
             inert("gpt_chat", "synth"),
             vec!["thinking_budget", "effort"],
             "hosted GPT chat sinks sampling but rejects reasoning effort and budget"
+        );
+    }
+
+    /// The three blind spots that let an inert knob render as effective, closed together
+    /// because they share one cause — the render used to resolve a slot's shape by its
+    /// own rules instead of asking the same question the wire asks.
+    ///
+    /// 1. **`[defaults]`-sourced effort.** The check keyed on a per-*slot* `effort`, so a
+    ///    `[defaults].synth_effort` — which lands on every cast at once — rendered as
+    ///    effective on a wire that drops it. The effective value is what matters.
+    /// 2. **`[defaults].thinking_style`.** The render resolved the style with
+    ///    `unwrap_or_default()` (→ `Auto`) while the wire uses the `[defaults]` fallback,
+    ///    so a forced `adaptive` moved the sinks on the wire and not in the render.
+    /// 3. **Lane-blindness.** A `lane = "batch"` slot never builds an interactive arm:
+    ///    batch hands the provider no sampling at all, and floors the effort — so a rung
+    ///    at or below `BATCH_EFFORT` is lifted and the configured value never ships.
+    #[test]
+    fn config_render_resolves_inert_tunables_the_way_the_wire_does() {
+        let config = Config::from_toml_str(
+            r#"
+            [defaults]
+            # Lands on every synth slot below; effective, not per-slot.
+            synth_effort = "medium"
+            # The wire honors this fallback; the render used to ignore it.
+            thinking_style = "adaptive"
+
+            [backends.lab]
+            kind = "openai"
+            base_url = "http://127.0.0.1:8080/v1"
+            key_optional = true
+
+            # Toggle-less wire: the defaults effort lands nowhere and must be flagged.
+            [casts.lab_cast]
+            synth = "lab/gemma"
+
+            # Forced adaptive gives Haiku an effort sink and takes away its budget one —
+            # the opposite of what the classifier alone would say.
+            [casts.forced]
+            synth = { backend = "anthropic", id = "claude-haiku-4-5", thinking_budget = 2048 }
+
+            # A batch slot: sampling is never sent, and `low` is below the batch floor.
+            [casts.bat]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "low", temperature = 0.4 }
+
+            # Same lane, a rung deeper than the floor: it ships as written now that batch
+            # floors rather than overrides, so it is NOT inert.
+            [casts.bat_deep]
+            synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "xhigh" }
+            "#,
+        )
+        .unwrap();
+        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
+        let inert = |cast: &str, role: &str| -> Vec<String> {
+            doc.get("casts")
+                .and_then(|c| c.get(cast))
+                .and_then(|c| c.get(role))
+                .and_then(|s| s.get("inert_tunables"))
+                .map(|a| {
+                    a.as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|v| v.as_str().unwrap().to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        assert_eq!(
+            inert("lab_cast", "synth"),
+            vec!["effort"],
+            "a [defaults] effort on a toggle-less wire is just as inert as a slot one"
+        );
+        assert_eq!(
+            inert("forced", "synth"),
+            vec!["thinking_budget"],
+            "[defaults].thinking_style = adaptive moves both sinks — the render must \
+             resolve it the way slot.tunables does"
+        );
+        assert_eq!(
+            inert("bat", "synth"),
+            vec!["effort", "temperature"],
+            "batch lifts a below-floor effort and sends no sampling at all"
+        );
+        assert!(
+            inert("bat_deep", "synth").is_empty(),
+            "a batch slot deeper than the floor keeps its effort: {:?}",
+            inert("bat_deep", "synth")
         );
     }
 

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -131,33 +131,51 @@ impl Resolver {
         };
 
         // Say it out loud, once, where both front doors pass: an `effort` the operator
-        // WROTE that this slot's wire has no place to put. Anthropic's budget tier and
-        // the generic OpenAI chat shape drop it in `to_params` and nothing downstream
-        // fails, so without this the knob just quietly does nothing — the silent
-        // fallback kaibo refuses. Not fatal, deliberately: the inherited default lands
-        // on a toggle-less wire in every ordinary local cast, and the *rule* (see
-        // `Config::inert_efforts`) is what keeps this to the cases someone chose.
+        // WROTE that doesn't ship as written. Not fatal, deliberately — the inherited
+        // default lands on a toggle-less wire in every ordinary local cast, and the
+        // *rule* (`Config::effort_diagnostics`) is what keeps this to the cases someone
+        // chose. The rule is shared with the `kaibo://config` render rather than
+        // restated, so the two can never tell an operator different stories.
         //
-        // Grouped by (source, value): one `[defaults]` line lands on every cast at once,
-        // and ten near-identical warnings for one mistyped setting reads as noise —
-        // which is how a warning gets tuned out. One line per thing the operator wrote.
-        let mut grouped: std::collections::BTreeMap<(&'static str, String), Vec<String>> =
-            std::collections::BTreeMap::new();
-        for inert in config.inert_efforts() {
+        // Grouped by (fate, source, value): one `[defaults]` line lands on every cast at
+        // once, and ten near-identical warnings for one mistyped setting reads as noise —
+        // which is how a warning gets tuned out. One line per thing the operator wrote,
+        // and the fate decides what the line says, since "dropped entirely" and "raised
+        // to the batch floor" want different fixes.
+        let mut grouped: std::collections::BTreeMap<
+            (crate::config::EffortFate, &'static str, String),
+            Vec<String>,
+        > = std::collections::BTreeMap::new();
+        for d in config.effort_diagnostics() {
             grouped
-                .entry((inert.source.as_str(), inert.effort))
+                .entry((
+                    d.disposition.fate,
+                    d.disposition.source.as_str(),
+                    d.disposition.configured,
+                ))
                 .or_default()
-                .push(format!("{}/{} ({})", inert.cast, inert.role, inert.model));
+                .push(format!("{}/{} ({})", d.cast, d.role, d.model));
         }
-        for ((source, effort), slots) in grouped {
+        for ((fate, source, effort), slots) in grouped {
+            let detail = match fate {
+                crate::config::EffortFate::NoSink => {
+                    "these models' wires carry no reasoning parameter, so it is dropped \
+                     before the request is built and the setting does nothing. Set it on \
+                     a slot whose provider takes one, or drop it."
+                }
+                _ => {
+                    "the batch lane floors reasoning depth, so this shallower value is \
+                     raised to kaibo's batch floor and never runs as written. Batch is \
+                     the lane that spends; use `effort = \"none\"` to turn reasoning off \
+                     there instead."
+                }
+            };
             tracing::warn!(
                 effort = %effort,
                 source = %source,
                 slots = %slots.join(", "),
-                "effort has no sink on these models' wires — it is dropped before the \
-                 request is built, so the setting does nothing there. Set it on a slot \
-                 whose provider takes a reasoning param, or drop it. See kaibo://config \
-                 (inert_tunables)."
+                "configured effort does not reach the provider as written: {detail} \
+                 See kaibo://config (inert_tunables)."
             );
         }
 
@@ -691,5 +709,78 @@ impl Resolver {
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ModelRole;
+
+    /// A per-call `model=` override deliberately drops the configured slot's `effort`
+    /// along with its other tunables — `override_model` builds a **bare** slot, because
+    /// the override names a *different* model and a depth pinned for the old one has no
+    /// claim on the new one. The effective effort then falls back to `[defaults]`.
+    ///
+    /// Behavior is unchanged and intentional (see this method's doc); it just wasn't
+    /// pinned anywhere, and it interacts with the effort-provenance work — a dropped
+    /// `effort = "xhigh"` must not leave an explicit-provenance ghost that then reports
+    /// itself inert against a model nobody wrote it for. Now a future change here has to
+    /// be deliberate.
+    #[test]
+    fn a_per_call_model_override_drops_the_configured_slot_effort() {
+        let config = std::sync::Arc::new(
+            crate::config::Config::from_toml_str(
+                r#"
+                [casts.pinned]
+                synth = { backend = "anthropic", id = "claude-opus-4-8", effort = "xhigh", max_tokens = 99 }
+                "#,
+            )
+            .expect("fixture config loads"),
+        );
+        let resolver = Resolver::from_config(config.clone()).expect("resolver builds");
+        let mut cast = config.resolve_cast("pinned").expect("cast exists").clone();
+        assert_eq!(
+            cast.require_slot(ModelRole::Synth)
+                .unwrap()
+                .effort
+                .as_deref(),
+            Some("xhigh"),
+            "fixture pins an effort on the configured slot"
+        );
+
+        resolver
+            .override_model(&mut cast, ModelRole::Synth, "claude-sonnet-4-6", None)
+            .expect("a per-call model override applies");
+
+        let slot = cast.require_slot(ModelRole::Synth).unwrap();
+        assert_eq!(slot.id, "claude-sonnet-4-6");
+        assert_eq!(
+            slot.effort, None,
+            "the configured model's effort does not ride along to a different model"
+        );
+        assert_eq!(slot.max_tokens, None, "nor its other tunables");
+
+        let t = slot.tunables(ModelRole::Synth, &config.defaults);
+        assert_eq!(
+            t.effort,
+            crate::consult::DEFAULT_EFFORT,
+            "the override falls back to [defaults]"
+        );
+        assert!(
+            !t.effort_explicit,
+            "and inherits [defaults]' provenance, not the discarded slot's — nobody wrote \
+             an effort for THIS model, so nothing should be reported about it"
+        );
+
+        // The other half of the same fallback: a `[defaults]` effort DOES apply to an
+        // overridden model, provenance included, because it was written for every cast
+        // rather than for the id that got replaced.
+        let mut defaults = config.defaults.clone();
+        defaults.synth_effort = "low".into();
+        defaults.synth_effort_explicit = true;
+        let t = slot.tunables(ModelRole::Synth, &defaults);
+        assert_eq!(t.effort, "low");
+        assert!(t.effort_explicit);
     }
 }

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -130,6 +130,37 @@ impl Resolver {
             }
         };
 
+        // Say it out loud, once, where both front doors pass: an `effort` the operator
+        // WROTE that this slot's wire has no place to put. Anthropic's budget tier and
+        // the generic OpenAI chat shape drop it in `to_params` and nothing downstream
+        // fails, so without this the knob just quietly does nothing — the silent
+        // fallback kaibo refuses. Not fatal, deliberately: the inherited default lands
+        // on a toggle-less wire in every ordinary local cast, and the *rule* (see
+        // `Config::inert_efforts`) is what keeps this to the cases someone chose.
+        //
+        // Grouped by (source, value): one `[defaults]` line lands on every cast at once,
+        // and ten near-identical warnings for one mistyped setting reads as noise —
+        // which is how a warning gets tuned out. One line per thing the operator wrote.
+        let mut grouped: std::collections::BTreeMap<(&'static str, String), Vec<String>> =
+            std::collections::BTreeMap::new();
+        for inert in config.inert_efforts() {
+            grouped
+                .entry((inert.source.as_str(), inert.effort))
+                .or_default()
+                .push(format!("{}/{} ({})", inert.cast, inert.role, inert.model));
+        }
+        for ((source, effort), slots) in grouped {
+            tracing::warn!(
+                effort = %effort,
+                source = %source,
+                slots = %slots.join(", "),
+                "effort has no sink on these models' wires — it is dropped before the \
+                 request is built, so the setting does nothing there. Set it on a slot \
+                 whose provider takes a reasoning param, or drop it. See kaibo://config \
+                 (inert_tunables)."
+            );
+        }
+
         Ok(Self {
             config,
             allowed_set: Arc::new(allowed),
@@ -390,8 +421,11 @@ impl Resolver {
             .config
             .resolve_backend(&slot.backend)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        // Name the cast on the way out: `from_slot` knows the backend, the role and the
+        // model, but not which team pulled them together — and "which cast do I edit?" is
+        // the first thing an operator needs from a shaping refusal.
         Arm::from_slot(backend, slot, role, &self.config.defaults)
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))
+            .map_err(|e| McpError::internal_error(format!("cast {:?}: {e:#}", cast.name), None))
     }
 
     /// Assemble the operator's house rules for this call against the resolved `root`:

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -1504,37 +1504,23 @@ async fn openrouter_consult_round_trips() {
 }
 
 /// One minimal OpenRouter completion carrying kaibo's shaped params, with the
-/// gateway's usage accounting on. Returns the parsed response JSON.
+/// gateway's usage accounting on. Returns the parsed response JSON, and refuses a
+/// rejection — this is the "does kaibo's shape work" probe, so a 4xx is a failure.
+///
+/// Delegates to [`openrouter_probe_raw`] rather than building its own request: the
+/// ladder probes below need the same body with a *different* prompt and the ability to
+/// read a 400 body, and two copies of one request shape is how a probe and the thing it
+/// probes drift apart.
 #[cfg(test)]
 async fn openrouter_probe_completion(key: &str, model: &str, params: &Value) -> Value {
-    let mut body = json!({
-        "model": model,
-        "messages": [{
-            "role": "user",
-            "content": "How many prime numbers are there between 10 and 50? \
-                        Work it out carefully, then answer with just the count.",
-        }],
-        "max_completion_tokens": 8192,
-        "usage": {"include": true},
-    });
-    for (k, v) in params.as_object().expect("shaped params are an object") {
-        body[k] = v.clone();
-    }
-    let http = kaibo::tls::https_client(std::time::Duration::from_secs(120)).unwrap();
-    let resp = http
-        .post("https://openrouter.ai/api/v1/chat/completions")
-        .bearer_auth(key)
-        .json(&body)
-        .send()
-        .await
-        .expect("openrouter request");
-    let status = resp.status();
-    let json: Value = resp.json().await.expect("openrouter response json");
-    assert!(
-        status.is_success(),
-        "openrouter rejected kaibo's shaped params ({status}): {json}"
-    );
-    json
+    openrouter_probe_completion_with(
+        key,
+        model,
+        params,
+        "How many prime numbers are there between 10 and 50? \
+         Work it out carefully, then answer with just the count.",
+    )
+    .await
 }
 
 #[tokio::test]
@@ -1547,10 +1533,11 @@ async fn openrouter_reasoning_accounting_live() {
     // rides — with OpenRouter's usage accounting on, and reads what the gateway
     // actually billed: effort-on must show reasoning tokens, and the structural
     // disable (`effort = "none"` ⇒ `{"reasoning":{"enabled":false}}`) must not.
-    let key = match load(ProviderKind::OpenRouter) {
-        Ok(k) => k,
-        Err(e) => panic!("no OpenRouter credential for live test: {e}"),
-    };
+    // `live_key`, not `credentials::load`: an operator's key file needn't sit at the
+    // built-in default path, and here it doesn't — the config points at
+    // `~/.openrouter-key.txt` while `load` looks for `~/.openrouter-key`, so this probe
+    // was unrunnable on the machine that owns the key. See `live_key`.
+    let key = live_key(ProviderKind::OpenRouter);
     // The built-in cast's explorer alias — the slot the doctrine most needs to
     // hold on, since the explorer runs the most turns.
     let model = "~google/gemini-flash-latest";
@@ -1637,4 +1624,679 @@ async fn adaptive_only_anthropic_model_round_trips() {
         "answer should explain the read-only sandbox mechanism, got: {}",
         out.answer
     );
+}
+
+// ===========================================================================
+// Live effort-ladder probes — what each PROVIDER really accepts
+// ===========================================================================
+//
+// The other half of `tests/effort_wire.rs`. That suite is offline and asks rig:
+// what will the *client* let kaibo send? These are live and ask the provider:
+// what does the endpoint actually do with it? Both are needed, because rig's
+// ceiling and the provider's ceiling are different numbers on two wires, and
+// kaibo's docs used to assert one universal `none|low|…|max` ladder for
+// everyone — wrong in every direction at once. Gemini is narrower (four rungs,
+// and narrower still per model), OpenAI's ceiling AND floor are per-model, and
+// DeepSeek's `none` didn't turn reasoning off the way kaibo was sending it.
+//
+// Every assertion here was observed on the wire on 2026-08-01 by raw HTTP
+// against each provider's real endpoint — deliberately NOT through rig, whose
+// typed enums reject before the wire and would tell us nothing about the
+// provider. Each doc comment carries its dated measurement, so a later reader
+// can tell what was measured from what was assumed.
+//
+// They follow the `openrouter_reasoning_accounting_live` precedent above: post
+// raw, read the provider's own accounting back, and assert on the response
+// BODY, not just the status. A rung that is accepted-but-ignored looks exactly
+// like one that works unless you check whether reasoning actually happened.
+//
+// All `#[ignore]`d: they cost money and need network + keys.
+
+/// Rungs kaibo can put in a slot's `effort` — the widest set any provider takes,
+/// which is what a probe must try in order to discover a narrower one.
+const ALL_RUNGS: &[&str] = &["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+/// A short arithmetic prompt: cheap, and every reasoning model spends *some*
+/// thinking on it, so "did reasoning happen" is a live signal rather than noise.
+const CHEAP_PROMPT: &str = "What is 1487 times 233? Give the number.";
+
+/// A prompt with enough depth that the ladder's rungs can actually separate.
+/// Used only where we assert *gradation*, never where we assert acceptance.
+const HARD_PROMPT: &str = "Prove or disprove: every integer n>1 that divides 2^n-2 \
+     must be composite or equal to 2. Reason carefully, then answer in one line.";
+
+/// The client every live probe here uses — kaibo's own rustls+ring stack, so a probe
+/// exercises the shipped TLS boundary too.
+fn probe_http() -> reqwest::Client {
+    kaibo::tls::https_client(std::time::Duration::from_secs(180)).expect("https client")
+}
+
+/// The API key a live probe should use for `kind`, resolved **the way kaibo itself
+/// resolves one**: the operator's config names the backend and where its key lives
+/// (`api_key_env` / `api_key_file`), and only when no configured backend of that kind
+/// exists do we fall back to the built-in `credentials::load` path.
+///
+/// Going through the config is not politeness, it's necessity in both directions. The
+/// `openai` kind is `key_optional` — a local llama.cpp server needs no key — so
+/// `credentials::load` refuses it outright and the hosted Platform key is reachable
+/// *only* through the backend that names it. And an operator's key file needn't sit at
+/// the built-in default path: on this machine OpenRouter's key is
+/// `~/.openrouter-key.txt` via config, while `load` looks for `~/.openrouter-key`.
+///
+/// Panics with the reason when no key resolves — an `#[ignore]`d probe that silently
+/// no-ops is worse than one that doesn't run.
+fn live_key(kind: ProviderKind) -> String {
+    if let Ok(cfg) = Config::load(None) {
+        let configured = cfg.backends.values().find(|b| {
+            b.kind == kind
+                // For the openai kind, only OpenAI Platform itself can answer a
+                // Platform probe; a local endpoint sharing the kind cannot.
+                && (kind != ProviderKind::Openai || b.is_hosted_openai())
+        });
+        if let Some(b) = configured {
+            match b.resolve_key() {
+                Ok(k) if k != kind.placeholder_key() => return k,
+                Ok(_) => {}
+                Err(e) => eprintln!("=== backend {:?} key did not resolve: {e}", b.name),
+            }
+        }
+    }
+    load(kind).unwrap_or_else(|e| panic!("no {kind:?} credential for live test: {e}"))
+}
+
+// --- DeepSeek --------------------------------------------------------------
+
+async fn deepseek_probe(key: &str, body: Value) -> (u16, Value) {
+    let resp = probe_http()
+        .post("https://api.deepseek.com/chat/completions")
+        .bearer_auth(key)
+        .json(&body)
+        .send()
+        .await
+        .expect("deepseek request");
+    let status = resp.status().as_u16();
+    (status, resp.json().await.expect("deepseek response json"))
+}
+
+fn deepseek_reasoning_tokens(j: &Value) -> u64 {
+    j["usage"]["completion_tokens_details"]["reasoning_tokens"]
+        .as_u64()
+        .unwrap_or(0)
+}
+
+/// DeepSeek validates `reasoning_effort` strictly against a *seven*-rung ladder — it is
+/// the one provider whose accepted set is exactly the universal ladder kaibo's docs once
+/// claimed for everyone. Observed 2026-08-01 on `deepseek-v4-pro`: all seven HTTP 200,
+/// and a garbage value 400s with the ladder spelled out in the error.
+///
+/// That error text is the real oracle: it means a future DeepSeek ladder change fails
+/// this test loudly instead of drifting past `docs/config.md`'s per-provider table.
+#[tokio::test]
+#[ignore = "hits the DeepSeek API; run with --ignored and a key"]
+async fn deepseek_effort_ladder_live() {
+    let key = live_key(ProviderKind::DeepSeek);
+
+    for rung in ALL_RUNGS {
+        let (status, json) = deepseek_probe(
+            &key,
+            json!({
+                "model": "deepseek-v4-pro",
+                "max_tokens": 2048,
+                "thinking": { "type": "enabled" },
+                "reasoning_effort": rung,
+                "messages": [{ "role": "user", "content": CHEAP_PROMPT }],
+            }),
+        )
+        .await;
+        assert_eq!(
+            status, 200,
+            "DeepSeek should accept effort={rung}, got {status}: {json}"
+        );
+    }
+
+    // The oracle: an off-ladder value is refused, and the refusal *enumerates* the
+    // ladder. If DeepSeek adds or drops a rung, this assertion is what notices.
+    let (status, json) = deepseek_probe(
+        &key,
+        json!({
+            "model": "deepseek-v4-pro",
+            "max_tokens": 16,
+            "thinking": { "type": "enabled" },
+            "reasoning_effort": "zzz",
+            "messages": [{ "role": "user", "content": "hi" }],
+        }),
+    )
+    .await;
+    assert_eq!(status, 400, "an off-ladder effort must be refused: {json}");
+    let msg = json["error"]["message"].as_str().unwrap_or_default();
+    for rung in ALL_RUNGS {
+        assert!(
+            msg.contains(rung),
+            "DeepSeek's rejection should still enumerate `{rung}` — the ladder moved: {msg}"
+        );
+    }
+}
+
+/// The provider behavior that forced kaibo's DeepSeek off-switch to be *structural*.
+///
+/// The off-switch on DeepSeek belongs to `thinking.type`, not to `reasoning_effort`.
+/// Observed 2026-08-01 on `deepseek-v4-pro`, one variable at a time:
+///
+/// | body                                              | reasoning tokens |
+/// |---------------------------------------------------|------------------|
+/// | `reasoning_effort: "none"` alone                   | 0                |
+/// | `thinking: {"type":"disabled"}` alone              | 0                |
+/// | `thinking: {"type":"enabled"}` + `effort: "none"`  | **160–253**      |
+///
+/// That third row is what kaibo used to send for `effort = "none"`: the explicit enable
+/// wins, so an operator's opt-out did nothing and they paid for the reasoning anyway —
+/// the silent-fallback shape this project refuses. `ThinkingStyle::DeepSeekEffort` now
+/// emits the structural disable instead (`src/consult/shaping.rs`), the way
+/// `OpenRouterEffort` already did.
+///
+/// So this test does two jobs. It pins the *provider* precedence that justifies the fix
+/// (if DeepSeek ever makes `effort` win, the fix is no longer load-bearing and the
+/// `none` guidance should be revisited), and it proves kaibo's own shaped params — the
+/// exact blob `ModelShape::to_params` builds — bill zero reasoning on the wire.
+#[tokio::test]
+#[ignore = "hits the DeepSeek API; run with --ignored and a key"]
+async fn deepseek_effort_none_needs_the_structural_disable_live() {
+    let key = live_key(ProviderKind::DeepSeek);
+    let base = |extra: Value| {
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "max_tokens": 2048,
+            "messages": [{ "role": "user", "content": CHEAP_PROMPT }],
+        });
+        for (k, v) in extra.as_object().expect("object") {
+            body[k] = v.clone();
+        }
+        body
+    };
+
+    // Each lever alone: really off.
+    let (_, bare) = deepseek_probe(&key, base(json!({ "reasoning_effort": "none" }))).await;
+    assert_eq!(
+        deepseek_reasoning_tokens(&bare),
+        0,
+        "effort=none alone should suppress reasoning, got usage: {}",
+        bare["usage"]
+    );
+    let (_, disabled) =
+        deepseek_probe(&key, base(json!({ "thinking": { "type": "disabled" } }))).await;
+    assert_eq!(
+        deepseek_reasoning_tokens(&disabled),
+        0,
+        "thinking.type=disabled should suppress reasoning, got usage: {}",
+        disabled["usage"]
+    );
+
+    // The pairing kaibo used to send. `thinking: enabled` wins and reasoning bills.
+    let (_, both) = deepseek_probe(
+        &key,
+        base(json!({ "thinking": { "type": "enabled" }, "reasoning_effort": "none" })),
+    )
+    .await;
+    assert!(
+        deepseek_reasoning_tokens(&both) > 0,
+        "documented provider precedence: thinking=enabled overrides effort=none. If this \
+         now reports 0, DeepSeek changed its precedence — the structural disable is no \
+         longer load-bearing and the `effort = \"none\"` guidance should be revisited. \
+         usage: {}",
+        both["usage"]
+    );
+
+    // And what kaibo sends TODAY: the shaped params, on the wire, billing nothing.
+    let shaped = ModelShape::resolve(
+        ProviderKind::DeepSeek,
+        "deepseek-v4-pro",
+        ThinkingStyleOverride::Auto,
+    )
+    .to_params(THINKING_BUDGET, None, None, "none")
+    .expect("deepseek always sends a thinking block");
+    let (status, kaibo_shape) = deepseek_probe(&key, base(shaped.clone())).await;
+    assert_eq!(
+        status, 200,
+        "kaibo's shaped params must be accepted: {kaibo_shape}"
+    );
+    assert_eq!(
+        deepseek_reasoning_tokens(&kaibo_shape),
+        0,
+        "kaibo's `effort = \"none\"` must actually stop the billing it names. sent {shaped}, \
+         got usage: {}",
+        kaibo_shape["usage"]
+    );
+}
+
+// --- Gemini ----------------------------------------------------------------
+
+async fn gemini_probe(key: &str, model: &str, level: &str, prompt: &str) -> (u16, Value) {
+    let url =
+        format!("https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent");
+    let resp = probe_http()
+        .post(url)
+        .header("x-goog-api-key", key)
+        .json(&json!({
+            "contents": [{ "parts": [{ "text": prompt }] }],
+            "generationConfig": {
+                "maxOutputTokens": 8192,
+                "thinkingConfig": { "thinkingLevel": level, "includeThoughts": true },
+            },
+        }))
+        .send()
+        .await
+        .expect("gemini request");
+    let status = resp.status().as_u16();
+    (status, resp.json().await.expect("gemini response json"))
+}
+
+/// rig's four-variant `ThinkingLevel` (`minimal|low|medium|high`) is a CORRECT model of
+/// Google's API, not a stale cap like its OpenAI `ReasoningEffort` enum. Observed
+/// 2026-08-01 on `gemini-3.5-flash`: `none`, `xhigh` and `max` all 400 with a protobuf
+/// enum error naming `google.ai.generativelanguage.v1beta.ThinkingConfig.ThinkingLevel`.
+/// A schema-level refusal, so no Gemini model can take those rungs.
+///
+/// Consequence kaibo's docs now carry: `effort = "none"` cannot turn reasoning off on
+/// the gemini kind at all — `minimal` is Google's off-switch (proven below).
+#[tokio::test]
+#[ignore = "hits the Gemini API; run with --ignored and a key"]
+async fn gemini_thinking_level_ladder_live() {
+    let key = live_key(ProviderKind::Gemini);
+
+    for level in ["minimal", "low", "medium", "high"] {
+        let (status, json) = gemini_probe(&key, "gemini-3.5-flash", level, CHEAP_PROMPT).await;
+        assert_eq!(
+            status, 200,
+            "gemini-3.5-flash should accept thinkingLevel={level}: {json}"
+        );
+    }
+
+    for level in ["none", "xhigh", "max"] {
+        let (status, json) = gemini_probe(&key, "gemini-3.5-flash", level, CHEAP_PROMPT).await;
+        assert_eq!(
+            status, 400,
+            "Google's ThinkingLevel enum has no `{level}` rung — if this now succeeds, \
+             Google widened the enum and rig's four-variant cap became a stale ceiling \
+             kaibo must document: {json}"
+        );
+        let msg = json["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            msg.contains("thinking_level") || msg.contains("ThinkingLevel"),
+            "expected a thinking_level enum rejection for `{level}`, got: {msg}"
+        );
+    }
+}
+
+/// The Gemini ladder is narrower still *per model*: `gemini-pro-latest` refuses
+/// `minimal` with a distinct, human-worded error (not the protobuf enum error) — a
+/// model-capability refusal layered on top of the schema enum. Observed 2026-08-01.
+///
+/// So a cast pinning a Pro model has a three-rung ladder and no way to run thinking-off
+/// at all — which is why `docs/config.md` says Gemini's off-switch is model-dependent
+/// rather than just naming `minimal`.
+#[tokio::test]
+#[ignore = "hits the Gemini API; run with --ignored and a key"]
+async fn gemini_pro_rejects_minimal_live() {
+    let key = live_key(ProviderKind::Gemini);
+    let (status, json) = gemini_probe(&key, "gemini-pro-latest", "minimal", CHEAP_PROMPT).await;
+    assert_eq!(
+        status, 400,
+        "gemini-pro-latest is expected to refuse thinkingLevel=minimal: {json}"
+    );
+    let msg = json["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("minimal"),
+        "expected a model-capability refusal naming MINIMAL, got: {msg}"
+    );
+}
+
+/// Gemini's rungs are *graded*, not decorative: thinking tokens climb with the level,
+/// and `minimal` is genuinely thinking-off (no `thoughtsTokenCount` at all). Observed
+/// 2026-08-01 on gemini-3.5-flash with `HARD_PROMPT`: minimal=0, low=494, medium=1269,
+/// high=1974.
+///
+/// This is the accepted-and-reasoned vs accepted-but-ignored discriminator for the
+/// gemini kind, and it doubles as the evidence that `minimal` is the right off-switch to
+/// point operators at.
+#[tokio::test]
+#[ignore = "hits the Gemini API; run with --ignored and a key"]
+async fn gemini_thinking_level_is_graded_live() {
+    let key = live_key(ProviderKind::Gemini);
+    let thoughts = |j: &Value| {
+        j["usageMetadata"]["thoughtsTokenCount"]
+            .as_u64()
+            .unwrap_or(0)
+    };
+
+    let mut seen = Vec::new();
+    for level in ["minimal", "low", "medium", "high"] {
+        let (status, json) = gemini_probe(&key, "gemini-3.5-flash", level, HARD_PROMPT).await;
+        assert_eq!(status, 200, "thinkingLevel={level}: {json}");
+        seen.push((level, thoughts(&json)));
+    }
+
+    assert_eq!(
+        seen[0].1, 0,
+        "thinkingLevel=minimal is Gemini's off-switch — it must spend no thinking \
+         tokens, got {seen:?}"
+    );
+    assert!(
+        seen[3].1 > seen[1].1,
+        "high must think measurably deeper than low, else the level is accepted but \
+         ignored: {seen:?}"
+    );
+}
+
+// --- OpenAI Platform -------------------------------------------------------
+
+async fn openai_probe(key: &str, model: &str, effort: &str) -> (u16, Value) {
+    let resp = probe_http()
+        .post("https://api.openai.com/v1/responses")
+        .bearer_auth(key)
+        .json(&json!({
+            "model": model,
+            "input": CHEAP_PROMPT,
+            "max_output_tokens": 2048,
+            "reasoning": { "effort": effort },
+        }))
+        .send()
+        .await
+        .expect("openai request");
+    let status = resp.status().as_u16();
+    (status, resp.json().await.expect("openai response json"))
+}
+
+/// The OpenAI ceiling is a **model** property, not a family property — and the *floor*
+/// moves too. Observed 2026-08-01 against `/v1/responses`:
+///
+/// | model     | rejects          | the model's own "Supported values"        |
+/// |-----------|------------------|-------------------------------------------|
+/// | gpt-5.6-* | (none of them)   | takes `xhigh` AND `max`                   |
+/// | gpt-5.2   | `max`            | none, low, medium, high, xhigh            |
+/// | gpt-5.1   | `xhigh`, `max`   | none, low, medium, high                   |
+/// | gpt-5     | `xhigh`, `max`   | minimal, low, medium, high  (no `none`!)  |
+///
+/// This is the measurement behind kaibo keeping **no** effort allowlist: any table we
+/// baked in would be wrong within a release, and it would be wrong per model id rather
+/// than per family, which is not a shape a classifier handles gracefully.
+///
+/// It also pins a trap for whoever re-derives this: validation is **two-layer**. An
+/// off-schema sentinel (`"zzz"`) returns the API's *superset* enum for every model,
+/// gpt-5 included — so the sentinel trick cannot reveal a model's real ladder. Only
+/// posting the actual rung surfaces the model-capability refusal.
+#[tokio::test]
+#[ignore = "hits the OpenAI Platform API; run with --ignored and a hosted-openai backend key"]
+async fn openai_effort_ceiling_is_per_model_live() {
+    let key = live_key(ProviderKind::Openai);
+
+    // The 5.6 line reaches the top of the ladder, cheap tier included — `max` is not
+    // reserved for the flagship.
+    for model in ["gpt-5.6-sol", "gpt-5.6-luna"] {
+        for effort in ["xhigh", "max"] {
+            let (status, json) = openai_probe(&key, model, effort).await;
+            assert_eq!(status, 200, "{model} should accept effort={effort}: {json}");
+            assert_eq!(
+                json["reasoning"]["effort"].as_str(),
+                Some(effort),
+                "{model} should echo the requested effort back: {json}"
+            );
+            assert!(
+                json["usage"]["output_tokens_details"]["reasoning_tokens"]
+                    .as_u64()
+                    .unwrap_or(0)
+                    > 0,
+                "{model} at effort={effort} must actually bill reasoning tokens: {}",
+                json["usage"]
+            );
+        }
+    }
+
+    // Older ids cap lower. These refusals are why kaibo cannot ship one ladder for the
+    // whole `openai` kind — nor even for the `gpt-5*` family.
+    for (model, rejected) in [
+        ("gpt-5.2", vec!["max"]),
+        ("gpt-5.1", vec!["xhigh", "max"]),
+        ("gpt-5", vec!["xhigh", "max"]),
+    ] {
+        for effort in rejected {
+            let (status, json) = openai_probe(&key, model, effort).await;
+            assert_eq!(
+                status, 400,
+                "{model} is expected to refuse effort={effort}: {json}"
+            );
+            let msg = json["error"]["message"].as_str().unwrap_or_default();
+            assert!(
+                msg.contains("not supported with the") && msg.contains(model),
+                "expected a model-capability refusal naming {model}, got: {msg}"
+            );
+        }
+    }
+
+    // The two-layer trap, pinned: an off-schema value reports the superset, so it must
+    // not be mistaken for the model's ladder.
+    let (status, json) = openai_probe(&key, "gpt-5", "zzz").await;
+    assert_eq!(status, 400, "an off-schema effort must be refused: {json}");
+    let msg = json["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("xhigh") && msg.contains("max"),
+        "the schema-level rejection is expected to list the superset even for a model \
+         that refuses those rungs — if this changed, the sentinel trick became usable \
+         for ladder discovery: {msg}"
+    );
+}
+
+// --- OpenRouter ------------------------------------------------------------
+
+/// One OpenRouter completion with the gateway's usage accounting on, returning whatever
+/// came back — including a rejection body. The ladder probes need both knobs the older
+/// `openrouter_probe_completion` lacked: a caller-chosen prompt (so rungs can separate
+/// on a hard question) and the ability to READ a 400 rather than panic on it, since the
+/// gateway's rejection text enumerates its ladder and that text is the oracle.
+#[cfg(test)]
+async fn openrouter_probe_raw(key: &str, model: &str, params: &Value, prompt: &str) -> Value {
+    let mut body = json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": prompt }],
+        "max_completion_tokens": 8192,
+        "usage": { "include": true },
+    });
+    for (k, v) in params.as_object().expect("shaped params are an object") {
+        body[k] = v.clone();
+    }
+    probe_http()
+        .post("https://openrouter.ai/api/v1/chat/completions")
+        .bearer_auth(key)
+        .json(&body)
+        .send()
+        .await
+        .expect("openrouter request")
+        .json()
+        .await
+        .expect("openrouter response json")
+}
+
+/// [`openrouter_probe_raw`] plus "and it must have worked" — the shape every probe that
+/// asserts *acceptance* wants. OpenRouter reports errors in the body with a 200-ish
+/// envelope as readily as a 4xx, so the check is on `error`, not the status.
+#[cfg(test)]
+async fn openrouter_probe_completion_with(
+    key: &str,
+    model: &str,
+    params: &Value,
+    prompt: &str,
+) -> Value {
+    let json = openrouter_probe_raw(key, model, params, prompt).await;
+    assert!(
+        json.get("error").is_none(),
+        "openrouter rejected the probe params: {json}"
+    );
+    json
+}
+
+/// OpenRouter really does expose the full seven-rung ladder, and `xhigh`/`max` are not
+/// decoration: reasoning tokens climb with the rung. Observed 2026-08-01 on
+/// `HARD_PROMPT` — `z-ai/glm-5.2` low=478, high=389, xhigh=809, max=1177;
+/// `~openai/gpt-latest` low=87, high=115, xhigh=127, max=142.
+///
+/// (Note low>high on GLM in that run: sampling noise at adjacent rungs is real, which is
+/// why the assertion below compares `max` against `high` — two rungs apart — rather than
+/// demanding a monotonic staircase a live probe can't promise.)
+///
+/// This is the probe behind the claim in `src/consult/shaping.rs` and `docs/config.md`
+/// that the openrouter kind reaches rungs the other kinds don't.
+#[tokio::test]
+#[ignore = "hits the OpenRouter API; run with --ignored and an OpenRouter key"]
+async fn openrouter_top_rungs_reach_deeper_live() {
+    let key = live_key(ProviderKind::OpenRouter);
+    let model = "z-ai/glm-5.2";
+
+    let mut seen = Vec::new();
+    for effort in ["high", "xhigh", "max"] {
+        let params = json!({ "reasoning": { "effort": effort }, "usage": { "include": true } });
+        let resp = openrouter_probe_completion_with(&key, model, &params, HARD_PROMPT).await;
+        let reasoning = resp["usage"]["completion_tokens_details"]["reasoning_tokens"]
+            .as_u64()
+            .unwrap_or(0);
+        assert!(
+            reasoning > 0,
+            "effort={effort} must bill reasoning tokens: {}",
+            resp["usage"]
+        );
+        seen.push((effort, reasoning));
+    }
+
+    assert!(
+        seen[2].1 > seen[0].1,
+        "`max` must reach deeper than `high`, else the extra rungs are accepted but \
+         ignored and the docs should stop advertising them: {seen:?}"
+    );
+
+    // And the ladder is validated, not free-form — the rejection enumerates it.
+    let params = json!({ "reasoning": { "effort": "zzz" } });
+    let resp = openrouter_probe_raw(&key, model, &params, "hi").await;
+    let msg = resp["error"]["message"].as_str().unwrap_or_default();
+    for rung in ALL_RUNGS {
+        assert!(
+            msg.contains(rung),
+            "OpenRouter's rejection should enumerate `{rung}` — the gateway ladder \
+             moved: {msg}"
+        );
+    }
+}
+
+/// The gateway asymmetry, settled: OpenRouter carries `xhigh` and `max` to upstream
+/// OpenAI models whose **direct** Platform API refuses those rungs. Observed 2026-08-01
+/// — `openai/gpt-5.1` and `openai/gpt-5` both succeed with reasoning tokens billed
+/// through OpenRouter, while the same rungs 400 against `api.openai.com` (see
+/// `openai_effort_ceiling_is_per_model_live`, which pins the other half).
+///
+/// So OpenRouter is NOT a passthrough for this field — it normalizes onto each
+/// upstream's native knob. That is the sentence `docs/config.md` and
+/// `EffortWire::Passthrough`'s doc now carry, and the operator-facing consequence is
+/// that the same `effort = "max"` is portable on the openrouter kind and model-gated on
+/// the gpt kind.
+#[tokio::test]
+#[ignore = "hits the OpenRouter API; run with --ignored and an OpenRouter key"]
+async fn openrouter_clamps_rungs_the_direct_backend_refuses_live() {
+    let key = live_key(ProviderKind::OpenRouter);
+
+    for model in ["openai/gpt-5.1", "openai/gpt-5"] {
+        for effort in ["xhigh", "max"] {
+            let params = json!({ "reasoning": { "effort": effort }, "usage": { "include": true } });
+            let resp = openrouter_probe_completion_with(&key, model, &params, CHEAP_PROMPT).await;
+            assert_eq!(
+                resp["model"].as_str(),
+                Some(model),
+                "OpenRouter should serve the pinned upstream, not silently reroute: {resp}"
+            );
+            assert!(
+                resp["usage"]["completion_tokens_details"]["reasoning_tokens"]
+                    .as_u64()
+                    .unwrap_or(0)
+                    > 0,
+                "the gateway is expected to translate effort={effort} into something the \
+                 upstream honors, billing reasoning tokens: {}",
+                resp["usage"]
+            );
+        }
+    }
+}
+
+// --- Anthropic — the one unprobed cell -------------------------------------
+
+/// UNVERIFIED. This probe is written and has never been observed to pass or fail on its
+/// own logic, because the key available on 2026-08-01 was unfunded: every request to
+/// `api.anthropic.com` returned HTTP 400 "Your credit balance is too low to access the
+/// Anthropic API" — on `/v1/messages` AND on the otherwise-free
+/// `/v1/messages/count_tokens`. The billing check runs *before* body validation, so
+/// there is no free path to validate `output_config.effort` on an unfunded account.
+/// Anthropic's adaptive ladder is the one cell of the provider matrix still unknown.
+///
+/// The credit-balance assertion below is deliberately the FIRST thing checked and is a
+/// hard failure, not a skip: an unfunded run must be impossible to mistake for a result.
+/// This test failing on billing means "we still don't know", which is the honest answer;
+/// silently passing would launder an unpaid bill into evidence.
+///
+/// OpenRouter's Anthropic route settles nothing here either — the gateway is proven
+/// above to accept rungs its upstream refuses, so an OpenRouter 200 on `~anthropic/…` at
+/// `max` is evidence about OpenRouter, not about Anthropic.
+///
+/// Run this with a funded key to settle two documents that currently disagree:
+/// `docs/config.example.toml` ships `effort = "max"` on an Opus slot, while
+/// `src/batch.rs` calls `high` "the proven-accepted top for the Anthropic adaptive
+/// tier". Exactly one of those is right. Both are deliberately left as they are until
+/// this probe can answer.
+#[tokio::test]
+#[ignore = "UNVERIFIED: needs a FUNDED Anthropic key; run with --ignored"]
+async fn anthropic_adaptive_effort_ladder_live() {
+    let key = live_key(ProviderKind::Anthropic);
+
+    for rung in ALL_RUNGS {
+        let resp = probe_http()
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&json!({
+                "model": "claude-opus-4-8",
+                "max_tokens": 2048,
+                "thinking": { "type": "adaptive" },
+                "output_config": { "effort": rung },
+                "messages": [{ "role": "user", "content": CHEAP_PROMPT }],
+            }))
+            .send()
+            .await
+            .expect("anthropic request");
+        let status = resp.status();
+        let json: Value = resp.json().await.expect("anthropic response json");
+
+        let err = json["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            !err.contains("credit balance is too low"),
+            "the Anthropic account is unfunded, so this probe cannot distinguish an \
+             unsupported rung from an unpaid bill — the ladder is still UNKNOWN, not \
+             disproven. Fund the key and re-run. (effort={rung}, {status}: {err})"
+        );
+
+        // Record, don't presume. Both outcomes are findings: a 400 names the real
+        // ceiling, a 200 with thinking blocks proves the rung reaches the model.
+        if status.is_success() {
+            let thinking: usize = json["content"]
+                .as_array()
+                .map(|blocks| {
+                    blocks
+                        .iter()
+                        .filter(|b| b["type"] == "thinking")
+                        .filter_map(|b| b["thinking"].as_str())
+                        .map(str::len)
+                        .sum()
+                })
+                .unwrap_or(0);
+            eprintln!(
+                "=== effort={rung} ACCEPTED thinking_chars={thinking} usage={}",
+                json["usage"]
+            );
+        } else {
+            eprintln!("=== effort={rung} REJECTED ({status}): {}", json["error"]);
+        }
+    }
 }

--- a/tests/effort_wire.rs
+++ b/tests/effort_wire.rs
@@ -40,8 +40,8 @@ use rig_core::OneOrMany;
 use serde_json::Value;
 
 use kaibo::consult::{
-    accepted_efforts, hosted_openai_responses_params, preflight_params, EffortWire, ModelShape,
-    ThinkingStyleOverride, EFFORT_LADDER,
+    accepted_efforts, hosted_openai_responses_params, known_efforts, preflight_params, EffortWire,
+    ModelShape, ThinkingStyleOverride,
 };
 use kaibo::credentials::ProviderKind;
 
@@ -283,7 +283,7 @@ async fn on_the_wire(path: Path, effort: &str) -> Result<Option<Value>, String> 
 }
 
 /// A rung kaibo will never find on any ladder — an operator's typo, or a provider name
-/// newer than [`EFFORT_LADDER`]. Both look the same from here, and both must behave the
+/// newer than kaibo's ladder. Both look the same from here, and both must behave the
 /// same: passed through where the wire is passthrough, refused where rig is typed.
 const UNRANKED: &str = "ludicrous";
 
@@ -296,7 +296,7 @@ const UNRANKED: &str = "ludicrous";
 async fn rig_effort_ladders_are_pinned() {
     for path in Path::ALL {
         let mut accepted = Vec::new();
-        for rung in EFFORT_LADDER {
+        for rung in known_efforts() {
             if on_the_wire(path, rung).await.is_ok() {
                 accepted.push(rung);
             }
@@ -312,7 +312,7 @@ async fn rig_effort_ladders_are_pinned() {
             }
             // `#[serde(flatten)]` all the way down: kaibo can express anything and the
             // provider is the one that answers for it.
-            EffortWire::Passthrough => EFFORT_LADDER.to_vec(),
+            EffortWire::Passthrough => known_efforts(),
         };
         assert_eq!(
             accepted, expected,
@@ -340,7 +340,7 @@ async fn rig_effort_ladders_are_pinned() {
 #[tokio::test]
 async fn kaibo_preflight_agrees_with_rig() {
     for path in Path::ALL {
-        for rung in EFFORT_LADDER.iter().copied().chain([UNRANKED]) {
+        for rung in known_efforts().into_iter().chain([UNRANKED]) {
             let rig_accepts = on_the_wire(path, rung).await.is_ok();
             let kaibo_accepts = preflight_params(path.wire(), path.shaped(rung).as_ref()).is_ok();
             assert_eq!(
@@ -359,7 +359,7 @@ async fn kaibo_preflight_agrees_with_rig() {
 async fn the_error_message_lists_what_the_wire_really_takes() {
     for path in Path::ALL {
         let mut actual = Vec::new();
-        for rung in EFFORT_LADDER {
+        for rung in known_efforts() {
             if on_the_wire(path, rung).await.is_ok() {
                 actual.push(rung);
             }

--- a/tests/effort_wire.rs
+++ b/tests/effort_wire.rs
@@ -1,0 +1,461 @@
+//! The reasoning-`effort` wire matrix, proven offline against rig's *real* clients.
+//!
+//! kaibo shapes a per-role `effort` into an `additional_params` blob and hands it to
+//! rig. Every unit test around that shaping asserts the shape of kaibo's own blob —
+//! which is exactly why a live landmine sat there unnoticed: nothing handed the blob to
+//! rig, so `effort = "xhigh"` on a Gemini slot stayed green in CI and died on every
+//! call. rig 0.38 parses the blob into a typed struct on two of the six wires, and those
+//! structs have a **closed** set of rungs. That ceiling is *rig's client*, not the
+//! provider's API — OpenAI's own Responses endpoint accepts `"max"` (probed live
+//! 2026-08-01: 200, echoed back) while rig's `ReasoningEffort` enum stops at `xhigh`.
+//!
+//! So this suite closes the loop with no key and no network: a fake `HttpClientExt`
+//! records the body rig builds, and the test drives a real `CompletionModel` for each
+//! wire kaibo ships. What comes back is the truth — the request rig would have sent, or
+//! the error rig raises before sending. Three things ride on it:
+//!
+//! 1. **The ladder each wire accepts is pinned** (`rig_effort_ladders_are_pinned`), so a
+//!    rig bump that narrows — or widens — a rung fails here instead of in someone's
+//!    consult.
+//! 2. **kaibo's preflight agrees with rig, rung for rung**
+//!    (`kaibo_preflight_agrees_with_rig`). `Arm::from_slot` asks rig's converter before
+//!    the call so a refusal names the cast/slot/backend instead of arriving as a bare
+//!    serde line mid-consult. This test is what keeps that preflight honest: it is the
+//!    *same* converter, so it can never grow into a second, drifting allowlist.
+//! 3. **The silent drops are documented as drops** (`toggle_less_wires_send_no_effort`).
+//!    Two wires carry no reasoning knob at all and swallow the setting; the wire says so
+//!    here, and `Config::inert_efforts` is what makes an operator hear it.
+
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use rig_core::client::CompletionClient;
+use rig_core::completion::{CompletionModel, CompletionRequest};
+use rig_core::http_client::{
+    self, HttpClientExt, LazyBody, MultipartForm, Request, Response, StreamingResponse,
+};
+use rig_core::message::Message;
+use rig_core::OneOrMany;
+use serde_json::Value;
+
+use kaibo::consult::{
+    accepted_efforts, hosted_openai_responses_params, preflight_params, EffortWire, ModelShape,
+    ThinkingStyleOverride, EFFORT_LADDER,
+};
+use kaibo::credentials::ProviderKind;
+
+/// An `HttpClientExt` that records the serialized request body and then fails. The
+/// failure is the point: everything under test is already built by the time rig hands
+/// the request over, so no network, no key, and no canned response are needed.
+#[derive(Clone, Debug, Default)]
+struct Capture(Arc<Mutex<Vec<Value>>>);
+
+impl Capture {
+    fn recorded(&self) -> Option<Value> {
+        self.0.lock().unwrap().first().cloned()
+    }
+}
+
+impl HttpClientExt for Capture {
+    fn send<T, U>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+    where
+        T: Into<Bytes> + Send,
+        U: From<Bytes> + Send + 'static,
+    {
+        let (_parts, body) = req.into_parts();
+        let bytes: Bytes = body.into();
+        self.0
+            .lock()
+            .unwrap()
+            .push(serde_json::from_slice(&bytes).unwrap_or(Value::Null));
+        async move { Err(http_client::Error::StreamEnded) }
+    }
+
+    // Unreachable for a completion, but the trait requires them. `async fn` can't
+    // express the trait's `+ Send + 'static` return bound, so the desugared form stays.
+    #[allow(clippy::manual_async_fn)]
+    fn send_multipart<U>(
+        &self,
+        _req: Request<MultipartForm>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+    where
+        U: From<Bytes> + Send + 'static,
+    {
+        async move { Err(http_client::Error::StreamEnded) }
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn send_streaming<T>(
+        &self,
+        _req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + Send
+    where
+        T: Into<Bytes> + Send,
+    {
+        async move { Err(http_client::Error::StreamEnded) }
+    }
+}
+
+/// The six request shapes kaibo builds, each named by the arm `Arm::from_slot` would
+/// construct for it. `Anthropic` splits by tier because the tiers differ in the one way
+/// this suite is about: adaptive routes the effort, budget has no place to put it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Path {
+    AnthropicAdaptive,
+    AnthropicBudget,
+    Gemini,
+    DeepSeek,
+    OpenRouter,
+    /// The generic `openai` kind on `/chat/completions` — every local llama.cpp / Ollama
+    /// / gateway backend.
+    OpenaiChat,
+    /// A backend resolved onto rig's Responses client (hosted OpenAI Platform, or an
+    /// explicit `wire = "responses"`), with a reasoning-family model id.
+    OpenaiResponses,
+}
+
+impl Path {
+    const ALL: [Path; 7] = [
+        Path::AnthropicAdaptive,
+        Path::AnthropicBudget,
+        Path::Gemini,
+        Path::DeepSeek,
+        Path::OpenRouter,
+        Path::OpenaiChat,
+        Path::OpenaiResponses,
+    ];
+
+    fn model(&self) -> &'static str {
+        match self {
+            Path::AnthropicAdaptive => "claude-sonnet-4-6",
+            Path::AnthropicBudget => "claude-haiku-4-5",
+            Path::Gemini => "gemini-3.5-flash",
+            Path::DeepSeek => "deepseek-v4-pro",
+            Path::OpenRouter => "z-ai/glm-5.2",
+            Path::OpenaiChat => "gemma-local",
+            Path::OpenaiResponses => "gpt-5.6-sol",
+        }
+    }
+
+    fn kind(&self) -> ProviderKind {
+        match self {
+            Path::AnthropicAdaptive | Path::AnthropicBudget => ProviderKind::Anthropic,
+            Path::Gemini => ProviderKind::Gemini,
+            Path::DeepSeek => ProviderKind::DeepSeek,
+            Path::OpenRouter => ProviderKind::OpenRouter,
+            Path::OpenaiChat | Path::OpenaiResponses => ProviderKind::Openai,
+        }
+    }
+
+    fn responses_wire(&self) -> bool {
+        *self == Path::OpenaiResponses
+    }
+
+    /// kaibo's `additional_params` blob for this path at `effort` — built by the same
+    /// public shaping calls `Arm::from_slot` makes, so the test can't shape it "nicer"
+    /// than production does.
+    fn shaped(&self, effort: &str) -> Option<Value> {
+        if self.responses_wire() {
+            return hosted_openai_responses_params(self.model(), None, effort);
+        }
+        ModelShape::resolve(self.kind(), self.model(), ThinkingStyleOverride::Auto)
+            .to_params(8192, None, None, effort)
+    }
+
+    /// The rig wire this path's blob has to survive, as kaibo classifies it.
+    fn wire(&self) -> EffortWire {
+        EffortWire::resolve(self.kind(), self.responses_wire())
+    }
+}
+
+fn request(params: Option<Value>) -> CompletionRequest {
+    CompletionRequest {
+        model: None,
+        preamble: Some("ground every claim".into()),
+        chat_history: OneOrMany::one(Message::user("hi")),
+        documents: Vec::new(),
+        tools: Vec::new(),
+        temperature: None,
+        max_tokens: Some(4096),
+        tool_choice: None,
+        additional_params: params,
+        output_schema: None,
+    }
+}
+
+async fn capture<M: CompletionModel>(
+    model: M,
+    cap: &Capture,
+    params: Option<Value>,
+) -> Result<Value, String> {
+    // The completion always errors (the capture client has no response to give); what
+    // matters is whether a body was built first. A recorded body means rig accepted the
+    // blob and serialized the request; nothing recorded means rig refused it, and its
+    // message is the one an operator would have seen mid-call.
+    let err = model.completion(request(params)).await.err();
+    match cap.recorded() {
+        Some(body) => Ok(body),
+        None => Err(err.map(|e| e.to_string()).unwrap_or_default()),
+    }
+}
+
+/// Drive one path at one rung through rig's real client and report what reached the
+/// wire: `Ok(Some(v))` — the effort landed as `v`; `Ok(None)` — rig built the request
+/// but this wire has no reasoning field, so the setting was dropped; `Err(msg)` — rig
+/// refused the blob before sending, with its own message.
+async fn on_the_wire(path: Path, effort: &str) -> Result<Option<Value>, String> {
+    let cap = Capture::default();
+    let params = path.shaped(effort);
+    let body = match path {
+        Path::AnthropicAdaptive | Path::AnthropicBudget => {
+            let c = rig_core::providers::anthropic::Client::builder()
+                .api_key("test-key")
+                .http_client(cap.clone())
+                .build()
+                .expect("anthropic client");
+            capture(c.completion_model(path.model()), &cap, params).await?
+        }
+        Path::Gemini => {
+            let c = rig_core::providers::gemini::Client::builder()
+                .api_key("test-key")
+                .http_client(cap.clone())
+                .build()
+                .expect("gemini client");
+            capture(c.completion_model(path.model()), &cap, params).await?
+        }
+        Path::DeepSeek => {
+            let c = rig_core::providers::deepseek::Client::builder()
+                .api_key("test-key")
+                .http_client(cap.clone())
+                .build()
+                .expect("deepseek client");
+            capture(c.completion_model(path.model()), &cap, params).await?
+        }
+        Path::OpenRouter => {
+            let c = rig_core::providers::openrouter::Client::builder()
+                .api_key("test-key")
+                .http_client(cap.clone())
+                .build()
+                .expect("openrouter client");
+            capture(c.completion_model(path.model()), &cap, params).await?
+        }
+        Path::OpenaiChat => {
+            let c = rig_core::providers::openai::CompletionsClient::builder()
+                .api_key("test-key")
+                .base_url("http://127.0.0.1:1/v1")
+                .http_client(cap.clone())
+                .build()
+                .expect("openai chat client");
+            capture(c.completion_model(path.model()), &cap, params).await?
+        }
+        Path::OpenaiResponses => {
+            let c = rig_core::providers::openai::Client::builder()
+                .api_key("test-key")
+                .base_url("https://api.openai.com/v1")
+                .http_client(cap.clone())
+                .build()
+                .expect("openai responses client");
+            capture(c.completion_model(path.model()), &cap, params).await?
+        }
+    };
+    // Where each wire puts the depth lever, read back out of the serialized body.
+    let landed = match path {
+        Path::AnthropicAdaptive | Path::AnthropicBudget => {
+            body.pointer("/output_config/effort").cloned()
+        }
+        Path::Gemini => body
+            .pointer("/generationConfig/thinkingConfig/thinkingLevel")
+            .cloned(),
+        Path::DeepSeek => body.pointer("/reasoning_effort").cloned(),
+        // OpenRouter's `none` is the structural disable rather than an effort string;
+        // either shape counts as "the setting reached the gateway".
+        Path::OpenRouter => body
+            .pointer("/reasoning/effort")
+            .or_else(|| body.pointer("/reasoning/enabled"))
+            .cloned(),
+        Path::OpenaiChat | Path::OpenaiResponses => body.pointer("/reasoning/effort").cloned(),
+    };
+    Ok(landed)
+}
+
+/// A rung kaibo will never find on any ladder — an operator's typo, or a provider name
+/// newer than [`EFFORT_LADDER`]. Both look the same from here, and both must behave the
+/// same: passed through where the wire is passthrough, refused where rig is typed.
+const UNRANKED: &str = "ludicrous";
+
+/// The ceilings, pinned. rig 0.38.2 parses the blob into a typed struct on exactly two
+/// wires, and this is what each accepts today. The list is not a claim about the
+/// providers — OpenAI's Responses API takes `"max"` on the wire; rig's enum does not.
+/// A rig bump that moves either ladder lands here first, which is the whole point: the
+/// last time one moved, we found out from a failed consult.
+#[tokio::test]
+async fn rig_effort_ladders_are_pinned() {
+    for path in Path::ALL {
+        let mut accepted = Vec::new();
+        for rung in EFFORT_LADDER {
+            if on_the_wire(path, rung).await.is_ok() {
+                accepted.push(rung);
+            }
+        }
+        let expected: Vec<&str> = match path.wire() {
+            // rig's `gemini_api_types::ThinkingLevel` — no `none`, no `xhigh`, no `max`.
+            // This is the landmine: `[defaults] synth_effort = "xhigh"` broke every
+            // Gemini cast, and every offline test stayed green.
+            EffortWire::Gemini => vec!["minimal", "low", "medium", "high"],
+            // rig's `responses_api::ReasoningEffort` — stops one rung short of OpenAI's.
+            EffortWire::OpenaiResponses => {
+                vec!["none", "minimal", "low", "medium", "high", "xhigh"]
+            }
+            // `#[serde(flatten)]` all the way down: kaibo can express anything and the
+            // provider is the one that answers for it.
+            EffortWire::Passthrough => EFFORT_LADDER.to_vec(),
+        };
+        assert_eq!(
+            accepted, expected,
+            "{path:?}: rig's accepted rungs moved — re-read rig's request builder for \
+             this wire, then update this pin deliberately"
+        );
+
+        // An unrankable rung is refused by exactly the typed wires, and only those.
+        let unranked_ok = on_the_wire(path, UNRANKED).await.is_ok();
+        assert_eq!(
+            unranked_ok,
+            path.wire() == EffortWire::Passthrough,
+            "{path:?}: a passthrough wire must carry an unknown rung to the provider, \
+             and a typed wire must refuse it"
+        );
+    }
+}
+
+/// kaibo asks rig's own converter before building an arm, so a refusal names the cast,
+/// the slot and the rungs that wire *does* take instead of surfacing "unknown variant
+/// `max`" halfway through a consult. That preflight is only trustworthy if it answers
+/// exactly as the live call would — every rung, every wire, including the ones outside
+/// any ladder. Any drift here means kaibo has grown a second opinion about efforts,
+/// which is the allowlist we deliberately refused to write.
+#[tokio::test]
+async fn kaibo_preflight_agrees_with_rig() {
+    for path in Path::ALL {
+        for rung in EFFORT_LADDER.iter().copied().chain([UNRANKED]) {
+            let rig_accepts = on_the_wire(path, rung).await.is_ok();
+            let kaibo_accepts = preflight_params(path.wire(), path.shaped(rung).as_ref()).is_ok();
+            assert_eq!(
+                kaibo_accepts, rig_accepts,
+                "{path:?} at effort {rung:?}: kaibo's preflight and rig's request \
+                 builder disagree"
+            );
+        }
+    }
+}
+
+/// The accepted-rung list kaibo shows an operator in a refusal is *derived from rig*,
+/// not declared beside it — so it can't be the stale half of a two-ladder problem. Pin
+/// it against what the wire actually took.
+#[tokio::test]
+async fn the_error_message_lists_what_the_wire_really_takes() {
+    for path in Path::ALL {
+        let mut actual = Vec::new();
+        for rung in EFFORT_LADDER {
+            if on_the_wire(path, rung).await.is_ok() {
+                actual.push(rung);
+            }
+        }
+        assert_eq!(
+            accepted_efforts(path.wire()),
+            actual,
+            "{path:?}: the rungs kaibo would offer an operator must be the rungs the \
+             wire accepts"
+        );
+    }
+}
+
+/// `effort = "none"` means *off*, and on the two providers that ship a structural
+/// off-switch it has to use it. Measured 2026-08-01: DeepSeek bills 160–253 reasoning
+/// tokens for `thinking:{"type":"enabled"}` + `reasoning_effort:"none"` — the explicit
+/// enable wins and the opt-out costs money while doing nothing. So the body that leaves
+/// kaibo must carry the disable and no effort string beside it. Asserted on the
+/// serialized request, not the blob, because the blob is what the old tests already
+/// watched while this shipped.
+#[tokio::test]
+async fn effort_none_is_a_structural_off_switch_on_the_wire() {
+    let cap = Capture::default();
+    let c = rig_core::providers::deepseek::Client::builder()
+        .api_key("test-key")
+        .http_client(cap.clone())
+        .build()
+        .expect("deepseek client");
+    let body = capture(
+        c.completion_model(Path::DeepSeek.model()),
+        &cap,
+        Path::DeepSeek.shaped("none"),
+    )
+    .await
+    .expect("deepseek accepts the disable");
+    assert_eq!(
+        body["thinking"]["type"], "disabled",
+        "deepseek `none` must reach the wire as the structural disable: {body}"
+    );
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "no zero-effort string beside the disable — that pairing is what billed: {body}"
+    );
+
+    let cap = Capture::default();
+    let c = rig_core::providers::openrouter::Client::builder()
+        .api_key("test-key")
+        .http_client(cap.clone())
+        .build()
+        .expect("openrouter client");
+    let body = capture(
+        c.completion_model(Path::OpenRouter.model()),
+        &cap,
+        Path::OpenRouter.shaped("none"),
+    )
+    .await
+    .expect("openrouter accepts the disable");
+    assert_eq!(
+        body["reasoning"]["enabled"], false,
+        "openrouter `none` must reach the gateway as its documented off-switch: {body}"
+    );
+}
+
+/// Two wires have no reasoning knob at all: Anthropic's legacy budget tier expresses
+/// depth as `budget_tokens`, and the generic OpenAI `/chat/completions` shape (every
+/// local llama.cpp / Ollama / gateway backend) has nothing to carry it. An `effort`
+/// aimed at either evaporates — rig builds a perfectly good request with the setting
+/// simply absent, and nothing anywhere fails. That is the drop `Config::inert_efforts`
+/// exists to make audible; this pins that it really is a drop, on the wire, for every
+/// rung — and that the effort-carrying wires really do carry it.
+#[tokio::test]
+async fn toggle_less_wires_send_no_effort() {
+    for path in Path::ALL {
+        let toggle_less = matches!(path, Path::AnthropicBudget | Path::OpenaiChat);
+        for rung in ["low", "high"] {
+            let landed = on_the_wire(path, rung)
+                .await
+                .unwrap_or_else(|e| panic!("{path:?} at {rung:?} must reach the wire: {e}"));
+            if toggle_less {
+                assert!(
+                    landed.is_none(),
+                    "{path:?}: effort {rung:?} must be absent from the request — it is \
+                     dropped, and pretending otherwise is the silent fallback: {landed:?}"
+                );
+            } else {
+                assert!(
+                    landed.is_some(),
+                    "{path:?}: effort {rung:?} must reach the wire"
+                );
+            }
+        }
+        // Sanity on the budget tier specifically: it drops the effort but still sends
+        // thinking, so "no effort" never means "no reasoning".
+        if path == Path::AnthropicBudget {
+            let params = path.shaped("high").expect("budget tier sends thinking");
+            assert_eq!(params["thinking"]["type"], "enabled");
+        }
+    }
+}


### PR DESCRIPTION
Started as "enable my new OpenAI key" and turned into the effort plumbing, because
the first thing the new backend did was fail on `effort = "max"` — with an error
that named a serde variant and nothing else.

## What was wrong

`effort` was a bare `String` from config to wire with **no validation at any layer**,
sitting two lines away from `thinking_style` and `lane`, which both `.parse()` into
enums and fail loudly. That asymmetry hid four separate problems:

- **Two typed ceilings inside `rig`, not the providers.** OpenAI's Responses client
  caps at `xhigh`; Gemini's `ThinkingLevel` accepts only `minimal|low|medium|high`. So
  `[defaults] synth_effort = "xhigh"` — which our own example config *invited* — broke
  every Gemini cast, and `effort = "max"` died in-process before any HTTP. OpenAI's API
  itself accepts `max` (probed: 200, echoed back). We couldn't send it.
- **Batch clobbered `effort` in both directions** while every neighbouring knob was a
  floor. A cast tuned `xhigh` for the offline lane was silently demoted to `high`.
- **`effort = "none"` on DeepSeek was a live billing bug.** kaibo emitted
  `thinking:{"type":"enabled"}` unconditionally beside `reasoning_effort:"none"`, and
  *enabled wins* — 160-253 reasoning tokens billed on a one-line prompt. An operator
  who turned reasoning off paid for it anyway. Measured three ways.
- **Three silent-drop exits.** Most importantly every `openai`-kind backend on the chat
  wire, so a local or gateway reasoner was called with reasoning entirely off.

And the reason none of this was caught: **our tests asserted the shape of kaibo's own
params blob and never handed that blob to `rig`.** They stayed green while the wire
path died.

## The decisions

**`effort` stays a passthrough string — no allowlist, no load-time ladder check.**
Deliberate. Four of six wire paths really are passthrough, so validating them would
mean kaibo inventing ceilings the providers don't have — the same mistake `rig` made.
An operator should be able to try a rung a provider shipped yesterday. Where a rung
genuinely can't be carried, the failure is now loud, early, and names the cast, the
slot, the backend, and *whose* ceiling it is — the accepted rungs are read back out of
`rig` rather than declared, so a `rig` bump widens them for free.

**Batch floors depth instead of fixing it**, matching `max_tokens`. Deeper wins,
shallower is still lifted (batch is the lane that spends), unrankable defers to the
operator.

**`none` is a sentinel, not the bottom rung.** This one came out of the review: two
capable models read the old code and reached *opposite* conclusions about what `none`
on a batch slot does, and neither misread anything — `EFFORT_LADDER` had `none` at
index 0 (a depth to order) while `is_effort_off` treated it as a structural
off-switch, the two never referenced each other, and `batch_effort` couldn't consult
the latter because it was private. Now the ladder is six rungs of depth, `EFFORT_OFF`
sits beside it, each doc names the other, and the floor asks "is this off?" before it
ranks anything. Turning reasoning back on isn't "more depth" — it's ignoring the
setting and billing for it.

**One disposition, two consumers.** The startup warning and the `kaibo://config`
render were two implementations of one policy and had *already* diverged on batch
flooring. `EffortFate` now names every outcome — `Sent`, `SentAsOff`, `SentUnranked`,
`LiftedToBatchFloor`, `NoSink` — and both front doors consume it, so they can't
disagree again. Only *explicitly written* efforts warn; an inherited default stays
quiet, because every local cast inherits `high` onto a wire that drops it and warning
there would train operators to ignore the one that matters.

## Tests

`tests/effort_wire.rs` drives `rig`'s **real** `CompletionModel` through a fake HTTP
client and asserts on the serialized request body — no key, no network. It pins each
wire's accepted ladder, proves kaibo's preflight agrees with `rig` rung-for-rung, and
pins the two silent drops *as* drops. This is the class of gap that let the Gemini
landmine sit unnoticed, and it closes in CI.

Nine `#[ignore]`d live probes record what the providers actually do (all run, results
in the commits): the OpenAI ladder is a property of the **model**, not the family
(5.6→`max`, 5.2→`xhigh`, 5.1/5→`high`, and the bottom rung moves too); Gemini's `rig`
cap is *correct* — Google's own protobuf enum refuses `none`/`xhigh`/`max`; OpenRouter
is **not** a passthrough, it normalizes onto each upstream's knob and carries
`xhigh`/`max` to `openai/gpt-5.1` and `openai/gpt-5`, which reject those rungs direct.

Anthropic's ladder is **still unknown** — that account is unfunded, and the billing
check runs before body validation, so there's no free path to probe it. Its test fails
loudly saying exactly that, rather than being weakened into a skip. `config.example.toml`
still ships `effort = "max"` on an Opus slot and `docs/issues.md` still calls `high`
the proven top; both are left untouched, because exactly one is right and we can't yet
say which.

## Worth knowing before merging

With the floor, a deep rung now **reaches** the provider on the batch lane — so a
Gemini batch slot pinned `xhigh` gets Google's error instead of a silent clamp to
`high`. That's the honest-failure doctrine, but it's a visible change.

Also fixed in passing: `openrouter_reasoning_accounting_live` resolved
`~/.openrouter-key` while the config uses `~/.openrouter-key.txt`, so it had never
been runnable. Pre-existing; it's green now.

**Follow-up to track separately:** batch builds its own JSON and never touches the
preflight, so per-item provider errors surface however that provider reports them.
Unaudited, and deliberately out of scope here.

Closes the `docs/issues.md` entries for the batch override-vs-floor, the lane-blind
inert render, and the render/validation shape mismatch.

## Review

Cross-family, no diff supplied — each model read the tree holistically.

- **GPT-5.6-sol** (offline, max thinking, via the batch lane this PR touches) caught
  the real defect: the startup warning and the config render disagreed about batch
  flooring. It also proposed the single-disposition shape that replaced them.
- **DeepSeek v4 Pro** reviewed twice — the second pass cold on the reworked code —
  and found the missing coverage on `none`-on-a-batch-slot, the undocumented
  load-bearing arm order in the fate chain, and that `SentAsOff` overclaimed on Gemini.
- One claim from each reviewer was checked and **rejected**: sol's "the two paths
  derive the OpenAI wire differently" (they're identical) and DeepSeek's "the error
  lists all seven rungs for passthrough wires" (unreachable — passthrough always
  returns `Ok`, so that branch can't run).

774 passed / 0 failed, `clippy --all-targets` silent.

Reviewed-by: GPT-5.6-sol (via kaibo deliberate)
Reviewed-by: DeepSeek v4 Pro (via kaibo consult)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
