### PR TITLE
deps: upgrade rig-core 0.38.2 → 0.41, and split out rig-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **`effort = "max"` now reaches hosted GPT-5.6.** kaibo has always accepted `max` as a
+  rung and always sent it faithfully; the wall was rig's, whose typed OpenAI Responses
+  request stopped one rung short of OpenAI's own API and refused `max` before the
+  request was even built. Upgrading to rig 0.41 removes that wall. Nothing in kaibo
+  changed to make it work — the accepted-rung list is read back out of rig on every
+  call rather than restated — so if you had `synth_effort = "max"` on a hosted GPT slot
+  and were getting a refusal naming the cast and the rungs, you simply stop getting one.
+  Gemini's ceiling (`high`) is unchanged and still correct: that one is Google's limit,
+  not rig's.
+
 - **New MCP resource: `kaibo://config/guide`** — the full configuration manual
   (`docs/config.md`), embedded in the binary the way the annotated template already is.
   An agent configuring kaibo over MCP has no access to kaibo's own `docs/`, so until now
@@ -94,11 +104,27 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **A vision model still sees the image after the `rig` 0.41 upgrade.** rig 0.41 stopped
+  inspecting a tool's text output to discover rich content in it, which would have
+  silently turned every `view_image` result into base64 text labelled JSON — the model
+  would have received a wall of characters instead of a picture, with no error anywhere.
+  `view_image` now hands rig a declared image block instead of a JSON envelope for rig to
+  recognize, which is both the supported path and a sturdier one.
+
+- **A tool failure is readable by the model again.** rig 0.41 began replacing an
+  arbitrary tool error with a generic "the tool failed" before showing it to the model.
+  kaibo's tool errors are written *for* the model — `view_image` names the file, the
+  workspace, and the fix (copy it in, crop it, use `run_kaish` instead); a dead
+  `explore` sweep is what tells the driver to answer from its own reads rather than
+  retry blind. All three tools now keep their message model-visible, so a recoverable
+  failure stays recoverable. The full text remains available to operators either way.
+
 - **A reasoning `effort` your provider client can't accept now fails with a message
   you can act on.** Two request shapes — Gemini and OpenAI's Responses API — go
   through a typed builder in the underlying `rig` client whose reasoning levels are a
-  closed set: Gemini takes only `minimal`/`low`/`medium`/`high`, and Responses stops
-  at `xhigh` even though OpenAI's own API accepts `max`. A rung outside those used to
+  closed set: Gemini takes only `minimal`/`low`/`medium`/`high`, and Responses stopped
+  at `xhigh` even though OpenAI's own API accepts `max` (rig 0.41 has since added
+  `max`; Gemini's ceiling stands). A rung outside those used to
   die mid-call with a bare ``unknown variant `max` `` naming neither the cast nor the
   slot that asked for it. kaibo now checks the same builder up front and refuses with
   the cast, the role, the backend, the model, whose ceiling it is, and the rungs that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,12 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,7 +508,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -523,7 +517,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -686,7 +680,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn",
 ]
 
@@ -731,47 +725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror",
-]
-
-[[package]]
-name = "deluxe"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed332aaf752b459088acf3dd4eca323e3ef4b83c70a84ca48fb0ec5305f1488"
-dependencies = [
- "deluxe-core",
- "deluxe-macros",
- "once_cell",
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "deluxe-core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddada51c8576df9d6a8450c351ff63042b092c9458b8ac7d20f89cbd0ffd313"
-dependencies = [
- "arrayvec",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "deluxe-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87546d9c837f0b7557e47b8bd6eae52c3c223141b76aa233c345c9ab41d9117"
-dependencies = [
- "deluxe-core",
- "heck 0.4.1",
- "if_chain",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1016,6 +969,10 @@ name = "futures-timer"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -1140,6 +1097,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "grep-matcher"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,12 +1185,6 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1548,12 +1511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
-
-[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,15 +1536,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -1829,6 +1777,7 @@ dependencies = [
  "opentelemetry_sdk 0.32.1",
  "regex",
  "reqwest",
+ "rig-agent",
  "rig-core",
  "rmcp",
  "rustls",
@@ -2193,15 +2142,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -2573,16 +2513,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
@@ -2868,10 +2798,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "rig-core"
-version = "0.38.2"
+name = "rig-agent"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557f11c26c2c2ea61d9cb843ce5adff138cc5785f58ff4b87d779de8acaa32ae"
+checksum = "2b0796bbf47d7b76670401aac975bc619cf7fba3482b22dfe14992edaa9c2e04"
+dependencies = [
+ "async-stream",
+ "fastrand",
+ "futures",
+ "http",
+ "indexmap",
+ "rig-core",
+ "rig-derive",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "rig-core"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f5520515ae8f6851adcbc6fde9eea8e96f657418c062e16c82cd81cce44e8e"
 dependencies = [
  "as-any",
  "async-stream",
@@ -2883,9 +2835,9 @@ dependencies = [
  "futures-timer",
  "glob",
  "http",
+ "indexmap",
  "mime",
  "mime_guess",
- "nanoid",
  "ordered-float",
  "pin-project-lite",
  "reqwest",
@@ -2902,17 +2854,14 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.38.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643eb495acbd4bd5976164cd068f186d534f741def8d5d052f860266b98d07f8"
+checksum = "eb868fcebdf3ba425e3afad2e4926bb6d9e1188a856843b00bcee2e15c07424f"
 dependencies = [
  "convert_case",
- "deluxe",
- "indoc",
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn",
 ]
 
@@ -3210,6 +3159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3440,12 +3395,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -3465,7 +3414,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3714,17 +3663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -4619,15 +4557,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -4666,7 +4595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -4677,7 +4606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,18 +38,20 @@ anyhow = "1"
 # that trait, so an `image` cast slot can reach them for free. Turned off by 986806f
 # when image generation was removed; back on with the media CAS.
 rig-core = { version = "0.41", default-features = false, features = ["reqwest", "derive", "image"] }
-# The agent/tool loop, which rig 0.41 split out of `rig-core` into its own crate
-# (rig PR #2197). kaibo takes `rig-core` + `rig-agent` **directly** rather than the
-# `rig` facade, and that is a TLS decision as much as an ergonomic one: the facade's
-# `rustls` feature fans out to the vector-store companions
+# The agent/tool loop, which rig ships as its own crate beside `rig-core`.
+#
+# DO NOT collapse these two onto the `rig` facade crate. It looks tidier and it is a
+# trap: the facade's `rustls` feature fans out to the vector-store companions
 # (`rig-fastembed?/hf-hub-rustls-tls`, `rig-helixdb?/rustls`, `rig-lancedb?/rig-rustls`,
-# `rig-milvus?/rustls`), which would be a *fourth* route for aws-lc into the tree beside
-# the three named in this file. Naming the two crates we actually use keeps the TLS
-# surface exactly as documented: `rig-agent` itself depends on `rig-core` with
-# `default-features = false`, so the "drop rig's default rustls" reasoning above stays
-# true and complete. Its `rmcp` feature is off (kaibo wraps kaish as an in-process rig
-# Tool, not over MCP), and `image` is forwarded so a tool can return image content.
-# Verified aws-lc-free with `cargo tree -i aws-lc-rs` on host and musl targets.
+# `rig-milvus?/rustls`) — a *fourth* route for aws-lc into the tree, beside the three
+# named in this file, and one that breaks the static musl build silently. Depending on
+# the two crates we actually use keeps the TLS surface exactly as documented above:
+# `rig-agent` takes `rig-core` with `default-features = false`, so the "drop rig's
+# default rustls" reasoning still covers the whole tree. Verify with
+# `cargo tree -i aws-lc-rs` on host *and* musl; both must be empty.
+#
+# `rmcp` is off (kaibo wraps kaish as an in-process rig Tool, not over MCP); `image` is
+# forwarded so a tool can return image content.
 rig-agent = { version = "0.41", default-features = false, features = ["derive", "image"] }
 # We construct the HTTP backend ourselves (a `reqwest::Client` carrying a
 # per-request timeout) and hand it to rig via `.http_client(..)` — rig has no

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,31 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] 
 async-trait = "0.1"
 anyhow = "1"
 
-# LLM providers + agent/tool loop. Native tools (no `rmcp` feature needed — kaibo
-# wraps kaish as an in-process rig Tool, not over MCP).
-# `default-features = false` drops rig's default `rustls` feature, which would
-# pull `reqwest/rustls` → the aws-lc-rs crypto provider (C + cmake, the one thing
-# that makes a static musl build painful). We re-add the other defaults rig needs
-# (`reqwest`, `derive`) and let TLS come from our own `rustls`+ring wiring below.
-# `image` gates rig's `image_generation` module (lib.rs:159) — the
-# `ImageGenerationModel` trait and its request/response types. It is a pure-Rust,
-# dependency-free feature flag (enabling it added ZERO crates to Cargo.lock, verified
-# 2026-07-25), and it buys more than the provider we hand-write: rig already ships
-# openai / xai / azure / huggingface impls of that trait, so an `image` cast slot can
-# reach them for free. Turned off by 986806f when image generation was removed; back
-# on with the media CAS.
-rig-core = { version = "0.38", default-features = false, features = ["reqwest", "derive", "image"] }
+# LLM providers + the wire types. `default-features = false` drops rig's default
+# `rustls` feature, which would pull `reqwest/rustls` → the aws-lc-rs crypto provider
+# (C + cmake, the one thing that makes a static musl build painful). We re-add the
+# other defaults rig needs (`reqwest`, `derive`) and let TLS come from our own
+# `rustls`+ring wiring below.
+# `image` gates rig's `image_generation` module — the `ImageGenerationModel` trait and
+# its request/response types. It is a pure-Rust, dependency-free feature flag (enabling
+# it added ZERO crates to Cargo.lock, verified 2026-07-25), and it buys more than the
+# provider we hand-write: rig already ships openai / xai / azure / huggingface impls of
+# that trait, so an `image` cast slot can reach them for free. Turned off by 986806f
+# when image generation was removed; back on with the media CAS.
+rig-core = { version = "0.41", default-features = false, features = ["reqwest", "derive", "image"] }
+# The agent/tool loop, which rig 0.41 split out of `rig-core` into its own crate
+# (rig PR #2197). kaibo takes `rig-core` + `rig-agent` **directly** rather than the
+# `rig` facade, and that is a TLS decision as much as an ergonomic one: the facade's
+# `rustls` feature fans out to the vector-store companions
+# (`rig-fastembed?/hf-hub-rustls-tls`, `rig-helixdb?/rustls`, `rig-lancedb?/rig-rustls`,
+# `rig-milvus?/rustls`), which would be a *fourth* route for aws-lc into the tree beside
+# the three named in this file. Naming the two crates we actually use keeps the TLS
+# surface exactly as documented: `rig-agent` itself depends on `rig-core` with
+# `default-features = false`, so the "drop rig's default rustls" reasoning above stays
+# true and complete. Its `rmcp` feature is off (kaibo wraps kaish as an in-process rig
+# Tool, not over MCP), and `image` is forwarded so a tool can return image content.
+# Verified aws-lc-free with `cargo tree -i aws-lc-rs` on host and musl targets.
+rig-agent = { version = "0.41", default-features = false, features = ["derive", "image"] }
 # We construct the HTTP backend ourselves (a `reqwest::Client` carrying a
 # per-request timeout) and hand it to rig via `.http_client(..)` — rig has no
 # native timeout knob, and its prompt loop is non-streaming, so a wedged provider
@@ -158,7 +169,8 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
-# Request-body capture in `tests/effort_wire.rs`: rig's `HttpClientExt` trait is
-# typed in `bytes::Bytes`, so implementing a fake transport needs the type by name.
-# Already in the tree via reqwest/rig-core — zero new crates.
+# Request-body capture in `tests/effort_wire.rs` and `test_support::CaptureHttp`:
+# rig's `HttpClientExt` trait is typed in `bytes::Bytes`, so implementing a fake
+# transport needs the type by name. Already in the tree via reqwest/rig-core — zero
+# new crates.
 bytes = "1"

--- a/docs/config.md
+++ b/docs/config.md
@@ -308,14 +308,15 @@ Every row above except the Anthropic one was measured against the live endpoint,
 is re-checkable: `tests/consult.rs` carries an `#[ignore]`d probe per provider that fails
 if a ladder moves, rather than letting this table quietly rot.
 
-**rig's client is a second, lower ceiling on two wires**, independent of the provider:
-rig 0.38 parses kaibo's params into a typed struct for Gemini and for OpenAI's Responses
-API, and those enums stop at `high` and `xhigh` respectively — so `max` fails for a
-hosted GPT slot even though OpenAI's own API accepts it. kaibo asks rig's converter
-before each call and refuses with a message naming the cast, the slot, the backend and
-the rungs that wire *does* take, rather than letting a bare ``unknown variant `max` ``
-surface mid-consult. That list is read back out of rig, so a rig upgrade widens it with
-no kaibo change.
+**rig's client can be a second ceiling on two wires**, independent of the provider: rig
+parses kaibo's params into a typed struct for Gemini and for OpenAI's Responses API, and
+a typed struct has a closed set of rungs. On rig 0.38 that made `max` fail for a hosted
+GPT slot even though OpenAI's own API accepted it; **rig 0.41 added the rung, so `max`
+now works there**. Gemini still stops at `high` — that one is Google's own limit, not
+rig's. kaibo asks rig's converter before each call and refuses with a message naming the
+cast, the slot, the backend and the rungs that wire *does* take, rather than letting a
+bare ``unknown variant `max` `` surface mid-consult. That list is read back out of rig,
+which is why the 0.41 upgrade widened it with no kaibo change.
 
 **`"none"` is an off-switch, not the shallowest rung.** kaibo treats it as a sentinel
 beside the ladder rather than a depth: where a provider ships a structural disable

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -616,12 +616,15 @@ P1 entry):
   grounding (all of which the `gpal` MCP sibling drives directly). This is why "voice
   on Gemini" is parked with TTS. Track rig's gemini coverage; adopt its traits when
   they broaden rather than hand-rolling media modalities over raw HTTP.
-- **OpenRouter provider silently drops `max_tokens`.** rig 0.38.2's native
-  `providers::openrouter` request struct (`openrouter/completion.rs`,
-  `OpenrouterCompletionRequest`) has no `max_tokens` field and its `TryFrom` never
-  reads `CompletionRequest.max_tokens`, so `AgentBuilder::max_tokens()` — kaibo's
-  per-arm headroom mechanism — is a no-op there. Confirmed still present on rig
-  `main` (2026-07-03), untracked upstream. Collides with the `large-token-headroom`
+- **OpenRouter provider silently drops `max_tokens`.** rig's native
+  `providers::openrouter` request never reads `CompletionRequest.max_tokens`, so
+  `AgentBuilder::max_tokens()` — kaibo's per-arm headroom mechanism — is a no-op there.
+  Confirmed still present on rig `main` (2026-07-03) and **re-measured on rig 0.41.0
+  (2026-08-01)**: rig 0.40 collapsed OpenRouter onto the shared
+  `GenericCompletionModel<OpenRouterExt>` without picking up the OpenAI path's native
+  `max_tokens`, and a real 0.41 model driven through a capture transport with
+  `max_tokens = Some(4096)` still serialized a body of only `messages`/`model`/
+  `reasoning`. Untracked upstream. Collides with the `large-token-headroom`
   doctrine (thinking eats the completion budget). Kaibo's workaround: inject
   `max_completion_tokens` (OpenRouter's preferred name; their spec deprecates
   `max_tokens`) via `additional_params`, guarded by a failing-first test. Watch
@@ -720,14 +723,17 @@ Remaining OpenRouter-specific forks:
 - **Spend visibility — token total shipped, two residuals.** The provenance footer
   now carries a `tokens · … in · … out` line (cache/reasoning splits when reported):
   `consult` sums the synth loop plus every delegated explorer sweep, drawn from rig's
-  `PromptResponse.usage` via `.extended_details()` (see `render::fmt_usage`,
-  `engine::run_phase`). Still open:
+  `PromptResponse.usage` (see `render::fmt_usage`, `engine::run_phase`). Still open:
   - **Undercount on the exceptional exits.** rig hands back no usage on
     `MaxTurnsError` / `PromptCancelled`, so a phase that hits its turn cap or breaks for
     an image-resume (`run_phase`'s view_image path) loses the tokens of the capped/broken
     run — only the finalize/resumed run's usage survives. The normal path is exact.
-    Recovering it means summing per-completion through a `PromptHook` rather than reading
-    the run's aggregate; deferred as low-value (both are rare paths) but real.
+    rig 0.41 makes the fix cheaper but not free: `AgentHook::on_completion_response`
+    now carries a per-turn `usage`, so a small tally hook could accumulate across every
+    turn including the lost ones. `PromptResponse.completion_calls` does *not* help —
+    it only exists on the `Ok` path, which is the path that was already exact. The
+    plumbing lands in `finalize_after_max_turns` and the resume loop, so it wants to
+    ride with whoever is next in that code rather than a dependency bump.
   - **Dollars, not just tokens.** rig's normalized `Usage` carries token counts only —
     even OpenRouter's response `usage.cost` is dropped in normalization. A per-call
     *cost* needs a kaibo-side price table keyed by model (input/output/cache-read rates),

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -427,9 +427,8 @@ impl Arm {
     /// `from_slot` must route through here.
     ///
     /// Generic over the HTTP backend so a test can drive it with a capture transport
-    /// and read the marker off the serialized body. rig 0.41 made the caching flag a
-    /// private field, so the wire is the only place left that can answer whether this
-    /// constructor did its job — and it was always the better question.
+    /// and read the marker off the serialized body — the only place that answers
+    /// whether this constructor did its job, since rig exposes no readable flag.
     fn openrouter_completion_model<H>(
         client: &openrouter::Client<H>,
         id: &str,
@@ -565,12 +564,6 @@ const VIEW_IMAGE_ACK: &str = "Loaded the requested image; it is shown in the nex
 /// triggering turn into the transcript and the stop returns it complete. Disabled
 /// (`enabled == false`) every callback is a no-op, so installing it on a transport
 /// that carries tool-result images (Anthropic/Gemini) is byte-for-byte the old path.
-///
-/// rig 0.41 made hooks non-generic (`AgentHook`, no `M`, so one hook can serve agents
-/// on different providers) and replaced the single `HookAction` with one action type
-/// per event. The decision here is unchanged — `ToolResultAction::Keep` is the old
-/// `cont()` on the observing side, `CompletionCallAction::Stop` the old `terminate` —
-/// but the compiler now rejects a stop from an event that cannot honour one.
 #[derive(Clone)]
 struct ViewImageBreakHook {
     enabled: bool,
@@ -858,12 +851,10 @@ where
         // must be scoped to *this* turn. Hoisting it out of the loop (or reusing the
         // agent across resumes) would carry a stale flag — breaking on the first
         // completion call of a resume that ran no view_image. Keep it built here.
-        // `AgentRunner` (rig 0.41's only managed execution path — the `Prompt` trait
-        // and its `.extended_details()` opt-in are gone) always yields a
-        // `PromptResponse` carrying the token `usage` the provider reported, summed
-        // across every turn of *this* run. The clean `Ok` path is the common case —
-        // one run, the full count. The two exceptional exits below (turn cap,
-        // view_image break) undercount: rig hands back no usage on
+        // The run yields a `PromptResponse` carrying the token `usage` the provider
+        // reported, summed across every turn of *this* run. The clean `Ok` path is the
+        // common case — one run, the full count. The two exceptional exits below (turn
+        // cap, view_image break) undercount: rig hands back no usage on
         // `MaxTurnsError`/`PromptCancelled`, so the turns spent in a capped or broken
         // run are lost and only the finalize/resumed run's usage survives. Deliberate —
         // recovering it would mean summing per-completion through a hook; documented as
@@ -1084,16 +1075,11 @@ impl Tool for RunExplore {
     type Args = RunExploreArgs;
     type Output = String;
 
-    /// Keep the failure text model-visible.
-    ///
-    /// rig 0.41's default (`ToolExecutionError::from_error`) redacts an arbitrary
-    /// source error down to a stable kind-level string — the model would read "the
-    /// tool failed" and nothing else. That is the right default for a tool whose
-    /// errors may carry secrets; it is the wrong one here, because a sweep that dies is something the
-    /// driver must *see* to recover from — it answers from its own direct reads instead
-    /// of retrying blind, and it can only make that choice if the failure reaches it.
-    /// The explicit constructor keeps the message model-visible while `with_source`
-    /// preserves the concrete error for operator diagnostics and downcasting.
+    /// Keep the failure text model-visible: rig's default would redact it to a
+    /// kind-level "the tool failed", and a dead sweep is something the driver must
+    /// *see* to recover from — it answers from its own direct reads instead of retrying
+    /// blind, and can only choose that if the failure reaches it. `with_source` keeps
+    /// the concrete error for operator diagnostics and downcasting.
     fn map_error(&self, error: Self::Error) -> ToolExecutionError {
         ToolExecutionError::other(error.to_string()).with_source(error)
     }
@@ -3858,12 +3844,10 @@ mod tests {
     /// them), and implicit-caching upstreams ignore the marker. `from_slot` routes
     /// through this constructor — so this pins the wiring, not an internal default.
     ///
-    /// **Asserted on the wire, not on a field.** Through rig 0.38 the flag was a public
-    /// field and this test read it. rig 0.41 made it private, and rather than delete the
-    /// guard we moved it one layer out to where it actually matters: the serialized
-    /// request body, captured from a fake transport. That is strictly better teeth — a
-    /// future rig release could keep `with_prompt_caching()` compiling while changing
-    /// what it emits, and the old field read would have stayed green through it.
+    /// **Asserted on the wire, not on a flag.** What matters is the serialized request
+    /// body, so that is what a fake transport captures here: rig could keep
+    /// `with_prompt_caching()` compiling while changing what it emits, and any check
+    /// short of the body would stay green through that.
     #[tokio::test]
     async fn openrouter_arm_enables_prompt_caching() {
         async fn system_block(model: openrouter::CompletionModel<CaptureHttp>, http: &CaptureHttp) -> Value {

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -9,15 +9,19 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use rig_core::agent::{AgentBuilder, HookAction, PromptHook};
+use rig_agent::agent::hook::{
+    AgentHook, CompletionCall, CompletionCallAction, HookContext, ToolResultAction, ToolResultEvent,
+};
+use rig_agent::agent::AgentBuilder;
+use rig_agent::completion::PromptError;
+use rig_agent::tool::{DynamicTool, Tool, ToolExecutionError};
 use rig_core::client::CompletionClient;
 use rig_core::completion::message::{
     AssistantContent, Image, ImageMediaType, MimeType, ToolChoice, ToolResult, ToolResultContent,
     UserContent,
 };
-use rig_core::completion::{CompletionModel, Message, Prompt, PromptError, ToolDefinition, Usage};
+use rig_core::completion::{CompletionModel, Message, Usage};
 use rig_core::providers::{anthropic, deepseek, gemini, openai, openrouter};
-use rig_core::tool::{Tool, ToolDyn};
 use rig_core::OneOrMany;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -42,7 +46,7 @@ use super::shaping::{ModelCaps, ModelShape};
 
 /// The toolset factory a phase loop rebuilds its tools from (once for the main
 /// loop, again for the turn-cap finalize turn — see [`run_phase`]).
-type ToolFactory<'a> = &'a (dyn Fn() -> Result<Vec<Box<dyn ToolDyn>>> + Send + Sync);
+type ToolFactory<'a> = &'a (dyn Fn() -> Result<Vec<DynamicTool>> + Send + Sync);
 
 /// The eventual `(answer, usage)` a phase loop yields, boxed `Send` for the
 /// [`PhaseRunner`] vtable: the model's answer paired with the token [`Usage`] the
@@ -419,13 +423,20 @@ impl Arm {
     /// instead of full input price every turn; implicit-caching upstreams
     /// (DeepSeek/GLM/Kimi/Gemini/OpenAI) ignore the marker. The growing
     /// transcript is not marked — an upstream rig limitation, tracked in
-    /// docs/issues.md. Kept as a named seam so the construction is unit-testable:
-    /// rig exposes the caching flag as a public field, and `from_slot` must
-    /// route through here.
-    fn openrouter_completion_model(
-        client: &openrouter::Client,
+    /// docs/issues.md. Kept as a named seam so the construction is unit-testable, and
+    /// `from_slot` must route through here.
+    ///
+    /// Generic over the HTTP backend so a test can drive it with a capture transport
+    /// and read the marker off the serialized body. rig 0.41 made the caching flag a
+    /// private field, so the wire is the only place left that can answer whether this
+    /// constructor did its job — and it was always the better question.
+    fn openrouter_completion_model<H>(
+        client: &openrouter::Client<H>,
         id: &str,
-    ) -> openrouter::CompletionModel {
+    ) -> openrouter::CompletionModel<H>
+    where
+        openrouter::Client<H>: CompletionClient<CompletionModel = openrouter::CompletionModel<H>>,
+    {
         client.completion_model(id).with_prompt_caching()
     }
 
@@ -544,22 +555,27 @@ const VIEW_IMAGE_ACK: &str = "Loaded the requested image; it is shown in the nex
 /// [`run_phase`] can move the image onto the **user-turn** channel for a transport
 /// that can't carry it in a tool result (an OpenAI VLM).
 ///
-/// **Why flag now, terminate next — not mid-turn.** A single assistant turn can call
-/// `view_image` *and* `run_kaish` together; terminating the instant `view_image`
-/// returns would drop the other tool's result and orphan its `tool_use`. And rig's
-/// `on_tool_result` Terminate hands back a transcript snapshotted *before* the turn's
-/// results are folded into `new_messages` (`prompt_request/mod.rs` ~:928), so it
-/// wouldn't even carry the image we came for. So we only *set a flag* on
-/// `on_tool_result`, and terminate on the **next** `on_completion_call` — the point
-/// where rig has written every tool result of the triggering turn into `new_messages`
-/// and `Terminate` returns the complete transcript (`:670`). Disabled
+/// **Why flag now, stop next — not mid-turn.** A single assistant turn can call
+/// `view_image` *and* `run_kaish` together; stopping the instant `view_image` returns
+/// would drop the other tool's result and orphan its `tool_use`. And a stop from
+/// `on_tool_result` hands back a transcript snapshotted *before* the turn's results are
+/// folded into the run's messages, so it wouldn't even carry the image we came for. So
+/// we only *set a flag* on `on_tool_result`, and stop on the **next**
+/// `on_completion_call` — the point where rig has written every tool result of the
+/// triggering turn into the transcript and the stop returns it complete. Disabled
 /// (`enabled == false`) every callback is a no-op, so installing it on a transport
 /// that carries tool-result images (Anthropic/Gemini) is byte-for-byte the old path.
+///
+/// rig 0.41 made hooks non-generic (`AgentHook`, no `M`, so one hook can serve agents
+/// on different providers) and replaced the single `HookAction` with one action type
+/// per event. The decision here is unchanged — `ToolResultAction::Keep` is the old
+/// `cont()` on the observing side, `CompletionCallAction::Stop` the old `terminate` —
+/// but the compiler now rejects a stop from an event that cannot honour one.
 #[derive(Clone)]
 struct ViewImageBreakHook {
     enabled: bool,
     /// Set once a `view_image` tool result lands this turn; read at the next
-    /// completion call. Interior mutability because `PromptHook`'s callbacks are `&self`
+    /// completion call. Interior mutability because `AgentHook`'s callbacks are `&self`
     /// and rig runs a turn's tools concurrently.
     saw_view_image: Arc<AtomicBool>,
 }
@@ -573,26 +589,27 @@ impl ViewImageBreakHook {
     }
 }
 
-impl<M: CompletionModel> PromptHook<M> for ViewImageBreakHook {
+impl AgentHook for ViewImageBreakHook {
     async fn on_tool_result(
         &self,
-        tool_name: &str,
-        _tool_call_id: Option<String>,
-        _internal_call_id: &str,
-        _args: &str,
-        _result: &str,
-    ) -> HookAction {
-        if self.enabled && tool_name == ViewImage::NAME {
+        _ctx: &HookContext,
+        event: ToolResultEvent<'_>,
+    ) -> ToolResultAction {
+        if self.enabled && event.tool_name == ViewImage::NAME {
             self.saw_view_image.store(true, Ordering::SeqCst);
         }
-        HookAction::cont()
+        ToolResultAction::Keep
     }
 
-    async fn on_completion_call(&self, _prompt: &Message, _history: &[Message]) -> HookAction {
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        _event: CompletionCall<'_>,
+    ) -> CompletionCallAction {
         if self.enabled && self.saw_view_image.load(Ordering::SeqCst) {
-            HookAction::terminate(VIEW_IMAGE_BREAK)
+            CompletionCallAction::Stop(VIEW_IMAGE_BREAK.to_string())
         } else {
-            HookAction::cont()
+            CompletionCallAction::Continue
         }
     }
 }
@@ -730,7 +747,7 @@ fn split_for_resume(mut history: Vec<Message>) -> (Vec<Message>, Message) {
 /// surface — `oneshot` ({} — no tools), the recomposed `consult`
 /// ({run_kaish, explore′}), and its nested `explore′` ({run_kaish}). The factory matters because of the
 /// turn-cap recovery below: a fresh toolset is built for the forced final turn, and
-/// `Box<dyn ToolDyn>` can't be cloned, so we rebuild rather than share. Each call
+/// A `DynamicTool` toolset is consumed by the builder, so we rebuild rather than share. Each call
 /// spawns its own `KaishWorker`(s); the caller owns their lifetime.
 ///
 /// **Turn-cap recovery.** When the model uses every turn without concluding, rig
@@ -783,7 +800,7 @@ pub(crate) async fn run_phase<M, F>(
 ) -> Result<(String, Usage)>
 where
     M: CompletionModel + 'static,
-    F: Fn() -> Result<Vec<Box<dyn ToolDyn>>>,
+    F: Fn() -> Result<Vec<DynamicTool>>,
 {
     // Loop state across view_image-break resumes. The caller hands us the *assembled*
     // first user turn — a bare `Message::user(prompt)` for every tool-driven phase, or a
@@ -835,27 +852,28 @@ where
         if let Some(params) = thinking {
             builder = builder.additional_params(params.clone());
         }
-        let agent = builder.tools(make_tools()?).build();
+        let agent = builder.dynamic_tools(make_tools()?).build();
 
         // A fresh hook per loop iteration is load-bearing: its `saw_view_image` flag
         // must be scoped to *this* turn. Hoisting it out of the loop (or reusing the
         // agent across resumes) would carry a stale flag — breaking on the first
         // completion call of a resume that ran no view_image. Keep it built here.
-        // `.extended_details()` swaps rig's plain-`String` result for a
+        // `AgentRunner` (rig 0.41's only managed execution path — the `Prompt` trait
+        // and its `.extended_details()` opt-in are gone) always yields a
         // `PromptResponse` carrying the token `usage` the provider reported, summed
-        // across every turn of *this* run (rig aggregates `usage += resp.usage` per
-        // completion). The clean `Ok` path is the common case — one run, the full
-        // count. The two exceptional exits below (turn cap, view_image break) undercount:
-        // rig hands back no usage on `MaxTurnsError`/`PromptCancelled`, so the turns
-        // spent in a capped or broken run are lost and only the finalize/resumed run's
-        // usage survives. Deliberate — recovering it would mean summing per-completion
-        // through a hook; documented as a known undercount rather than silently exact.
+        // across every turn of *this* run. The clean `Ok` path is the common case —
+        // one run, the full count. The two exceptional exits below (turn cap,
+        // view_image break) undercount: rig hands back no usage on
+        // `MaxTurnsError`/`PromptCancelled`, so the turns spent in a capped or broken
+        // run are lost and only the finalize/resumed run's usage survives. Deliberate —
+        // recovering it would mean summing per-completion through a hook; documented as
+        // a known undercount rather than silently exact.
         let result = agent
-            .prompt(prompt.clone())
-            .with_history(history.clone())
-            .with_hook(ViewImageBreakHook::new(break_on_view_image))
+            .runner(prompt.clone())
+            .history(history.clone())
+            .add_hook(ViewImageBreakHook::new(break_on_view_image))
             .max_turns(remaining)
-            .extended_details()
+            .run()
             .await;
 
         match result {
@@ -904,7 +922,7 @@ async fn finalize_after_max_turns<M>(
     max_tokens: u64,
     temperature: Option<f64>,
     thinking: Option<&Value>,
-    tools: Vec<Box<dyn ToolDyn>>,
+    tools: Vec<DynamicTool>,
     chat_history: Vec<Message>,
     max_turns: usize,
 ) -> Result<(String, Usage)>
@@ -922,15 +940,15 @@ where
     if let Some(params) = thinking {
         builder = builder.additional_params(params.clone());
     }
-    let agent = builder.tools(tools).build();
+    let agent = builder.dynamic_tools(tools).build();
     // max_turns(1): one constrained completion. With tools forbidden the model can't
     // loop, so a single round is enough — and if a provider ignores ToolChoice::None
     // and still calls a tool, we surface that rather than recurse.
     agent
-        .prompt(prompt)
-        .with_history(history)
+        .runner(prompt)
+        .history(history)
         .max_turns(1)
-        .extended_details()
+        .run()
         .await
         .map(|resp| (resp.output, resp.usage))
         .map_err(|e| {
@@ -969,7 +987,7 @@ pub(crate) async fn run_explore_phase(
         Message::user(question.to_string()),
         max_turns,
         progress.as_ref(),
-        &|| -> Result<Vec<Box<dyn ToolDyn>>> {
+        &|| -> Result<Vec<DynamicTool>> {
             Ok(vec![traced(RunKaish::with_progress(
                 KaishWorker::spawn_with(&root, sandbox.clone())?,
                 progress.clone(),
@@ -1066,28 +1084,46 @@ impl Tool for RunExplore {
     type Args = RunExploreArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Delegate a broad sweep to a fast investigator that rips \
-                through the repo on a read-only kaish shell and reports back with \
-                concrete `file:line` citations. Give it a focused question; use it \
-                to cover breadth, and read the code yourself with `run_kaish`."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "question": {
-                        "type": "string",
-                        "description": "the question or sub-question to investigate"
-                    }
-                },
-                "required": ["question"]
-            }),
-        }
+    /// Keep the failure text model-visible.
+    ///
+    /// rig 0.41's default (`ToolExecutionError::from_error`) redacts an arbitrary
+    /// source error down to a stable kind-level string — the model would read "the
+    /// tool failed" and nothing else. That is the right default for a tool whose
+    /// errors may carry secrets; it is the wrong one here, because a sweep that dies is something the
+    /// driver must *see* to recover from — it answers from its own direct reads instead
+    /// of retrying blind, and it can only make that choice if the failure reaches it.
+    /// The explicit constructor keeps the message model-visible while `with_source`
+    /// preserves the concrete error for operator diagnostics and downcasting.
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        ToolExecutionError::other(error.to_string()).with_source(error)
     }
 
-    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+    fn description(&self) -> String {
+        "Delegate a broad sweep to a fast investigator that rips \
+         through the repo on a read-only kaish shell and reports back with \
+         concrete `file:line` citations. Give it a focused question; use it \
+         to cover breadth, and read the code yourself with `run_kaish`."
+            .to_string()
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "the question or sub-question to investigate"
+                }
+            },
+            "required": ["question"]
+        })
+    }
+
+    async fn call(
+        &self,
+        _ctx: &mut rig_agent::tool::ToolContext,
+        args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
         // Bracket the delegation: the start carries the sub-question, the finish fires
         // on both success and failure (the `?` below short-circuits, so emit it before
         // unwrapping the result).
@@ -1209,7 +1245,7 @@ fn consult_tools(
     reports: Arc<Mutex<Vec<String>>>,
     explore_usage: Arc<Mutex<Usage>>,
     synth_vision: bool,
-) -> Result<Vec<Box<dyn ToolDyn>>> {
+) -> Result<Vec<DynamicTool>> {
     // run_kaish for precise reads by the consult model itself — carries the sink so
     // the driver's own reads show up as progress alongside the delegated sweeps'.
     let worker = KaishWorker::spawn_with(root, cfg.explore.sandbox.clone())?;
@@ -1244,7 +1280,7 @@ fn consult_tools(
         cfg.explore.phase.progress.clone(),
         explorer_preamble,
     );
-    let mut tools: Vec<Box<dyn ToolDyn>> = vec![
+    let mut tools: Vec<DynamicTool> = vec![
         traced(RunKaish::with_progress(
             worker.clone(),
             cfg.explore.phase.progress.clone(),
@@ -1526,8 +1562,9 @@ mod tests {
     use crate::session::{SessionStore, Sessions};
     use crate::test_support::{
         has_tool, is_finalize_turn, provider_error, text_response, tool_call_response,
-        transcript_text, usage, with_usage, RecordingSink, ScriptedClient,
+        transcript_text, usage, with_usage, CaptureHttp, RecordingSink, ScriptedClient,
     };
+    use rig_core::completion::CompletionRequest;
     use std::fs;
     use std::num::NonZeroUsize;
     use std::path::Path;
@@ -3818,30 +3855,76 @@ mod tests {
     /// The OpenRouter arm rides with rig's explicit prompt caching ON: Anthropic-
     /// upstream slugs need `cache_control` breakpoints to bill cache-read rates
     /// (2026-07-03: a consult re-billed its full growing prefix every turn without
-    /// them), and implicit-caching upstreams ignore the marker. rig exposes the
-    /// flag as a public field, and `from_slot` routes through this constructor —
-    /// so this pins the wiring, not an internal default.
-    #[test]
-    fn openrouter_arm_enables_prompt_caching() {
-        // Built through kaibo's one TLS client-build site (ring installed there) —
-        // a bare reqwest builder panics under `rustls-no-provider` unless another
-        // test happened to install the provider first.
-        let http = crate::tls::https_client(Duration::from_secs(30)).unwrap();
+    /// them), and implicit-caching upstreams ignore the marker. `from_slot` routes
+    /// through this constructor — so this pins the wiring, not an internal default.
+    ///
+    /// **Asserted on the wire, not on a field.** Through rig 0.38 the flag was a public
+    /// field and this test read it. rig 0.41 made it private, and rather than delete the
+    /// guard we moved it one layer out to where it actually matters: the serialized
+    /// request body, captured from a fake transport. That is strictly better teeth — a
+    /// future rig release could keep `with_prompt_caching()` compiling while changing
+    /// what it emits, and the old field read would have stayed green through it.
+    #[tokio::test]
+    async fn openrouter_arm_enables_prompt_caching() {
+        async fn system_block(model: openrouter::CompletionModel<CaptureHttp>, http: &CaptureHttp) -> Value {
+            let request = CompletionRequest {
+                model: None,
+                preamble: Some("ground every claim".into()),
+                chat_history: OneOrMany::one(Message::user("hi")),
+                documents: Vec::new(),
+                tools: Vec::new(),
+                temperature: None,
+                max_tokens: Some(4096),
+                tool_choice: None,
+                additional_params: None,
+                output_schema: None,
+                record_telemetry_content: false,
+            };
+            // The capture transport always errors; the body is already built by then.
+            let _ = model.completion(request).await;
+            http.recorded()
+                .expect("rig serialized a request body")
+                .pointer("/messages/0")
+                .cloned()
+                .expect("the system message leads the body")
+        }
+
+        let http = CaptureHttp::default();
         let client = openrouter::Client::builder()
             .api_key("sk-or-test")
-            .http_client(http)
+            .http_client(http.clone())
             .build()
             .expect("offline openrouter client construction");
-        let plain = client.completion_model("~anthropic/claude-sonnet-latest");
+
+        let plain_http = CaptureHttp::default();
+        let plain_client = openrouter::Client::builder()
+            .api_key("sk-or-test")
+            .http_client(plain_http.clone())
+            .build()
+            .expect("offline openrouter client construction");
+        let plain = system_block(
+            plain_client.completion_model("~anthropic/claude-sonnet-latest"),
+            &plain_http,
+        )
+        .await;
         assert!(
-            !plain.prompt_caching,
-            "rig defaults the flag off — the arm constructor below is load-bearing"
+            !plain.to_string().contains("cache_control"),
+            "rig marks no breakpoint by default — the arm constructor is load-bearing: \
+             {plain}"
         );
-        let armed =
-            Arm::openrouter_completion_model(&client, "~anthropic/claude-sonnet-latest");
+
+        let armed = system_block(
+            Arm::openrouter_completion_model(&client, "~anthropic/claude-sonnet-latest"),
+            &http,
+        )
+        .await;
         assert!(
-            armed.prompt_caching,
-            "the OpenRouter arm must build its model with prompt caching enabled"
+            armed.to_string().contains(r#""cache_control""#),
+            "the OpenRouter arm must put a cache breakpoint on the system prompt: {armed}"
+        );
+        assert!(
+            armed.to_string().contains("ephemeral"),
+            "the breakpoint is the ephemeral kind OpenRouter bills against: {armed}"
         );
     }
 
@@ -4228,7 +4311,7 @@ mod tests {
         )
         .expect("building the consult toolset should succeed");
 
-        let names: Vec<String> = tools.iter().map(|t| t.name()).collect();
+        let names: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
         assert!(
             names.iter().any(|n| n == "run_kaish"),
             "missing run_kaish, got {names:?}"
@@ -4263,7 +4346,7 @@ mod tests {
         )
         .expect("building the consult toolset should succeed");
 
-        let names: Vec<String> = tools.iter().map(|t| t.name()).collect();
+        let names: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
         assert!(
             names.iter().any(|n| n == "view_image"),
             "a vision synth must get view_image, got {names:?}"
@@ -4293,7 +4376,7 @@ mod tests {
             false,
         )
         .expect("blind toolset builds");
-        let blind_names: Vec<String> = blind.iter().map(|t| t.name()).collect();
+        let blind_names: Vec<String> = blind.iter().map(|t| t.name().to_string()).collect();
         assert!(blind_names.iter().any(|n| n == "run_kaish"));
         assert!(blind_names.iter().any(|n| n == "explore"));
         assert!(
@@ -4303,7 +4386,7 @@ mod tests {
 
         let seeing = consult_tools(&explorer, dir.path(), &cfg, reports, usage_sink, true)
             .expect("vision toolset builds");
-        let seeing_names: Vec<String> = seeing.iter().map(|t| t.name()).collect();
+        let seeing_names: Vec<String> = seeing.iter().map(|t| t.name().to_string()).collect();
         assert!(
             seeing_names.iter().any(|n| n == "view_image"),
             "view_image present with vision, got {seeing_names:?}"
@@ -4383,7 +4466,7 @@ mod tests {
     }
 
     /// A `view_image` tool result: the load note (text) *and* the image part — the
-    /// hybrid shape rig's `from_tool_output` produces.
+    /// two typed content blocks `ViewImage` returns.
     fn vi_result(id: &str) -> UserContent {
         UserContent::ToolResult(ToolResult {
             id: id.to_string(),

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -579,8 +579,10 @@ pub fn effort_sinks(
 /// body, so whatever an operator writes reaches the provider and the *provider* decides.
 /// Two paths don't: rig deserializes the blob into a typed struct first, and a typed
 /// struct has a closed set of reasoning rungs. That ceiling belongs to **rig's client**,
-/// not the provider's API — OpenAI accepts `effort = "max"` on the wire (probed live
-/// 2026-08-01, 200 + echoed) while rig 0.38's `ReasoningEffort` enum stops at `xhigh`.
+/// not the provider's API, and it moves on rig's release schedule: rig 0.38's
+/// `ReasoningEffort` stopped at `xhigh` while OpenAI already accepted `effort = "max"`
+/// (probed live 2026-08-01, 200 + echoed); rig 0.41 added the rung and the two are now
+/// level. Gemini's `ThinkingLevel` ceiling is the provider's own and has not moved.
 ///
 /// Naming the wire lets kaibo ask rig *before* the call (see [`preflight_params`]) and
 /// report the ceiling honestly instead of surfacing a bare serde message mid-consult.
@@ -1036,14 +1038,24 @@ mod tests {
         );
     }
 
-    /// Canary tying `inject_output_budget` to the rig 0.38 pin. The workaround
-    /// exists because rig's `OpenrouterCompletionRequest` has no `max_tokens`
-    /// field; the day a rig bump adds one, `AgentBuilder::max_tokens` starts
-    /// arriving natively and the injected `max_completion_tokens` rides alongside
-    /// it — redundant at best, a provider 400 at worst, and silent either way.
-    /// This failing test is the tripwire: on a rig bump, re-read rig's
-    /// `openrouter/completion.rs`, retire (or deliberately keep) the injection,
-    /// then advance the version prefix here.
+    /// Canary tying `inject_output_budget` to the rig pin. The workaround exists
+    /// because rig's OpenRouter request has no `max_tokens` field; the day a rig bump
+    /// adds one, `AgentBuilder::max_tokens` starts arriving natively and the injected
+    /// `max_completion_tokens` rides alongside it — redundant at best, a provider 400
+    /// at worst, and silent either way. This failing test is the tripwire: on a rig
+    /// bump, re-read rig's `openrouter/completion.rs`, retire (or deliberately keep)
+    /// the injection, then advance the version prefix here.
+    ///
+    /// **Audit log — 0.38.2 → 0.41.0 (2026-08-01): the defect persists; the injection
+    /// stays.** rig 0.40 collapsed OpenRouter onto the shared
+    /// `GenericCompletionModel<OpenRouterExt>` (rig PR #2054), which was the plausible
+    /// moment for it to inherit the OpenAI path's native `max_tokens`. It did not.
+    /// Measured rather than read: a real 0.41 `openrouter::CompletionModel` driven
+    /// through a capture transport with `CompletionRequest.max_tokens = Some(4096)`
+    /// serialized a body whose only keys were `messages`, `model`, and `reasoning` —
+    /// no `max_tokens`, no `max_completion_tokens`. So a thinking-on OpenRouter answer
+    /// still runs on the gateway's default budget unless kaibo injects the ceiling
+    /// itself. Re-run that probe, don't re-derive this from the source, on the next bump.
     #[test]
     fn rig_bump_reaudits_the_openrouter_budget_workaround() {
         let lock = include_str!("../../Cargo.lock");
@@ -1055,10 +1067,10 @@ mod tests {
             .nth(1)
             .expect("version line follows the name line");
         assert!(
-            version.contains("version = \"0.38."),
-            "rig-core moved past 0.38 ({version}): re-audit the \
-             OpenrouterCompletionRequest max_tokens defect before shipping — \
-             see inject_output_budget"
+            version.contains("version = \"0.41."),
+            "rig-core moved past 0.41 ({version}): re-audit the OpenRouter max_tokens \
+             defect before shipping — see inject_output_budget, and the audit log on \
+             this test for how it was last measured"
         );
     }
 }

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -417,7 +417,7 @@ impl ModelShape {
                 // silently ignore a slot's `effort = "low"`.
                 //
                 // Unlike the other effort sinks this one is NOT a passthrough string: rig
-                // 0.38 models the level as a closed enum (`minimal|low|medium|high`), so
+                // models the level as a closed enum (`minimal|low|medium|high`), so
                 // `xhigh`/`max`/`none` are refused by rig's own converter before the
                 // request leaves the process. [`EffortWire::Gemini`] names that, and
                 // `Arm::from_slot` turns it into a legible error rather than a mid-call
@@ -579,10 +579,9 @@ pub fn effort_sinks(
 /// body, so whatever an operator writes reaches the provider and the *provider* decides.
 /// Two paths don't: rig deserializes the blob into a typed struct first, and a typed
 /// struct has a closed set of reasoning rungs. That ceiling belongs to **rig's client**,
-/// not the provider's API, and it moves on rig's release schedule: rig 0.38's
-/// `ReasoningEffort` stopped at `xhigh` while OpenAI already accepted `effort = "max"`
-/// (probed live 2026-08-01, 200 + echoed); rig 0.41 added the rung and the two are now
-/// level. Gemini's `ThinkingLevel` ceiling is the provider's own and has not moved.
+/// not the provider's API, and the two can disagree in either direction — rig has
+/// trailed OpenAI's own ladder by a rung before. Gemini's is the exception: its
+/// `ThinkingLevel` mirrors a limit Google actually enforces.
 ///
 /// Naming the wire lets kaibo ask rig *before* the call (see [`preflight_params`]) and
 /// report the ceiling honestly instead of surfacing a bare serde message mid-consult.
@@ -688,9 +687,9 @@ pub fn accepted_efforts(wire: EffortWire) -> Vec<&'static str> {
 }
 
 /// Fold this arm's output-token budget into `params` where the provider needs it
-/// carried out-of-band. **OpenRouter only, and it's a rig-defect workaround**: rig
-/// 0.38's `OpenrouterCompletionRequest` (openrouter/completion.rs) has no `max_tokens`
-/// field and its `TryFrom` never reads `CompletionRequest.max_tokens`, so
+/// carried out-of-band. **OpenRouter only, and it's a rig-defect workaround**: rig's
+/// OpenRouter request (`openrouter/completion.rs`) never reads
+/// `CompletionRequest.max_tokens`, so
 /// `AgentBuilder::max_tokens()` is silently a no-op for that provider — the answer
 /// would run on OpenRouter's own default budget, starving a thinking-on completion.
 /// `additional_params` *is* `#[serde(flatten)]`-merged into the body, so we inject the
@@ -1046,16 +1045,11 @@ mod tests {
     /// bump, re-read rig's `openrouter/completion.rs`, retire (or deliberately keep)
     /// the injection, then advance the version prefix here.
     ///
-    /// **Audit log — 0.38.2 → 0.41.0 (2026-08-01): the defect persists; the injection
-    /// stays.** rig 0.40 collapsed OpenRouter onto the shared
-    /// `GenericCompletionModel<OpenRouterExt>` (rig PR #2054), which was the plausible
-    /// moment for it to inherit the OpenAI path's native `max_tokens`. It did not.
-    /// Measured rather than read: a real 0.41 `openrouter::CompletionModel` driven
-    /// through a capture transport with `CompletionRequest.max_tokens = Some(4096)`
-    /// serialized a body whose only keys were `messages`, `model`, and `reasoning` —
-    /// no `max_tokens`, no `max_completion_tokens`. So a thinking-on OpenRouter answer
-    /// still runs on the gateway's default budget unless kaibo injects the ceiling
-    /// itself. Re-run that probe, don't re-derive this from the source, on the next bump.
+    /// **Audit log.** 0.38.2 → 0.41.0 (2026-08-01): defect persists, injection stays.
+    /// Measured, not read — a real `openrouter::CompletionModel` driven through a
+    /// capture transport with `max_tokens = Some(4096)` serialized a body whose only
+    /// keys were `messages`, `model`, `reasoning`. Run that probe again on the next
+    /// bump rather than re-deriving the answer from rig's source.
     #[test]
     fn rig_bump_reaudits_the_openrouter_budget_workaround() {
         let lock = include_str!("../../Cargo.lock");

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -64,15 +64,10 @@ impl Tool for RunKaish {
     type Args = RunKaishArgs;
     type Output = String;
 
-    /// Keep the failure text model-visible.
-    ///
-    /// rig 0.41's default (`ToolExecutionError::from_error`) redacts an arbitrary
-    /// source error down to a stable kind-level string — the model would read "the
-    /// tool failed" and nothing else. That is the right default for a tool whose
-    /// errors may carry secrets; it is the wrong one here, because this message names what the shell
-    /// refused and is the only thing telling the model how to reshape its script.
-    /// The explicit constructor keeps the message model-visible while `with_source`
-    /// preserves the concrete error for operator diagnostics and downcasting.
+    /// Keep the failure text model-visible: rig's default would redact it to a
+    /// kind-level "the tool failed", and this message names what the shell refused —
+    /// the only thing telling the model how to reshape its script. `with_source` keeps
+    /// the concrete error for operator diagnostics and downcasting.
     fn map_error(&self, error: Self::Error) -> ToolExecutionError {
         ToolExecutionError::other(error.to_string()).with_source(error)
     }

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -7,8 +7,7 @@
 
 use std::sync::Arc;
 
-use rig_core::completion::ToolDefinition;
-use rig_core::tool::Tool;
+use rig_agent::tool::{Tool, ToolContext, ToolExecutionError};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -65,24 +64,41 @@ impl Tool for RunKaish {
     type Args = RunKaishArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: run_kaish_tool_description(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "script": {
-                        "type": "string",
-                        "description": "kaish script to execute, e.g. `grep -rn TODO src | head`"
-                    }
-                },
-                "required": ["script"]
-            }),
-        }
+    /// Keep the failure text model-visible.
+    ///
+    /// rig 0.41's default (`ToolExecutionError::from_error`) redacts an arbitrary
+    /// source error down to a stable kind-level string — the model would read "the
+    /// tool failed" and nothing else. That is the right default for a tool whose
+    /// errors may carry secrets; it is the wrong one here, because this message names what the shell
+    /// refused and is the only thing telling the model how to reshape its script.
+    /// The explicit constructor keeps the message model-visible while `with_source`
+    /// preserves the concrete error for operator diagnostics and downcasting.
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        ToolExecutionError::other(error.to_string()).with_source(error)
     }
 
-    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+    fn description(&self) -> String {
+        run_kaish_tool_description()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "kaish script to execute, e.g. `grep -rn TODO src | head`"
+                }
+            },
+            "required": ["script"]
+        })
+    }
+
+    async fn call(
+        &self,
+        _ctx: &mut ToolContext,
+        args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
         // Announce the read before running it — the beat fires even if the script
         // then errors, which is exactly the liveness a stuck call wants to show.
         self.progress.emit(PhaseEvent::KaishRun {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -188,8 +188,8 @@ pub struct ScriptedModel {
 pub struct NoStream;
 
 impl GetTokenUsage for NoStream {
-    // rig 0.41 dropped the `Option`: a zero-valued `Usage` is the documented sentinel
-    // for "the provider reported none", so there is one shape instead of two.
+    // A zero-valued `Usage` is rig's documented sentinel for "the provider reported
+    // none" — there is no separate absent case.
     fn token_usage(&self) -> Usage {
         Usage::new()
     }
@@ -199,9 +199,9 @@ impl GetTokenUsage for NoStream {
 ///
 /// The failure is the point: everything under test is already decided by the time rig
 /// hands the request to the transport, so no network, no key, and no canned response
-/// are needed. This is how a unit test asks "what would kaibo actually have sent?" —
-/// the only honest question once a provider option stops being a readable field on
-/// rig's model and becomes a transformation of the outgoing body.
+/// are needed. This is how a unit test asks "what would kaibo actually have sent?",
+/// which is the only honest form of the question for a provider option that shows up
+/// as a transformation of the outgoing body rather than a readable field.
 #[derive(Clone, Debug, Default)]
 pub struct CaptureHttp(Arc<Mutex<Vec<serde_json::Value>>>);
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -40,6 +40,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use bytes::Bytes;
 use rig_core::client::CompletionClient;
 use rig_core::completion::message::{
     AssistantContent, Message, ToolChoice, ToolResultContent, UserContent,
@@ -47,6 +48,7 @@ use rig_core::completion::message::{
 use rig_core::completion::{
     CompletionError, CompletionModel, CompletionRequest, CompletionResponse, GetTokenUsage, Usage,
 };
+use rig_core::http_client::{self, HttpClientExt};
 use rig_core::OneOrMany;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -186,8 +188,76 @@ pub struct ScriptedModel {
 pub struct NoStream;
 
 impl GetTokenUsage for NoStream {
-    fn token_usage(&self) -> Option<Usage> {
-        None
+    // rig 0.41 dropped the `Option`: a zero-valued `Usage` is the documented sentinel
+    // for "the provider reported none", so there is one shape instead of two.
+    fn token_usage(&self) -> Usage {
+        Usage::new()
+    }
+}
+
+/// An [`HttpClientExt`] that records the request body rig built, then fails.
+///
+/// The failure is the point: everything under test is already decided by the time rig
+/// hands the request to the transport, so no network, no key, and no canned response
+/// are needed. This is how a unit test asks "what would kaibo actually have sent?" —
+/// the only honest question once a provider option stops being a readable field on
+/// rig's model and becomes a transformation of the outgoing body.
+#[derive(Clone, Debug, Default)]
+pub struct CaptureHttp(Arc<Mutex<Vec<serde_json::Value>>>);
+
+impl CaptureHttp {
+    /// The first body rig serialized, if it got that far.
+    pub fn recorded(&self) -> Option<serde_json::Value> {
+        self.0.lock().unwrap().first().cloned()
+    }
+}
+
+impl HttpClientExt for CaptureHttp {
+    fn send<T, U>(
+        &self,
+        req: http_client::Request<T>,
+    ) -> impl std::future::Future<
+        Output = http_client::Result<http_client::Response<http_client::LazyBody<U>>>,
+    > + Send
+           + 'static
+    where
+        T: Into<Bytes> + Send,
+        U: From<Bytes> + Send + 'static,
+    {
+        let (_parts, body) = req.into_parts();
+        let bytes: Bytes = body.into();
+        self.0
+            .lock()
+            .unwrap()
+            .push(serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null));
+        async move { Err(http_client::Error::StreamEnded) }
+    }
+
+    // Unreachable for a completion, but the trait requires them. `async fn` can't
+    // express the trait's `+ Send + 'static` return bound, so the desugared form stays.
+    #[allow(clippy::manual_async_fn)]
+    fn send_multipart<U>(
+        &self,
+        _req: http_client::Request<http_client::MultipartForm>,
+    ) -> impl std::future::Future<
+        Output = http_client::Result<http_client::Response<http_client::LazyBody<U>>>,
+    > + Send
+           + 'static
+    where
+        U: From<Bytes> + Send + 'static,
+    {
+        async move { Err(http_client::Error::StreamEnded) }
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn send_streaming<T>(
+        &self,
+        _req: http_client::Request<T>,
+    ) -> impl std::future::Future<Output = http_client::Result<http_client::StreamingResponse>> + Send
+    where
+        T: Into<Bytes> + Send,
+    {
+        async move { Err(http_client::Error::StreamEnded) }
     }
 }
 

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -16,21 +16,13 @@
 //! slice — the read-size question the explorer A/Bs turn on.
 //!
 //! It's *our* span on *our* tools, independent of what rig or a given provider
-//! instruments, so it lands the same on every backend. The wrapper sits at rig's
-//! **erased dispatch seam** — a [`DynamicTool`], where the call still carries raw JSON
-//! args — so it can summarize the call; it is otherwise transparent: name,
-//! description, parameters, output, and errors all pass straight through.
-//!
-//! rig 0.41 removed the public `ToolDyn` trait, so [`traced`] now *performs* the
-//! erasure instead of layering over rig's: it reads the typed tool's definition
-//! eagerly (0.41's `description`/`parameters` are synchronous, where the old
-//! `definition` was `async`), then owns the arg-parse → call → output/error
-//! normalization that rig's private `ErasedTool` blanket impl does for a registered
-//! typed tool. Two consequences worth naming: a malformed-args refusal is now *inside*
-//! the span (so `outcome = error` covers it, which is the honest reading of "did this
-//! call work"), and the arg summary is taken from the re-serialized JSON value rig
-//! hands a dynamic tool rather than the model's original string — same content,
-//! normalized whitespace.
+//! instruments, so it lands the same on every backend. [`traced`] is where a typed
+//! tool becomes the erased [`DynamicTool`] rig dispatches — the seam that still sees
+//! raw JSON args, so it can summarize the call — and it is otherwise transparent:
+//! name, description, parameters, output, and errors all pass straight through.
+//! Because the erasure is ours, the arg-parse happens inside the span too, so a
+//! malformed-args refusal is reported as `outcome = error` rather than never
+//! appearing — the honest reading of "did this call work".
 
 use std::sync::Arc;
 
@@ -43,10 +35,9 @@ use tracing::{field, info_span, Instrument, Span};
 
 /// Parse a dynamic tool's JSON args into the wrapped tool's typed `Args`.
 ///
-/// Mirrors rig's own `parse_tool_args`, including the part that matters in practice:
-/// a no-argument tool is routinely called with `null` rather than `{}`, and both must
-/// mean "no arguments". Getting this wrong would surface as a tool that fails only for
-/// the models that spell an empty argument list the other way.
+/// `null` and `{}` both mean "no arguments" — a no-argument tool is routinely called
+/// either way, so treating only one as valid yields a tool that fails for some models
+/// and not others.
 fn parse_args<A>(args: Value) -> Result<A, ToolExecutionError>
 where
     A: for<'de> serde::Deserialize<'de>,
@@ -76,10 +67,9 @@ pub(crate) fn record_kaish_result(exit_code: i64, output_bytes: usize) {
 }
 
 /// Erase a typed tool into a span-wrapped [`DynamicTool`] — the toolset-assembly
-/// drop-in, so every tool in a phase's toolset is traced uniformly.
-///
-/// The definition is read once, here, and the returned tool is what rig registers and
-/// dispatches; the span brackets exactly the work rig attributes to this call.
+/// drop-in, so every tool in a phase's toolset is traced uniformly. The returned tool
+/// is what rig registers and dispatches, so the span brackets exactly the work rig
+/// attributes to this call.
 pub fn traced<T: Tool + 'static>(tool: T) -> DynamicTool {
     let definition = tool_definition(&tool);
     let name = definition.name.clone();
@@ -120,9 +110,9 @@ pub fn traced<T: Tool + 'static>(tool: T) -> DynamicTool {
 }
 
 /// The erased call itself: parse, dispatch, then normalize both halves of the typed
-/// result the way rig does for a registered typed tool — output through
-/// [`IntoToolOutput`](rig_agent::tool::IntoToolOutput), error through the tool's own
-/// `map_error`, so a tool that classifies its failures keeps that classification.
+/// result — output through [`IntoToolOutput`](rig_agent::tool::IntoToolOutput), error
+/// through the tool's own `map_error`, so a tool that classifies its failures keeps
+/// that classification.
 async fn run_traced<T: Tool>(
     tool: &T,
     context: &mut ToolContext,
@@ -171,8 +161,8 @@ mod tests {
     use tracing_subscriber::Layer;
 
     /// Dispatch a span-wrapped tool the way rig does — through a registered
-    /// [`ToolSet`], the public execution surface. rig 0.41 made the erased `call` it
-    /// used to expose private, so this *is* the production path, not a stand-in.
+    /// [`ToolSet`], the public execution surface. This is the production path, not a
+    /// stand-in: rig's erased `call` is private.
     async fn dispatch(tool: DynamicTool, args: &str) -> ToolResult {
         let name = tool.name().to_string();
         let tools = ToolSet::from_dynamic_tools(vec![tool]);
@@ -415,9 +405,8 @@ mod tests {
     }
 
     /// Malformed args are refused *inside* the span, so the trace shows the attempt
-    /// and tags it `outcome = error` rather than dropping it. rig 0.41 moved the
-    /// arg-parse into [`traced`]'s own erasure, and this is the seam where that could
-    /// silently start reporting a failed call as a success.
+    /// and tags it `outcome = error`. [`traced`] owns the arg-parse, which is where a
+    /// failed call could quietly start being reported as a success.
     #[test]
     fn malformed_args_are_refused_inside_the_span() {
         serialized_capture(async {
@@ -489,7 +478,7 @@ mod tests {
             let _g = tracing::subscriber::set_default(sub);
 
             // `null` args, not `{}` — a no-argument tool is routinely called that way,
-            // and the erasure `traced` now owns has to mean the same thing by it.
+            // and [`parse_args`] has to mean the same thing by both.
             let result = dispatch(traced(TruncatedRead), "null").await;
             assert!(result.is_success(), "null args mean no args: {result:?}");
 

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -16,62 +16,55 @@
 //! slice — the read-size question the explorer A/Bs turn on.
 //!
 //! It's *our* span on *our* tools, independent of what rig or a given provider
-//! instruments, so it lands the same on every backend. The wrapper sits at the
-//! `ToolDyn` seam (where `call` carries the raw JSON args) so it can summarize the
-//! call; it is otherwise transparent — name, definition, output, and errors pass
-//! straight through.
+//! instruments, so it lands the same on every backend. The wrapper sits at rig's
+//! **erased dispatch seam** — a [`DynamicTool`], where the call still carries raw JSON
+//! args — so it can summarize the call; it is otherwise transparent: name,
+//! description, parameters, output, and errors all pass straight through.
+//!
+//! rig 0.41 removed the public `ToolDyn` trait, so [`traced`] now *performs* the
+//! erasure instead of layering over rig's: it reads the typed tool's definition
+//! eagerly (0.41's `description`/`parameters` are synchronous, where the old
+//! `definition` was `async`), then owns the arg-parse → call → output/error
+//! normalization that rig's private `ErasedTool` blanket impl does for a registered
+//! typed tool. Two consequences worth naming: a malformed-args refusal is now *inside*
+//! the span (so `outcome = error` covers it, which is the honest reading of "did this
+//! call work"), and the arg summary is taken from the re-serialized JSON value rig
+//! hands a dynamic tool rather than the model's original string — same content,
+//! normalized whitespace.
 
-use rig_core::completion::ToolDefinition;
-use rig_core::tool::{Tool, ToolDyn, ToolError};
+use std::sync::Arc;
+
+use rig_agent::tool::{
+    tool_definition, DynamicTool, IntoToolOutput, Tool, ToolContext, ToolExecutionError, ToolOutput,
+};
 use rig_core::wasm_compat::WasmBoxedFuture;
+use serde_json::Value;
 use tracing::{field, info_span, Instrument, Span};
 
-/// Wraps a boxed [`ToolDyn`], emitting a `tool` span per `call`. Delegates the rest.
-pub struct Traced {
-    inner: Box<dyn ToolDyn>,
-}
-
-impl ToolDyn for Traced {
-    fn name(&self) -> String {
-        self.inner.name()
-    }
-
-    fn definition<'a>(&'a self, prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
-        self.inner.definition(prompt)
-    }
-
-    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
-        let name = self.inner.name();
-        // Summarize before the args are moved into the call. `outcome` is filled
-        // after, so one span carries which tool, with what, and whether it worked;
-        // the span's start/end bracket the latency.
-        let summary = arg_summary(&args);
-        Box::pin(async move {
-            let span = info_span!(
-                "tool",
-                "gen_ai.tool.name" = %name,
-                "gen_ai.tool.arguments" = %summary,
-                outcome = field::Empty,
-                // Filled by `run_kaish` (via `record_kaish_result`) from inside the
-                // instrumented call — `Span::current()` is this span there. Every other
-                // tool leaves them empty, so they don't export.
-                "kaish.exit_code" = field::Empty,
-                "kaish.output_bytes" = field::Empty,
-            );
-            async {
-                let result = self.inner.call(args).await;
-                Span::current().record("outcome", if result.is_ok() { "ok" } else { "error" });
-                result
-            }
-            .instrument(span)
-            .await
-        })
-    }
+/// Parse a dynamic tool's JSON args into the wrapped tool's typed `Args`.
+///
+/// Mirrors rig's own `parse_tool_args`, including the part that matters in practice:
+/// a no-argument tool is routinely called with `null` rather than `{}`, and both must
+/// mean "no arguments". Getting this wrong would surface as a tool that fails only for
+/// the models that spell an empty argument list the other way.
+fn parse_args<A>(args: Value) -> Result<A, ToolExecutionError>
+where
+    A: for<'de> serde::Deserialize<'de>,
+{
+    let args = if args.is_null() {
+        Value::Object(serde_json::Map::new())
+    } else {
+        args
+    };
+    serde_json::from_value(args).map_err(|error| {
+        ToolExecutionError::invalid_args(format!("failed to parse tool arguments: {error}"))
+            .with_source(error)
+    })
 }
 
 /// Record a `run_kaish` script's result onto the enclosing `tool` span — its exit
 /// code and delivered stdout size. Called from inside [`RunKaish::call`](crate::explorer),
-/// which runs under the [`Traced`] wrapper's span, so [`Span::current`] is that span
+/// which runs under the [`traced`] wrapper's span, so [`Span::current`] is that span
 /// and its pre-declared `kaish.*` fields fill in. Off the wrapped path (e.g. a direct
 /// worker call with no `tool` span current) this is a harmless no-op — best-effort
 /// observability, never load-bearing. The field names live *here*, with their
@@ -82,12 +75,64 @@ pub(crate) fn record_kaish_result(exit_code: i64, output_bytes: usize) {
     span.record("kaish.output_bytes", output_bytes as u64);
 }
 
-/// Box a tool as a span-wrapped [`ToolDyn`] — the toolset-assembly drop-in for
-/// `Box::new(tool)`, so every tool in a phase's toolset is traced uniformly.
-pub fn traced<T: Tool + 'static>(tool: T) -> Box<dyn ToolDyn> {
-    Box::new(Traced {
-        inner: Box::new(tool),
-    })
+/// Erase a typed tool into a span-wrapped [`DynamicTool`] — the toolset-assembly
+/// drop-in, so every tool in a phase's toolset is traced uniformly.
+///
+/// The definition is read once, here, and the returned tool is what rig registers and
+/// dispatches; the span brackets exactly the work rig attributes to this call.
+pub fn traced<T: Tool + 'static>(tool: T) -> DynamicTool {
+    let definition = tool_definition(&tool);
+    let name = definition.name.clone();
+    let tool = Arc::new(tool);
+    DynamicTool::new(
+        definition.name,
+        definition.description,
+        definition.parameters,
+        move |context: &mut ToolContext, args: Value| {
+            let tool = Arc::clone(&tool);
+            let name = name.clone();
+            // Summarize before the args are moved into the call. `outcome` is filled
+            // after, so one span carries which tool, with what, and whether it worked;
+            // the span's start/end bracket the latency.
+            let summary = arg_summary(&args.to_string());
+            Box::pin(async move {
+                let span = info_span!(
+                    "tool",
+                    "gen_ai.tool.name" = %name,
+                    "gen_ai.tool.arguments" = %summary,
+                    outcome = field::Empty,
+                    // Filled by `run_kaish` (via `record_kaish_result`) from inside the
+                    // instrumented call — `Span::current()` is this span there. Every
+                    // other tool leaves them empty, so they don't export.
+                    "kaish.exit_code" = field::Empty,
+                    "kaish.output_bytes" = field::Empty,
+                );
+                async move {
+                    let result = run_traced(tool.as_ref(), context, args).await;
+                    Span::current().record("outcome", if result.is_ok() { "ok" } else { "error" });
+                    result
+                }
+                .instrument(span)
+                .await
+            }) as WasmBoxedFuture<'_, Result<ToolOutput, ToolExecutionError>>
+        },
+    )
+}
+
+/// The erased call itself: parse, dispatch, then normalize both halves of the typed
+/// result the way rig does for a registered typed tool — output through
+/// [`IntoToolOutput`](rig_agent::tool::IntoToolOutput), error through the tool's own
+/// `map_error`, so a tool that classifies its failures keeps that classification.
+async fn run_traced<T: Tool>(
+    tool: &T,
+    context: &mut ToolContext,
+    args: Value,
+) -> Result<ToolOutput, ToolExecutionError> {
+    let args = parse_args::<T::Args>(args)?;
+    match tool.call(context, args).await {
+        Ok(output) => output.into_tool_output(),
+        Err(error) => Err(tool.map_error(error)),
+    }
 }
 
 /// A short, span-friendly summary of a tool call's JSON args: the most informative
@@ -117,12 +162,23 @@ fn arg_summary(args: &str) -> String {
 mod tests {
     use super::*;
     use crate::test_support::serialized_capture;
+    use rig_agent::tool::{ToolResult, ToolSet};
     use serde::Deserialize;
     use serde_json::json;
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::layer::{Context, SubscriberExt};
     use tracing_subscriber::registry::LookupSpan;
     use tracing_subscriber::Layer;
+
+    /// Dispatch a span-wrapped tool the way rig does — through a registered
+    /// [`ToolSet`], the public execution surface. rig 0.41 made the erased `call` it
+    /// used to expose private, so this *is* the production path, not a stand-in.
+    async fn dispatch(tool: DynamicTool, args: &str) -> ToolResult {
+        let name = tool.name().to_string();
+        let tools = ToolSet::from_dynamic_tools(vec![tool]);
+        let mut context = ToolContext::default();
+        tools.execute(&name, args, &mut context).await
+    }
 
     /// A trivial tool to wrap: echoes its `msg`, or errors on "boom".
     struct Echo;
@@ -143,14 +199,13 @@ mod tests {
         type Error = EchoErr;
         type Args = EchoArgs;
         type Output = String;
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            ToolDefinition {
-                name: "echo".into(),
-                description: "echo".into(),
-                parameters: json!({}),
-            }
+        fn description(&self) -> String {
+            "echo".into()
         }
-        async fn call(&self, args: Self::Args) -> Result<String, EchoErr> {
+        fn parameters(&self) -> serde_json::Value {
+            json!({})
+        }
+        async fn call(&self, _ctx: &mut ToolContext, args: Self::Args) -> Result<String, EchoErr> {
             if args.msg == "boom" {
                 Err(EchoErr)
             } else {
@@ -313,8 +368,9 @@ mod tests {
             let sub = tracing_subscriber::registry().with(cap.clone());
             let _g = tracing::subscriber::set_default(sub);
 
-            let tool = traced(Echo);
-            let out = tool.call(r#"{"msg":"hi"}"#.to_string()).await.unwrap();
+            let result = dispatch(traced(Echo), r#"{"msg":"hi"}"#).await;
+            assert!(result.is_success(), "echo succeeded: {result:?}");
+            let out = result.output().render();
             assert!(out.contains("hi"), "output passes through: {out}");
 
             drop(_g);
@@ -344,8 +400,8 @@ mod tests {
             let sub = tracing_subscriber::registry().with(cap.clone());
             let _g = tracing::subscriber::set_default(sub);
 
-            let tool = traced(Echo);
-            assert!(tool.call(r#"{"msg":"boom"}"#.to_string()).await.is_err());
+            let result = dispatch(traced(Echo), r#"{"msg":"boom"}"#).await;
+            assert!(result.is_error(), "the tool's own failure: {result:?}");
 
             drop(_g);
             let spans = cap.0.lock().unwrap().clone();
@@ -354,6 +410,35 @@ mod tests {
                     .iter()
                     .any(|s| s.name == "tool" && s.tool == "echo" && s.outcome == "error"),
                 "a `tool` span tagged outcome=error"
+            );
+        });
+    }
+
+    /// Malformed args are refused *inside* the span, so the trace shows the attempt
+    /// and tags it `outcome = error` rather than dropping it. rig 0.41 moved the
+    /// arg-parse into [`traced`]'s own erasure, and this is the seam where that could
+    /// silently start reporting a failed call as a success.
+    #[test]
+    fn malformed_args_are_refused_inside_the_span() {
+        serialized_capture(async {
+            let cap = Capture::default();
+            let sub = tracing_subscriber::registry().with(cap.clone());
+            let _g = tracing::subscriber::set_default(sub);
+
+            // `msg` is required and an integer is not a string.
+            let result = dispatch(traced(Echo), r#"{"msg":7}"#).await;
+            assert!(
+                result.is_error(),
+                "unparseable args fail the call: {result:?}"
+            );
+
+            drop(_g);
+            let spans = cap.0.lock().unwrap().clone();
+            assert!(
+                spans
+                    .iter()
+                    .any(|s| s.name == "tool" && s.tool == "echo" && s.outcome == "error"),
+                "the refused call still emits its span, tagged outcome=error"
             );
         });
     }
@@ -382,14 +467,17 @@ mod tests {
             type Error = Never;
             type Args = NoArgs;
             type Output = String;
-            async fn definition(&self, _prompt: String) -> ToolDefinition {
-                ToolDefinition {
-                    name: "run_kaish".into(),
-                    description: "run_kaish".into(),
-                    parameters: json!({}),
-                }
+            fn description(&self) -> String {
+                "run_kaish".into()
             }
-            async fn call(&self, _args: Self::Args) -> Result<String, Never> {
+            fn parameters(&self) -> serde_json::Value {
+                json!({})
+            }
+            async fn call(
+                &self,
+                _ctx: &mut ToolContext,
+                _args: Self::Args,
+            ) -> Result<String, Never> {
                 super::record_kaish_result(3, 4321);
                 Ok("exit: 3\n".into())
             }
@@ -400,8 +488,10 @@ mod tests {
             let sub = tracing_subscriber::registry().with(cap.clone());
             let _g = tracing::subscriber::set_default(sub);
 
-            let tool = traced(TruncatedRead);
-            tool.call("{}".to_string()).await.unwrap();
+            // `null` args, not `{}` — a no-argument tool is routinely called that way,
+            // and the erasure `traced` now owns has to mean the same thing by it.
+            let result = dispatch(traced(TruncatedRead), "null").await;
+            assert!(result.is_success(), "null args mean no args: {result:?}");
 
             drop(_g);
             let spans = cap.0.lock().unwrap().clone();
@@ -441,11 +531,13 @@ mod tests {
             let sub = tracing_subscriber::registry().with(cap.clone());
             let _g = tracing::subscriber::set_default(sub);
 
-            let tool = traced(RunKaish::new(worker));
-            let out = tool
-                .call(r#"{"script":"cat -n big.txt"}"#.to_string())
-                .await
-                .unwrap();
+            let result = dispatch(
+                traced(RunKaish::new(worker)),
+                r#"{"script":"cat -n big.txt"}"#,
+            )
+            .await;
+            assert!(result.is_success(), "the script ran: {result:?}");
+            let out = result.output().render();
             assert!(out.contains("exit: 3"), "the read truncated: {out}");
 
             drop(_g);

--- a/src/view_image.rs
+++ b/src/view_image.rs
@@ -6,18 +6,28 @@
 //! docs. So the whole input surface is a **path**: the model names a file, this tool
 //! reads its bytes *through the kaish VFS* (the same read-only mount `run_kaish`
 //! uses, so containment and read-only stay structural), and returns them as a rig
-//! image part — the one channel that carries an image into model context (rig's
-//! [`ToolResultContent::from_tool_output`] parses `{"response":…, "parts":[{"type":
-//! "image","data":…,"mimeType":…}]}`). There is deliberately no base64/attach input:
-//! if a genuinely-never-a-file image ever needs viewing, that's added then (see the
-//! media-spine entry in `docs/issues.md`).
+//! image part — the one channel that carries an image into model context. There is
+//! deliberately no base64/attach input: if a genuinely-never-a-file image ever needs
+//! viewing, that's added then (see the media-spine entry in `docs/issues.md`).
+//!
+//! **The image part is declared, not sniffed.** Through rig 0.38 this tool returned a
+//! hybrid JSON envelope (`{"response":…, "parts":[{"type":"image",…}]}`) that rig's
+//! `ToolResultContent::from_tool_output` re-parsed out of the tool's *string* output
+//! to discover the image. rig 0.41 removed that guessing — "Rig never reparses strings
+//! to infer rich content" — so a tool that still returned the envelope would hand the
+//! model base64 text labelled JSON and no image at all, silently. The output is now a
+//! typed [`ToolOutput`] carrying a [`ToolResultContent::Text`] note and a
+//! [`ToolResultContent::Image`] block, which is both the supported multimodal path and
+//! a stronger one: the image block that reaches the transcript is the one this tool
+//! constructed, so [`run_phase`](crate::consult)'s user-turn rewrite reads a real
+//! `Image` rather than a JSON shape two crates have to agree on.
 //!
 //! The tool is only ever placed in a phase's toolset when that phase's [`Arm`]'s
 //! resolved caps say the model is vision-capable (`consult.rs`), so a blind model
 //! never sees it — there is no "image handed to a model that can't read it" path.
 //!
-//! **The envelope is the same; the channel is not.** This tool always produces the
-//! tool-result image envelope. On a transport that carries an image inside a tool
+//! **The output is the same; the channel is not.** This tool always produces the same
+//! text-plus-image tool result. On a transport that carries an image inside a tool
 //! result (Anthropic `tool_result` blocks, Gemini `functionResponse` inline data)
 //! that's the whole story. On one that can't — the OpenAI wire forbids an image in a
 //! `role:tool` message — the loop ([`run_phase`](crate::consult)) breaks at the turn
@@ -27,16 +37,18 @@
 //! `ModelCaps.tool_result_images`. The invariant: a vision model on a no-tool-result-
 //! image transport still gets the image — via a user turn, never silently dropped.
 //!
-//! [`ToolResultContent::from_tool_output`]: rig_core::completion::message
 //! [`Arm`]: crate::consult::Arm
 
 use std::path::{Path, PathBuf};
 
 use base64::Engine;
-use rig_core::completion::ToolDefinition;
-use rig_core::tool::Tool;
+use rig_agent::tool::{Tool, ToolContext, ToolExecutionError, ToolOutput};
+use rig_core::completion::message::{
+    DocumentSourceKind, Image, ImageMediaType, MimeType, ToolResultContent,
+};
+use rig_core::OneOrMany;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::json;
 
 use crate::sandbox::KaishWorker;
 
@@ -121,14 +133,13 @@ impl ViewImage {
         Ok(canon)
     }
 
-    /// The core: resolve → read through the VFS → size-check → sniff → encode →
-    /// envelope. Split out of [`Tool::call`] so it's directly testable. Returns the
-    /// rig hybrid envelope as a [`Value`] — *not* a `String`: rig serializes a tool's
-    /// `Output` with `serde_json::to_string`, so a `String` would arrive double-encoded
-    /// (a quoted JSON string) and `from_tool_output` would treat it as text, never
-    /// extracting the image. A `Value::Object` serializes to the bare object the
-    /// parser needs.
-    async fn view(&self, path_arg: &str) -> Result<Value, ViewImageError> {
+    /// The core: resolve → read through the VFS → size-check → sniff → encode → typed
+    /// content. Split out of [`Tool::call`] so it's directly testable. Returns a
+    /// [`ToolOutput`] — *not* a `String` or a `Value`: rig 0.41 renders an ordinary
+    /// serializable output as text or JSON and never re-reads it looking for rich
+    /// content, so the image has to be a declared [`ToolResultContent::Image`] block or
+    /// it does not reach the model as an image at all.
+    async fn view(&self, path_arg: &str) -> Result<ToolOutput, ViewImageError> {
         let canon = self.resolve_in_workspace(path_arg)?;
         // Read at most one byte past the limit: a file swapped to something enormous
         // between the caller's view and this read stops at the cap instead of slurping
@@ -172,12 +183,22 @@ impl ViewImage {
             "Loaded image {label} ({mime}, {:.1} KiB).",
             bytes.len() as f64 / 1024.0
         );
-        // The rig hybrid envelope: `response` is text the model also sees; `parts`
-        // carries the image. The part key is camelCase `mimeType` (rig-core 0.34).
-        Ok(json!({
-            "response": note,
-            "parts": [ { "type": "image", "data": data, "mimeType": mime } ],
-        }))
+        // Two typed blocks in one result: the note is text the model also reads,
+        // and the image is a declared `Image` block — no envelope for rig to
+        // re-discover. `run_phase` moves exactly this block onto a user turn on a
+        // transport that can't carry an image inside a tool result.
+        Ok(ToolOutput::content(
+            OneOrMany::many([
+                ToolResultContent::text(note),
+                ToolResultContent::Image(Image {
+                    data: DocumentSourceKind::Base64(data),
+                    media_type: ImageMediaType::from_mime_type(mime),
+                    detail: None,
+                    additional_params: None,
+                }),
+            ])
+            .expect("two blocks is never empty"),
+        ))
     }
 }
 
@@ -205,34 +226,52 @@ impl Tool for ViewImage {
     const NAME: &'static str = "view_image";
     type Error = ViewImageError;
     type Args = ViewImageArgs;
-    type Output = Value;
+    type Output = ToolOutput;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Look at an image file in the project so you can see it \
+    /// Keep the failure text model-visible.
+    ///
+    /// rig 0.41's default (`ToolExecutionError::from_error`) redacts an arbitrary
+    /// source error down to a stable kind-level string — the model would read "the
+    /// tool failed" and nothing else. That is the right default for a tool whose
+    /// errors may carry secrets; it is the wrong one here, because every `ViewImageError` is written *for*
+    /// the model — it names the file, the workspace, and the fix (copy it in, crop it,
+    /// use run_kaish instead), and a model that cannot read it cannot retry correctly.
+    /// The explicit constructor keeps the message model-visible while `with_source`
+    /// preserves the concrete error for operator diagnostics and downcasting.
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        ToolExecutionError::other(error.to_string()).with_source(error)
+    }
+
+    fn description(&self) -> String {
+        "Look at an image file in the project so you can see it \
                           directly — a screenshot, a diagram, a design asset, a \
                           rendered figure. Pass the path to a PNG, JPEG, GIF, or WebP \
                           (relative to the project root, or an absolute path inside \
                           it); the image is loaded into your view. Use this whenever \
                           the question involves what an image shows. For source or \
                           text files, use run_kaish instead."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the image file (PNG/JPEG/GIF/WebP), \
-                                        relative to the project root or absolute inside it."
-                    }
-                },
-                "required": ["path"]
-            }),
-        }
+            .to_string()
     }
 
-    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the image file (PNG/JPEG/GIF/WebP), \
+                                    relative to the project root or absolute inside it."
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    async fn call(
+        &self,
+        _ctx: &mut ToolContext,
+        args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
         self.view(&args.path).await
     }
 }
@@ -300,16 +339,40 @@ mod tests {
         std::fs::write(root.join("shot.png"), &bytes).unwrap();
 
         let tool = ViewImage::new(worker_over(&root), &root);
-        let v = tool.view("shot.png").await.expect("view should succeed");
+        let out = tool.view("shot.png").await.expect("view should succeed");
 
-        // The hybrid envelope rig parses into an image part.
-        assert!(v["response"].as_str().unwrap().contains("image/png"));
-        let part = &v["parts"][0];
-        assert_eq!(part["type"], "image");
-        assert_eq!(part["mimeType"], "image/png");
+        // A declared image block, not a JSON shape rig has to recognize. This is the
+        // assertion that fails if the output ever regresses to the old envelope: rig
+        // 0.41 would carry that to the model as JSON text, and a vision model would
+        // receive base64 instead of a picture.
+        let blocks: Vec<_> = out.as_content().iter().cloned().collect();
+        assert_eq!(blocks.len(), 2, "one text note plus one image: {out:?}");
+        let note = blocks
+            .iter()
+            .find_map(|b| match b {
+                ToolResultContent::Text(t) => Some(t.text.clone()),
+                _ => None,
+            })
+            .expect("the load note rides along as text");
+        assert!(
+            note.contains("image/png"),
+            "the note names the type: {note}"
+        );
+
+        let image = blocks
+            .iter()
+            .find_map(|b| match b {
+                ToolResultContent::Image(i) => Some(i.clone()),
+                _ => None,
+            })
+            .expect("a typed image block reaches the transcript");
+        assert_eq!(image.media_type, Some(ImageMediaType::PNG));
         // The data round-trips to exactly the file's bytes.
+        let DocumentSourceKind::Base64(data) = &image.data else {
+            panic!("the image rides as base64, not a URL: {:?}", image.data);
+        };
         let decoded = base64::engine::general_purpose::STANDARD
-            .decode(part["data"].as_str().unwrap())
+            .decode(data)
             .unwrap();
         assert_eq!(decoded, bytes, "the model sees the real file bytes");
     }
@@ -335,6 +398,18 @@ mod tests {
         assert!(msg.contains("OUTSIDE"), "names the boundary: {msg}");
         assert!(msg.contains("cp "), "suggests copying it in: {msg}");
         assert!(msg.contains("workspace"), "{msg}");
+
+        // …and the model actually reads it. rig 0.41 redacts an arbitrary tool error
+        // down to a stable kind-level string ("the tool failed") unless the tool
+        // overrides `map_error` — which would leave every fix-it message above visible
+        // only to an operator reading a log. These messages exist so the *model* can
+        // act on them, so assert the presentation, not just the `Display`.
+        let mapped = tool.map_error(err);
+        assert_eq!(
+            mapped.model_feedback(),
+            Some(msg.as_str()),
+            "the actionable message must reach the model, not be redacted"
+        );
     }
 
     #[tokio::test]

--- a/src/view_image.rs
+++ b/src/view_image.rs
@@ -10,17 +10,13 @@
 //! deliberately no base64/attach input: if a genuinely-never-a-file image ever needs
 //! viewing, that's added then (see the media-spine entry in `docs/issues.md`).
 //!
-//! **The image part is declared, not sniffed.** Through rig 0.38 this tool returned a
-//! hybrid JSON envelope (`{"response":…, "parts":[{"type":"image",…}]}`) that rig's
-//! `ToolResultContent::from_tool_output` re-parsed out of the tool's *string* output
-//! to discover the image. rig 0.41 removed that guessing — "Rig never reparses strings
-//! to infer rich content" — so a tool that still returned the envelope would hand the
-//! model base64 text labelled JSON and no image at all, silently. The output is now a
-//! typed [`ToolOutput`] carrying a [`ToolResultContent::Text`] note and a
-//! [`ToolResultContent::Image`] block, which is both the supported multimodal path and
-//! a stronger one: the image block that reaches the transcript is the one this tool
-//! constructed, so [`run_phase`](crate::consult)'s user-turn rewrite reads a real
-//! `Image` rather than a JSON shape two crates have to agree on.
+//! **The image part is declared, not sniffed.** The output is a typed [`ToolOutput`]
+//! carrying a [`ToolResultContent::Text`] note and a [`ToolResultContent::Image`]
+//! block. rig does not inspect a tool's text output looking for rich content in it, so
+//! an image described by some JSON convention instead of declared would reach the model
+//! as a wall of base64 — no image, and no error. Declaring it also means
+//! [`run_phase`](crate::consult)'s user-turn rewrite reads the very block this tool
+//! constructed, rather than a shape two crates have to keep agreeing on.
 //!
 //! The tool is only ever placed in a phase's toolset when that phase's [`Arm`]'s
 //! resolved caps say the model is vision-capable (`consult.rs`), so a blind model
@@ -135,10 +131,8 @@ impl ViewImage {
 
     /// The core: resolve → read through the VFS → size-check → sniff → encode → typed
     /// content. Split out of [`Tool::call`] so it's directly testable. Returns a
-    /// [`ToolOutput`] — *not* a `String` or a `Value`: rig 0.41 renders an ordinary
-    /// serializable output as text or JSON and never re-reads it looking for rich
-    /// content, so the image has to be a declared [`ToolResultContent::Image`] block or
-    /// it does not reach the model as an image at all.
+    /// [`ToolOutput`] — *not* a `String` or a `Value`, which rig would render as text or
+    /// JSON; only a declared [`ToolResultContent::Image`] reaches the model as an image.
     async fn view(&self, path_arg: &str) -> Result<ToolOutput, ViewImageError> {
         let canon = self.resolve_in_workspace(path_arg)?;
         // Read at most one byte past the limit: a file swapped to something enormous
@@ -230,14 +224,12 @@ impl Tool for ViewImage {
 
     /// Keep the failure text model-visible.
     ///
-    /// rig 0.41's default (`ToolExecutionError::from_error`) redacts an arbitrary
-    /// source error down to a stable kind-level string — the model would read "the
-    /// tool failed" and nothing else. That is the right default for a tool whose
-    /// errors may carry secrets; it is the wrong one here, because every `ViewImageError` is written *for*
-    /// the model — it names the file, the workspace, and the fix (copy it in, crop it,
-    /// use run_kaish instead), and a model that cannot read it cannot retry correctly.
-    /// The explicit constructor keeps the message model-visible while `with_source`
-    /// preserves the concrete error for operator diagnostics and downcasting.
+    /// rig's default redacts an arbitrary tool error to a kind-level string — the model
+    /// reads "the tool failed" and nothing more. Right for errors that may carry
+    /// secrets, wrong here: every `ViewImageError` is written *for* the model, naming
+    /// the file, the workspace, and the fix (copy it in, crop it, use run_kaish
+    /// instead). A model that can't read it can't retry correctly. `with_source` keeps
+    /// the concrete error for operator diagnostics and downcasting.
     fn map_error(&self, error: Self::Error) -> ToolExecutionError {
         ToolExecutionError::other(error.to_string()).with_source(error)
     }
@@ -341,10 +333,9 @@ mod tests {
         let tool = ViewImage::new(worker_over(&root), &root);
         let out = tool.view("shot.png").await.expect("view should succeed");
 
-        // A declared image block, not a JSON shape rig has to recognize. This is the
-        // assertion that fails if the output ever regresses to the old envelope: rig
-        // 0.41 would carry that to the model as JSON text, and a vision model would
-        // receive base64 instead of a picture.
+        // A declared image block, not a JSON shape rig has to recognize — this is the
+        // assertion that fails if the output ever regresses to describing an image
+        // instead of declaring one, which a vision model receives as base64 text.
         let blocks: Vec<_> = out.as_content().iter().cloned().collect();
         assert_eq!(blocks.len(), 2, "one text note plus one image: {out:?}");
         let note = blocks
@@ -399,11 +390,10 @@ mod tests {
         assert!(msg.contains("cp "), "suggests copying it in: {msg}");
         assert!(msg.contains("workspace"), "{msg}");
 
-        // …and the model actually reads it. rig 0.41 redacts an arbitrary tool error
-        // down to a stable kind-level string ("the tool failed") unless the tool
-        // overrides `map_error` — which would leave every fix-it message above visible
-        // only to an operator reading a log. These messages exist so the *model* can
-        // act on them, so assert the presentation, not just the `Display`.
+        // …and the model actually reads it. Without `map_error`, rig shows the model a
+        // kind-level "the tool failed" and every fix-it message above is visible only
+        // to an operator reading a log. These messages exist so the *model* can act on
+        // them, so assert the presentation, not just the `Display`.
         let mapped = tool.map_error(err);
         assert_eq!(
             mapped.model_feedback(),

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -691,8 +691,8 @@ struct ScriptedModel {
 struct NoStream;
 
 impl rig_core::completion::GetTokenUsage for NoStream {
-    fn token_usage(&self) -> Option<rig_core::completion::Usage> {
-        None
+    fn token_usage(&self) -> rig_core::completion::Usage {
+        rig_core::completion::Usage::new()
     }
 }
 
@@ -1002,7 +1002,7 @@ fn request_has_user_image(req: &rig_core::completion::CompletionRequest) -> bool
 /// calls it on a real file in the tree, and the bytes return as a rig *image part* in
 /// the next turn — not text. The synth can only reach its answer once it has seen the
 /// image, so a green run proves the whole chain: caps → toolset assembly → VFS read
-/// through the read-only kernel → base64 envelope → rig `from_tool_output` → image in
+/// through the read-only kernel → a typed `ToolResultContent::Image` block → image in
 /// model context. The proof of the "all phases" decision, exercised on the `consult`
 /// driver (the synth arm) — where `view_image` rides now.
 #[tokio::test]

--- a/tests/effort_wire.rs
+++ b/tests/effort_wire.rs
@@ -7,8 +7,7 @@
 //! call. rig parses the blob into a typed struct on two of the six wires, and those
 //! structs have a **closed** set of rungs — a ceiling that is *rig's client*, not the
 //! provider's API, and that moves on rig's release schedule rather than the provider's.
-//! rig 0.38 stopped at `xhigh` on the OpenAI Responses wire while OpenAI itself already
-//! accepted `"max"`; rig 0.41 closed that gap. Gemini's ceiling is real and stays.
+//! The two have disagreed before, in both directions.
 //!
 //! So this suite closes the loop with no key and no network: a fake `HttpClientExt`
 //! records the body rig builds, and the test drives a real `CompletionModel` for each
@@ -185,8 +184,8 @@ fn request(params: Option<Value>) -> CompletionRequest {
         tool_choice: None,
         additional_params: params,
         output_schema: None,
-        // rig 0.41 added this: local observability policy, never serialized into a
-        // provider payload, so it cannot affect what this suite measures.
+        // Local observability policy, never serialized into a provider payload, so it
+        // cannot affect what this suite measures.
         record_telemetry_content: false,
     }
 }
@@ -291,26 +290,22 @@ async fn on_the_wire(path: Path, effort: &str) -> Result<Option<Value>, String> 
 /// same: passed through where the wire is passthrough, refused where rig is typed.
 const UNRANKED: &str = "ludicrous";
 
-/// The ceilings, pinned. rig 0.41.0 parses the blob into a typed struct on exactly two
-/// wires, and this is what each accepts today. The list is not a claim about the
-/// providers — it is a claim about *rig*, which is the thing that can refuse a rung
-/// before the request is ever sent. A rig bump that moves either ladder lands here
-/// first, which is the whole point: the last time one moved, we found out from a
-/// failed consult.
+/// The ceilings, pinned. rig parses the blob into a typed struct on exactly two wires,
+/// and this is what each accepts today. The list is not a claim about the providers —
+/// it is a claim about *rig*, the thing that can refuse a rung before the request is
+/// ever sent. A bump that moves either ladder lands here first, which is the whole
+/// point: the last time one moved, we found out from a failed consult.
 ///
-/// **Moved on the 0.38.2 → 0.41.0 bump (2026-08-01): `max` opened on the Responses
-/// wire.** This pin previously stopped at `xhigh` and the comment recorded the gap as
-/// rig's, not OpenAI's — OpenAI's Responses endpoint took `"max"` (probed live
-/// 2026-08-01: 200, echoed back) while `responses_api::ReasoningEffort` did not have
-/// the variant. rig 0.41 added it (`Max`, "supported by the GPT-5.6 model family", rig
-/// PR #2106), so the ladder here is now exactly [`known_efforts`] — kaibo's top rung
-/// reaches hosted GPT-5.6 with no kaibo logic change, because `accepted_efforts`
-/// derives the list by probing rig instead of declaring one. That derivation is why
-/// this test failing was the *only* work the bump needed on this surface.
+/// **Audit log.** 0.38.2 → 0.41.0 (2026-08-01): `max` opened on the Responses wire.
+/// rig had trailed OpenAI by a rung — the endpoint took `"max"` (probed live: 200,
+/// echoed back) while rig's enum lacked the variant — and 0.41 closed the gap, so the
+/// ladder is now exactly [`known_efforts`]. Updating this pin was the *only* work the
+/// bump needed here, because `accepted_efforts` derives the list by probing rig rather
+/// than declaring one.
 ///
 /// Gemini did not move, and should not: `thinkingLevel` is a closed protobuf enum and
-/// Google rejects `none`/`xhigh`/`max` (verified live). A future bump that "widens"
-/// Gemini here is a rig bug, not a feature.
+/// Google rejects `none`/`xhigh`/`max` (verified live). A bump that "widens" Gemini
+/// here is a rig bug, not a feature.
 #[tokio::test]
 async fn rig_effort_ladders_are_pinned() {
     for path in Path::ALL {
@@ -325,8 +320,7 @@ async fn rig_effort_ladders_are_pinned() {
             // This is the landmine: `[defaults] synth_effort = "xhigh"` broke every
             // Gemini cast, and every offline test stayed green.
             EffortWire::Gemini => vec!["minimal", "low", "medium", "high"],
-            // rig's `responses_api::ReasoningEffort` — as of 0.41, level with OpenAI's
-            // own ladder, `max` included.
+            // rig's `responses_api::ReasoningEffort` — level with OpenAI's own ladder.
             EffortWire::OpenaiResponses => {
                 vec!["none", "minimal", "low", "medium", "high", "xhigh", "max"]
             }

--- a/tests/effort_wire.rs
+++ b/tests/effort_wire.rs
@@ -4,10 +4,11 @@
 //! rig. Every unit test around that shaping asserts the shape of kaibo's own blob —
 //! which is exactly why a live landmine sat there unnoticed: nothing handed the blob to
 //! rig, so `effort = "xhigh"` on a Gemini slot stayed green in CI and died on every
-//! call. rig 0.38 parses the blob into a typed struct on two of the six wires, and those
-//! structs have a **closed** set of rungs. That ceiling is *rig's client*, not the
-//! provider's API — OpenAI's own Responses endpoint accepts `"max"` (probed live
-//! 2026-08-01: 200, echoed back) while rig's `ReasoningEffort` enum stops at `xhigh`.
+//! call. rig parses the blob into a typed struct on two of the six wires, and those
+//! structs have a **closed** set of rungs — a ceiling that is *rig's client*, not the
+//! provider's API, and that moves on rig's release schedule rather than the provider's.
+//! rig 0.38 stopped at `xhigh` on the OpenAI Responses wire while OpenAI itself already
+//! accepted `"max"`; rig 0.41 closed that gap. Gemini's ceiling is real and stays.
 //!
 //! So this suite closes the loop with no key and no network: a fake `HttpClientExt`
 //! records the body rig builds, and the test drives a real `CompletionModel` for each
@@ -184,6 +185,9 @@ fn request(params: Option<Value>) -> CompletionRequest {
         tool_choice: None,
         additional_params: params,
         output_schema: None,
+        // rig 0.41 added this: local observability policy, never serialized into a
+        // provider payload, so it cannot affect what this suite measures.
+        record_telemetry_content: false,
     }
 }
 
@@ -287,11 +291,26 @@ async fn on_the_wire(path: Path, effort: &str) -> Result<Option<Value>, String> 
 /// same: passed through where the wire is passthrough, refused where rig is typed.
 const UNRANKED: &str = "ludicrous";
 
-/// The ceilings, pinned. rig 0.38.2 parses the blob into a typed struct on exactly two
+/// The ceilings, pinned. rig 0.41.0 parses the blob into a typed struct on exactly two
 /// wires, and this is what each accepts today. The list is not a claim about the
-/// providers — OpenAI's Responses API takes `"max"` on the wire; rig's enum does not.
-/// A rig bump that moves either ladder lands here first, which is the whole point: the
-/// last time one moved, we found out from a failed consult.
+/// providers — it is a claim about *rig*, which is the thing that can refuse a rung
+/// before the request is ever sent. A rig bump that moves either ladder lands here
+/// first, which is the whole point: the last time one moved, we found out from a
+/// failed consult.
+///
+/// **Moved on the 0.38.2 → 0.41.0 bump (2026-08-01): `max` opened on the Responses
+/// wire.** This pin previously stopped at `xhigh` and the comment recorded the gap as
+/// rig's, not OpenAI's — OpenAI's Responses endpoint took `"max"` (probed live
+/// 2026-08-01: 200, echoed back) while `responses_api::ReasoningEffort` did not have
+/// the variant. rig 0.41 added it (`Max`, "supported by the GPT-5.6 model family", rig
+/// PR #2106), so the ladder here is now exactly [`known_efforts`] — kaibo's top rung
+/// reaches hosted GPT-5.6 with no kaibo logic change, because `accepted_efforts`
+/// derives the list by probing rig instead of declaring one. That derivation is why
+/// this test failing was the *only* work the bump needed on this surface.
+///
+/// Gemini did not move, and should not: `thinkingLevel` is a closed protobuf enum and
+/// Google rejects `none`/`xhigh`/`max` (verified live). A future bump that "widens"
+/// Gemini here is a rig bug, not a feature.
 #[tokio::test]
 async fn rig_effort_ladders_are_pinned() {
     for path in Path::ALL {
@@ -306,9 +325,10 @@ async fn rig_effort_ladders_are_pinned() {
             // This is the landmine: `[defaults] synth_effort = "xhigh"` broke every
             // Gemini cast, and every offline test stayed green.
             EffortWire::Gemini => vec!["minimal", "low", "medium", "high"],
-            // rig's `responses_api::ReasoningEffort` — stops one rung short of OpenAI's.
+            // rig's `responses_api::ReasoningEffort` — as of 0.41, level with OpenAI's
+            // own ladder, `max` included.
             EffortWire::OpenaiResponses => {
-                vec!["none", "minimal", "low", "medium", "high", "xhigh"]
+                vec!["none", "minimal", "low", "medium", "high", "xhigh", "max"]
             }
             // `#[serde(flatten)]` all the way down: kaibo can express anything and the
             // provider is the one that answers for it.

--- a/tests/explore_send.rs
+++ b/tests/explore_send.rs
@@ -13,11 +13,11 @@
 use kaibo::consult::RunExplore;
 
 fn assert_send_sync<T: Send + Sync>() {}
-fn assert_is_tool<T: rig_core::tool::Tool>() {}
+fn assert_is_tool<T: rig_agent::tool::Tool>() {}
 
 #[test]
 fn run_explore_is_a_send_sync_rig_tool() {
-    // Send + Sync so it can be a `Box<dyn ToolDyn>` in a consult toolset.
+    // Send + Sync so it can back a `DynamicTool` in a consult toolset.
     assert_send_sync::<RunExplore>();
     // `Tool` — and the trait's `call -> impl Future + Send` bound is checked at the
     // impl site, so this also proves the nested-agent future is Send.


### PR DESCRIPTION
Upgrades `rig-core` three minor versions and adopts the `rig-agent` crate the agent
runtime moved into. The reason to do it now is one line in rig's changelog:

## `effort = "max"` becomes reachable

rig 0.41 adds `ReasoningEffort::Max`, documented as *"supported by the GPT-5.6 model
family"*. kaibo already had `max` on `EFFORT_LADDER`; what blocked it was rig's typed
enum stopping at `xhigh`, which PR #112 diagnosed and turned into an actionable
refusal rather than a bare serde error.

**No kaibo logic changed to gain the rung.** `accepted_efforts` derives each wire's
ladder by *probing rig* instead of restating it, so the new variant is picked up for
free. The only work was updating the pin that exists to fail on exactly this event.
That design decision is now proven on its first real bump.

0.41 also adds `ReasoningMode::Pro` and `ReasoningContext`, both reachable through the
existing `{"reasoning": {...}}` blob with no new plumbing. Not wired up here.

## Dependency shape: `rig-core` + `rig-agent`, deliberately not the `rig` facade

The facade would read more cleanly and would have quietly broken the static musl build.
Its `rustls` feature fans out to the vector-store companions — `rig-fastembed?/hf-hub-rustls-tls`,
`rig-helixdb?/rustls`, `rig-lancedb?/rig-rustls`, `rig-milvus?/rustls` — **a fourth
route by which aws-lc re-enters the tree**, beside the three our `Cargo.toml` comments
already name. Taking the two crates directly avoids it: `rig-agent` depends on
`rig-core` with `default-features = false`, so the existing invariant comment stays
true. It's been rewritten to describe the new shape, with the reasoning inline.

Verified empty on host **and** `x86_64-unknown-linux-musl`: `aws-lc-rs`, `aws-lc-sys`,
`openssl-sys`, `mimalloc`.

## Two silent regressions the test suite caught

Neither was in the pre-migration inventory. Both would have shipped as *silence*, which
is the failure class this codebase is built to refuse:

1. **`view_image` would have stopped showing images.** 0.41 removed
   `ToolResultContent::from_tool_output` ("Rig never reparses strings to infer rich
   content"), so our `{"response":…,"parts":[…]}` envelope would have reached a vision
   model as base64 text labelled JSON — **with no error anywhere**. Tools now return
   declared `Text` + `Image` blocks, which is also sturdier: the block `run_phase`'s
   user-turn rewrite reads is the one the tool constructed.

2. **Tool errors would have stopped being actionable.** `ToolExecutionError::from_error`
   redacts to a kind-level string, so a model reads only "the tool failed".
   `a_failed_sweep_surfaces_and_the_driver_recovers` failed exactly as designed: the
   driver couldn't see a dead sweep, burned all 200 turns, and died on the finalize
   turn. All three tools now override `map_error`.

## Both rig tripwires fired, and both were answered rather than silenced

- `rig_effort_ladders_are_pinned` — the Responses ladder is now exactly `known_efforts()`.
  The doc comment records this as rig catching up to OpenAI, dated, and notes that a
  future *widening* of Gemini's `ThinkingLevel` would be a rig bug, since Google's own
  schema refuses those rungs.
- `rig_bump_reaudits_the_openrouter_budget_workaround` — **the defect persists through
  0.41**, measured rather than assumed: a real 0.41 model with `max_tokens = Some(4096)`
  still serializes only `messages`/`model`/`reasoning`. `inject_output_budget` stays, and
  the measurement is written into the test doc and `docs/issues.md` so the next bump
  doesn't re-derive it.

## Deliberately out of scope

- **The token-usage undercount.** An earlier assessment claimed `PromptResponse.completion_calls`
  would fix it. That was wrong: `completion_calls` exists only on the `Ok` path, which was
  already exact. The real fix is a tally hook on `AgentHook::on_completion_response`, and its
  plumbing lands in `finalize_after_max_turns` — code another branch is actively changing.
  Recorded in `docs/issues.md` for whoever is next in there.
- **Telemetry**, where the diagnosis changed under 0.41 and is worth writing down: rig now
  *deliberately refuses* to record onto a span it did not create (`created_agent_span`), and
  `record_telemetry_content` defaults to **false**. So the earlier "declare the missing fields
  on `run_phase`" theory would not have worked — that path isn't even reached. Per-completion
  telemetry is not lost; rig declines adoption and builds a fresh `rig::completions` child
  span under `run_phase`, which degrades safely by design.

## Note for reviewers holding other branches

`engine.rs` changed a lot, but **answer extraction was left untouched** —
`Ok(resp) => return Ok((resp.output, resp.usage))` and `finalize_after_max_turns`'s
`.map()` are not in this diff, so the in-flight empty-answer work reconciles cleanly.
Changed regions: imports (12-25), `Arm::openrouter_completion_model` (~426, now generic
over `H`), `ViewImageBreakHook` (~558-612, `PromptHook<M>` → `AgentHook`), the two call
chains at ~863 and ~944 (`.prompt().extended_details()` → `.runner().run()`, `.tools()`
→ `.dynamic_tools()`), `RunExplore`'s `Tool` impl (~1087-1122), toolset signatures
(1248, 1283), and the test module.

No preamble or tool-description wording changed (a parallel branch owns that); the two
description literals were only re-indented when `definition()` was split, contents
byte-identical.

788 passed / 0 failed / 20 ignored. `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
