### PR TITLE
feat: see the provider's finish_reason on every turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,20 @@ project and cannot run external commands.
   into the generic entry points (`run_phase`, `consult_with`, `consult_session_turn`),
   while the public `consult`/`oneshot` run on arms the server resolves with
   `Arm::from_slot` — the single live construction point that wraps the real rig client.
+  The scripted model's `Response` is a bare `serde_json::Value`, so a responder can hand
+  back any provider's *raw* payload shape (`with_raw`) — that's what drives
+  `completion_watch` offline.
+- **Seeing what the provider said.** rig's agent hook is medium-neutral (content, usage,
+  no `raw_response`), so `finish_reason` never reaches kaibo through it. `Watched`
+  (`src/completion_watch.rs`) wraps the *model* instead — `traced`'s sibling, a
+  transparent `CompletionModel` — recording each turn into a per-call `CompletionLog`
+  that `run_phase_logged` hands back, tool-loop turns included, and the last turn's
+  reason onto the `run_phase` span. Provider-agnostic by construction: the reason is read
+  out of the serialized raw response under the spellings providers ship, so an unknown
+  shape degrades to `None` instead of needing a new match arm. The single-shot phases
+  (`oneshot`, `deliberate` direct) skip the agent entirely via `Arm::complete` — one
+  request, built with rig's own `CompletionRequestBuilder` so both paths move together on
+  a rig bump.
 - **`docs/issues.md` is the live tracker** — open work only, kept cheap to skim
   before new work. Delete entries when they ship; don't mark them done.
 - **`docs/devlog.md`** is a durable narrative from the agent's perspective — write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **Traces now say how each model turn *ended*.** A `run_phase` span carries
+  `gen_ai.response.finish_reason` — the provider's own word for why generation stopped
+  (`end_turn`, `max_tokens`, `content_filter`, Gemini's `MAX_TOKENS`, OpenAI Responses'
+  `max_output_tokens`). Providers have always reported it; rig's agent layer discarded it
+  before kaibo could look, which is why a consult that came back empty was
+  indistinguishable from one that was truncated or refused by a classifier. kaibo now
+  observes every completion on its way past — the turns *inside* the tool loop included —
+  with no per-provider code, and an unfamiliar response shape simply reports nothing
+  rather than breaking the call.
+
 - **`effort = "max"` now reaches hosted GPT-5.6.** kaibo has always accepted `max` as a
   rung and always sent it faithfully; the wall was rig's, whose typed OpenAI Responses
   request stopped one rung short of OpenAI's own API and refused `max` before the
@@ -37,6 +47,13 @@ record. Each later release appends a new section at the top.
   all three.
 
 ### Changed
+
+- **`oneshot` and `deliberate`'s direct lane are now one literal request.** Both are
+  toolless by definition — the caller owns the context — but both reached the provider
+  through the managed tool loop carrying an empty toolset, arriving at the same place by
+  a longer road. They now ask the model directly. Same preamble, same params, same
+  answer, same token accounting; the request that goes out is proven request-for-request
+  identical to the one the loop built.
 
 - **Batch treats `effort` as a floor, not an override.** Every other batch knob
   already worked this way: `max_tokens` and the thinking budget rise to a batch

--- a/src/completion_watch.rs
+++ b/src/completion_watch.rs
@@ -1,0 +1,564 @@
+//! One record per completion. Wrap a phase's completion model so every turn's
+//! provider response is *seen* on its way past — most of all the **finish reason**,
+//! which rig's agent layer discards before kaibo can read it.
+//!
+//! The gap this closes: `rig_core::completion::CompletionResponse<T>` carries
+//! `raw_response: T`, the untouched provider payload, but the agent hook event
+//! (`rig-agent`'s `CompletionCall`) is a deliberately medium-neutral shape — prompt,
+//! content, usage, message id, and no raw response. So a consult that came back
+//! empty was reported as a plain success and nothing on the wire could tell an early
+//! stop from a `content_filter` refusal from a truncation. `CompletionModel` is a
+//! *trait*, and `Agent<M: CompletionModel>` is generic over it, so wrapping the model
+//! the loop calls puts us on the one path every turn takes — including the turns
+//! *inside* the tool loop, which no hook reaches.
+//!
+//! This is [`crate::tool_span`]'s sibling: `traced` wraps a tool so each call is
+//! observed, [`watched`] wraps a model so each completion is. Both are transparent —
+//! [`Watched`] forwards `completion`/`stream` verbatim and returns the provider's
+//! response and errors untouched, so nothing about a call changes except that we now
+//! know how it ended.
+//!
+//! **Provider-agnostic by construction, not by a match arm per backend.** The trait
+//! bounds require `type Response: Serialize + DeserializeOwned`, so the wrapper
+//! serializes the raw response and reads the finish reason out of the JSON under the
+//! spellings providers actually ship ([`finish_reason`]). An unfamiliar shape yields
+//! `None` — "we don't know", never a broken call — which is the right degrade for a
+//! gateway or a provider rig grows next month.
+//!
+//! **What we keep, and what we let go.** Per turn: the finish reason, the reported
+//! [`Usage`], and two cheap counts read straight off `choice` (assistant text length,
+//! tool calls emitted) — together they say "this turn produced nothing, and here is
+//! why". We deliberately do *not* retain the raw JSON: it rides every turn of every
+//! phase and carries the full assistant message (and, on some providers, the echoed
+//! reasoning), so holding it would grow with the transcript for a payload nothing
+//! reads. The extraction is the point; the haystack is not worth keeping.
+
+use std::sync::{Arc, Mutex};
+
+use rig_core::completion::message::AssistantContent;
+use rig_core::completion::{
+    CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Usage,
+};
+use serde::Serialize;
+use serde_json::Value;
+
+/// The field names a provider spells its finish reason with, in preference order.
+///
+/// Confirmed against the vendored rig-core 0.41 provider sources rather than
+/// guessed — each entry names where it lives:
+///
+/// - `finish_reason` — the OpenAI-compatible chat-completions `Choice`
+///   (`providers/openai/completion/mod.rs`, `providers/deepseek.rs`,
+///   `providers/openrouter/completion.rs`), nested under `choices[]`. OpenRouter
+///   carries a `native_finish_reason` beside it; we take the normalized one.
+/// - `stop_reason` — Anthropic's Messages response, at the top level
+///   (`providers/anthropic/completion.rs`). `Option<String>`, so it can be null.
+/// - `finishReason` — Gemini's `ContentCandidate` under `candidates[]`, camelCased
+///   by `#[serde(rename_all = "camelCase")]`, with `SCREAMING_SNAKE_CASE` values
+///   (`STOP`, `MAX_TOKENS`, `SAFETY`, …) (`providers/gemini/completion.rs`).
+/// - `stopReason` — the camelCase spelling an Anthropic-compatible gateway may use.
+/// - `incomplete_details` / `incompleteDetails` — OpenAI's **Responses** API, which
+///   has no finish-reason field at all: it reports `status` plus, when the run did
+///   not finish cleanly, `incomplete_details: { reason: "max_output_tokens" | … }`
+///   (`providers/openai/responses_api/mod.rs`). We read that object's `reason`, so a
+///   *completed* Responses call reports no finish reason — absence is the normal
+///   stop there. `status` is deliberately left out: `"completed"` is noise as a
+///   finish reason, and the word also appears on per-item tool statuses deeper in
+///   the same payload.
+const FINISH_KEYS: &[&str] = &[
+    "finish_reason",
+    "stop_reason",
+    "finishReason",
+    "stopReason",
+    "incomplete_details",
+    "incompleteDetails",
+];
+
+/// How deep to look for a finish reason. Every shape above puts it at depth 0
+/// (Anthropic), 1 (the Responses object), or 2 (`choices[]` / `candidates[]`); the
+/// cap keeps an unfamiliar payload from turning observation into a deep walk.
+const MAX_DEPTH: usize = 4;
+
+/// Read a provider's finish reason out of its serialized raw response.
+///
+/// Breadth-first, so the shallowest match wins — Anthropic's top-level `stop_reason`
+/// is found before anything nested, and an OpenAI-compatible `choices[0]` is reached
+/// on the next level. A key whose value is a string *is* the reason; a key whose
+/// value is an object with a string `reason` (OpenAI Responses' `incomplete_details`)
+/// yields that. Anything else — a null (Anthropic's unfinished case), a missing key,
+/// a shape we've never seen — keeps the search going and finally yields `None`.
+///
+/// Returning `None` is a real answer: "this response reports no finish reason".
+/// It is what an unknown provider degrades to, and it is what a clean OpenAI
+/// Responses call genuinely says.
+pub fn finish_reason(raw: &Value) -> Option<String> {
+    let mut frontier = vec![raw];
+    for _ in 0..=MAX_DEPTH {
+        let mut next: Vec<&Value> = Vec::new();
+        for node in frontier {
+            match node {
+                Value::Object(map) => {
+                    for key in FINISH_KEYS {
+                        match map.get(*key) {
+                            Some(Value::String(s)) => return Some(s.clone()),
+                            // `incomplete_details: { reason: "max_output_tokens" }`
+                            Some(Value::Object(inner)) => {
+                                if let Some(Value::String(s)) = inner.get("reason") {
+                                    return Some(s.clone());
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    next.extend(map.values());
+                }
+                Value::Array(items) => next.extend(items.iter()),
+                _ => {}
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+    None
+}
+
+/// What one completion told us, once the provider-specific wrapping is off.
+///
+/// `finish_reason` is the reason this exists — the field that separates "the model
+/// answered" from "the provider truncated us" from "a classifier refused". The rest
+/// is the cheap context that makes it actionable: an empty answer with
+/// `text_chars = 0`, `tool_calls = 0`, and `finish_reason = Some("content_filter")`
+/// is a diagnosis, where any one of the three alone is a guess.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TurnRecord {
+    /// The provider's own word for why generation stopped, verbatim — `"stop"`,
+    /// `"max_tokens"`, `"MAX_TOKENS"`, `"content_filter"`, `"tool_use"`, … Never
+    /// normalized: the vocabulary differs per provider and flattening it would throw
+    /// away exactly the detail a diagnosis needs. `None` means this response reported
+    /// none (see [`finish_reason`]).
+    pub finish_reason: Option<String>,
+    /// The token usage the provider reported for *this* completion. rig sums these
+    /// across a run; here they stay per turn, so a run's spend can be read turn by
+    /// turn. Zero-valued is rig's documented "the provider reported nothing".
+    pub usage: Usage,
+    /// Characters of assistant text this turn emitted (0 for a pure tool-call turn,
+    /// and for the empty answer this module exists to explain).
+    pub text_chars: usize,
+    /// Tool calls this turn emitted.
+    pub tool_calls: usize,
+}
+
+impl TurnRecord {
+    /// Read one response. The raw payload is serialized here and dropped immediately;
+    /// only the extraction survives (see the module doc on what we keep).
+    ///
+    /// A raw response that refuses to serialize degrades to "no finish reason" and a
+    /// debug log — observation must never fail a completion the caller already paid
+    /// for. That is the *only* thing this swallows, and it is loud in the log.
+    fn observe<T: Serialize>(response: &CompletionResponse<T>) -> Self {
+        let raw = match serde_json::to_value(&response.raw_response) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::debug!(
+                    %error,
+                    "raw provider response would not serialize; finish reason unavailable"
+                );
+                Value::Null
+            }
+        };
+        let mut text_chars = 0;
+        let mut tool_calls = 0;
+        for content in response.choice.iter() {
+            match content {
+                AssistantContent::Text(text) => text_chars += text.text.chars().count(),
+                AssistantContent::ToolCall(_) => tool_calls += 1,
+                _ => {}
+            }
+        }
+        Self {
+            finish_reason: finish_reason(&raw),
+            usage: response.usage,
+            text_chars,
+            tool_calls,
+        }
+    }
+}
+
+/// The per-call slot [`Watched`] records into: every completion of one phase, in
+/// order. Cheaply cloneable and `Send + Sync`, because the model is cloned into each
+/// agent rig builds (once per loop iteration, again for the forced final turn) and
+/// every clone must land in the *same* log.
+///
+/// **Scoped to one call, never global.** A phase makes its own log and hands it to
+/// its own wrapper, so two concurrent consults never see each other's turns. It has
+/// nothing to do with the kaish kernel — the log holds plain data, crosses `.await`
+/// freely, and never touches the `!Send` kernel behind `KaishWorker`.
+#[derive(Clone, Default, Debug)]
+pub struct CompletionLog(Arc<Mutex<Vec<TurnRecord>>>);
+
+impl CompletionLog {
+    /// An empty log for one phase call.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every completion recorded so far, oldest first — tool-loop turns included.
+    pub fn turns(&self) -> Vec<TurnRecord> {
+        self.0.lock().expect("completion log poisoned").clone()
+    }
+
+    /// The most recent completion — the turn that produced the answer (or failed to).
+    pub fn last(&self) -> Option<TurnRecord> {
+        self.0
+            .lock()
+            .expect("completion log poisoned")
+            .last()
+            .cloned()
+    }
+
+    /// The most recent completion's finish reason, if it reported one. The one-liner
+    /// a caller reaches for when asking "why did this answer come back empty?".
+    pub fn last_finish_reason(&self) -> Option<String> {
+        self.last().and_then(|turn| turn.finish_reason)
+    }
+
+    /// How many completions this phase has made — every turn of the tool loop, plus
+    /// any forced final turn.
+    pub fn len(&self) -> usize {
+        self.0.lock().expect("completion log poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn push(&self, turn: TurnRecord) {
+        self.0.lock().expect("completion log poisoned").push(turn);
+    }
+}
+
+/// A completion model that records what each response reported, then hands the
+/// response back untouched.
+///
+/// Pure passthrough by construction: `completion` awaits the inner model, reads the
+/// response, and returns the very same `Ok`/`Err`. Output, usage, `message_id`,
+/// `raw_response`, and every error are identical to the unwrapped model's — the only
+/// difference is that a [`TurnRecord`] landed in the log.
+#[derive(Clone, Debug)]
+pub struct Watched<M> {
+    inner: M,
+    log: CompletionLog,
+}
+
+impl<M> Watched<M> {
+    /// Wrap `model` so its completions record into `log`.
+    pub fn new(model: M, log: CompletionLog) -> Self {
+        Self { inner: model, log }
+    }
+}
+
+/// Wrap a completion model so every turn records into `log` — the drop-in at an
+/// agent-builder call site, mirroring [`traced`](crate::tool_span::traced) for tools.
+pub fn watched<M: CompletionModel>(model: M, log: CompletionLog) -> Watched<M> {
+    Watched::new(model, log)
+}
+
+impl<M: CompletionModel> CompletionModel for Watched<M> {
+    type Response = M::Response;
+    type StreamingResponse = M::StreamingResponse;
+    type Client = M::Client;
+
+    /// Unreachable, and loudly so. `make` is only ever called through
+    /// `CompletionClient::completion_model`, and no client's `CompletionModel` is a
+    /// `Watched` — kaibo always wraps an already-built model with [`watched`]. Building
+    /// one here would have to invent a log nobody holds, silently discarding every
+    /// observation; a panic names the correct constructor instead.
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        unreachable!("Watched is built by `watched(model, log)`, never by CompletionModel::make")
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        let response = self.inner.completion(request).await?;
+        self.log.push(TurnRecord::observe(&response));
+        Ok(response)
+    }
+
+    /// Forwarded verbatim. kaibo drives the non-streaming loop, so nothing here calls
+    /// this today; a streamed response reports its finish reason through rig's own
+    /// stream events rather than a single raw payload, so wrapping it would be a
+    /// different job than this one.
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<
+        rig_core::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
+        CompletionError,
+    > {
+        self.inner.stream(request).await
+    }
+
+    /// Forwarded: this is a provider capability, and the wrapper must not change what
+    /// rig believes the model can do.
+    fn composes_native_output_with_tools(&self) -> bool {
+        self.inner.composes_native_output_with_tools()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{
+        provider_error, text_response, tool_call_response, usage, with_raw, with_usage,
+        ScriptedClient, ScriptedModel,
+    };
+    use rig_core::client::CompletionClient;
+    use rig_core::message::Message;
+    use rig_core::OneOrMany;
+    use serde_json::json;
+
+    /// A one-turn request, the shape rig's agent builds for a toolless call.
+    fn req() -> CompletionRequest {
+        CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(Message::user("q")),
+            documents: Vec::new(),
+            tools: Vec::new(),
+            temperature: None,
+            max_tokens: Some(64),
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+            record_telemetry_content: false,
+        }
+    }
+
+    /// A scripted model whose every call answers with `respond`.
+    fn model<F>(respond: F) -> ScriptedModel
+    where
+        F: Fn(&CompletionRequest) -> Result<CompletionResponse<Value>, CompletionError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        ScriptedClient::builder()
+            .on_model("m", respond)
+            .build()
+            .completion_model("m")
+    }
+
+    /// The shape each provider's raw response takes on the wire, as rig's own
+    /// response structs serialize it — the fixtures the extractor must handle.
+    /// Trimmed to the fields under test; the nesting is the real nesting.
+    fn anthropic_raw(stop: Value) -> Value {
+        json!({
+            "id": "msg_1",
+            "model": "claude-sonnet-4-6",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "stop_reason": stop,
+            "stop_sequence": null,
+            "usage": {"input_tokens": 3, "output_tokens": 1}
+        })
+    }
+
+    fn openai_raw(finish: &str) -> Value {
+        json!({
+            "id": "chatcmpl-1",
+            "model": "gpt-5.6",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "logprobs": null,
+                "finish_reason": finish
+            }]
+        })
+    }
+
+    fn gemini_raw(finish: &str) -> Value {
+        json!({
+            "candidates": [{
+                "content": {"parts": [{"text": "hi"}], "role": "model"},
+                "finishReason": finish
+            }],
+            "usageMetadata": {"promptTokenCount": 3}
+        })
+    }
+
+    /// The OpenAI **Responses** wire, which has no finish-reason field: a clean run
+    /// is `status: completed` with `incomplete_details: null`; a truncated one names
+    /// its reason there.
+    fn responses_raw(incomplete: Value) -> Value {
+        json!({
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 1,
+            "status": if incomplete.is_null() { "completed" } else { "incomplete" },
+            "error": null,
+            "incomplete_details": incomplete,
+            "model": "gpt-5.6-terra",
+            "output": [{"type": "message", "status": "completed",
+                        "content": [{"type": "output_text", "text": "hi"}]}]
+        })
+    }
+
+    /// The whole point, across the spellings kaibo's five provider kinds actually
+    /// ship: one extractor, no per-provider branch, each nesting found where it
+    /// really sits.
+    #[test]
+    fn reads_the_finish_reason_from_every_provider_spelling() {
+        // Anthropic: `stop_reason`, top level.
+        assert_eq!(
+            finish_reason(&anthropic_raw(json!("max_tokens"))),
+            Some("max_tokens".to_string())
+        );
+        // OpenAI-compatible chat completions (openai, deepseek): `choices[].finish_reason`.
+        assert_eq!(
+            finish_reason(&openai_raw("content_filter")),
+            Some("content_filter".to_string())
+        );
+        // Gemini: camelCased, SCREAMING_SNAKE valued, under `candidates[]`.
+        assert_eq!(
+            finish_reason(&gemini_raw("MAX_TOKENS")),
+            Some("MAX_TOKENS".to_string())
+        );
+        // OpenAI Responses: the reason hides inside `incomplete_details`.
+        assert_eq!(
+            finish_reason(&responses_raw(json!({"reason": "max_output_tokens"}))),
+            Some("max_output_tokens".to_string())
+        );
+    }
+
+    /// OpenRouter reports both a normalized and a native reason on the same choice.
+    /// We take the normalized one — the vocabulary the other four kinds share.
+    #[test]
+    fn prefers_the_normalized_reason_over_openrouter_native() {
+        let raw = json!({
+            "choices": [{
+                "index": 0,
+                "native_finish_reason": "COMPLETE",
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop"
+            }]
+        });
+        assert_eq!(finish_reason(&raw), Some("stop".to_string()));
+    }
+
+    /// An unrecognized payload — a gateway rig has never seen, a provider that
+    /// reports nothing, Anthropic's null, a clean Responses call — degrades to "no
+    /// finish reason". Never an error, never a guess.
+    #[test]
+    fn an_unknown_shape_degrades_to_no_finish_reason() {
+        assert_eq!(finish_reason(&json!({"result": "who knows"})), None);
+        assert_eq!(finish_reason(&Value::Null), None);
+        assert_eq!(finish_reason(&json!([1, 2, 3])), None);
+        // The unit raw response our scripted client uses.
+        assert_eq!(finish_reason(&json!(null)), None);
+        // Anthropic's `stop_reason: null` — present, unset.
+        assert_eq!(finish_reason(&anthropic_raw(Value::Null)), None);
+        // A completed Responses call genuinely reports none.
+        assert_eq!(finish_reason(&responses_raw(Value::Null)), None);
+    }
+
+    /// A finish reason buried past the cap isn't hunted for — observation stays
+    /// cheap on a payload we don't recognize.
+    #[test]
+    fn the_search_is_depth_capped() {
+        let mut deep = json!({"finish_reason": "stop"});
+        for _ in 0..MAX_DEPTH + 1 {
+            deep = json!({ "nested": deep });
+        }
+        assert_eq!(finish_reason(&deep), None);
+    }
+
+    /// Drive the wrapper the way rig does — one `completion()` call — and prove it
+    /// changes nothing observable: same content, same usage, same `message_id`, same
+    /// raw response. Only the log is new.
+    #[tokio::test]
+    async fn the_wrapper_is_a_pure_passthrough() {
+        let model = model(|_req| {
+            Ok(with_raw(
+                with_usage(text_response("the answer"), usage(11, 7)),
+                openai_raw("stop"),
+            ))
+        });
+
+        let bare = model.completion(req()).await.expect("bare completion");
+        let log = CompletionLog::new();
+        let wrapped = watched(model.clone(), log.clone())
+            .completion(req())
+            .await
+            .expect("wrapped completion");
+
+        assert_eq!(
+            serde_json::to_value(&wrapped.choice).unwrap(),
+            serde_json::to_value(&bare.choice).unwrap(),
+            "the wrapper must not touch the content"
+        );
+        assert_eq!(wrapped.usage, bare.usage, "usage passes through");
+        assert_eq!(
+            wrapped.message_id, bare.message_id,
+            "message id passes through"
+        );
+        assert_eq!(
+            wrapped.raw_response, bare.raw_response,
+            "the raw provider response is handed back untouched"
+        );
+        assert_eq!(
+            log.turns(),
+            vec![TurnRecord {
+                finish_reason: Some("stop".to_string()),
+                usage: usage(11, 7),
+                text_chars: "the answer".len(),
+                tool_calls: 0,
+            }],
+            "one turn recorded, with the reason the provider gave"
+        );
+    }
+
+    /// An error from the provider stays an error, verbatim, and records nothing —
+    /// there is no response to read.
+    #[tokio::test]
+    async fn an_error_passes_through_unchanged() {
+        let model = model(|_req| Err(provider_error("overloaded_error")));
+        let log = CompletionLog::new();
+
+        let bare = model.completion(req()).await;
+        let wrapped = watched(model.clone(), log.clone()).completion(req()).await;
+
+        assert_eq!(
+            format!("{:?}", wrapped.unwrap_err()),
+            format!("{:?}", bare.unwrap_err()),
+            "the provider's error reaches the caller unchanged"
+        );
+        assert!(log.is_empty(), "a failed call records no turn");
+    }
+
+    /// A tool-call turn is recorded too — no text, one call, and whatever the
+    /// provider said about stopping. This is the turn a hook could see only in a
+    /// medium-neutral form, and the loop's inner turns are all this shape.
+    #[tokio::test]
+    async fn a_tool_call_turn_is_recorded_with_no_text() {
+        let model = model(|_req| {
+            Ok(with_raw(
+                tool_call_response("c1", "run_kaish", json!({"script": "ls"})),
+                anthropic_raw(json!("tool_use")),
+            ))
+        });
+        let log = CompletionLog::new();
+        watched(model, log.clone())
+            .completion(req())
+            .await
+            .expect("completion");
+
+        let turn = log.last().expect("one turn");
+        assert_eq!(turn.finish_reason.as_deref(), Some("tool_use"));
+        assert_eq!(turn.text_chars, 0);
+        assert_eq!(turn.tool_calls, 1);
+    }
+}

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -27,6 +27,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::attach::Attachment;
+use crate::completion_watch::{watched, CompletionLog, Watched};
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot};
 use crate::credentials::ProviderKind;
 use crate::explorer::RunKaish;
@@ -75,6 +76,19 @@ trait PhaseRunner: Send + Sync {
         make_tools: ToolFactory<'a>,
         break_on_view_image: bool,
     ) -> PhaseFuture<'a>;
+
+    /// One completion, straight to the provider — no agent, no tool loop. The
+    /// single-shot phases (`oneshot`, `deliberate`'s direct lane) are exactly one
+    /// upstream request by definition, so they say so instead of asking a tool loop
+    /// to arrive at the same place with an empty toolset. See [`run_completion`].
+    fn complete<'a>(
+        &'a self,
+        preamble: &'a str,
+        max_tokens: u64,
+        temperature: Option<f64>,
+        prompt: Message,
+        params: Option<&'a Value>,
+    ) -> PhaseFuture<'a>;
 }
 
 /// The concrete pre-built completion model behind the [`PhaseRunner`] vtable.
@@ -118,6 +132,29 @@ where
             make_tools,
             break_on_view_image,
         ))
+    }
+
+    fn complete<'a>(
+        &'a self,
+        preamble: &'a str,
+        max_tokens: u64,
+        temperature: Option<f64>,
+        prompt: Message,
+        params: Option<&'a Value>,
+    ) -> PhaseFuture<'a> {
+        Box::pin(async move {
+            run_completion(
+                &self.model,
+                &self.name,
+                &CompletionLog::new(),
+                preamble,
+                max_tokens,
+                temperature,
+                prompt,
+                params,
+            )
+            .await
+        })
     }
 }
 
@@ -474,6 +511,27 @@ impl Arm {
             )
             .await
     }
+
+    /// Ask this arm one question and take its answer: a single completion with this
+    /// arm's params and `max_tokens`, no tools and no loop. The single-shot seam
+    /// behind `oneshot` and `deliberate`'s direct lane — prompt in, answer out, one
+    /// upstream request. Returns the answer paired with the provider's reported
+    /// [`Usage`] (zero-valued when it reported none), exactly as [`run`](Self::run) does.
+    pub(crate) async fn complete(
+        &self,
+        preamble: &str,
+        prompt: Message,
+    ) -> Result<(String, Usage)> {
+        self.runner
+            .complete(
+                preamble,
+                self.max_tokens,
+                self.temperature,
+                prompt,
+                self.params.as_ref(),
+            )
+            .await
+    }
 }
 
 /// The result of a consult: the final answer, the explorer's report (kept so
@@ -758,8 +816,64 @@ fn split_for_resume(mut history: Vec<Message>) -> (Vec<Message>, Message) {
 /// ([`rewrite_view_image_history`]) and re-enter the loop with the remaining turn
 /// budget. The model now sees the image in user content, the one channel every
 /// provider accepts. When unset the hook is inert and this is the old single call.
+///
+/// **Seeing how each turn ended.** This is [`run_phase_logged`] with a log nobody
+/// keeps — reach for that one when the phase's per-turn finish reasons are the point.
+#[allow(clippy::too_many_arguments)] // each arg is a distinct, named loop input
+pub(crate) async fn run_phase<M, F>(
+    model: &M,
+    model_name: &str,
+    preamble: &str,
+    max_tokens: u64,
+    temperature: Option<f64>,
+    initial_prompt: Message,
+    max_turns: usize,
+    thinking: Option<&Value>,
+    progress: &dyn ProgressSink,
+    make_tools: F,
+    break_on_view_image: bool,
+) -> Result<(String, Usage)>
+where
+    M: CompletionModel + 'static,
+    F: Fn() -> Result<Vec<DynamicTool>>,
+{
+    run_phase_logged(
+        &CompletionLog::new(),
+        model,
+        model_name,
+        preamble,
+        max_tokens,
+        temperature,
+        initial_prompt,
+        max_turns,
+        thinking,
+        progress,
+        make_tools,
+        break_on_view_image,
+    )
+    .await
+}
+
+/// [`run_phase`] with the per-turn completion record kept.
+///
+/// rig's agent layer hands back only what its medium-neutral hook event carries —
+/// content and usage — so a phase that stopped early, got truncated, or was refused
+/// by a classifier looks identical to one that finished. The provider *did* say which
+/// (`finish_reason` / `stop_reason` / `finishReason`); it lives on
+/// `CompletionResponse::raw_response`, which the loop discards. Wrapping the model in
+/// [`Watched`] puts the record on the one path every completion takes — **including
+/// the turns inside the tool loop and the forced final turn**, which no hook reaches —
+/// and `log` is the caller's slot for it, readable after this returns whether the
+/// phase succeeded or failed.
+///
+/// The log is per call, never global: a phase makes its own, so concurrent consults
+/// never mix. It holds plain data and crosses `.await` freely — nothing to do with the
+/// `!Send` kaish kernel, which stays on its `KaishWorker` thread as always.
+///
+/// [`run_phase`] is this with a log nobody keeps; the *last* turn's finish reason is
+/// recorded on the span either way, so the phase's ending is visible in telemetry
+/// today.
 #[allow(clippy::too_many_arguments)]
-// each arg is a distinct, named loop input
 // A named parent for rig's GenAI spans: rig's `invoke_agent` checks the current
 // span and nests under this one, so a phase's whole model loop (every `chat` turn,
 // every `tool` call) hangs off one `run_phase` span carrying the model. Inert
@@ -776,11 +890,63 @@ fn split_for_resume(mut history: Vec<Message>) -> (Vec<Message>, Message) {
         // known non-None, so a `None` (toggle-less) provider records nothing and
         // telemetry-off stays a no-op.
         gen_ai.request.thinking = tracing::field::Empty,
+        // How the phase's LAST completion ended, in the provider's own words. Empty
+        // when the provider reported none (or nothing ran), so it exports only when
+        // there's something to say.
+        gen_ai.response.finish_reason = tracing::field::Empty,
     )
 )]
-pub(crate) async fn run_phase<M, F>(
+pub(crate) async fn run_phase_logged<M, F>(
+    log: &CompletionLog,
     model: &M,
     model_name: &str,
+    preamble: &str,
+    max_tokens: u64,
+    temperature: Option<f64>,
+    initial_prompt: Message,
+    max_turns: usize,
+    thinking: Option<&Value>,
+    progress: &dyn ProgressSink,
+    make_tools: F,
+    break_on_view_image: bool,
+) -> Result<(String, Usage)>
+where
+    M: CompletionModel + 'static,
+    F: Fn() -> Result<Vec<DynamicTool>>,
+{
+    // Surface the exact reasoning/sampling params this phase ships (constant across the
+    // resume loop), so a trace shows whether — and at what depth — thinking was on: the
+    // wire truth behind the `chat` spans' `reasoning_tokens`. Inert with no exporter.
+    if let Some(t) = thinking {
+        tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
+    }
+    let result = run_phase_loop(
+        &watched(model.clone(), log.clone()),
+        preamble,
+        max_tokens,
+        temperature,
+        initial_prompt,
+        max_turns,
+        thinking,
+        progress,
+        make_tools,
+        break_on_view_image,
+    )
+    .await;
+    // Read the ending off the log — after the loop, on every exit path, so a failed
+    // phase reports how its last completion ended too.
+    if let Some(reason) = log.last_finish_reason() {
+        tracing::Span::current().record("gen_ai.response.finish_reason", reason.as_str());
+    }
+    result
+}
+
+/// The bounded tool loop itself, driving whatever model it's handed — in production a
+/// [`Watched`] wrapper, so every turn below (main loop, view_image resume, forced
+/// finalize) records on its way past.
+#[allow(clippy::too_many_arguments)] // each arg is a distinct, named loop input
+async fn run_phase_loop<M, F>(
+    model: &Watched<M>,
     preamble: &str,
     max_tokens: u64,
     temperature: Option<f64>,
@@ -803,13 +969,6 @@ where
     // the transcript and re-enters here (holistic review, Gemini Pro 2026-06-22).
     let mut prompt: Message = initial_prompt;
     let mut history: Vec<Message> = Vec::new();
-
-    // Surface the exact reasoning/sampling params this phase ships (constant across the
-    // resume loop), so a trace shows whether — and at what depth — thinking was on: the
-    // wire truth behind the `chat` spans' `reasoning_tokens`. Inert with no exporter.
-    if let Some(t) = thinking {
-        tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
-    }
 
     loop {
         // Outer turn budget: rig's `max_turns` resets each resume, so subtract the
@@ -948,6 +1107,85 @@ where
                  also failed to conclude: {e}"
             )
         })
+}
+
+/// One completion, no agent and no loop — the single-shot phases said plainly.
+///
+/// `oneshot` and `deliberate`'s direct lane are each *one* upstream request by
+/// definition: the caller owns the context, there is nothing to explore, and there are
+/// no tools to call. Running them through the managed tool loop with an empty toolset
+/// arrived at the same place by a longer road; this asks the provider directly.
+///
+/// **Byte-identical to what the agent built.** rig's agent prepares its request with
+/// the same [`CompletionRequestBuilder`](rig_core::completion::CompletionRequestBuilder)
+/// this uses, and `build()` is what turns a preamble into the leading
+/// `Message::System` — so preamble placement, params, `max_tokens`, temperature, the
+/// empty tool list, and the absent `tool_choice` all land exactly as before. Using
+/// rig's own builder rather than a hand-written literal is deliberate: a rig bump that
+/// changes how a request is assembled moves both paths together.
+///
+/// The answer text is the assistant turn's text content concatenated, which is how
+/// rig's runner builds `PromptResponse::output`; `usage` is the provider's report for
+/// this one call, zero-valued when it reported none.
+///
+/// `log` records how the completion ended, the same seam [`run_phase_logged`] gives
+/// the loop.
+#[allow(clippy::too_many_arguments)] // each arg is a distinct, named request input
+#[tracing::instrument(
+    name = "run_phase",
+    skip_all,
+    fields(
+        model = %model_name,
+        // Honest, not decorative: this phase *is* one turn.
+        max_turns = 1,
+        gen_ai.request.thinking = tracing::field::Empty,
+        gen_ai.response.finish_reason = tracing::field::Empty,
+    )
+)]
+pub(crate) async fn run_completion<M>(
+    model: &M,
+    model_name: &str,
+    log: &CompletionLog,
+    preamble: &str,
+    max_tokens: u64,
+    temperature: Option<f64>,
+    prompt: Message,
+    thinking: Option<&Value>,
+) -> Result<(String, Usage)>
+where
+    M: CompletionModel + 'static,
+{
+    if let Some(t) = thinking {
+        tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
+    }
+    let mut builder = watched(model.clone(), log.clone())
+        .completion_request(prompt)
+        .preamble(preamble.to_string())
+        .max_tokens(max_tokens);
+    if let Some(t) = temperature {
+        builder = builder.temperature(t);
+    }
+    if let Some(params) = thinking {
+        builder = builder.additional_params(params.clone());
+    }
+    // `send()` is `model.completion(builder.build())` — the one provider call.
+    let response = builder.send().await;
+    if let Some(reason) = log.last_finish_reason() {
+        tracing::Span::current().record("gen_ai.response.finish_reason", reason.as_str());
+    }
+    // "model call failed" keeps this on the provider side of `classify_failure`
+    // (`server/render.rs`), where a loop failure lands via "model loop failed" — an
+    // overload or rate limit here is still worth a caller retry.
+    let response = response.map_err(|e| anyhow!("model call failed: {e}"))?;
+    let answer = response
+        .choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<String>();
+    Ok((answer, response.usage))
 }
 
 /// Run the explorer phase once and return its cited report. The explorer [`Arm`]
@@ -1150,15 +1388,14 @@ impl Tool for RunExplore {
 /// The `oneshot` seam: one direct completion on the resolved arm — no tools, no
 /// shell, no exploration. The thin counterpart to `consult` (prompt in, answer out)
 /// for when the caller already owns the context and just wants the model's take.
-/// Built on the one loop primitive with an empty toolset and a single turn, so it is
-/// exactly one upstream request. Neither orientation nor operator house rules are
-/// spliced — both are project guidance, and oneshot reads no project.
+/// Exactly one upstream request, and now literally so: [`Arm::complete`] asks the
+/// provider directly rather than routing a toolless single turn through the managed
+/// loop. Neither orientation nor operator house rules are spliced — both are project
+/// guidance, and oneshot reads no project.
 ///
-/// Safe-by-accident note: a vision synth arm carries `break_on_view_image = true`
-/// (via `Arm::rewrites_view_image`), but the empty toolset has no `view_image` tool,
-/// so the break hook can never fire and the single turn always completes cleanly. If
-/// you ever give oneshot a tool, revisit this — a live break would consume the turn
-/// and land in the turn-cap finalize path.
+/// Give oneshot a tool one day and this is the line to revisit: a direct completion
+/// has nowhere to dispatch a tool call to, so a toolful oneshot belongs back on
+/// [`run_phase`], not here.
 ///
 /// `attachments` are caller-named workspace files inlined as context (the `attach` arg),
 /// resolved server-side so their bytes never transit the calling agent's context — the
@@ -1204,7 +1441,7 @@ pub async fn oneshot(
     with_call_deadline(
         cfg.call_deadline,
         "oneshot",
-        arm.run(
+        arm.complete(
             &resolve_phase_preamble(
                 Phase::Oneshot,
                 &cfg.prompts,
@@ -1212,9 +1449,6 @@ pub async fn oneshot(
                 cfg.house_rules.as_deref(),
             ),
             initial_prompt,
-            1,
-            cfg.progress.as_ref(),
-            &|| Ok(Vec::new()),
         ),
     )
     .await
@@ -1374,17 +1608,13 @@ pub async fn deliberate_direct(
     synth: &Arm,
     system: &str,
     deadline: Duration,
-    progress: &Arc<dyn ProgressSink>,
 ) -> Result<(String, Usage)> {
     with_call_deadline(
         deadline,
         "deliberate",
-        synth.run(
+        synth.complete(
             system,
             Message::user(deliberation_prompt(question, dossier)),
-            1,
-            progress.as_ref(),
-            &|| Ok(Vec::new()),
         ),
     )
     .await
@@ -1548,7 +1778,7 @@ mod tests {
     use crate::session::{SessionStore, Sessions};
     use crate::test_support::{
         has_tool, is_finalize_turn, provider_error, text_response, tool_call_response,
-        transcript_text, usage, with_usage, CaptureHttp, RecordingSink, ScriptedClient,
+        transcript_text, usage, with_raw, with_usage, CaptureHttp, RecordingSink, ScriptedClient,
     };
     use rig_core::completion::CompletionRequest;
     use std::fs;
@@ -2046,6 +2276,162 @@ mod tests {
         );
     }
 
+    /// `oneshot` is now one *literal* upstream request — a direct completion, no agent
+    /// and no tool loop — and it must ask for exactly what the loop used to ask for.
+    ///
+    /// The proof is a side-by-side: the same preamble, params, `max_tokens`, and prompt
+    /// go down the old road (`Arm::run` with an empty toolset and a single turn) and the
+    /// new one (`oneshot` → `Arm::complete`), on two scripted models sharing one request
+    /// log. The two serialized [`CompletionRequest`]s must be identical — every field,
+    /// including the ones no accessor names: preamble placement (rig turns it into the
+    /// leading `System` message), the empty `tools`/`documents`, the absent
+    /// `tool_choice`, `additional_params`. Comparing whole requests is the point: a
+    /// spot-check of a few fields would pass while a dropped one changed the call.
+    #[tokio::test]
+    async fn oneshot_asks_exactly_what_the_agent_loop_asked() {
+        const VIA_LOOP: &str = "via-agent-loop";
+        const VIA_DIRECT: &str = "via-direct-call";
+        let client = ScriptedClient::builder()
+            .on_model(VIA_LOOP, |_req| Ok(text_response("done")))
+            .on_model(VIA_DIRECT, |_req| Ok(text_response("done")))
+            .build();
+        // A real params blob, so the thinking toggle rides both paths.
+        let params = Some(json!({"thinking": {"type": "enabled", "budget_tokens": 4096}}));
+        let cfg = PhaseContext::default();
+        let preamble = resolve_phase_preamble(
+            Phase::Oneshot,
+            &cfg.prompts,
+            cfg.orientation.as_deref(),
+            cfg.house_rules.as_deref(),
+        );
+
+        // The pre-change path, reproduced: the managed loop, one turn, no tools.
+        let (loop_answer, loop_usage) = arm_with(&client, VIA_LOOP, params.clone())
+            .run(
+                &preamble,
+                Message::user("what changed?"),
+                1,
+                cfg.progress.as_ref(),
+                &|| Ok(Vec::new()),
+            )
+            .await
+            .expect("the agent-loop path answers");
+
+        // The shipped path.
+        let (direct_answer, direct_usage) = oneshot(
+            "what changed?",
+            &[],
+            &arm_with(&client, VIA_DIRECT, params),
+            &cfg,
+        )
+        .await
+        .expect("the direct path answers");
+
+        assert_eq!(direct_answer, loop_answer, "same answer text");
+        assert_eq!(direct_usage, loop_usage, "same usage accounting");
+
+        let looped = client.requests_for(VIA_LOOP);
+        let direct = client.requests_for(VIA_DIRECT);
+        assert_eq!(
+            looped.len(),
+            1,
+            "the loop made one request to compare against"
+        );
+        assert_eq!(
+            direct.len(),
+            1,
+            "oneshot is exactly ONE upstream request, got {}",
+            direct.len()
+        );
+        assert_eq!(
+            direct[0].raw, looped[0].raw,
+            "the direct completion must be request-for-request what the agent built"
+        );
+    }
+
+    /// The whole reason the wrapper exists: a phase's completion record reaches
+    /// [`run_phase_logged`]'s caller **including the turns inside the tool loop** — the
+    /// ones rig's agent hook can only see in its medium-neutral form, with no
+    /// `raw_response` and so no finish reason.
+    ///
+    /// Two turns here: the driver calls `run_kaish` (a provider reporting
+    /// `finish_reason: "tool_calls"`, nested under `choices[]` the OpenAI way), then
+    /// answers (an Anthropic-shaped top-level `stop_reason: "end_turn"`). Both land in
+    /// the log, in order, each with the reason its own payload gave — two spellings
+    /// through one extractor, from inside one real loop.
+    #[tokio::test]
+    async fn the_completion_log_carries_every_turn_including_inside_the_tool_loop() {
+        const MODEL: &str = "driver";
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, |req| {
+                if transcript_text(req).contains("TOOL_RAN") {
+                    // The answering turn: Anthropic's top-level spelling.
+                    Ok(with_raw(
+                        text_response("the answer"),
+                        json!({"stop_reason": "end_turn"}),
+                    ))
+                } else {
+                    // A turn INSIDE the loop: the OpenAI-compatible spelling, nested.
+                    Ok(with_raw(
+                        tool_call_response("c1", "run_kaish", json!({"script": "echo TOOL_RAN"})),
+                        json!({"choices": [{"index": 0, "finish_reason": "tool_calls"}]}),
+                    ))
+                }
+            })
+            .build();
+
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let log = CompletionLog::new();
+        let model = client.completion_model(MODEL);
+        let (answer, _usage) = run_phase_logged(
+            &log,
+            &model,
+            MODEL,
+            "answer the question",
+            16384,
+            None,
+            Message::user("q"),
+            4,
+            None,
+            &crate::progress::NullSink,
+            || {
+                Ok(vec![traced(RunKaish::new(KaishWorker::spawn_with(
+                    &root,
+                    SandboxConfig::default(),
+                )?))])
+            },
+            false,
+        )
+        .await
+        .expect("the scripted loop answers");
+
+        assert_eq!(answer, "the answer");
+        let turns = log.turns();
+        assert_eq!(
+            turns.len(),
+            2,
+            "every completion is recorded, tool turn included: {turns:?}"
+        );
+        assert_eq!(
+            turns[0].finish_reason.as_deref(),
+            Some("tool_calls"),
+            "the turn inside the loop — the one no hook can reach"
+        );
+        assert_eq!(turns[0].tool_calls, 1);
+        assert_eq!(turns[0].text_chars, 0);
+        assert_eq!(
+            turns[1].finish_reason.as_deref(),
+            Some("end_turn"),
+            "a different provider spelling, same extractor"
+        );
+        assert_eq!(
+            log.last_finish_reason().as_deref(),
+            Some("end_turn"),
+            "the phase's ending is one call away"
+        );
+    }
+
     /// oneshot carries the provider's reported token usage back out — the thin
     /// single-turn seam threads `PromptResponse.usage` the same as the loop does.
     #[tokio::test]
@@ -2524,7 +2910,6 @@ mod tests {
             &arm(&client, SYNTH),
             "You are a capable model answering a hard question offline.",
             cfg.call_deadline,
-            &cfg.progress,
         )
         .await
         .expect("scripted direct deliberation should succeed");
@@ -2638,7 +3023,6 @@ mod tests {
                 &arm(&client, SYNTH),
                 "offline synth preamble",
                 Duration::from_millis(50),
-                &(Arc::new(crate::progress::NullSink) as Arc<dyn ProgressSink>),
             ),
         )
         .await

--- a/src/consult/mod.rs
+++ b/src/consult/mod.rs
@@ -31,10 +31,12 @@ pub use engine::{
     RunExploreError, Session,
 };
 // `run_phase` is the offline-testable loop primitive; re-exported at crate scope so
-// `crate::consult::run_phase` (referenced in module docs) resolves. No in-crate `use`
-// imports it by that path today, so silence the re-export's unused-import lint.
+// `crate::consult::run_phase` (referenced in module docs) resolves. `run_phase_logged`
+// is that same loop with the per-turn completion record kept — the seam to reach for
+// when *how* a turn ended is the question (see [`crate::completion_watch`]). No in-crate
+// `use` imports either by that path today, so silence the unused-import lint.
 #[allow(unused_imports)]
-pub(crate) use engine::run_phase;
+pub(crate) use engine::{run_phase, run_phase_logged};
 pub use prompts::{
     batch_preamble, batch_system_prompt, consult_preamble, consult_user_prompt,
     deliberation_prompt, oneshot_preamble, report_preamble, resolve_phase_preamble,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod attach;
 pub mod batch;
 pub mod cas;
 pub mod cli;
+pub mod completion_watch;
 pub mod config;
 pub mod consult;
 pub mod context;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1781,10 +1781,9 @@ impl KaiboHandler {
         let deadline = deliberate_direct_deadline(synth_backend);
         // Same progress plumbing as consult_submit: a job has no live peer, so route
         // liveness onto `tracing` and let the ProgressLog remember the latest beat for
-        // `job_get`/`job_list`. The sink handed to the phase is the same Arc the job
-        // snapshots, so what it reads is what the completion emitted.
+        // `job_get`/`job_list`. The direct lane is a single completion with no tools, so
+        // it emits no beats of its own — the log carries the job's own start/finish.
         let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
-        let sink: Arc<dyn ProgressSink> = progress_log.clone();
         let cast_name = cast.name.clone();
         let explorer_model = explorer_model.to_string();
         let question = question.to_string();
@@ -1793,10 +1792,8 @@ impl KaiboHandler {
         let label = format!("cast `{cast_name}` deliberate (direct synth `{synth_model}`)");
 
         let job_id = self.jobs.submit(label, progress_log, async move {
-            match crate::consult::deliberate_direct(
-                &question, &dossier, &synth, &system, deadline, &sink,
-            )
-            .await
+            match crate::consult::deliberate_direct(&question, &dossier, &synth, &system, deadline)
+                .await
             {
                 Ok((answer, synth_usage)) => Ok(JobResult {
                     answer: with_provenance(

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -52,10 +52,12 @@ enum FailureKind {
 /// error text**, by necessity: rig collapses the HTTP status into the response *body*
 /// (`CompletionError::ProviderError(text)` carries Anthropic's `overloaded_error` JSON, a
 /// Gemini `RESOURCE_EXHAUSTED`, etc. — not the number `529`), so we match the providers'
-/// transient *vocabulary* rather than a status code. The model loop wraps its errors as
-/// `"model loop failed: …"` (`consult.rs`); an error chain lacking that marker came from
-/// *before* a model ran (a kaish kernel build inside the toolset factory), so it's a
-/// kaibo-side failure, not the provider's.
+/// transient *vocabulary* rather than a status code. A failure that reached a model wears
+/// one of kaibo's markers (`consult/engine.rs`): `"model loop failed: …"` from the tool
+/// loop, `"model call failed: …"` from a single-shot direct completion (`oneshot`,
+/// `deliberate`'s direct lane), `"model used all …"` from the forced final turn. An error
+/// chain lacking every marker came from *before* a model ran (a kaish kernel build inside
+/// the toolset factory), so it's a kaibo-side failure, not the provider's.
 fn classify_failure(err: &anyhow::Error) -> FailureKind {
     let s = format!("{err:#}").to_lowercase();
     // Our own wall-clock backstop firing (`call_deadline`): the backend stalled past
@@ -66,8 +68,10 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
     if s.contains("wall-clock deadline") {
         return FailureKind::TransientProvider;
     }
-    let from_model_loop = s.contains("model loop failed") || s.contains("model used all");
-    if !from_model_loop {
+    let reached_a_model = s.contains("model loop failed")
+        || s.contains("model call failed")
+        || s.contains("model used all");
+    if !reached_a_model {
         return FailureKind::Internal;
     }
     // Transient vocabulary across Anthropic / Gemini / OpenAI / DeepSeek bodies and the
@@ -642,6 +646,12 @@ mod tests {
             "model loop failed: HttpError: error sending request: operation timed out",
             "model loop failed: HttpError: connection reset by peer",
             "model loop failed: ProviderError: RESOURCE_EXHAUSTED",
+            // The single-shot direct lane (`oneshot`, `deliberate` direct) reaches the
+            // provider without a tool loop, so it wears its own marker. An overload
+            // there is every bit as retryable — a classifier that only knew the loop's
+            // marker would call this a kaibo bug and tell the caller not to retry.
+            "model call failed: ProviderError: {\"type\":\"overloaded_error\"}",
+            "model call failed: HttpError: error sending request: operation timed out",
         ] {
             let result = consultation_failed("consult", "gemini", anyhow::anyhow!(body));
             let text = answer_text(&result).to_lowercase();

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -56,7 +56,7 @@ use serde_json::Value;
 /// How the mock answers one request for one model: branch on the request's content
 /// and return a response, or an error to exercise the failure paths.
 pub type Responder = Arc<
-    dyn Fn(&CompletionRequest) -> Result<CompletionResponse<()>, CompletionError> + Send + Sync,
+    dyn Fn(&CompletionRequest) -> Result<CompletionResponse<Value>, CompletionError> + Send + Sync,
 >;
 
 /// A snapshot of one inbound completion request, captured for post-hoc assertions.
@@ -83,6 +83,12 @@ pub struct RecordedRequest {
     pub max_tokens: Option<u64>,
     /// `Some(ToolChoice::None)` marks the forced finalize turn after a turn-cap hit.
     pub tool_choice: Option<ToolChoice>,
+    /// The **whole** request as rig built it, serialized. The distilled fields above
+    /// answer "did the preamble/history/params reach the model"; this one answers
+    /// "are two requests the *same* request" — which is the only honest way to prove a
+    /// hand-rolled direct completion is equivalent to the one the agent loop produced,
+    /// field for field, including the ones no accessor above names.
+    pub raw: Value,
 }
 
 impl RecordedRequest {
@@ -96,6 +102,7 @@ impl RecordedRequest {
             additional_params: req.additional_params.clone(),
             max_tokens: req.max_tokens,
             tool_choice: req.tool_choice.clone(),
+            raw: serde_json::to_value(req).unwrap_or(Value::Null),
         }
     }
 }
@@ -146,7 +153,7 @@ impl ScriptedBuilder {
     /// and returns a response (or an error, to drive a failure path).
     pub fn on_model<F>(mut self, id: impl Into<String>, responder: F) -> Self
     where
-        F: Fn(&CompletionRequest) -> Result<CompletionResponse<()>, CompletionError>
+        F: Fn(&CompletionRequest) -> Result<CompletionResponse<Value>, CompletionError>
             + Send
             + Sync
             + 'static,
@@ -266,7 +273,13 @@ impl CompletionClient for ScriptedClient {
 }
 
 impl CompletionModel for ScriptedModel {
-    type Response = ();
+    /// The **raw provider response**, as free-form JSON. A real provider's raw payload
+    /// is its own struct; here it is a `Value` a responder can shape into whatever
+    /// wire form the test is about — an Anthropic `stop_reason`, a Gemini
+    /// `candidates[].finishReason` — which is what lets the offline harness drive
+    /// [`Watched`](crate::completion_watch::Watched), whose whole job is reading that
+    /// payload. `Value::Null` is the default: a response that reports nothing.
+    type Response = Value;
     type StreamingResponse = NoStream;
     type Client = ScriptedClient;
 
@@ -318,7 +331,7 @@ impl CompletionModel for ScriptedModel {
 // ---- response builders -----------------------------------------------------
 
 /// A final text answer — ends the tool loop.
-pub fn text_response(text: impl Into<String>) -> CompletionResponse<()> {
+pub fn text_response(text: impl Into<String>) -> CompletionResponse<Value> {
     response(OneOrMany::one(AssistantContent::text(text)))
 }
 
@@ -327,7 +340,7 @@ pub fn tool_call_response(
     id: impl Into<String>,
     name: impl Into<String>,
     args: Value,
-) -> CompletionResponse<()> {
+) -> CompletionResponse<Value> {
     response(OneOrMany::one(AssistantContent::tool_call(id, name, args)))
 }
 
@@ -335,7 +348,7 @@ pub fn tool_call_response(
 /// that calls `view_image` alongside `run_kaish`). rig runs them together and folds
 /// all their results into a single user turn, which is exactly the shape the
 /// view_image turn-boundary break must tolerate without orphaning a `tool_use`.
-pub fn tool_calls_response(calls: Vec<(&str, &str, Value)>) -> CompletionResponse<()> {
+pub fn tool_calls_response(calls: Vec<(&str, &str, Value)>) -> CompletionResponse<Value> {
     let contents: Vec<AssistantContent> = calls
         .into_iter()
         .map(|(id, name, args)| AssistantContent::tool_call(id, name, args))
@@ -343,13 +356,24 @@ pub fn tool_calls_response(calls: Vec<(&str, &str, Value)>) -> CompletionRespons
     response(OneOrMany::many(contents).expect("at least one tool call"))
 }
 
-fn response(choice: OneOrMany<AssistantContent>) -> CompletionResponse<()> {
+fn response(choice: OneOrMany<AssistantContent>) -> CompletionResponse<Value> {
     CompletionResponse {
         choice,
         usage: Usage::new(),
-        raw_response: (),
+        // Nothing reported — the default a test that doesn't care about the provider's
+        // own payload gets. Shape one with [`with_raw`] when the payload is the point.
+        raw_response: Value::Null,
         message_id: None,
     }
+}
+
+/// Stamp a **raw provider payload** onto a scripted response — the untouched JSON a
+/// real provider would return alongside the parsed choice. This is what
+/// [`Watched`](crate::completion_watch::Watched) reads, so a test that cares how a
+/// turn *ended* (`finish_reason` / `stop_reason` / `finishReason`) shapes it here.
+pub fn with_raw(mut resp: CompletionResponse<Value>, raw: Value) -> CompletionResponse<Value> {
+    resp.raw_response = raw;
+    resp
 }
 
 /// A [`Usage`] a scripted provider "reports" for one completion, `input`/`output`
@@ -369,7 +393,7 @@ pub fn usage(input: u64, output: u64) -> Usage {
 
 /// Stamp a reported [`usage`] onto a scripted response. `text_response`/`tool_call_response`
 /// default to `Usage::new()` (nothing reported); wrap them here to drive the accounting.
-pub fn with_usage(mut resp: CompletionResponse<()>, usage: Usage) -> CompletionResponse<()> {
+pub fn with_usage(mut resp: CompletionResponse<Value>, usage: Usage) -> CompletionResponse<Value> {
     resp.usage = usage;
     resp
 }


### PR DESCRIPTION
kaibo could not see `finish_reason`, and that blindness is why a real bug was hard to
diagnose: #115 investigates a `consult` that returned an empty answer as success, and we
could not distinguish an early stop from a `content_filter` refusal from a truncation.

## Why we couldn't see it

The data was never missing — rig's agent layer strips it on the way past.

`rig_core::completion::CompletionResponse<T>` carries **`raw_response: T`**, the untouched
provider response. But the agent hook event is a *different, narrower* type
(`rig-agent/src/agent/hook.rs:400`): `prompt`, `content`, `usage`, `message_id`. No raw
response. It is deliberately "medium-neutral", so provider specifics are designed out.
That is a coherent choice for a portability layer and exactly wrong for kaibo, whose value
is telling a caller *why* something didn't happen.

## The fix: wrap the model the loop calls

`CompletionModel` is a **`rig-core`** trait and `Agent<M: CompletionModel>` is generic over
it, so a delegating wrapper slots straight into the builder. rig's loop keeps running; we
observe every turn on its way past — **including turns inside the tool loop, which the hook
cannot reach.**

This is the pattern kaibo already uses for tools, and the new file is written to read as its
sibling: `traced` wraps a tool, **`watched` wraps a model**.

`run_phase` became a thin wrapper over `run_phase_logged`, so the log covers the main loop,
every `view_image` resume, **and** `finalize_after_max_turns`. It records
`gen_ai.response.finish_reason` onto the `run_phase` span on both success and failure paths.

**No per-provider extraction code.** The trait bounds require
`type Response: Serialize + DeserializeOwned`, so the wrapper serializes the raw response and
walks it breadth-first, depth-capped, shallowest match wins:

| spelling | where | confirmed at |
|---|---|---|
| `finish_reason` | `choices[].finish_reason` | `openai/completion/mod.rs:1290`, `deepseek.rs:289`, `openrouter/completion.rs:1080` |
| `stop_reason` | top level, nullable | `anthropic/completion.rs:64` |
| `finishReason` | `candidates[].finishReason`, SCREAMING_SNAKE | `gemini/completion.rs:651` |
| `incomplete_details.reason` | OpenAI **Responses** | `openai/responses_api/mod.rs:1460` |

OpenRouter's `native_finish_reason` sits beside `finish_reason`; we take the normalized one.

## The asymmetry a consumer must know about

**OpenAI's Responses API has no finish-reason field at all.** It reports `status`
(`completed`/`incomplete`/`failed`) plus `incomplete_details.reason`. We read the latter and
deliberately skip `status` — `"completed"` is noise as a finish reason, and the same word
appears on per-item tool statuses deeper in the payload.

So **on the hosted GPT wire a normal completion reports `None`**: absence *is* the clean stop
there. That is exactly the signal #115's empty-answer path wants, but it is **not symmetric
with `"stop"`**, and anything consuming this must not read `None` as "no information".

## What is captured, and what isn't

Captured per turn: `finish_reason`, `usage`, `text_chars`, `tool_calls`.

**Not captured: the raw JSON.** It rides every turn, grows with the transcript, and carries
the full assistant message plus echoed reasoning on some providers. Extraction was the point.
The only thing swallowed is a raw response that refuses to serialize — it degrades to "no
finish reason" plus a `debug!`, because observation must never fail a paid completion.

`Watched::make()` is `unreachable!()` naming `watched(model, log)`: it is only reachable via
`CompletionClient::completion_model`, and no client yields a `Watched`, so building one there
would have to invent a log nobody holds — a silent discard, refused.

## Direct completion for the single-shot paths

`oneshot` (toolless by definition) and `deliberate`'s direct lane (one long completion) no
longer pay for an agent loop they don't use. AGENTS.md already described `oneshot` as "one
upstream request, prompt in / answer out"; that is now literally true. Built with rig's own
`CompletionRequestBuilder` rather than a literal, so `build()`'s preamble transform and a
future rig bump move both paths together.

**The forced finalize turn was left alone**, though it is also a single `ToolChoice::None`
completion. #115 has rewritten `forced_finish_turn` and converting it here would collide —
and it needs no conversion for visibility, since it runs through the agent and the wrapper
already records it.

One thing this turned up: `classify_failure` gated on the literal `"model loop failed"`. A
direct call isn't a loop, so a provider overload on `oneshot` or `deliberate` would have been
reported as an internal kaibo failure with no retry hint. The classifier learned the new
marker; test added.

## Tests

Nine new, each mutation-checked rather than assumed to have teeth. The two that carry the
design:

- **`the_completion_log_carries_every_turn_including_inside_the_tool_loop`** — real loop, real
  kaish, two turns with two different provider spellings. Turn 0 is the in-loop tool turn the
  hook cannot reach, which is the entire reason for this approach.
- **`oneshot_asks_exactly_what_the_agent_loop_asked`** — the same inputs sent down both roads
  against two models sharing one request log; the serialized `CompletionRequest`s must be
  equal. Removing `additional_params` from the direct path fails it (verified).

Plus pure-passthrough (content, usage, message id, raw response), error passthrough, all four
spellings, OpenRouter normalized-vs-native, graceful degradation on unknown/null/array shapes,
and the depth cap.

`ScriptedModel::Response` was `()`, so nothing offline could carry a raw payload — now
`serde_json::Value` with a `with_raw` builder. The harness stays content-driven; no reshaping.

797 passed / 0 failed / 20 ignored. `clippy --all-targets` clean. `cargo tree -i` empty for
`aws-lc-rs`, `aws-lc-sys`, `openssl-sys`, `mimalloc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
