### PR TITLE
chore: follow-ups from the merged attach/empty-answer/rig-0.41 work

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -334,6 +334,22 @@ DeepSeek CLI-subcommands review (2026-07-17).
 
 ## P3 — Infra, perf, polish
 
+### Batch results don't cross-check returned `custom_id`s against the submitted set
+From the 2026-08-02 batch error-propagation audit (DeepSeek agentic consult, key claims
+verified by hand — the audit's overall verdict was that per-item propagation is SOUND:
+loud per-item `Err`s on all three providers, `finish_gated_answer` on every succeeded
+path at `batch.rs:548/986/1625`, no error detail discarded). The one blind spot: none of
+the three result parsers (`parse_results_jsonl` `batch.rs:524`, `parse_gemini_inlined`
+`:975`, `parse_openai_output_jsonl` `:1579`) verifies that every submitted `custom_id`
+came back. A provider that silently drops an item yields N-1 results with no error about
+the missing one — "Batch complete — 9 result(s)" after submitting 10. Fix shape: carry
+the submitted count (or id set) on the handle and emit a synthetic per-item failure for
+each absentee at parse time. Two accepted-as-designed observations from the same audit,
+recorded so they aren't re-flagged: Anthropic has no batch-level `Failed` state ("ended"
+covers all outcomes; per-item errors live inside `Done`, and `job_list` is a triage view —
+`job_get` has the detail), and Gemini's errored-item summarizer probes only
+`error.message` before falling back to the full JSON (data preserved, label coarser).
+
 ### Release pipeline — harden native matrix + GitHub-native signing (plan in `docs/releases.md`)
 The full plan and its decisions live in **`docs/releases.md`** (living doc); this is the
 tracker pointer. Direction settled 2026-06-25 (w/ Amy): **stay OSS / GitHub-native** —

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -334,42 +334,6 @@ DeepSeek CLI-subcommands review (2026-07-17).
 
 ## P3 — Infra, perf, polish
 
-### Server-level test: a sweep-routed image survives the whole `deliberate` handler
-The engine layer pins dossier stitching and `deliberate_direct`-with-images, but
-neither `deliberate_batch` nor `deliberate_direct_job` has a server-level test
-proving a sweep-routed image survives the full handler pipeline (dossier sweep →
-`sink.drain()` → image collection → lane dispatch). The code reads correctly
-(`src/server/mod.rs`, `deliberate`), and the engine tests cover the seams — but a
-future refactor could drop the `images` variable between drain and dispatch
-undetected. Flagged by the DeepSeek cross-family review of the explorer `attach`
-feature (2026-07-26).
-
-### Stale code comments + test assertions that predate the 5th backend / the direct lane
-Surfaced by a kaibo `or-gpt` (gpt-5.6-luna) review of PR #110, verified against the code.
-Three spots still describe a world with four built-ins and no tool routing to `direct`.
-None affects behavior; all three are places a reader (or a future us) would be misled, and
-the test one could let a real regression pass:
-
-- **`tests/config.rs`** (~:35) — "Four built-in backends + four single-backend casts", and
-  the loop below it iterates only Anthropic/DeepSeek/Gemini/Openai. `openrouter` is a real
-  built-in (`config.rs::builtin_registry`), so removing it would keep this test green.
-  Same undercount in a `src/server/config_resource.rs` test (~:831).
-- **`src/config.rs`** (~:225) — a doc-comment still says the `direct` lane has no tool
-  route. `deliberate` routes to it now (`config.rs::cast_can_deliberate`,
-  `server/mod.rs::CAST_ENUM_RULES`).
-
-Fix is mechanical; kept out of PR #110 because that one is a docs PR and this touches
-tests. Do it with the next change that lands in `tests/config.rs`.
-
-### Shipped config template omits four knobs its own resource description promises
-`kaibo://config/example`'s description said "every option with its default"; the template
-was missing `[persistence]`, `[orientation]`, `job_capacity`, and `inline_attach_budget`.
-Added in PR #110, so the claim is true again — **the open work is the guard**: nothing
-tests that the template covers the config surface, so the next new knob can silently
-reintroduce the gap. A test walking `RawConfig`'s field names against
-`CONFIG_EXAMPLE_TOML` would close it, in the spirit of the `no_write_path.rs` pinned-count
-guard. (The example's *parse* test exists already; coverage is the missing half.)
-
 ### Release pipeline — harden native matrix + GitHub-native signing (plan in `docs/releases.md`)
 The full plan and its decisions live in **`docs/releases.md`** (living doc); this is the
 tracker pointer. Direction settled 2026-06-25 (w/ Amy): **stay OSS / GitHub-native** —

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,9 +250,9 @@ impl std::str::FromStr for ModelRole {
 /// Lane lives on the **slot**, not the cast: a `deliberate` cast can pair an
 /// interactive explorer with an offline synth, and the synth slot's lane is what
 /// classifies the whole cast for the batch/interactive tool split (see
-/// [`Config::cast_offline_lane`]). `Direct` is forward-declared here — validated,
-/// parsed, and rendered — but no tool routes to it yet (see `server.rs`
-/// `reject_offline_cast`/the roster split).
+/// [`Config::cast_offline_lane`]). `deliberate` routes to `Direct` when a cast
+/// pairs an explorer with a direct-lane synth (see `cast_can_deliberate` and
+/// `CAST_ENUM_RULES`/`live_tools` in `server/mod.rs`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Lane {
@@ -1904,7 +1904,7 @@ fn builtin_backends(defaults: &Defaults) -> BTreeMap<String, Backend> {
     m
 }
 
-/// The four built-in casts: same-named single-backend compositions carrying
+/// The five built-in casts: same-named single-backend compositions carrying
 /// today's default models, so a missing config file and `cast = "anthropic"`
 /// reproduce kaibo's historical behavior byte-for-byte.
 fn builtin_casts() -> BTreeMap<String, Cast> {
@@ -4833,5 +4833,82 @@ mod tests {
             "#,
         )
         .is_err());
+    }
+
+    // --- The shipped template covers the config surface -------------------------
+
+    /// Every field a raw config struct accepts, as serde itself enumerates them.
+    /// `deny_unknown_fields` bakes the field list into the `Deserialize` impl, and
+    /// serde's unknown-field error recites it ("unknown field `…`, expected one of
+    /// `a`, `b`, …") — so feeding each struct one bogus key yields the full set with
+    /// no hand-kept list to drift from the parser. A new field lands in this
+    /// enumeration the moment it lands on the struct.
+    fn serde_fields<T: serde::de::DeserializeOwned>() -> Vec<String> {
+        let Err(err) = toml::from_str::<T>("kaibo_bogus_probe_key_zz = 1") else {
+            panic!("the probe key must be unknown to the struct");
+        };
+        let err = err.to_string();
+        let expected = err
+            .split("expected")
+            .nth(1)
+            .unwrap_or_else(|| panic!("no expected-fields list in serde error: {err}"));
+        let fields: Vec<String> = expected
+            .split('`')
+            .skip(1)
+            .step_by(2)
+            .map(str::to_string)
+            .collect();
+        assert!(
+            !fields.is_empty(),
+            "serde error carried no field names: {err}"
+        );
+        fields
+    }
+
+    /// The shipped template (`kaibo://config/example`) promises "every option with
+    /// its default". This walks every raw struct's serde field set and requires each
+    /// name to appear somewhere in the template text — live, commented out, or as a
+    /// section header. History says the gap recurs: `[persistence]`,
+    /// `[orientation]`, `job_capacity`, `inline_attach_budget` (PR #110) and then
+    /// `max_attachments` (PR #96) all shipped before the template mentioned them.
+    /// With this, the next new knob fails the suite until the template names it.
+    #[test]
+    fn the_shipped_template_documents_every_config_field() {
+        let template = crate::server::CONFIG_EXAMPLE_TOML;
+        // Deliberately absent from the template: `profiles` is a tombstone whose only
+        // job is a migration-pointing load error, not a knob anyone should type.
+        let undocumented = ["profiles"];
+        let mut missing = Vec::new();
+        let mut check = |strukt: &str, fields: Vec<String>| {
+            for f in fields {
+                if undocumented.contains(&f.as_str()) {
+                    continue;
+                }
+                if !template.contains(&f) {
+                    missing.push(format!("{strukt}.{f}"));
+                }
+            }
+        };
+        check("RawConfig", serde_fields::<RawConfig>());
+        check("RawServer", serde_fields::<RawServer>());
+        check("RawTools", serde_fields::<RawTools>());
+        check("RawDefaults", serde_fields::<RawDefaults>());
+        check("RawTelemetry", serde_fields::<RawTelemetry>());
+        check("RawPersistence", serde_fields::<RawPersistence>());
+        check("RawContext", serde_fields::<RawContext>());
+        check("RawPrompts", serde_fields::<RawPrompts>());
+        check("RawOrientation", serde_fields::<RawOrientation>());
+        check("RawSandbox", serde_fields::<RawSandbox>());
+        check("RawKaish", serde_fields::<RawKaish>());
+        check("RawIgnore", serde_fields::<RawIgnore>());
+        check("RawBackend", serde_fields::<RawBackend>());
+        check("RawCast", serde_fields::<RawCast>());
+        check("RawSlotTable", serde_fields::<RawSlotTable>());
+        assert!(
+            missing.is_empty(),
+            "docs/config.example.toml promises \"every option with its default\" but \
+             never mentions: {missing:?} — add each knob to the template (a commented \
+             default line is enough)"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4879,12 +4879,24 @@ mod tests {
         // job is a migration-pointing load error, not a knob anyone should type.
         let undocumented = ["profiles"];
         let mut missing = Vec::new();
+        // A word-boundary match, not bare `contains`: short names (`id`, `log`,
+        // `lane`, `kind`) are substrings of ordinary prose (`guide`, `changelog`),
+        // and a bare containment check would keep passing after the knob's real
+        // documentation vanished (gemini cross-family review, 2026-08-02).
+        let mentions = |field: &str| {
+            let is_word =
+                |c: Option<char>| c.is_some_and(|c| c.is_alphanumeric() || c == '_');
+            template.match_indices(field).any(|(i, _)| {
+                !is_word(template[..i].chars().next_back())
+                    && !is_word(template[i + field.len()..].chars().next())
+            })
+        };
         let mut check = |strukt: &str, fields: Vec<String>| {
             for f in fields {
                 if undocumented.contains(&f.as_str()) {
                     continue;
                 }
-                if !template.contains(&f) {
+                if !mentions(&f) {
                     missing.push(format!("{strukt}.{f}"));
                 }
             }

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -1180,6 +1180,19 @@ where
                 // second re-ask. That is a stronger guarantee than a `finalized` flag,
                 // which a later edit could reset; the shape itself forbids the loop. Pinned
                 // by `an_empty_forced_write_up_turn_errors_and_is_never_retried_twice`.
+                //
+                // **Why not rig-agent's `on_model_turn_finished` + `ModelTurnAction::
+                // Retry`?** Evaluated 2026-08-02 (rig-agent 0.41 `hook.rs`) and rejected:
+                // the first-class retry is weaker than this recovery on the three counts
+                // that matter here. (1) `Retry(Feedback)` cannot constrain the retried
+                // turn — [`forced_finish_turn`] sends `ToolChoice::None`, so the model
+                // must write rather than spend the nudge on another tool call. (2) A hook
+                // retry "consumes the run's existing total model-call budget", so an
+                // empty answer at the cap would get no recovery, where this path runs the
+                // write-up turn deliberately outside the budget. (3) `Stop(reason)` is a
+                // string; [`empty_answer_error`]'s diagnostics (turns, tokens, the
+                // provider's finish_reason off the [`CompletionLog`]) would flatten into
+                // it. Re-evaluate if rig grows a constrained retry.
                 tracing::warn!(
                     model = model_name,
                     turns,

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -1037,8 +1037,14 @@ mod tests {
             body.contains("/tmp/test-allowed"),
             "config resource must show the allowed set:\n{body}"
         );
-        // Backends and casts include the built-in four.
-        for name in ["anthropic", "deepseek", "gemini", "openai-local"] {
+        // Backends and casts include the built-in five.
+        for name in [
+            "anthropic",
+            "deepseek",
+            "gemini",
+            "openrouter",
+            "openai-local",
+        ] {
             assert!(
                 body.contains(&format!("[backends.{name}]")),
                 "config resource must list the {name} backend:\n{body}"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -145,6 +145,36 @@ fn deliberate_direct_deadline(synth_backend: &Backend) -> std::time::Duration {
     synth_backend.request_timeout + DELIBERATE_DEADLINE_MARGIN
 }
 
+/// Fold a `deliberate` dossier sweep's routed `attach` delivery into the dossier and
+/// hand back the routed images for the lane dispatch.
+///
+/// Text bodies, notes, and demotions become dossier text ([`sweep_evidence_block`]);
+/// images are returned separately because they ride the offline synth's single turn
+/// as native image parts, never as dossier text. `None` (attach disabled, or a sweep
+/// that routed nothing) leaves the dossier untouched and returns no images.
+///
+/// Extracted from the `deliberate` handler so the drain → stitch → images hand-off is
+/// pinned by a test: the images the sweep routed MUST be what the lane dispatch
+/// receives, and a refactor that drops them between drain and dispatch fails the
+/// suite instead of silently blinding the synth (DeepSeek cross-family review,
+/// 2026-07-26).
+fn stitch_dossier_delivery(
+    dossier: &mut String,
+    consumer: &SweepConsumer,
+    sink: Option<&std::sync::Arc<SweepAttachSink>>,
+) -> Vec<crate::attach::Attachment> {
+    match sink {
+        Some(sink) => {
+            let delivery = sink.drain();
+            if let Some(block) = sweep_evidence_block(consumer, &delivery) {
+                dossier.push_str(&block);
+            }
+            delivery.images()
+        }
+        None => Vec::new(),
+    }
+}
+
 /// Which tools to advertise. All on by default; each `--no-<tool>` flips one off.
 ///
 /// Composes to any posture: `{oneshot:false}` ≈ the codebase-only surface; only
@@ -1710,16 +1740,7 @@ impl KaiboHandler {
         // Stitch whatever the dossier sweep routed via `attach` into the dossier text
         // itself (text bodies, notes, demotions); collect any routed images separately
         // — they ride the synth's single turn as native parts, not as dossier text.
-        let images: Vec<crate::attach::Attachment> = match &sink {
-            Some(sink) => {
-                let delivery = sink.drain();
-                if let Some(block) = sweep_evidence_block(&consumer, &delivery) {
-                    dossier.push_str(&block);
-                }
-                delivery.images()
-            }
-            None => Vec::new(),
-        };
+        let images = stitch_dossier_delivery(&mut dossier, &consumer, sink.as_ref());
 
         // Stage 2 — hand the dossier to the offline synth. Its lane picks the mechanism
         // and the handle; both share the offline-synth preamble (`batch_system_prompt`,
@@ -3509,6 +3530,119 @@ mod tests {
             "a 3h-patience local synth must outlast the interactive ceiling ({:?}), not be capped by it",
             cfg.defaults.call_deadline
         );
+    }
+
+    /// The deliberate pipeline's image hand-off, pinned across the server seam: a file
+    /// the dossier sweep routes via the REAL `attach` tool must survive
+    /// drain → stitch → lane dispatch → the offline synth's single turn. The engine
+    /// tests pin each stage in isolation; this pins the hand-offs between them — the
+    /// exact place a refactor could drop the `images` value between drain and dispatch
+    /// with nothing failing (flagged by the DeepSeek cross-family review, 2026-07-26).
+    #[tokio::test]
+    async fn a_sweep_routed_image_survives_drain_stitch_and_direct_dispatch() {
+        use crate::sweep_attach::{SweepAttach, SweepAttachArgs};
+        use rig_agent::tool::{Tool as _, ToolContext};
+
+        // A workspace holding one real-by-magic-bytes PNG and one text file.
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        let mut png = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        png.extend(std::iter::repeat_n(0xAB, 32));
+        std::fs::write(root.join("arch.png"), &png).unwrap();
+        std::fs::write(root.join("notes.md"), "the design in one line\n").unwrap();
+
+        // The sink and consumer exactly as the `deliberate` handler builds them:
+        // offline synth, vision on (the synth's cap is what admits the image).
+        let consumer = SweepConsumer {
+            kind: SweepConsumerKind::OfflineSynth,
+            label: std::sync::Arc::from("the offline synth (`scripted-synth`)"),
+            vision: true,
+        };
+        let sink = std::sync::Arc::new(SweepAttachSink::new(
+            8,
+            consumer.clone(),
+            std::collections::HashSet::new(),
+        ));
+
+        // Route both files through the real tool — the same resolve/read/classify/
+        // commit path a live explorer's `attach` call runs.
+        let tool = SweepAttach::new(
+            crate::sandbox::KaishWorker::spawn(&root).expect("spawn read-only worker"),
+            &root,
+            sink.clone(),
+            std::sync::Arc::new(crate::progress::NullSink),
+        );
+        let receipt = tool
+            .call(
+                &mut ToolContext::new(),
+                SweepAttachArgs {
+                    paths: vec!["arch.png".into(), "notes.md".into()],
+                    note: None,
+                },
+            )
+            .await
+            .expect("attach succeeds on both files");
+        assert!(
+            receipt.contains("attached: arch.png"),
+            "the image must route: {receipt}"
+        );
+
+        // Drain + stitch — the extracted handler step.
+        let mut dossier = String::from("src/x.rs:1 DOSSIER");
+        let images = stitch_dossier_delivery(&mut dossier, &consumer, Some(&sink));
+        assert!(
+            dossier.contains("notes.md"),
+            "the text body is stitched into the dossier: {dossier}"
+        );
+        assert!(
+            dossier.contains("arch.png"),
+            "the image is named in the dossier manifest: {dossier}"
+        );
+        assert_eq!(
+            images.len(),
+            1,
+            "exactly the routed image reaches the lane dispatch"
+        );
+
+        // Lane dispatch, direct: the image must land on the synth's single turn as a
+        // native image part.
+        let client = crate::test_support::ScriptedClient::builder()
+            .on_model("scripted-synth", |req| {
+                let carries_image = req.chat_history.iter().any(|m| {
+                    matches!(m, rig_core::completion::Message::User { content }
+                    if content.iter().any(|c| matches!(
+                        c,
+                        rig_core::completion::message::UserContent::Image(_)
+                    )))
+                });
+                assert!(
+                    carries_image,
+                    "the routed image must ride the synth's turn as an image part"
+                );
+                Ok(crate::test_support::text_response("DELIBERATION: seen"))
+            })
+            .build();
+        let synth = crate::consult::Arm::new(
+            client.clone(),
+            "scripted-synth",
+            1 << 14,
+            None,
+            crate::consult::ModelCaps {
+                vision: true,
+                tool_result_images: true,
+            },
+        );
+        let (out, _usage) = crate::consult::deliberate_direct(
+            "does the diagram confirm it?",
+            &dossier,
+            &images,
+            &synth,
+            "system",
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        .expect("scripted direct deliberation succeeds");
+        assert!(out.contains("DELIBERATION"), "the answer came back: {out}");
     }
 
     /// consult `attach` validates files are under the consult root (so the model's shell

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -32,13 +32,16 @@ fn builtin_reproduces_the_historical_defaults() {
     // The per-request LLM deadline default: 15 min (see Defaults::default).
     assert_eq!(c.defaults.request_timeout, Duration::from_secs(900));
 
-    // Four built-in backends + four single-backend casts, carrying the model ids
+    // Five built-in backends + five single-backend casts, carrying the model ids
     // that used to live on the profiles. Named after their kind, except the OpenAI
-    // built-in, which is `openai-local` (it defaults to a local endpoint).
+    // built-in, which is `openai-local` (it defaults to a local endpoint). Every
+    // kind in the registry is enumerated here, so silently dropping a built-in
+    // fails this test.
     for kind in [
         ProviderKind::Anthropic,
         ProviderKind::DeepSeek,
         ProviderKind::Gemini,
+        ProviderKind::OpenRouter,
         ProviderKind::Openai,
     ] {
         let name = kind.builtin_name();


### PR DESCRIPTION
The four follow-ups agreed after the 2026-08-02 merge sweep (#114/#115/#96/#116), each small on its own:

**Template coverage guard.** `kaibo://config/example` promises "every option with its default", and history says the gap recurs — PR #110 found four missing knobs, then `max_attachments` shipped in #96 without a template line until the merge reconciliation added one by hand. The new test asks serde itself for every raw struct's field set (`deny_unknown_fields` bakes the list into the `Deserialize` impl, and the unknown-field error recites it), then requires each name to appear in the template — no hand-kept list to drift from the parser. Teeth proven: deleting `max_attachments` from the template fails the test naming `RawDefaults.max_attachments`.

**The deliberate image hand-off is pinned at the server seam.** The residual worry from the explorer-attach cross-family review: a refactor could drop the routed `images` between `sink.drain()` and lane dispatch with nothing failing. The drain-and-stitch step is now an extracted `stitch_dossier_delivery`, and a test drives the *real* `attach` tool over a real workspace (PNG + text file), stitches, and dispatches to a scripted synth — proving the routed image survives to the offline synth's single turn as a native image part.

**Stale "four built-ins" text.** `tests/config.rs` and the config-resource test now enumerate all five kinds (OpenRouter included), so silently dropping a built-in fails the suite; the `Lane::Direct` doc stops claiming no tool routes to it.

**`ModelTurnAction::Retry`: evaluated, rejected, recorded.** The plan was to convert #115's hand-rolled forced write-up turn to rig-agent's first-class retry. Reading the API says no: `Retry(Feedback)` cannot carry `ToolChoice::None` (the retried turn could burn more tool calls instead of writing), a hook retry consumes the run's turn budget (an empty answer at the cap would get no recovery, where today's path deliberately runs the write-up outside the budget), and `Stop(reason)` is a string that would flatten `empty_answer_error`'s typed diagnostics. The decision now lives as a comment on the recovery arm, with a pointer to re-evaluate if rig grows a constrained retry.

Internal-only (tests, comments, tracker) — no CHANGELOG entry. The three shipped `docs/issues.md` entries are deleted per the tracker discipline. 849 tests green, clippy silent, fmt drift only where authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)