### PR TITLE
fix: an empty-answer failure is a retryable model outcome, not a kaibo bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,14 @@ record. Each later release appends a new section at the top.
   the provider's own finish reason when it reported one) rather than pressing an
   evidence-free model into an ungrounded answer.
 
+- **An empty-answer failure now reads as what it is — a retryable model outcome, not a
+  kaibo bug.** The failure classifier predates the empty-answer guard above and did not
+  know its vocabulary, so every empty-answer error was wrapped in "This is a kaibo-side
+  error (not the provider) — please report it" around inner text that said "Retry" —
+  contradictory guidance blaming kaibo for the model's silence. The guidance now says the
+  model delivered no answer text, invites a retry or a different cast, and points at the
+  slot's `max_tokens` when the provider reported the answer was cut off by length.
+
 - **A vision model still sees the image after the `rig` 0.41 upgrade.** rig 0.41 stopped
   inspecting a tool's text output to discover rich content in it, which would have
   silently turned every `view_image` result into base64 text labelled JSON — the model

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -321,6 +321,39 @@ advice split. Distinct from the upstream rig retry/backoff entry above — that'
 level 429/503 backoff; this is a mid-loop model fumble kaibo can re-prompt around itself.
 Surfaced by the DeepSeek CLI-subcommands review (2026-07-17).
 
+### Empty answers keep happening — the guard is a backstop, not a cure
+The empty-answer guard shipped 2026-08-02 (#115, meeting #116's finish_reason plumbing and
+the attach work in #118): no lane returns an empty answer as success. The tool loop gets one
+evidence-gated forced write-up turn (`consult/engine.rs::run_phase`, `empty_answer_error`),
+the turn-cap finalize and the single-shot lanes fail loudly with diagnostics (turns, tokens,
+the provider's own `finish_reason`), and batch has long had `finish_gated_answer`. But the
+guard changes the *failure mode*, not the *frequency*: DeepSeek still sometimes produces the
+textless terminal turn (Amy, 2026-08-02, same day the guard merged), and other families
+likely do too. Experiments the same day: a starved oneshot (256-token synth cap) repros the
+`finish_reason "length"` class on demand — reasoning ate the whole completion budget, guard
+errored loudly — while three grep-heavy review consults on the default deepseek cast all
+completed clean, so the wild stopped-without-answering class is sporadic (or already
+lowered by #114's role-identity preambles; n=3 can't tell). Open work, in order:
+- **Characterize from telemetry before touching prompts.** The plumbing to answer "which
+  models, how often, which finish_reason, does the forced re-ask rescue it" is all in place:
+  `gen_ai.response.finish_reason` on every `run_phase` span (#116), the `warn` event
+  "phase returned an empty answer with evidence gathered — forcing one final write-up turn"
+  (`engine.rs`), and `empty_answer_error`'s token/turn diagnostics in the error text.
+  Collect real occurrences from OTLP over normal use; the interesting split is
+  rescued-by-forced-turn vs. errored-anyway, and `finish_reason "stop"` (model chose to
+  stop) vs. `"length"` (starved — a `max_tokens` problem, different fix).
+- **Prevention is prompt work, and #114 already aims at it.** The measured failure shape is
+  a driver ending a turn with a tool call as its last act and no text (the 2026-08-01
+  DeepSeek run: explorer report delivered, fifteen greps returned, then a 14-token terminal
+  turn). #114's role-identity preambles ("the synth's final turn *is* the answer") target
+  exactly this; measure whether incidence drops post-#114 before adding more prompt mass.
+- **If the forced re-ask often fails**, consider a second differently-worded re-ask or
+  per-model shaping — but only with data showing the single re-ask isn't enough.
+- **The un-catchable neighbor, recorded so it isn't mistaken for a gap:** a non-empty but
+  vacuous answer ("I will now analyze…" then stop) passes the trim gate by construction.
+  If that shape shows up in practice it's a different problem (answer-quality, not
+  emptiness) and wants its own thinking, not a heuristic bolted onto this gate.
+
 ### Dossier checkpointing via the persistence store
 `deliberate`'s dossier (the synchronous explorer sweep) is the expensive artifact — minutes
 of live exploration — yet it lives only in memory until the offline synth consumes it.

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -47,6 +47,11 @@ enum FailureKind {
     TransientProvider,
     /// A non-transient model/provider error (auth, bad request). Retrying won't help.
     Provider,
+    /// A model ran and delivered no answer text (`consult/engine.rs::empty_answer_error`,
+    /// or the forced write-up turn's own failure wrapper). A model-side outcome that the
+    /// guard's diagnostics already frame as retryable — distinct from [`Provider`], whose
+    /// "retrying is unlikely to help" would contradict them.
+    EmptyAnswer,
     /// A kaibo-*side* failure (e.g. the synth's kaish kernel failed to build) — not the
     /// provider's fault, so we must not say it was.
     Internal,
@@ -59,7 +64,9 @@ enum FailureKind {
 /// transient *vocabulary* rather than a status code. A failure that reached a model wears
 /// one of kaibo's markers (`consult/engine.rs`): `"model loop failed: …"` from the tool
 /// loop, `"model call failed: …"` from a single-shot direct completion (`oneshot`,
-/// `deliberate`'s direct lane), `"model used all …"` from the forced final turn. An error
+/// `deliberate`'s direct lane), `"model used all …"` from the forced final turn, and
+/// `"returned an empty answer"` from the empty-answer guard (every lane's gate plus the
+/// forced write-up turn's failure wrapper). An error
 /// chain lacking every marker came from *before* a model ran (a kaish kernel build inside
 /// the toolset factory), so it's a kaibo-side failure, not the provider's.
 fn classify_failure(err: &anyhow::Error) -> FailureKind {
@@ -72,9 +79,16 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
     if s.contains("wall-clock deadline") {
         return FailureKind::TransientProvider;
     }
+    // The empty-answer guard's marker (`empty_answer_error` and the forced-turn failure
+    // wrapper, `consult/engine.rs`). An empty answer definitionally means a model ran, so
+    // it counts toward `reached_a_model`; its own classification is decided *after* the
+    // transient vocabulary below, so a forced write-up turn that died on an overload is
+    // framed transient (the more specific retry guidance) rather than generically empty.
+    let empty_answer = s.contains("returned an empty answer");
     let reached_a_model = s.contains("model loop failed")
         || s.contains("model call failed")
-        || s.contains("model used all");
+        || s.contains("model used all")
+        || empty_answer;
     if !reached_a_model {
         return FailureKind::Internal;
     }
@@ -99,6 +113,8 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
     ];
     if TRANSIENT.iter().any(|t| s.contains(t)) {
         FailureKind::TransientProvider
+    } else if empty_answer {
+        FailureKind::EmptyAnswer
     } else {
         FailureKind::Provider
     }
@@ -136,6 +152,12 @@ pub(crate) fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Err
         FailureKind::Provider => {
             "The model or its provider rejected the request; retrying is unlikely to help \
              — proceed without the consultation, or check the cast and config."
+        }
+        FailureKind::EmptyAnswer => {
+            "The model ran but delivered no answer text — a model-side outcome, not a \
+             kaibo bug. You may retry, and a different cast often helps; if the \
+             diagnostics report finish_reason \"length\", raise that slot's max_tokens \
+             so reasoning cannot starve the answer."
         }
         FailureKind::Internal => {
             "This is a kaibo-side error (not the provider) — please report it; you can \
@@ -426,7 +448,10 @@ pub(super) fn fmt_usage(usage: &Usage) -> Option<String> {
         line.push_str(&format!(" · {} cached", usage.cached_input_tokens));
     }
     if usage.cache_creation_input_tokens > 0 {
-        line.push_str(&format!(" · {} cache-write", usage.cache_creation_input_tokens));
+        line.push_str(&format!(
+            " · {} cache-write",
+            usage.cache_creation_input_tokens
+        ));
     }
     Some(line)
 }
@@ -676,6 +701,68 @@ mod tests {
             !text.to_lowercase().contains("you may retry")
                 && !text.to_lowercase().contains("retry this call"),
             "a non-transient error must not invite a retry: {text}"
+        );
+    }
+
+    /// An empty-answer failure (`consult/engine.rs::empty_answer_error`) means a model
+    /// ran and delivered no text — a model-side outcome. It must read as retryable and
+    /// must NOT be framed as a kaibo internal bug: the guard's own diagnostics say
+    /// "Retry, or try the same question on a different cast", and wrapping that in
+    /// "kaibo-side error — please report it" is contradictory guidance. (Live repro,
+    /// 2026-08-02: a starved deepseek oneshot — 256 reasoning tokens, empty content,
+    /// finish_reason "length" — surfaced as an Internal failure.)
+    #[test]
+    fn an_empty_answer_failure_invites_retry_and_is_not_called_a_kaibo_bug() {
+        for body in [
+            // The tool loop's gate (stopped without answering, no evidence gathered).
+            "model deepseek-v4-pro returned an EMPTY answer — it stopped without \
+             answering, and its transcript holds no tool results to write up. \
+             Diagnostics: 16 of 200 turns used; finish_reason \"stop\" reported by the \
+             provider. Retry, or try the same question on a different cast.",
+            // The single-shot lanes (oneshot, deliberate direct).
+            "model deepseek-v4-pro returned an EMPTY answer — the single toolless \
+             completion returned no answer text. Diagnostics: 1 of 1 turns used, 256 \
+             reasoning tokens reported; finish_reason \"length\" reported by the \
+             provider. Retry, or try the same question on a different cast.",
+            // The recovery's own failure wrapper (`run_phase`'s forced write-up turn).
+            "model deepseek-v4-pro returned an empty answer, and the forced \
+             final-answer turn also failed: prompt error",
+        ] {
+            let text = answer_text(&consultation_failed(
+                "consult",
+                "deepseek",
+                anyhow::anyhow!(body),
+            ));
+            let lower = text.to_lowercase();
+            assert!(
+                lower.contains("retry"),
+                "an empty answer is worth a retry: {body} -> {text}"
+            );
+            assert!(
+                !lower.contains("kaibo-side error") && !lower.contains("please report"),
+                "a model outcome must not be framed as a kaibo bug: {body} -> {text}"
+            );
+            assert!(
+                !lower.contains("retrying is unlikely to help"),
+                "must not contradict the guard's own retry advice: {body} -> {text}"
+            );
+        }
+    }
+
+    /// When the forced write-up turn itself died on a *transient* provider condition,
+    /// the transient framing wins — "retry" guidance with the overload named beats the
+    /// generic empty-answer framing, and both invite the same next step anyway.
+    #[test]
+    fn an_empty_answer_whose_forced_turn_hit_a_transient_error_stays_retryable() {
+        let err = anyhow::anyhow!(
+            "model deepseek-v4-pro returned an empty answer, and the forced final-answer \
+             turn also failed: ProviderError: {{\"type\":\"overloaded_error\"}}"
+        );
+        let text = answer_text(&consultation_failed("consult", "deepseek", err));
+        let lower = text.to_lowercase();
+        assert!(
+            lower.contains("transient") && lower.contains("retry"),
+            "a transient failure inside the recovery is still framed transient: {text}"
         );
     }
 


### PR DESCRIPTION
## What

The #115 empty-answer guard added a new error vocabulary (`"returned an EMPTY answer"`) that `classify_failure` (`src/server/render.rs`) never learned: its reached-a-model markers predate the guard, so every empty-answer failure fell through to `FailureKind::Internal` and the calling agent read *"This is a kaibo-side error (not the provider) — please report it"* wrapped around inner diagnostics that say *"Retry, or try the same question on a different cast."* Contradictory guidance, blaming kaibo for a model outcome.

Found live the same day the guard merged: a starved deepseek oneshot (256-token synth cap) spent all 256 output tokens on reasoning, returned empty content with `finish_reason "length"`, and the loud error came back labeled a kaibo bug.

## Decisions

- **Empty-answer gets its own `FailureKind`** rather than riding `Provider`, whose "retrying is unlikely to help" would contradict the guard's own diagnostics. The new guidance names the outcome (model ran, no answer text), invites a retry or a different cast, and points at the slot's `max_tokens` when the provider reported a length cutoff — the actual fix for the starved class.
- **The marker counts toward `reached_a_model` but classifies after the transient vocabulary**, so a forced write-up turn that died on an overload keeps the more specific transient framing.
- **The issues.md entry tracking the empty-answer recurrence** (the guard is a backstop, not a cure; characterize from telemetry before touching prompts) lands here. Its classifier-bug bullet ships in this same change, so per the delete-when-shipped convention it is not recorded.

## Tests

Written failing-first: the three empty paths (loop gate, single-shot, forced-turn wrapper) pin retry-inviting, non-kaibo-blaming guidance; the transient-during-recovery case pins transient framing. Full suite green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)