### PR TITLE
feat: surface model output ceilings and size synth budgets from them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **Model listings now show each model's output ceiling.** `kaibo models` and the
+  `list_models` tool render the provider's advertised max completion tokens beside the
+  context window (OpenRouter's `top_provider.max_completion_tokens`, Gemini's
+  `outputTokenLimit`; providers that don't publish one show nothing), and the `--json` /
+  structured face carries it as `output_ceiling`. This is the number to size a synth
+  slot's `max_tokens` from — reasoning bills into the same completion budget as the
+  answer — and the `configure` prompt and the `max_tokens` entry in
+  `kaibo://config/guide` now both say so.
+
 - **The explorer can now hand whole files to whoever reads its report.** Inside
   `consult` and `deliberate`, the delegated investigator gets an `attach` tool: when a
   whole file is the evidence, it routes the file's real bytes (numbered, `cat -n`
@@ -59,6 +68,12 @@ record. Each later release appends a new section at the top.
   all three.
 
 ### Changed
+
+- **The built-in deepseek and anthropic casts give their synth more room to answer.**
+  Both pin the synth slot's `max_tokens` to 32768, twice the 16384 `[defaults]` floor,
+  because a measured consult showed deepseek-v4-pro spending half its completion budget
+  on reasoning before the answer even started. The `[defaults]` floor itself is
+  unchanged, and every other built-in cast stays on it until measured.
 
 - **kaibo's models now work from a role, not a job description.** Every preamble opens
   on who the model is on kaibo's team — "You are the synthesis agent", "You are the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,10 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
-- **Model listings now show each model's output ceiling.** `kaibo models` and the
-  `list_models` tool render the provider's advertised max completion tokens beside the
-  context window (OpenRouter's `top_provider.max_completion_tokens`, Gemini's
-  `outputTokenLimit`; providers that don't publish one show nothing), and the `--json` /
-  structured face carries it as `output_ceiling`. This is the number to size a synth
-  slot's `max_tokens` from — reasoning bills into the same completion budget as the
-  answer — and the `configure` prompt and the `max_tokens` entry in
-  `kaibo://config/guide` now both say so.
+- **Model listings show each model's output ceiling.** `kaibo models` and `list_models`
+  render the provider's advertised max completion tokens beside the context window
+  (`output_ceiling` in the JSON face); the configure prompt and config guide now say to
+  size a synth slot's `max_tokens` from it.
 
 - **The explorer can now hand whole files to whoever reads its report.** Inside
   `consult` and `deliberate`, the delegated investigator gets an `attach` tool: when a
@@ -69,11 +65,9 @@ record. Each later release appends a new section at the top.
 
 ### Changed
 
-- **The built-in deepseek and anthropic casts give their synth more room to answer.**
-  Both pin the synth slot's `max_tokens` to 32768, twice the 16384 `[defaults]` floor,
-  because a measured consult showed deepseek-v4-pro spending half its completion budget
-  on reasoning before the answer even started. The `[defaults]` floor itself is
-  unchanged, and every other built-in cast stays on it until measured.
+- **The built-in deepseek and anthropic synths pin `max_tokens = 32768`** (the 16384
+  `[defaults]` floor is unchanged): a measured consult showed reasoning consuming half
+  the completion budget before the answer started.
 
 - **kaibo's models now work from a role, not a job description.** Every preamble opens
   on who the model is on kaibo's team — "You are the synthesis agent", "You are the

--- a/docs/config.md
+++ b/docs/config.md
@@ -269,7 +269,9 @@ bills against the completion budget, so `max_tokens` must sit well above
 `budget_tokens` tier) an inverted pair is rejected at load on the slot's resolved
 values, because Anthropic would 400 on it mid-call. A slot with no budget sink (Gemini
 takes a `thinkingLevel`, Anthropic's adaptive tier an effort) carries an inert
-`thinking_budget` and the pair is not checked.
+`thinking_budget` and the pair is not checked. `kaibo models` (CLI) and the
+`list_models` tool report each model's advertised output ceiling where the provider
+publishes one; size a synth slot's `max_tokens` from that value.
 
 **Sampling.** The explorer gathers exact citations and runs cold; the synth composes the
 answer and gets slightly more room. Sent where a model accepts them: top-level for

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,45 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-03 — Output ceilings surfaced, and the feature's first catch was its own premise
+
+Configure-time agents were sizing synth `max_tokens` blind: the ceiling arrived in
+`DiscoveredModel.raw` (OpenRouter's `top_provider.max_completion_tokens`, Gemini's
+`outputTokenLimit`) and died there, unrendered. Meanwhile reasoning bills into the
+same completion budget as the answer, so a blind budget starves exactly the models we
+run with thinking on. The 2026-08-02 probes (attach `render.rs`, exhaustive-review
+ask, at the 16384 `[defaults]` floor) made it concrete:
+
+| cast | completion used / cap | reasoning share |
+|---|---|---|
+| deepseek | 10.6K / 16.4K | ~half the completion |
+| or-glm | 10.2K / 16.4K | 0 |
+| or-kimi | 15,916 / 16,384 (97%) | hidden inside output; ~1.35 chars/token |
+
+So: normalize the ceiling, render it beside context on both faces, teach the
+configure prompt and the guide to size from it, and pin the two measured built-in
+synths (deepseek, anthropic) at 32768. The `[defaults]` floor stayed put — a pin
+without a measurement is a guess, and the unmeasured casts keep the floor.
+
+Then live validation handed us the good part. The freshly rendered catalog said
+kimi-k2.7-code's ceiling was **262144** — flatly contradicting the session-old note
+"or-kimi's provider ceiling IS 16384" that had shaped the pin decision. That probe
+had grazed kaibo's *own* 16384 default, not a provider wall, and OpenRouter's
+`top_provider` figure moves as serving providers change. The first thing the
+feature did in production was invalidate the stale note that motivated one of its
+own constraints. That is the argument for rendering live catalog facts instead of
+recording them: a noted ceiling goes stale silently; a rendered one is read fresh.
+
+Validation also exposed a cosmetic-but-telling gap: OpenRouter models rendered
+`(output: N)` with no context beside it, because `parse_openai_models` had never
+normalized `context_length` — invisible until the ceiling landed next to the hole.
+DeepSeek's cross-family review (ready-to-merge, no blockers) contributed two folds:
+the configure directive now says where to look when a provider publishes no ceiling,
+and the role-wise-merge test now pins that a string-form slot override
+(`synth = "backend/other-model"`) replaces the slot whole and drops the built-in
+pin — pre-existing semantics, but `max_tokens` is the first pin where the loss
+matters, so it's asserted as deliberate rather than discovered later.
+
 ## 2026-07-26 — Configure names host-agent sandbox access and per-client state
 
 The first Codex MCP bring-up surfaced a setup mismatch rather than a kaibo runtime bug:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -704,6 +704,36 @@ global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.
 
+### Synth output budgets — measure the remaining casts before moving them
+
+Shipped 2026-08-03: output ceilings are normalized (`DiscoveredModel.output_ceiling`:
+OpenRouter `top_provider.max_completion_tokens`, Gemini `outputTokenLimit`) and
+rendered by `kaibo models` / `list_models`; the configure prompt and the
+`max_tokens` guide entry both say to size a synth slot from the ceiling; the built-in
+deepseek and anthropic casts pin synth `max_tokens = 32768`
+(`config.rs::builtin_casts`, test `builtin_synth_max_tokens_pins_are_deliberate`).
+
+The measurement that drove the pins (2026-08-02, attach `render.rs`,
+exhaustive-review ask, at the 16384 `[defaults]` floor):
+
+| cast | completion used / cap | reasoning share |
+|---|---|---|
+| deepseek | 10.6K / 16.4K | ~half of the completion |
+| or-glm | 10.2K / 16.4K | 0 |
+| or-kimi | 15,916 / 16,384 (97%) | hidden inside output; odd accounting, ~1.35 chars/token |
+
+Open work:
+
+- **The unmeasured built-ins stay on the 16384 floor** (gemini, openrouter/qwen,
+  openai-local, gemini-batch, anthropic-batch). Measure each the same way before
+  pinning — a pin without a measurement is a guess.
+- **or-kimi sits at 97% of its cap and its provider ceiling IS 16384** — raising it
+  is not an option; watch it for truncation/starvation and consider whether a
+  16384-capped reasoner belongs in a synth slot at all.
+- **Anthropic providers don't report a ceiling on `/v1/models`**, so the anthropic
+  pin rests on the DeepSeek measurement plus known thinking-on billing, not a
+  catalog number. Confirm with a live probe when convenient.
+
 ### OpenRouter cost + shaping follow-ups (measured $4 GLM consult, 2026-07-03)
 First live `or-glm` consult (GLM-5 explorer / GLM-5.2 synth, 8 whole files attached):
 203 chat turns in 21 min, 18.2M cumulative input tokens (16.4M cache reads) for ~40K
@@ -732,9 +762,9 @@ Remaining OpenRouter-specific forks:
 - **Per-slot output ceilings vary by pinned slug** (`top_provider.max_completion_tokens`:
   glm-5.2 32768, kimi-k2.7-code 16384, gpt-5.5 128000) and reasoning bills into the
   same completion budget — the `[defaults]` 16384 starved a real GLM oneshot answer
-  mid-sentence. Per-slot `max_tokens` already exists; the gap is doctrine: set a synth
-  slot's ceiling from the catalog when pinning a slug, and watch 16384-capped reasoners
-  (kimi) for starvation.
+  mid-sentence. The doctrine half shipped (ceilings rendered by `list_models`, sizing
+  guidance in the configure prompt and config guide — see "Synth output budgets"
+  above); still open here: watch 16384-capped reasoners (kimi) for starvation.
 - **Provider routing variance — data policy shipped, the rest open.** One slug routes
   to multiple upstream hosts differing in cache support, quantization, pricing, and
   parameter fidelity. `provider.data_collection = "deny"` now rides every request by

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -704,35 +704,17 @@ global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.
 
-### Synth output budgets — measure the remaining casts before moving them
+### Synth output budgets — measure the remaining casts before pinning them
 
-Shipped 2026-08-03: output ceilings are normalized (`DiscoveredModel.output_ceiling`:
-OpenRouter `top_provider.max_completion_tokens`, Gemini `outputTokenLimit`) and
-rendered by `kaibo models` / `list_models`; the configure prompt and the
-`max_tokens` guide entry both say to size a synth slot from the ceiling; the built-in
-deepseek and anthropic casts pin synth `max_tokens = 32768`
-(`config.rs::builtin_casts`, test `builtin_synth_max_tokens_pins_are_deliberate`).
+The built-in deepseek and anthropic synths now pin `max_tokens = 32768` from a
+measured consult (numbers in the 2026-08-03 devlog entry). Still open:
 
-The measurement that drove the pins (2026-08-02, attach `render.rs`,
-exhaustive-review ask, at the 16384 `[defaults]` floor):
-
-| cast | completion used / cap | reasoning share |
-|---|---|---|
-| deepseek | 10.6K / 16.4K | ~half of the completion |
-| or-glm | 10.2K / 16.4K | 0 |
-| or-kimi | 15,916 / 16,384 (97%) | hidden inside output; odd accounting, ~1.35 chars/token |
-
-Open work:
-
-- **The unmeasured built-ins stay on the 16384 floor** (gemini, openrouter/qwen,
-  openai-local, gemini-batch, anthropic-batch). Measure each the same way before
-  pinning — a pin without a measurement is a guess.
-- **or-kimi sits at 97% of its cap and its provider ceiling IS 16384** — raising it
-  is not an option; watch it for truncation/starvation and consider whether a
-  16384-capped reasoner belongs in a synth slot at all.
-- **Anthropic providers don't report a ceiling on `/v1/models`**, so the anthropic
-  pin rests on the DeepSeek measurement plus known thinking-on billing, not a
-  catalog number. Confirm with a live probe when convenient.
+- The unmeasured built-ins (gemini, openrouter/qwen, openai-local, both batch
+  casts) stay on the 16384 floor — a pin without a measurement is a guess.
+- The anthropic pin has no catalog backing (`/v1/models` reports no ceiling);
+  confirm with a live probe when the key is funded.
+- Ceilings drift: kimi-k2.7-code advertised 16384 on 2026-08-02 and 262144 on
+  2026-08-03. Read `kaibo models` fresh when pinning; a noted ceiling goes stale.
 
 ### OpenRouter cost + shaping follow-ups (measured $4 GLM consult, 2026-07-03)
 First live `or-glm` consult (GLM-5 explorer / GLM-5.2 synth, 8 whole files attached):
@@ -759,12 +741,6 @@ Remaining OpenRouter-specific forks:
   re-bills at full input price every turn — the preamble is the only cached prefix.
   Upstream rig gap; the fix wants a trailing-message breakpoint like rig's native
   Anthropic path carries.
-- **Per-slot output ceilings vary by pinned slug** (`top_provider.max_completion_tokens`:
-  glm-5.2 32768, kimi-k2.7-code 16384, gpt-5.5 128000) and reasoning bills into the
-  same completion budget — the `[defaults]` 16384 starved a real GLM oneshot answer
-  mid-sentence. The doctrine half shipped (ceilings rendered by `list_models`, sizing
-  guidance in the configure prompt and config guide — see "Synth output budgets"
-  above); still open here: watch 16384-capped reasoners (kimi) for starvation.
 - **Provider routing variance — data policy shipped, the rest open.** One slug routes
   to multiple upstream hosts differing in cache support, quantization, pricing, and
   parameter fidelity. `provider.data_collection = "deny"` now rides every request by

--- a/src/config.rs
+++ b/src/config.rs
@@ -1930,11 +1930,28 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
             ..ModelSlot::bare(&name, id)
         };
         let or = matches!(kind, ProviderKind::OpenRouter);
+        // Synth headroom pins, from measurement (2026-08-02, whole-file attach +
+        // exhaustive-review ask at the 16384 default): reasoning bills into the same
+        // completion budget as the answer, and deepseek-v4-pro spent HALF of a 10.6K
+        // completion on reasoning — so the deepseek and anthropic synths (both
+        // thinking-on by default, ceilings far above this) get 2× the [defaults]
+        // floor. The other built-ins are unmeasured and stay on the floor; the pin
+        // table lives with `builtin_synth_max_tokens_pins_are_deliberate`.
+        let synth_max_tokens = match kind {
+            ProviderKind::Anthropic | ProviderKind::DeepSeek => Some(32_768),
+            _ => None,
+        };
         // Both agent roles are seeded. A cast may omit one in config — absent means
         // the capability is absent, and nothing downstream errors on that.
         let slots = BTreeMap::from([
             (ModelRole::Explorer, slot(explorer, or.then_some(true))),
-            (ModelRole::Synth, slot(synth, None)),
+            (
+                ModelRole::Synth,
+                ModelSlot {
+                    max_tokens: synth_max_tokens,
+                    ..slot(synth, None)
+                },
+            ),
         ]);
         m.insert(name.clone(), Cast { name, slots });
     }
@@ -3321,6 +3338,36 @@ mod tests {
         assert_eq!(b.kind, ProviderKind::Anthropic);
         assert_eq!(b.api_key_env.as_deref(), Some("ANTHROPIC_API_KEY"));
         assert!(!b.key_optional);
+    }
+
+    /// Built-in synth `max_tokens` pins are deliberate — a future edit moves this
+    /// test, not just the cast table. Measured 2026-08-02 at the 16384 default
+    /// (whole-file attach, exhaustive-review ask): deepseek-v4-pro used 10.6K of
+    /// 16.4K with half spent on reasoning, which bills into the same completion
+    /// budget as the answer — so the deepseek and anthropic synths get 2× headroom.
+    /// The unmeasured casts stay on the `[defaults]` floor (16384) rather than
+    /// guessing a ceiling.
+    #[test]
+    fn builtin_synth_max_tokens_pins_are_deliberate() {
+        let cfg = Config::builtin();
+        for (name, expected) in [
+            ("deepseek", Some(32_768)),
+            ("anthropic", Some(32_768)),
+            ("gemini", None),
+            ("openrouter", None),
+            ("openai-local", None),
+            ("gemini-batch", None),
+            ("anthropic-batch", None),
+        ] {
+            let cast = cfg.resolve_cast(name).unwrap();
+            let s = cast.require_slot(ModelRole::Synth).unwrap();
+            assert_eq!(s.max_tokens, expected, "synth max_tokens pin for {name:?}");
+            // Explorers sweep and cite; none has shown reasoning pressure, so every
+            // explorer slot inherits the [defaults] floor.
+            if let Some(e) = cast.slots.get(&ModelRole::Explorer) {
+                assert_eq!(e.max_tokens, None, "explorer stays on the floor for {name:?}");
+            }
+        }
     }
 
     /// Every interactive built-in cast exists, each single-backend with

--- a/src/config.rs
+++ b/src/config.rs
@@ -4288,9 +4288,15 @@ mod tests {
         )
         .unwrap();
         let cast = cfg.resolve_cast("anthropic").unwrap();
+        let synth = cast.require_slot(ModelRole::Synth).unwrap();
+        assert_eq!(synth.id, "claude-opus-4-8");
+        // A file slot REPLACES the built-in slot whole, so the built-in synth's
+        // 32768 max_tokens pin is gone and the slot inherits [defaults] again.
+        // Deliberate: a slot override is a whole-slot statement, and the pin is
+        // headroom for the built-in model, not the operator's replacement.
         assert_eq!(
-            cast.require_slot(ModelRole::Synth).unwrap().id,
-            "claude-opus-4-8"
+            synth.max_tokens, None,
+            "a string-form slot override drops the built-in pin"
         );
         // The explorer slot is untouched (still the built-in default).
         assert_eq!(

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -66,6 +66,13 @@ pub struct DiscoveredModel {
     pub created: Option<i64>,
     /// Anthropic `max_input_tokens`, Gemini `inputTokenLimit`.
     pub context_window: Option<u64>,
+    /// The model's advertised max *completion* tokens — OpenRouter
+    /// `top_provider.max_completion_tokens`, Gemini `outputTokenLimit`. `None` where
+    /// the provider's list endpoint doesn't report one (Anthropic, plain OpenAI wire).
+    /// Surfaced so a configure-time caller can size a synth slot's `max_tokens` from
+    /// it: reasoning bills into the same completion budget as the answer, so a budget
+    /// set below the ceiling starves answers.
+    pub output_ceiling: Option<u64>,
     /// The provider's per-model object, untouched — the passthrough half of the
     /// contract, so a caller who needs a field we didn't normalize still has it.
     pub raw: Value,
@@ -194,6 +201,12 @@ pub fn parse_openai_models(v: &Value) -> Vec<DiscoveredModel> {
             display_name: None,
             created: item.get("created").and_then(Value::as_i64),
             context_window: None,
+            // OpenRouter nests the completion ceiling under `top_provider`; the
+            // other OpenAI-wire endpoints simply don't carry the field.
+            output_ceiling: item
+                .get("top_provider")
+                .and_then(|tp| tp.get("max_completion_tokens"))
+                .and_then(Value::as_u64),
             pricing: parse_openai_pricing(item),
             raw: item.clone(),
         })
@@ -252,7 +265,8 @@ pub fn parse_anthropic_models(v: &Value) -> Vec<DiscoveredModel> {
                 .and_then(Value::as_str)
                 .and_then(rfc3339_to_epoch),
             context_window: item.get("max_input_tokens").and_then(Value::as_u64),
-            // Anthropic's `/v1/models` doesn't advertise pricing.
+            // Anthropic's `/v1/models` advertises neither pricing nor an output ceiling.
+            output_ceiling: None,
             pricing: None,
             raw: item.clone(),
         })
@@ -277,6 +291,7 @@ pub fn parse_gemini_models(v: &Value) -> Vec<DiscoveredModel> {
                     .map(str::to_string),
                 created: None,
                 context_window: item.get("inputTokenLimit").and_then(Value::as_u64),
+                output_ceiling: item.get("outputTokenLimit").and_then(Value::as_u64),
                 // Gemini's `/v1beta/models` doesn't advertise pricing.
                 pricing: None,
                 raw: item.clone(),
@@ -418,7 +433,7 @@ async fn discover_paginated(
 }
 
 /// Render a multi-backend sweep as prose: one section per backend, each model's `id` +
-/// `display_name` (when present) + `context_window` (when present); a backend that
+/// `display_name` (when present) + `context_window`/`output_ceiling` (when present); a backend that
 /// errored gets an inline error line instead of a model list. Shared by the MCP tool
 /// and the CLI so the two faces can't drift on what a sweep looks like (the
 /// `render_config_resource` discipline).
@@ -442,8 +457,18 @@ pub fn render_models(results: &BTreeMap<String, Result<Vec<DiscoveredModel>, Str
                     if let Some(dn) = &m.display_name {
                         line.push_str(&format!(" — {dn}"));
                     }
+                    // Context window and output ceiling share one paren group; either
+                    // may be absent alone, and an absent fact renders nothing (no
+                    // placeholder noise).
+                    let mut limits = Vec::new();
                     if let Some(ctx) = m.context_window {
-                        line.push_str(&format!(" (context: {ctx})"));
+                        limits.push(format!("context: {ctx}"));
+                    }
+                    if let Some(ceiling) = m.output_ceiling {
+                        limits.push(format!("output: {ceiling}"));
+                    }
+                    if !limits.is_empty() {
+                        line.push_str(&format!(" ({})", limits.join(", ")));
                     }
                     if let Some(p) = &m.pricing {
                         let mut parts = Vec::new();
@@ -487,6 +512,7 @@ pub fn models_json_envelope(results: &BTreeMap<String, Result<Vec<DiscoveredMode
                             "display_name": m.display_name,
                             "created": m.created,
                             "context_window": m.context_window,
+                            "output_ceiling": m.output_ceiling,
                             "pricing": m.pricing.as_ref().map(|p| serde_json::json!({
                                 "input": p.input,
                                 "output": p.output,
@@ -729,6 +755,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_openai_shape_normalizes_openrouter_output_ceiling() {
+        // OpenRouter's catalog nests the completion ceiling under `top_provider` —
+        // the field a configure-time caller sizes a synth `max_tokens` from.
+        let body = serde_json::json!({
+            "data": [
+                {
+                    "id": "moonshotai/kimi-k2.7-code",
+                    "top_provider": {
+                        "context_length": 262_144,
+                        "max_completion_tokens": 16_384,
+                    },
+                },
+                {"id": "no-ceiling/model", "top_provider": {"context_length": 8192}},
+            ]
+        });
+        let models = parse_openai_models(&body);
+        assert_eq!(models[0].output_ceiling, Some(16_384));
+        assert_eq!(models[1].output_ceiling, None);
+        // .raw keeps the nested object untouched either way.
+        assert_eq!(
+            models[0].raw["top_provider"]["max_completion_tokens"],
+            16_384
+        );
+    }
+
+    #[test]
     fn parse_openai_shape_is_defensive_on_missing_fields() {
         let body = serde_json::json!({ "data": [ {"object": "model"} ] });
         let models = parse_openai_models(&body);
@@ -765,6 +817,7 @@ mod tests {
         assert_eq!(m.display_name.as_deref(), Some("Claude X"));
         assert_eq!(m.created, Some(1_767_225_600));
         assert_eq!(m.context_window, Some(200_000));
+        assert_eq!(m.output_ceiling, None, "anthropic's list reports no ceiling");
         assert_eq!(m.raw, body["data"][0]);
     }
 
@@ -798,6 +851,7 @@ mod tests {
         assert_eq!(m.id, "gemini-x");
         assert_eq!(m.display_name.as_deref(), Some("Gemini X"));
         assert_eq!(m.context_window, Some(1_000_000));
+        assert_eq!(m.output_ceiling, Some(8192));
         assert_eq!(m.created, None);
         // .raw keeps the original "models/..." name untouched.
         assert_eq!(m.raw["name"], "models/gemini-x");
@@ -952,6 +1006,7 @@ mod tests {
                 display_name: Some("Model One".to_string()),
                 created: None,
                 context_window: Some(128_000),
+                output_ceiling: Some(16_384),
                 pricing: Some(ModelPricing {
                     input: Some("0.0000015".to_string()),
                     output: Some("0.000006".to_string()),
@@ -969,9 +1024,35 @@ mod tests {
         assert!(text.contains("Model One"));
         assert!(text.contains("128000") || text.contains("128,000"));
         assert!(
+            text.contains("(context: 128000, output: 16384)"),
+            "expected the output ceiling beside context, got: {text}"
+        );
+        assert!(
             text.contains("[in $0.0000015/tok, out $0.000006/tok]"),
             "expected a pricing suffix, got: {text}"
         );
+    }
+
+    #[test]
+    fn render_models_shows_a_ceiling_without_a_context_window() {
+        // The OpenRouter shape today: ceiling normalized, context not — the paren
+        // group must render the one fact it has, with no placeholder for the other.
+        let mut results: BTreeMap<String, Result<Vec<DiscoveredModel>, String>> = BTreeMap::new();
+        results.insert(
+            "or".to_string(),
+            Ok(vec![DiscoveredModel {
+                id: "m1".to_string(),
+                display_name: None,
+                created: None,
+                context_window: None,
+                output_ceiling: Some(16_384),
+                pricing: None,
+                raw: serde_json::json!({"id": "m1"}),
+            }]),
+        );
+        let text = render_models(&results);
+        assert!(text.contains("(output: 16384)"), "got: {text}");
+        assert!(!text.contains("context"), "no context means no context label, got: {text}");
     }
 
     #[test]
@@ -984,6 +1065,7 @@ mod tests {
                 display_name: None,
                 created: None,
                 context_window: None,
+                output_ceiling: None,
                 pricing: None,
                 raw: serde_json::json!({"id": "m1"}),
             }]),
@@ -1008,6 +1090,7 @@ mod tests {
                 display_name: None,
                 created: Some(42),
                 context_window: None,
+                output_ceiling: Some(65_536),
                 pricing: Some(ModelPricing {
                     input: Some("0.000001".to_string()),
                     output: None,
@@ -1028,6 +1111,7 @@ mod tests {
         assert_eq!(ok["models"][0]["id"], "m1");
         assert_eq!(ok["models"][0]["created"], 42);
         assert_eq!(ok["models"][0]["raw"]["extra"], "field");
+        assert_eq!(ok["models"][0]["output_ceiling"], 65_536);
         assert_eq!(ok["models"][0]["pricing"]["input"], "0.000001");
         assert!(ok["models"][0]["pricing"]["output"].is_null());
 
@@ -1049,6 +1133,7 @@ mod tests {
                 display_name: None,
                 created: None,
                 context_window: None,
+                output_ceiling: None,
                 pricing: None,
                 raw: serde_json::json!({"id": "m1"}),
             }]),

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -200,7 +200,17 @@ pub fn parse_openai_models(v: &Value) -> Vec<DiscoveredModel> {
                 .to_string(),
             display_name: None,
             created: item.get("created").and_then(Value::as_i64),
-            context_window: None,
+            // OpenRouter carries the model's context at the top level, with the
+            // serving provider's figure under `top_provider` as the fallback; the
+            // other OpenAI-wire endpoints carry neither.
+            context_window: item
+                .get("context_length")
+                .and_then(Value::as_u64)
+                .or_else(|| {
+                    item.get("top_provider")
+                        .and_then(|tp| tp.get("context_length"))
+                        .and_then(Value::as_u64)
+                }),
             // OpenRouter nests the completion ceiling under `top_provider`; the
             // other OpenAI-wire endpoints simply don't carry the field.
             output_ceiling: item
@@ -762,8 +772,9 @@ mod tests {
             "data": [
                 {
                     "id": "moonshotai/kimi-k2.7-code",
+                    "context_length": 262_144,
                     "top_provider": {
-                        "context_length": 262_144,
+                        "context_length": 131_072,
                         "max_completion_tokens": 16_384,
                     },
                 },
@@ -773,6 +784,10 @@ mod tests {
         let models = parse_openai_models(&body);
         assert_eq!(models[0].output_ceiling, Some(16_384));
         assert_eq!(models[1].output_ceiling, None);
+        // Context rides the same catalog: the model-level `context_length` wins,
+        // the `top_provider` figure is the fallback (live catalogs carry both).
+        assert_eq!(models[0].context_window, Some(262_144));
+        assert_eq!(models[1].context_window, Some(8192));
         // .raw keeps the nested object untouched either way.
         assert_eq!(
             models[0].raw["top_provider"]["max_completion_tokens"],

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2864,7 +2864,10 @@ tool-capable coding models (a consult cast needs `tools` support); `q=` / `conte
 `reasoning` capability block. Favor the drift-proof `~author/family-latest` aliases \
 (e.g. `~anthropic/claude-sonnet-latest`) over a pinned slug, and know that `:free` / \
 `:nitro` / `:floor` suffixes pick a free, fastest, or cheapest variant of a concrete \
-slug where offered.
+slug where offered. When you pick a synth model, read its output ceiling from kaibo's \
+model listing (the `list_models` tool, or `kaibo models` on the CLI) and set that \
+slot's `max_tokens` from the ceiling, because reasoning bills into the same completion \
+budget as the answer.
 4. Keep secrets in the environment or a key file. A backend names an env var \
 (`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
 the secret stays outside it. Tell me which env vars to set or files to write, and let \
@@ -5362,6 +5365,7 @@ mod tests {
             "config.toml",          // write target
             "api_key_env",          // keys-by-reference, not inline
             "both within it",       // shared roster-design substance
+            "output ceiling",       // synth max_tokens sizing rides the shared core
         ] {
             assert!(
                 text.contains(needle),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2867,7 +2867,8 @@ tool-capable coding models (a consult cast needs `tools` support); `q=` / `conte
 slug where offered. When you pick a synth model, read its output ceiling from kaibo's \
 model listing (the `list_models` tool, or `kaibo models` on the CLI) and set that \
 slot's `max_tokens` from the ceiling, because reasoning bills into the same completion \
-budget as the answer.
+budget as the answer. Some providers publish no ceiling; there, look it up in the \
+provider's own model documentation.
 4. Keep secrets in the environment or a key file. A backend names an env var \
 (`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
 the secret stays outside it. Tell me which env vars to set or files to write, and let \

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -409,16 +409,30 @@ fn per_slot_tunables_override_defaults_others_inherit() {
     assert_eq!(et.max_tokens, 20000);
     assert_eq!(et.thinking_budget, 9000);
 
-    // A built-in cast that overrode nothing inherits the file-set defaults too.
+    // A built-in slot with no pin inherits the file-set defaults too (gemini's
+    // synth carries no built-in max_tokens pin).
+    let g = c
+        .resolve_cast("gemini")
+        .unwrap()
+        .require_slot(ModelRole::Synth)
+        .unwrap()
+        .tunables(ModelRole::Synth, &c.defaults);
+    assert_eq!(g.max_tokens, 20000);
+    assert_eq!(g.thinking_budget, 9000);
+    assert_eq!(g.temperature, 0.5);
+
+    // A built-in slot pin is an ordinary slot override, so it wins over the
+    // file-set default the same way a user cast's pin does (the built-in
+    // anthropic synth pins 32768 — see
+    // `builtin_synth_max_tokens_pins_are_deliberate` in src/config.rs).
     let a = c
         .resolve_cast("anthropic")
         .unwrap()
         .require_slot(ModelRole::Synth)
         .unwrap()
         .tunables(ModelRole::Synth, &c.defaults);
-    assert_eq!(a.max_tokens, 20000);
+    assert_eq!(a.max_tokens, 32768);
     assert_eq!(a.thinking_budget, 9000);
-    assert_eq!(a.temperature, 0.5);
 }
 
 #[test]
@@ -1059,9 +1073,12 @@ fn env_overrides_file_defaults_and_flows_into_slot_tunables() {
     let env: HashMap<&str, &str> = [("KAIBO_MAX_TOKENS", "22222")].into_iter().collect();
     let c = Config::load_with(None, Some(path), |k| env.get(k).map(|s| s.to_string())).unwrap();
     assert_eq!(c.defaults.max_tokens, 22222);
-    // And the env'd default flows into a slot that inherits it.
+    // And the env'd default flows into a slot that inherits it — gemini's synth,
+    // which carries no built-in max_tokens pin (the anthropic and deepseek synths
+    // do, and a slot pin wins over [defaults] from any layer; see
+    // `builtin_synth_max_tokens_pins_are_deliberate` in src/config.rs).
     let t = c
-        .resolve_cast("anthropic")
+        .resolve_cast("gemini")
         .unwrap()
         .require_slot(ModelRole::Synth)
         .unwrap()


### PR DESCRIPTION
A configure-prompt-running agent today cannot see model output ceilings anywhere: `list_models` renders context+pricing only, while the ceiling sits unnormalized in `DiscoveredModel.raw`. Meanwhile reasoning bills into the same completion budget as the answer, and the 2026-08-02 budget probes showed the default 16384 is tight for thinking-on synths (deepseek spent half a 10.6K completion on reasoning; or-kimi hit 97% of cap).

Four parts, all agreed with Amy in-session ("yeah definitely do 1. 2 as well. 3 as well, can be one pr for those" + "yes on the max tokens pins"):

1. **Normalize `output_ceiling` on `DiscoveredModel`** (OpenRouter `top_provider.max_completion_tokens`, Gemini `outputTokenLimit`; Anthropic/plain-OpenAI honestly `None`) and render it beside context in `render_models`, so both the MCP `list_models` face and `kaibo models` inherit it. The JSON envelope carries the field too.
2. **Configure prompt**: `CONFIGURE_STEPS_CORE` step 3 now tells the configuring agent to read the ceiling from the model listing and set the synth slot's `max_tokens` *from* it (not *to* it — a 128K ceiling is not a recommendation).
3. **Guide**: the `max_tokens` entry points at `kaibo models` / `list_models` as the ceiling source.
4. **Built-in synth pins from measurement**: deepseek and anthropic synths pin `max_tokens = 32768` (2× the floor; both thinking-on by default). Unmeasured casts stay on the `[defaults]` 16384 floor rather than guessing. A table-pinning test makes future edits deliberate.

**Behavior change worth a reviewer's eye**: with the pins, `[defaults] max_tokens` and `KAIBO_MAX_TOKENS` no longer flow into the built-in deepseek/anthropic *synth* slots — a slot pin wins, same as in a user cast. Two inheritance tests were repointed at the unpinned gemini synth, plus a new assertion that the pin beats a file-set default.

The anthropic 32768 pin has no catalog backing (Anthropic's `/v1/models` reports no ceiling); it rests on the DeepSeek measurement plus thinking-on billing, and is flagged in `docs/issues.md` for a live probe. The measured table now lives in the new "Synth output budgets" issues entry.

854 tests green (+3 new, failing-first), clippy silent, no new config knob so the template-coverage guard is untouched.

Patch written by a Claude subagent from the in-session brief; cross-family review to follow as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)