### PR TITLE
feat: image generation through a media CAS — the generate tool, stages 3-4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,12 @@ It augments a calling agent (Codex, Claude, Gemini, local agents, etc.) with a t
 models, lending one kind of help — *consultation*: grounded, cited, read-only answers
 about a codebase. The team
 *perceives* what fuses into its reasoning (image input today — `view_image` and image
-attachments on the model-driven tools; more modalities as the models gain them), but
-kaibo produces **no output artifacts** — it reasons over code, it doesn't render or
-emit. (When it needs to *record* something, that's a specific mediated tool, not a
-general write path; see the read-only invariant.)
+attachments on the model-driven tools; more modalities as the models gain them), and —
+when a cast carries an `image` slot — *produces*: the `generate` tool writes artifacts
+into kaibo's own media CAS (content-addressed, provenance-recorded, retrieved by the
+operator via `kaibo://cas/<digest>`), **never into the project**. Recording and emitting
+are always a specific mediated tool over kaibo's own store, not a general write path;
+see the read-only invariant.
 
 ## For agents working here
 
@@ -37,9 +39,11 @@ loop. Each consultation tool is that loop wearing different clothes:
 Both model-driven tools name their cast + answering model(s) in a provenance footer
 (`with_provenance` in `server.rs`), so a cross-model study sees which model answered.
 
-Seven `--no-<tool>` capability flags gate the surface (all on by default; `consult` also
-gates `consult_submit`, `batch` gates `batch_submit`, and the `job_*` verbs follow their
-live producers). A tool also needs a cast that can **staff** it, or its route is dropped;
+Eight `--no-<tool>` capability flags gate the surface (all on by default; `consult` also
+gates `consult_submit`, `batch` gates `batch_submit`, `generate` additionally needs the
+media CAS on, and the `job_*` verbs follow their live producers — a deferred `generate`
+mints a `job-N` like the other producers). A tool also needs a cast that can **staff**
+it, or its route is dropped;
 a server left with nothing advertised is refused at startup, by either road. See
 `CAST_ENUM_RULES` and `live_tools` in `server.rs`, and "Tool gating" in `docs/config.md`.
 Multi-provider over `rig-core`: a **`ProviderKind`** is the wire protocol (keyed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ record. Each later release appends a new section at the top.
   when the store is on disk. Provider-native options (`aspect_ratio`,
   `output_format`, `seed`, `negative_prompt`, ...) pass through a `fields` object
   verbatim. Operations the provider declares deferred return a `job-N` handle on the
-  existing `job_wait`/`job_get`/`job_list`/`job_cancel` verbs. The tool follows the
+  existing `job_wait`/`job_get`/`job_list`/`job_cancel` verbs (the lane ships
+  offline-tested; every Stability operation wired today is synchronous). The tool
+  follows the
   staffing discipline: no configured cast with an `image` slot (a stock install)
   means it is not advertised and costs nothing; `--no-generate` /
   `KAIBO_NO_GENERATE` / `[server.tools] generate = false` switch it off explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,36 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **kaibo can now generate images.** A new `generate` tool turns a text prompt into
+  artifacts through the cast's new `image` slot — a media backend (Stability's v2beta
+  `core`/`ultra`/SD3.5 family) riding beside the reasoning slots, e.g.
+  `[casts.artist] image = "sd/core"`. The tool never inlines bytes: every artifact
+  lands in kaibo's content-addressed media store under its own SHA-256 digest with a
+  provenance sidecar (prompt, model, cast, timestamp, mime, seed), and the result
+  lists per-artifact `kaibo://cas/<digest>` resource URIs — plus the real file path
+  when the store is on disk. Provider-native options (`aspect_ratio`,
+  `output_format`, `seed`, `negative_prompt`, ...) pass through a `fields` object
+  verbatim. Operations the provider declares deferred return a `job-N` handle on the
+  existing `job_wait`/`job_get`/`job_list`/`job_cancel` verbs. The tool follows the
+  staffing discipline: no configured cast with an `image` slot (a stock install)
+  means it is not advertised and costs nothing; `--no-generate` /
+  `KAIBO_NO_GENERATE` / `[server.tools] generate = false` switch it off explicitly.
+
+- **The media CAS has a lifecycle, and it follows persistence.** While persistence is
+  active, generated artifacts are durable on disk at `[cas] dir` (default
+  `$XDG_DATA_HOME/kaibo/cas`). Without persistence (off, or degraded) the CAS runs
+  in memory: artifacts stay fetchable by digest for that run only, and startup warns
+  loudly that they will not survive a restart. `[cas] enabled = false` turns the
+  store off entirely and un-advertises every tool that needs it. `kaibo://config`
+  gains a `[cas]` section reporting the knob and the live mode
+  (`disk` / `memory` / `off`).
+
+- **Artifact retrieval is operator-surface only.** The new `kaibo://cas/{digest}` MCP
+  resource serves an artifact's bytes (base64, correct mime) to the calling client —
+  the inner model team never sees the CAS: it is not mounted into kaish and no
+  cast-facing tool reads it, so one project's team can never enumerate another
+  project's artifacts.
+
 - **The explorer can now hand whole files to whoever reads its report.** Inside
   `consult` and `deliberate`, the delegated investigator gets an `attach` tool: when a
   whole file is the evidence, it routes the file's real bytes (numbered, `cat -n`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ path = "src/main.rs"
 # read-only safety is thus structural (the dangerous surface doesn't exist),
 # backed by the runtime read-only mount; see src/sandbox.rs.
 kaish-kernel = { version = "0.13.0", default-features = false, features = ["localfs"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+# `time` is used by the deferred `generate` job's poll cadence (sleep + Instant) —
+# named here rather than inherited from a transitive enabler.
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 async-trait = "0.1"
 anyhow = "1"
 
@@ -171,6 +173,9 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+# `start_paused` tests (the deferred-generate poll loop) auto-advance tokio's clock
+# instead of really sleeping the poll interval.
+tokio = { version = "1", features = ["test-util"] }
 # Request-body capture in `tests/effort_wire.rs` and `test_support::CaptureHttp`:
 # rig's `HttpClientExt` trait is typed in `bytes::Bytes`, so implementing a fake
 # transport needs the type by name. Already in the tree via reqwest/rig-core — zero

--- a/README.md
+++ b/README.md
@@ -449,6 +449,17 @@ code + stdout + stderr. For an agent that already has a shell tool, this mostly 
 *safety* — writes and external commands are refused, so exploration leaves nothing to
 review: there's no diff, because nothing it runs can change your tree.
 
+### `generate` — images through the cast's media member
+
+kaibo's first artifact-*producing* tool: a text prompt in, generated images out —
+through a cast's `image` slot (a Stability backend today). The bytes never inline into
+your context: each artifact lands in kaibo's content-addressed media store with a
+provenance sidecar (prompt, model, cast, seed), and the result lists per-artifact
+digests as `kaibo://cas/<digest>` resource URIs — plus the real file path when the
+store is on disk. Advertised only when a configured cast carries an `image` slot and
+the `[cas]` store is on; the project stays untouched — the store lives at a fixed XDG
+data path the model can't steer. See "Media CAS" in [`docs/config.md`](docs/config.md).
+
 ---
 
 ## Backends, Roles, and Casts
@@ -467,8 +478,9 @@ config has three concepts for configuring models:
   never live in the TOML — only the *name* of an env var or the path to a key file.
   `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every major
   model family, reasoning on by default via its unified `effort` param.
-- **role** — a *job* a model does: `explorer` (fast sweeps) and `synth` (the voice that
-  answers). A slot that reads images carries a `vision` pin (see [`docs/casts.md`](docs/casts.md)).
+- **role** — a *job* a model does: `explorer` (fast sweeps), `synth` (the voice that
+  answers), and `image` (the media member behind `generate`). A reasoning slot that
+  reads images carries a `vision` pin (see [`docs/casts.md`](docs/casts.md)).
 - **cast** — a *composition*: a named team assigning models to roles. The `cast` call
   argument selects the ensemble; the calling agent sees these names in its tool listing,
   so a descriptive name (`local-only`, `deep-dive`) lets it pick a team by intent without

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -468,6 +468,20 @@ synth    = "gemma/Gemma-4-26B-A4B-it-GGUF"
 explorer = "llama/qwen2.5-coder-7b"                              # bare ref: just the id
 synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
+# --- The `image` slot: a MEDIA member on the team. It points at a media backend
+#     (kind = "stability") and produces artifacts instead of text, so the reasoning
+#     tunables (effort, thinking_budget, temperature, ...) do not apply to it —
+#     writing one there is inert and kaibo://config flags it. A cast carries it
+#     beside its reasoning slots; a cast without one cannot staff the media tools. ---
+
+# [backends.sd]
+# kind = "stability"              # key: STABILITY_API_KEY / ~/.stability-key.txt
+
+# [casts.artist]
+# explorer = "deepseek/deepseek-v4-flash"
+# synth    = "deepseek/deepseek-v4-pro"
+# image    = "sd/core"            # core | ultra | an sd3.5 variant (e.g. sd3.5-large)
+
 # --- The table form, part 2: per-slot tunables. Each overrides its [defaults]
 #     per-role value for THIS slot only; knobs you omit fall back. Available:
 #     max_tokens, thinking_budget, temperature, effort, thinking_style, and

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -79,7 +79,7 @@ cast = "anthropic"
 # tracing/EnvFilter directive used when RUST_LOG is unset.
 log = "kaibo=info"
 
-# Tool gating — seven capability flags (the --no-<tool> flags), all default true. They
+# Tool gating — eight capability flags (the --no-<tool> flags), all default true. They
 # are not one-per-tool: `consult` also gates consult_submit, `batch` gates batch_submit,
 # and the job_* verbs follow whichever handle producers are live. A config that leaves
 # nothing advertised is refused at startup, whether by turning every flag off or by
@@ -87,10 +87,11 @@ log = "kaibo=info"
 #
 # A tool also needs a cast that can STAFF it. One nothing can staff is not advertised at
 # all, so it costs no resident tokens and no call of it can fail. Out of the box that
-# affects `deliberate`: no built-in cast pairs an explorer with an offline synth, so it
-# stays dark until you configure one (see DELIBERATE casts below). kaibo warns at startup
-# naming the cast shape it wants, and kaibo://config's [runtime].unstaffable_tools reports
-# it live. Full table: kaibo://config/guide, "Tool gating".
+# affects `deliberate` (no built-in cast pairs an explorer with an offline synth — see
+# DELIBERATE casts below) and `generate` (no built-in cast carries an `image` slot — see
+# the image-slot example below). kaibo warns at startup naming the cast shape it wants,
+# and kaibo://config's [runtime].unstaffable_tools reports it live. Full table:
+# kaibo://config/guide, "Tool gating".
 [server.tools]
 consult        = true
 explore        = true
@@ -99,6 +100,7 @@ oneshot        = true
 run_kaish      = true
 batch          = true
 list_models    = true
+generate       = true      # ...and needs a cast with an `image` slot AND [cas] on
 
 # ---------------------------------------------------------------------------
 # [defaults] — tunables every cast slot falls back to. The model-tracking knobs

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -311,18 +311,21 @@ scratch_limit_bytes = 67108864
 #                                          # 0 is a load error, not "refuse everything".
 
 # ---------------------------------------------------------------------------
-# [backends.<name>] — CONNECTIONS only: `kind` picks the wire protocol/rig client
-# (anthropic | deepseek | gemini | openai); the rest describes the wire (endpoint,
-# key source, per-request deadline). Models live on cast slots, never here.
+# [backends.<name>] — CONNECTIONS only: `kind` picks the wire and its client. The
+# completion wires (anthropic | deepseek | gemini | openrouter | openai) serve the
+# reasoning slots; the media wire (stability) serves `image` slots only. The rest
+# describes the wire (endpoint, key source, per-request deadline). Models live on
+# cast slots, never here.
 #
 # Keys are referenced, never inlined: api_key_env names an env var, api_key_file a
 # path (~ ok). env wins over file. key_optional=true falls back to a placeholder
 # bearer token (keyless local servers). base_url is legal on the openai kind
-# (required for a new backend) and the anthropic and gemini kinds (optional —
-# unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com;
-# set it to point at an Anthropic/Gemini-API-compatible gateway/proxy instead —
-# a HOST ROOT in both cases, since rig appends its own versioned path). Every
-# other keyed kind rejects base_url at load (rig fixes those endpoints).
+# (required for a new backend), the anthropic and gemini kinds (optional —
+# unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com),
+# and the stability kind (optional — unset dials api.stability.ai); set it to point
+# the same wire at a compatible gateway/proxy instead — a HOST ROOT in every case,
+# since the client appends its own versioned path. Every other keyed kind rejects
+# base_url at load (rig fixes those endpoints).
 # ---------------------------------------------------------------------------
 
 # --- The five built-ins, shown with their current defaults. You only need to
@@ -430,8 +433,9 @@ wire = "responses"
 # The calling agent sees your cast names — name them for intent (`local-only`,
 # `deep-dive`) so it can route by name without reading this file.
 #
-# Roles: explorer, synth (the agent phases). There are no output/production roles —
-# kaibo reasons over code and renders nothing. A typo'd role is a loud load
+# Roles: explorer, synth (the reasoning phases), and image (the media member — it
+# points at a stability backend and staffs `generate`; see the image-slot example
+# below). A typo'd role is a loud load
 # error. A cast may omit roles — the tool that needs a missing role fails at call time,
 # naming the gap ("cast `notes` has no synth slot"); absent = capability absent.
 #

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -274,9 +274,12 @@ scratch_limit_bytes = 67108864
 
 # ---------------------------------------------------------------------------
 # [cas] — the media content-addressed store: where an artifact-producing tool writes
-# what it generated. There is NO enabled flag: the CAS exists exactly when such a tool
-# does, and those carry their own --no-<tool> gate plus the cast staffing gate, so a
-# second switch would only be a way for the two to disagree.
+# what it generated. On by default, and it follows persistence: while the state db is
+# open the CAS writes to disk at the dir below; while persistence is off (or degraded)
+# it runs IN MEMORY — artifacts stay fetchable by digest for this run only, and startup
+# warns loudly that they will not survive a restart. `enabled = false` turns it off
+# entirely and un-advertises every tool that needs it (the startup log and
+# kaibo://config's [cas] section say which state you are in, and why).
 #
 # It lives under the XDG *data* dir, deliberately NOT beside the state db: the session
 # store is reconstructible bookkeeping, while these are artifacts you spent real provider
@@ -299,6 +302,8 @@ scratch_limit_bytes = 67108864
 # ---------------------------------------------------------------------------
 
 # [cas]
+# enabled   = true                         # false turns the CAS off and un-advertises
+#                                          # every tool that needs it
 # dir       = "~/.local/share/kaibo/cas"   # default: $XDG_DATA_HOME/kaibo/cas
 # max_bytes = 8589934592                   # 8 GiB. OMIT for no cap (the default);
 #                                          # 0 is a load error, not "refuse everything".

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -200,6 +200,37 @@ scratch_limit_bytes = 67108864
 # headers = { authorization = "Bearer <token>" }
 
 # ---------------------------------------------------------------------------
+# [cas] — the media content-addressed store: where an artifact-producing tool writes
+# what it generated. There is NO enabled flag: the CAS exists exactly when such a tool
+# does, and those carry their own --no-<tool> gate plus the cast staffing gate, so a
+# second switch would only be a way for the two to disagree.
+#
+# It lives under the XDG *data* dir, deliberately NOT beside the state db: the session
+# store is reconstructible bookkeeping, while these are artifacts you spent real provider
+# credits on and may never be able to reproduce (the seed is recorded in a sidecar, but
+# not every operation has one). A backup tool should carry them.
+#
+# NO GC, on purpose. kaibo never prunes this store and never rewrites an object — the
+# address IS the content hash, so an "edit" is a new object. Every artifact gets a
+# <hex>.json sidecar (prompt, model, cast, timestamp, mime, seed) precisely so YOU can
+# prune intelligently: `find -mtime`, jq over the sidecars, restic. A TTL may come later.
+#
+# max_bytes is OPT-IN, and unset is not the same as a huge number. Enforcing a ceiling
+# means summing every file in the store, on the write path, for EVERY new object — over
+# a store that never deletes and is sharded two levels deep. That walk is O(objects) and
+# only slows as the store fills, so an operator who never asked for a ceiling pays none
+# of it. Set it and you opt into that cost; leave it and disk-full is the backstop (the
+# OS reports it honestly). A write past a configured cap is REFUSED loudly — kaibo never
+# evicts to make room, because eviction would quietly make "we never delete" a lie.
+# Env: KAIBO_CAS_DIR / KAIBO_CAS_MAX_BYTES. CLI: --cas-dir / --cas-max-bytes.
+# ---------------------------------------------------------------------------
+
+# [cas]
+# dir       = "~/.local/share/kaibo/cas"   # default: $XDG_DATA_HOME/kaibo/cas
+# max_bytes = 8589934592                   # 8 GiB. OMIT for no cap (the default);
+#                                          # 0 is a load error, not "refuse everything".
+
+# ---------------------------------------------------------------------------
 # [backends.<name>] — CONNECTIONS only: `kind` picks the wire protocol/rig client
 # (anthropic | deepseek | gemini | openai); the rest describes the wire (endpoint,
 # key source, per-request deadline). Models live on cast slots, never here.

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,7 +19,8 @@ of backends and casts. A missing file at the default path is not an error.
 ## The model: backends, roles, casts
 
 ```
-ProviderKind = anthropic | deepseek | gemini | openrouter | openai   (the wire protocol)
+ProviderKind = anthropic | deepseek | gemini | openrouter | openai   (completion wires)
+             | stability                                             (media wire)
 Backend      = { name, kind, base_url?, key source, request_timeout }
 Cast         = { name, role → ModelSlot }                  (freely spans backends)
 ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
@@ -28,11 +29,16 @@ ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
 Each concept owns one idea:
 
 - **backend** — a *connection*. Carries `kind` (the closed `ProviderKind` enum; it
-  selects the rig client and the request shape), `base_url`, a key source, and
-  `request_timeout`. Answers "how do I reach Gemini".
-- **role** — a *job* a model serves. Two exist: `explorer` and `synth`, the two agent
-  phases. There are no output or production roles, because kaibo reasons over code and
-  renders nothing. Image input is a slot capability (the `vision` pin), not a role.
+  selects the client and the request shape), `base_url`, a key source, and
+  `request_timeout`. Answers "how do I reach Gemini". Kinds divide into two classes:
+  the completion wires (everything through rig's completion clients) and the media
+  wire (`stability`, an image-generation API with no completion surface).
+- **role** — a *job* a model serves. Three exist: `explorer` and `synth`, the two
+  reasoning phases, and `image`, the media member that staffs the `generate` tool.
+  A reasoning role takes a completion backend; the `image` role takes a media backend
+  (kind `stability`) — pairing either with the wrong class is a load error naming the
+  fix. Image *input* is a slot capability (the `vision` pin on a reasoning slot), not
+  a role.
 - **cast** — a *composition*. A named assignment of models to roles. This is what the
   `cast` call parameter selects.
 
@@ -47,8 +53,8 @@ Connection settings only. Models are never declared here.
 
 | key | type | default | notes |
 |---|---|---|---|
-| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` | required on a new backend | closed enum; selects client + request shape |
-| `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini`; load error elsewhere |
+| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` | required on a new backend | closed enum; selects client + request shape (`stability` is the media wire — image slots only) |
+| `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini`/`stability`; load error elsewhere |
 | `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
 | `api_key_env` | env var *name* | seeded from `kind` | env source, checked first |
 | `api_key_file` | path | seeded from `kind` | file source, checked second |
@@ -73,6 +79,9 @@ by re-declaration.
 - **`kind = "anthropic"` / `kind = "gemini"`** — optional. Unset resolves to rig's
   built-in `https://api.anthropic.com` / `https://generativelanguage.googleapis.com`.
   Set, it points that wire protocol at a compatible gateway or proxy.
+- **`kind = "stability"`** — optional, same contract: unset dials
+  `https://api.stability.ai`; set, it points the media wire at a compatible
+  gateway or proxy.
 - **Every other kind** — a load error. rig fixes those endpoints.
 
 The value is a **host root**, not a versioned path. rig's `ClientBuilder` appends the
@@ -194,13 +203,18 @@ synth    = "claude/claude-sonnet-4-6"       # the model that answers
 # explorer = { backend = "openai-local", id = "Gemma-4-E4B-it", preamble = "..." }
 ```
 
-**Roles.** `explorer` and `synth`. A misspelled role, or a misspelled per-slot key, is
-a load error rather than a silent no-op.
+**Roles.** `explorer`, `synth`, and `image`. A misspelled role, or a misspelled
+per-slot key, is a load error rather than a silent no-op. The `image` slot is the
+media member: it points at a `stability`-kind backend (its model id picks the route —
+`core`, `ultra`, or an SD3.5 variant) and staffs the `generate` tool. It sends one
+generation request, not a reasoning loop, so the reasoning tunables (`effort`,
+`thinking_budget`, `temperature`, ...) written on it are inert — `kaibo://config`
+flags them under `inert_tunables`.
 
-A cast may omit a role. The interactive built-ins carry both; the batch built-ins carry
-`synth` only. A user cast that omits a role is valid config, and the tool needing the
-missing role fails at call time naming the gap (`cast "lite" has no synth slot`). Absent
-means the capability is absent.
+A cast may omit a role. The interactive built-ins carry explorer + synth; the batch
+built-ins carry `synth` only; none carries `image`. A user cast that omits a role is
+valid config, and the tool needing the missing role fails at call time naming the gap
+(`cast "lite" has no synth slot`). Absent means the capability is absent.
 
 **Slot references.** An unknown backend in a slot is a load error naming the known
 backends. An empty model id is rejected at load, since it would otherwise surface as an
@@ -826,10 +840,13 @@ projects and a browsable CAS would let one project's team enumerate another's ar
 nothing is deleted to make room. The cap is opt-in because enforcing it costs an
 O(objects) walk of the store per new write.
 
-**Failure is loud.** In disk mode, a CAS dir that cannot open — including one that
-resolves inside an allowed project tree, which is refused the same way the state db is —
-fails startup with an error naming the escape hatches. Memory mode is the one warned
-degrade, mirroring the persistence posture it follows.
+**Failure is loud.** In disk mode, a structurally unusable CAS path fails startup with
+an error naming the escape hatches: a dir that resolves inside an allowed project tree
+(refused the same way the state db is), or a file sitting where the store or one of its
+ancestors must be a directory. Write errors that only a real write can reveal
+(permissions, disk full, a read-only mount) surface on the first generation instead —
+opening the store writes nothing, so it cannot probe for them. Memory mode is the one
+warned degrade, mirroring the persistence posture it follows.
 
 ## House rules: `[context]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -781,6 +781,49 @@ It is not silent. The startup log says so, and `kaibo://config` shows `persisten
 Close the other kaibo, point `--state-db` elsewhere, or pass `--no-persistence` to make it
 explicit. Every other open failure stays fatal.
 
+## Media CAS: `[cas]`
+
+**On by default, and it follows persistence.** The CAS is the content-addressed store
+where an artifact-producing tool (image generation) writes what it made. Its lifecycle
+has three states, reported as `mode` in `kaibo://config`'s `[cas]` section:
+
+| mode | when | what it means |
+|---|---|---|
+| `disk` | persistence is active | artifacts land at `dir`, durable across restarts |
+| `memory` | persistence is off or degraded, or no `dir` resolves | artifacts are fetchable by digest for this run only; startup warns loudly |
+| `off` | `enabled = false` | no store, and every tool that needs one is not advertised |
+
+```toml
+[cas]
+enabled   = true                            # default true; false un-advertises the tools that need it
+dir       = "$XDG_DATA_HOME/kaibo/cas"      # default; else ~/.local/share/kaibo/cas
+max_bytes = 8589934592                      # optional soft cap; omit for no cap (the default)
+```
+
+CLI/env: `--cas-dir` / `KAIBO_CAS_DIR` move the store; `--cas-max-bytes` /
+`KAIBO_CAS_MAX_BYTES` set the cap. `enabled` is file-only.
+
+**The address is the content.** Every object's filename is the SHA-256 of its bytes, so
+nothing (model or operator) can aim a write at a chosen path, and identical content is
+stored once. Objects are written once and never rewritten, unlinked, or evicted. Each
+object gets a `<hex>.json` provenance sidecar (prompt, model, cast, timestamp, mime,
+seed) so you can prune by hand with `find`/`jq`/`restic` — kaibo ships no GC.
+
+**Retrieval is operator-surface only.** A generation result returns each artifact's
+digest, a `kaibo://cas/<digest>` resource URI, and (in disk mode) the real filesystem
+path. The MCP client and CLI read those; the inner model team never sees the CAS — it is
+not mounted into kaish and no cast-facing tool reads it, because kaibo state spans
+projects and a browsable CAS would let one project's team enumerate another's artifacts.
+
+**`max_bytes` refuses, never evicts.** A write that would pass the cap fails loudly and
+nothing is deleted to make room. The cap is opt-in because enforcing it costs an
+O(objects) walk of the store per new write.
+
+**Failure is loud.** In disk mode, a CAS dir that cannot open — including one that
+resolves inside an allowed project tree, which is refused the same way the state db is —
+fails startup with an error naming the escape hatches. Memory mode is the one warned
+degrade, mirroring the persistence posture it follows.
+
 ## House rules: `[context]`
 
 kaibo's models work for other agents, so they benefit from inheriting the calling agent's

--- a/docs/config.md
+++ b/docs/config.md
@@ -603,9 +603,11 @@ stale `provider` is now an invalid-params error like every other tombstone above
 A tool clears **two** gates to be advertised: the `[server.tools]` flag (equivalently
 `--no-<tool>` or `KAIBO_NO_<TOOL>`), and a configured cast that can **staff** it.
 
-The seven flags are *capability* switches, not one per MCP tool. `consult` gates both
+The eight flags are *capability* switches, not one per MCP tool. `consult` gates both
 `consult` and `consult_submit`; `batch` gates `batch_submit`; the `job_*` verbs have no
-flag of their own and follow whichever handle producers are live.
+flag of their own and follow whichever handle producers are live. `generate` clears a
+third gate as well: the media CAS must be on (`[cas] enabled`), because an
+artifact-producing tool needs somewhere to store artifacts.
 
 A tool nothing can staff has its route removed rather than shipping unusable. The calling
 agent never sees a tool whose every call would fail, and an unusable tool stops costing
@@ -619,10 +621,13 @@ Which cast shape staffs which tool:
 | `explore` | a cast with an `explorer` slot |
 | `batch_submit` | a cast whose synth runs on `lane = "batch"` (or the `batch = true` sugar) |
 | `deliberate` | a cast with an `explorer` **and** an offline synth (`lane = "batch"` or `lane = "direct"`) |
+| `generate` | a cast with an `image` slot (a media backend, kind `stability`) — plus `[cas]` on |
 | `job_get`, `job_cancel`, `job_list`, `job_wait` | at least one live handle *producer*; they follow whatever survives above |
 | `run_kaish`, `list_models` | no cast at all; advertised whenever their flag is on |
 
-**Default installs.** This affects one tool. No built-in cast pairs an explorer with an
+**Default installs.** This affects two tools. No built-in cast carries an `image` slot,
+so `generate` stays dark until you configure one (the image-slot example in
+`docs/config.example.toml`). And no built-in cast pairs an explorer with an
 offline synth — the two built-in offline casts, `anthropic-batch` and `gemini-batch`, are
 synth-only — so `deliberate` is not advertised until you configure a cast carrying both
 slots. The DELIBERATE casts section of `docs/config.example.toml` is the worked example.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -30,47 +30,31 @@ the argument against it, and the CAS that makes the write path acceptable are in
 `docs/devlog.md` (2026-07-25); the shape rationale lives in `src/cas.rs`'s module doc. The
 perception half below stands unchanged.
 
-**Open work to make it reachable.** `src/cas.rs` and `src/stability.rs` exist and are
-tested, but nothing constructs either outside their own tests — no `ProviderKind::Stability`,
-no `image` cast slot (`986806f` reduced `ModelRole` to Explorer/Synth and made `image =` a
-loud `deny_unknown_fields` error), no MCP tool or CLI verb, no `[cas]` config. Three things
-must land *together* with the first tool, because each is unsafe or dishonest alone:
+**The production spine shipped** (feat/media-cas, 2026-08-03): `ProviderKind::Stability`
+behind the `ProviderKind::class()` Wire|Media funnel, the revived `ModelRole::Image` cast
+slot, `MediaModel`/`MediaArm` (complete outcomes are `Vec<MediaArtifact>` — one digest and
+one provenance sidecar per artifact, Amy 2026-08-03), the `[cas]` lifecycle (disk with
+persistence / in-memory without, SEVERE-warned / `enabled = false` off, un-advertising the
+tools that need it), the `generate` tool (its own `--no-generate` flag, staffed by the
+`image` slot via `CAST_ENUM_RULES`, deferred shapes on the `job-N` verbs), and the
+operator-only `kaibo://cas/<digest>` retrieval resource. The tool returns digests +
+URIs (+ real path on disk), never inline bytes — as decided.
 
-- **A loud guard when the CAS is on ephemeral storage.** The ghcr image is a first-class
-  distribution path, and a CAS at `$XDG_DATA_HOME/kaibo/cas` in a container with no volume
-  mounted will accept the prompt, **spend the user's provider credits**, verify and write
-  the artifact, then destroy it on exit. Silently evaporating paid artifacts is exactly what
-  a store that refuses to ever delete exists to prevent. Ranked the top remaining risk by
-  the Gemini design pass. **Decided (Amy, 2026-07-30): detect overlay/tmpfs backing and warn
-  severely, then proceed** — not a refusal gated on an acknowledgement flag. The container
-  path stays frictionless for someone who genuinely doesn't want persistence; what must not
-  happen is proceeding *quietly*.
-- **`AGENTS.md`'s opening paragraph** still says kaibo "produces no output artifacts." That
-  is *true today* (nothing reachable produces anything) and becomes false the moment a tool
-  lands. Rewrite it in that same change.
-- **Gating is done** — the staffing gate shipped 2026-07-30 (a tool no configured cast can
-  staff is not advertised, with the reason in the startup log and `kaibo://config`'s
-  `[runtime].unstaffable_tools`). An image tool inherits it by adding a `CAST_ENUM_RULES`
-  entry with an `cast_can_generate_image` predicate, so a user who configures no image cast
-  pays zero resident tokens for it. Nothing further to build here — just wire the rule.
+**Open work that remains:**
 
-**Decided with Amy, 2026-07-30 — the shape of the first image tool:**
-- **The image model is a cast SLOT, not a separate config concept.** Revive
-  `ModelRole::Image` (undoing that part of `986806f`) so a cast reads
-  `[casts.artist] explorer = … / synth = … / image = "stability/core"`. Considered and
-  rejected: a standalone `[image]`/backend-only concept divorced from casts, on the argument
-  that a cast is a *reasoning* team. Amy's call went the other way, and it buys a real
-  simplification — the staffing gate, the `cast` enum, and the per-call `cast` argument all
-  keep working unchanged, with `cast_can_generate_image` sitting beside
-  `cast_can_deliberate` in exactly the same shape.
-- **The tool returns the digest and the path — not the bytes.** No inline image content
-  block: a multi-megabyte artifact should not land in the calling agent's context unless it
-  asks, and the caller may not even share kaibo's filesystem. A by-digest read verb can come
-  later if wanted (and see the egress-gateway note below, which already argues a by-digest
-  fetch leaks nothing).
-- Still open, not yet decided: whether `ProviderKind::Stability` is the right home for the
-  image backend (it is not a rig `CompletionModel`, so it does not slot into the existing
-  arm machinery), and the `[cas]` config surface (dir override, `max_bytes` cap).
+- **A loud guard when the CAS is on ephemeral DISK storage.** The ghcr image is a
+  first-class distribution path, and a disk CAS at `$XDG_DATA_HOME/kaibo/cas` in a
+  container with no volume mounted will accept the prompt, **spend the user's provider
+  credits**, verify and write the artifact, then destroy it on exit. Ranked the top
+  remaining risk by the Gemini design pass. **Decided (Amy, 2026-07-30): detect
+  overlay/tmpfs backing and warn severely, then proceed** — not a refusal gated on an
+  acknowledgement flag. The memory-mode SEVERE warn that shipped covers the
+  no-persistence path; this remaining piece is the disk mode whose backing store is
+  secretly ephemeral (statfs the CAS dir, warn on overlay/tmpfs magic).
+- **Cross-agent CAS sharing is DEFERRED** (Amy, 2026-08-03): no tracking of which agent
+  created which object, no allow-listing, until a concrete need shows up. The CAS's job
+  in one line, hers: "cas should be a way for the kaibo agents to get stuff to the
+  client efficiently. like images. maybe reports."
 
 **Decided, so it isn't re-litigated:** audio and 3D are *not* refused on principle. The
 account-fleet argument that justifies image generation extends to them; the real constraint

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -36,7 +36,8 @@ slot, `MediaModel`/`MediaArm` (complete outcomes are `Vec<MediaArtifact>` — on
 one provenance sidecar per artifact, Amy 2026-08-03), the `[cas]` lifecycle (disk with
 persistence / in-memory without, SEVERE-warned / `enabled = false` off, un-advertising the
 tools that need it), the `generate` tool (its own `--no-generate` flag, staffed by the
-`image` slot via `CAST_ENUM_RULES`, deferred shapes on the `job-N` verbs), and the
+`image` slot via `CAST_ENUM_RULES`, deferred shapes on the `job-N` verbs — the lane
+only; every Stability operation wired today is synchronous), and the
 operator-only `kaibo://cas/<digest>` retrieval resource. The tool returns digests +
 URIs (+ real path on disk), never inline bytes — as decided.
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -51,7 +51,7 @@ use serde_json::{json, Map, Value};
 
 use crate::attach::Attachment;
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot, SlotTunables};
-use crate::credentials::ProviderKind;
+use crate::credentials::{ProviderKind, WireKind};
 
 /// Anthropic's default API base, used when the backend sets no `base_url` of its own
 /// (the common case — rig fixes the endpoint for most keyed kinds, but the anthropic
@@ -1950,13 +1950,15 @@ impl BatchProvider for OpenaiBatch {
 /// gateway has no `/v1/batches` to submit to. Same seam the interactive Responses routing
 /// uses ([`Backend::is_hosted_openai`]).
 pub fn batch_supported(backend: &Backend) -> bool {
-    match backend.kind {
-        ProviderKind::Anthropic | ProviderKind::Gemini => true,
-        ProviderKind::Openai => backend.is_hosted_openai(),
-        ProviderKind::DeepSeek | ProviderKind::OpenRouter => false,
-        // Not a completion wire at all — an image API with no batch endpoint, and no
-        // reasoning slot can point at it (see `ProviderKind::Stability`).
-        ProviderKind::Stability => false,
+    // A media kind is not a completion wire at all — no batch endpoint, and no
+    // reasoning slot can point at one (see `ProviderKind::class`).
+    let Some(wire) = backend.kind.wire() else {
+        return false;
+    };
+    match wire {
+        WireKind::Anthropic | WireKind::Gemini => true,
+        WireKind::Openai => backend.is_hosted_openai(),
+        WireKind::DeepSeek | WireKind::OpenRouter => false,
     }
 }
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1897,6 +1897,9 @@ pub fn batch_supported(backend: &Backend) -> bool {
         ProviderKind::Anthropic | ProviderKind::Gemini => true,
         ProviderKind::Openai => backend.is_hosted_openai(),
         ProviderKind::DeepSeek | ProviderKind::OpenRouter => false,
+        // Not a completion wire at all — an image API with no batch endpoint, and no
+        // reasoning slot can point at it (see `ProviderKind::Stability`).
+        ProviderKind::Stability => false,
     }
 }
 

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -102,11 +102,17 @@
 //! caller to handle a truncated/failed read as a first-class outcome — not carrying this
 //! module's verify-before-return contract over unexamined. Read this before adding one.
 //!
-//! # The soft cap refuses; it never evicts
+//! # The soft cap is opt-in; when set it refuses, and it never evicts
 //!
-//! [`Cas::open`] takes a `max_bytes` ceiling. A [`Cas::put`] that would push the store's
-//! total size over that ceiling is refused with [`CasError::CapacityExceeded`] — loudly,
-//! before any bytes are written. It never deletes anything to make room: eviction would
+//! [`Cas::open`] takes an **optional** `max_bytes` ceiling, and the default is `None` —
+//! no ceiling, and no size accounting whatsoever. Enforcing a ceiling means summing every
+//! file in the store on the *write* path, for every new object, over a store that never
+//! deletes and is sharded two levels deep; that walk is O(objects) and only slows down as
+//! the store fills. An operator who never asked for a ceiling should not pay it, so they
+//! do not. Cleanup is theirs to do (`find -mtime` over the sidecars); a TTL may come later.
+//!
+//! When a cap *is* set, a [`Cas::put`] that would push the store's total size over it is
+//! refused with [`CasError::CapacityExceeded`] — loudly, before any bytes are written. It never deletes anything to make room: eviction would
 //! quietly make "write-only" a lie (a lie exactly one write-time trust judgment away from
 //! looking corrupt), and disk-full-in-effect is precisely the crash-over-corrupt case
 //! kaibo's read-only posture already treats as correct. A dedup write of content already
@@ -331,13 +337,26 @@ pub struct Provenance {
 #[derive(Debug, Clone)]
 pub struct Cas {
     root: PathBuf,
-    max_bytes: u64,
+    /// The optional soft cap. `None` — the default — means no ceiling AND no size
+    /// accounting: [`Cas::put`] never walks the store. See [`Cas::open`].
+    max_bytes: Option<u64>,
 }
 
 impl Cas {
     /// Open (but do not yet create — see below) the CAS rooted at `dir`, refusing if
     /// `dir` resolves inside any `allowed_trees` entry (the read-only sandbox's project
-    /// roots). `max_bytes` is the soft cap enforced by every [`Cas::put`].
+    /// roots).
+    ///
+    /// `max_bytes` is an **optional** soft cap, and `None` (the default) is meaningfully
+    /// different from a very large number: it means [`Cas::put`] does no size accounting
+    /// at all. That matters because enforcing a cap requires summing every file in the
+    /// store, on the *write* path, for every new object — over a store that by design
+    /// never deletes anything, sharded two levels deep. That walk only gets slower as the
+    /// store fills, which is exactly the cost an operator who never asked for a ceiling
+    /// should not pay. Amy's call (2026-07-30): leave the accounting off until someone has
+    /// a problem that needs it. Disk-full is the real backstop and the OS reports it
+    /// honestly; pruning is `find -mtime` over the provenance sidecars (see the module
+    /// doc's "No GC here, on purpose").
     ///
     /// Unlike [`crate::store::SessionStore::open`], this does **not** create any
     /// directory — there is nothing to eagerly create. The root (and every shard
@@ -353,7 +372,7 @@ impl Cas {
     /// canonicalize the deepest *existing* ancestor of `dir` (following symlinks) and
     /// re-append the not-yet-created tail lexically, and refuse if that resolves inside
     /// any allowed tree.
-    pub fn open(dir: &Path, allowed_trees: &[&Path], max_bytes: u64) -> Result<Self> {
+    pub fn open(dir: &Path, allowed_trees: &[&Path], max_bytes: Option<u64>) -> Result<Self> {
         let dir = absolutize(dir)?;
         let resolved = resolve_existing_ancestor(&dir);
         for tree in allowed_trees {
@@ -432,9 +451,12 @@ impl Cas {
     }
 
     /// Recursively sum the size in bytes of every file currently in the store. Backs the
-    /// soft-cap check in [`Cas::put`]. A read-only directory walk — no writes, no
-    /// caching, no separate counter file to keep in sync (and thus no extra write site
-    /// this module would otherwise need).
+    /// soft-cap check in [`Cas::put`], and is called ONLY when a cap is configured — see
+    /// [`Cas::open`] for why an uncapped store must never pay for this. A read-only
+    /// directory walk: no writes, no caching, no separate counter file to keep in sync
+    /// (and thus no extra write site this module would otherwise need). The flip side of
+    /// holding no counter is that the cost is O(objects) per capped write, which is
+    /// precisely why the cap is opt-in rather than a default ceiling.
     fn total_bytes(&self) -> Result<u64> {
         fn walk(dir: &Path) -> std::io::Result<u64> {
             if !dir.is_dir() {
@@ -496,13 +518,15 @@ impl Cas {
                 ))
             })?;
             verify(&digest, existing)?;
-        } else {
-            // New content only: check the soft cap before growing the store at all.
+        } else if let Some(max_bytes) = self.max_bytes {
+            // New content, and a cap is configured: measure before growing the store at
+            // all. This is the ONLY call site that walks the store, and it is reached only
+            // when an operator opted into a ceiling — an uncapped CAS never sizes itself.
             let current = self.total_bytes()?;
             let incoming = bytes.len() as u64;
-            if current.saturating_add(incoming) > self.max_bytes {
+            if current.saturating_add(incoming) > max_bytes {
                 return Err(CasError::CapacityExceeded {
-                    max_bytes: self.max_bytes,
+                    max_bytes,
                     current_bytes: current,
                 });
             }

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -291,6 +291,33 @@ impl Extension {
             Extension::Gif => "gif",
         }
     }
+
+    /// The canonical mime type this on-disk format serves as — what the
+    /// `kaibo://cas/<digest>` resource stamps on a blob it hands back.
+    pub fn mime(&self) -> &'static str {
+        match self {
+            Extension::Png => "image/png",
+            Extension::Jpeg => "image/jpeg",
+            Extension::Webp => "image/webp",
+            Extension::Gif => "image/gif",
+        }
+    }
+
+    /// Map a wire mime string (a provider's own spelling, case-insensitive per RFC
+    /// 7231) onto the closed on-disk set. `None` for anything the CAS cannot name on
+    /// disk — the caller decides loudly what that means (see
+    /// `stability::MediaType::to_cas_extension` for the same refusal argued at length);
+    /// this helper never invents an extension for unknown bytes.
+    pub fn from_mime(mime: &str) -> Option<Self> {
+        let essence = mime.split(';').next().unwrap_or(mime).trim();
+        match essence.to_ascii_lowercase().as_str() {
+            "image/png" => Some(Extension::Png),
+            "image/jpeg" => Some(Extension::Jpeg),
+            "image/webp" => Some(Extension::Webp),
+            "image/gif" => Some(Extension::Gif),
+            _ => None,
+        }
+    }
 }
 
 /// The provenance sidecar recorded next to every object: `prompt`, `model`, `cast`,
@@ -415,9 +442,16 @@ impl Cas {
     /// under. `None` if no object with this digest has ever been written (or an ancestor
     /// directory doesn't exist yet, which reads the same way: nothing is here).
     pub fn path_for(&self, digest: &Digest) -> Option<PathBuf> {
+        self.entry_for(digest).map(|(path, _)| path)
+    }
+
+    /// [`path_for`](Self::path_for) plus which [`Extension`] the object was written
+    /// under — the extension carries the mime type a resource read needs to stamp on
+    /// the bytes, and re-deriving it from the path string would be a second parser.
+    pub fn entry_for(&self, digest: &Digest) -> Option<(PathBuf, Extension)> {
         Extension::ALL.into_iter().find_map(|ext| {
             let path = self.object_path(digest, ext);
-            path.is_file().then_some(path)
+            path.is_file().then_some((path, ext))
         })
     }
 
@@ -550,6 +584,154 @@ impl Cas {
         })?;
 
         Ok(digest)
+    }
+}
+
+/// One artifact held by the in-memory store: the bytes plus the metadata a disk
+/// object keeps in its filename (`ext`) and sidecar (`provenance`).
+#[derive(Debug, Clone)]
+struct MemObject {
+    bytes: Vec<u8>,
+    ext: Extension,
+    provenance: Provenance,
+}
+
+/// The in-memory CAS: the same content-addressed contract as [`Cas`] — the address is
+/// the content's own hash, `put` takes no destination, nothing is ever deleted or
+/// rewritten — held in a `HashMap` instead of on disk. This is the degraded mode Amy
+/// decided for a run without persistence ("cas should be on when persistence is, and
+/// ideally on but in memory only when it's not", 2026-07-30): artifacts stay
+/// retrievable by digest for the life of the process and are gone on restart, which
+/// startup warns about LOUDLY (see `main.rs`) and `kaibo://config` reports as
+/// `mode = "memory"`. Touches no filesystem at all, so the write-path guard
+/// (`tests/no_write_path.rs`) has nothing to bless here.
+///
+/// The optional `max_bytes` cap is honored with the same refuse-never-evict posture as
+/// [`Cas::put`] — in memory the accounting is a cheap sum over held objects, but the
+/// *meaning* of the knob (a ceiling that refuses, loudly) must not change with the mode.
+#[derive(Debug)]
+pub struct MemoryCas {
+    objects: std::sync::Mutex<std::collections::HashMap<Digest, MemObject>>,
+    max_bytes: Option<u64>,
+}
+
+impl MemoryCas {
+    pub fn new(max_bytes: Option<u64>) -> Self {
+        Self {
+            objects: std::sync::Mutex::new(std::collections::HashMap::new()),
+            max_bytes,
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, std::collections::HashMap<Digest, MemObject>> {
+        self.objects.lock().expect("memory CAS mutex poisoned")
+    }
+
+    /// Store `bytes` under their own digest. A repeat of identical content is a
+    /// no-op returning the same digest (dedup needs no verification here: the map is
+    /// keyed by the digest of exactly the bytes it holds, and nothing between put and
+    /// get can corrupt process memory the way a torn disk write can). A new object is
+    /// checked against the cap first, mirroring [`Cas::put`].
+    pub fn put(&self, bytes: &[u8], ext: Extension, provenance: &Provenance) -> Result<Digest> {
+        let digest = Digest::of_bytes(bytes);
+        let mut objects = self.lock();
+        if objects.contains_key(&digest) {
+            return Ok(digest);
+        }
+        if let Some(max_bytes) = self.max_bytes {
+            let current: u64 = objects.values().map(|o| o.bytes.len() as u64).sum();
+            if current.saturating_add(bytes.len() as u64) > max_bytes {
+                return Err(CasError::CapacityExceeded {
+                    max_bytes,
+                    current_bytes: current,
+                });
+            }
+        }
+        objects.insert(
+            digest,
+            MemObject {
+                bytes: bytes.to_vec(),
+                ext,
+                provenance: provenance.clone(),
+            },
+        );
+        Ok(digest)
+    }
+
+    /// Read an object back by digest: the bytes and the extension it was stored
+    /// under. `None` if nothing with this digest was ever put.
+    pub fn get(&self, digest: &Digest) -> Option<(Vec<u8>, Extension)> {
+        self.lock().get(digest).map(|o| (o.bytes.clone(), o.ext))
+    }
+
+    /// The provenance recorded with an object, if it exists — the in-memory analogue
+    /// of reading a disk sidecar.
+    pub fn provenance(&self, digest: &Digest) -> Option<Provenance> {
+        self.lock().get(digest).map(|o| o.provenance.clone())
+    }
+}
+
+/// The media store a running kaibo actually holds: the disk [`Cas`] when persistence
+/// is active, the [`MemoryCas`] when it is not. One seam so every consumer (the
+/// generate lane, the `kaibo://cas/<digest>` resource, the `kaibo://config` render)
+/// dispatches over the mode instead of each carrying its own two-armed match — and so
+/// the *contract* (content-addressed, write-only, no destination parameter) is the
+/// same sentence in both modes.
+#[derive(Debug)]
+pub enum MediaStore {
+    Disk(Cas),
+    Memory(MemoryCas),
+}
+
+impl MediaStore {
+    /// Store an artifact; the digest is its address in either mode.
+    pub fn put(&self, bytes: &[u8], ext: Extension, provenance: &Provenance) -> Result<Digest> {
+        match self {
+            MediaStore::Disk(cas) => cas.put(bytes, ext, provenance),
+            MediaStore::Memory(mem) => mem.put(bytes, ext, provenance),
+        }
+    }
+
+    /// Read an object back with the extension (and thus mime) it was stored under.
+    /// Disk reads verify content against the digest ([`Cas::get`]'s contract); memory
+    /// reads need no verification (see [`MemoryCas::put`]).
+    pub fn get(&self, digest: &Digest) -> Result<Option<(Vec<u8>, Extension)>> {
+        match self {
+            MediaStore::Disk(cas) => {
+                let Some((_, ext)) = cas.entry_for(digest) else {
+                    return Ok(None);
+                };
+                Ok(cas.get(digest)?.map(|bytes| (bytes, ext)))
+            }
+            MediaStore::Memory(mem) => Ok(mem.get(digest)),
+        }
+    }
+
+    /// The real filesystem path of an object — `Some` only in disk mode, where an
+    /// operator (or the calling agent, acting as the operator's proxy) can reach the
+    /// file directly. Memory mode has no path; the `kaibo://cas/<digest>` resource is
+    /// the only retrieval channel there.
+    pub fn path_for(&self, digest: &Digest) -> Option<PathBuf> {
+        match self {
+            MediaStore::Disk(cas) => cas.path_for(digest),
+            MediaStore::Memory(_) => None,
+        }
+    }
+
+    /// The store's root directory — `Some` only in disk mode.
+    pub fn root(&self) -> Option<&Path> {
+        match self {
+            MediaStore::Disk(cas) => Some(cas.root()),
+            MediaStore::Memory(_) => None,
+        }
+    }
+
+    /// The mode word `kaibo://config` renders: `"disk"` or `"memory"`.
+    pub fn mode(&self) -> &'static str {
+        match self {
+            MediaStore::Disk(_) => "disk",
+            MediaStore::Memory(_) => "memory",
+        }
     }
 }
 

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -173,6 +173,14 @@ pub enum CasError {
          the CAS directory by hand)"
     )]
     CapacityExceeded { max_bytes: u64, current_bytes: u64 },
+    /// The requested CAS root — or a path component on the way to it — exists but is
+    /// not a directory, so the store structurally cannot live there. Caught at
+    /// [`Cas::open`] so it fails startup, not the first paid generation.
+    #[error(
+        "media CAS path cannot be used: {0} is not a directory — the store needs a \
+         directory (or a creatable path whose existing ancestors are directories)"
+    )]
+    NotADirectory(String),
     /// A filesystem operation failed for a reason other than the ones above (permissions,
     /// disk full, an unreadable existing file, …), surfaced verbatim.
     #[error("media CAS io: {0}")]
@@ -367,6 +375,12 @@ pub struct Cas {
     /// The optional soft cap. `None` — the default — means no ceiling AND no size
     /// accounting: [`Cas::put`] never walks the store. See [`Cas::open`].
     max_bytes: Option<u64>,
+    /// Serializes [`Cas::put`] across threads sharing this store (clones share it —
+    /// the handler holds one `Arc<MediaStore>` across concurrent MCP calls).
+    /// Generation is rare and writes are small, so a plain mutex buys the whole
+    /// check-then-write path (dedup verify, cap accounting, object + sidecar) its
+    /// atomicity with no cleverness. See [`Cas::put`].
+    write_lock: std::sync::Arc<std::sync::Mutex<()>>,
 }
 
 impl Cas {
@@ -408,9 +422,21 @@ impl Cas {
                 return Err(CasError::PathInAllowedTree(dir.display().to_string()));
             }
         }
+        // Structural check, still with zero side effects: the deepest EXISTING path on
+        // the way to the root must be a directory (the root itself included, when it
+        // exists). A file sitting there means every future write must fail — caught
+        // here so it fails startup, not the first paid generation. What this can NOT
+        // vouch for without writing is writability (permissions, disk full, a
+        // read-only mount); those still surface on first use.
+        if let Some(existing) = first_existing_ancestor(&dir) {
+            if !existing.is_dir() {
+                return Err(CasError::NotADirectory(existing.display().to_string()));
+            }
+        }
         Ok(Self {
             root: dir,
             max_bytes,
+            write_lock: std::sync::Arc::new(std::sync::Mutex::new(())),
         })
     }
 
@@ -525,15 +551,31 @@ impl Cas {
     /// into a poisoned slot — the caller's data was never at risk, only the report of
     /// success was. A verified dedup is **not** re-checked against the soft cap — it adds
     /// zero new bytes, so it cannot be what pushes the store over the line. Otherwise (new
-    /// content) the soft cap is checked *before* any write: if the current total plus
-    /// `bytes.len()` would exceed `max_bytes`, the write is refused with
+    /// content) the soft cap is checked *before* any write, and it counts the whole
+    /// footprint this put would add — the artifact **and** its provenance sidecar,
+    /// which is real disk usage written by the same call: if the current total plus
+    /// both would exceed `max_bytes`, the write is refused with
     /// [`CasError::CapacityExceeded`] and nothing is written — never evicted, see the
     /// module doc.
+    ///
+    /// The whole body runs under the store's write mutex, so concurrent puts on
+    /// clones/`Arc`s of one store serialize: the dedup check, the cap accounting, and
+    /// the two writes are atomic with respect to each other. If `create_new` still
+    /// loses to something that appeared from outside this process (another kaibo, an
+    /// operator's copy), the existing bytes are read back and **verified** before
+    /// success is reported — never trusted from the path alone.
     pub fn put(&self, bytes: &[u8], ext: Extension, provenance: &Provenance) -> Result<Digest> {
         let digest = Digest::of_bytes(bytes);
         let shard = self.shard_dir(&digest);
         let obj_path = self.object_path(&digest, ext);
         let sidecar_path = self.sidecar_path(&digest);
+
+        let _write_guard = self.write_lock.lock().expect("cas write mutex poisoned");
+
+        // Serialized up front so the cap admission below can count it — the sidecar is
+        // part of this put's disk footprint, not an afterthought.
+        let sidecar_json = serde_json::to_vec_pretty(provenance)
+            .map_err(|e| CasError::Serialize(e.to_string()))?;
 
         if obj_path.is_file() {
             // Dedup path: the module doc's "AlreadyExists means these exact bytes are
@@ -557,7 +599,7 @@ impl Cas {
             // all. This is the ONLY call site that walks the store, and it is reached only
             // when an operator opted into a ceiling — an uncapped CAS never sizes itself.
             let current = self.total_bytes()?;
-            let incoming = bytes.len() as u64;
+            let incoming = bytes.len() as u64 + sidecar_json.len() as u64;
             if current.saturating_add(incoming) > max_bytes {
                 return Err(CasError::CapacityExceeded {
                     max_bytes,
@@ -571,11 +613,25 @@ impl Cas {
                 CasError::Io(format!("creating cas shard dir {}: {e}", shard.display()))
             })?;
 
-        write_new_file(&obj_path, bytes)
+        let wrote = write_new_file(&obj_path, bytes)
             .map_err(|e| CasError::Io(format!("writing cas object {}: {e}", obj_path.display())))?;
+        if !wrote {
+            // The pre-check saw nothing here, yet `create_new` lost: something claimed
+            // the path from outside this process (the in-process race is excluded by
+            // the mutex above). The contract stands — an existing object is a VERIFIED
+            // no-op — so read back and verify before reporting success. A path that
+            // exists but cannot even be read (a dangling symlink, permissions) is a
+            // loud Io error, never a silent "someone else surely wrote it".
+            let existing = std::fs::read(&obj_path).map_err(|e| {
+                CasError::Io(format!(
+                    "cas object {} was claimed concurrently but cannot be read back to \
+                     verify: {e}",
+                    obj_path.display()
+                ))
+            })?;
+            verify(&digest, existing)?;
+        }
 
-        let sidecar_json = serde_json::to_vec_pretty(provenance)
-            .map_err(|e| CasError::Serialize(e.to_string()))?;
         write_new_file(&sidecar_path, &sidecar_json).map_err(|e| {
             CasError::Io(format!(
                 "writing cas provenance sidecar {}: {e}",
@@ -737,12 +793,13 @@ impl MediaStore {
 
 /// Create `path` as a brand-new file (`create_new` — `O_EXCL` on Unix), write `bytes` to
 /// it, and `sync_all` before returning — pushing both data and metadata to durable storage
-/// rather than leaving them in a page-cache buffer a crash could still lose. If `path`
-/// already exists this is a deliberate no-op (`Ok(())`, not an error): on a
-/// content-addressed path that *should* only mean these exact bytes are already there —
-/// see [`CasError::Corrupt`] and [`Cas::get`] for why callers can no longer take that on
-/// faith alone. Any other I/O failure (permissions, disk full, the parent directory
-/// missing) is propagated. There is no unlink, truncate, or rename anywhere in this
+/// rather than leaving them in a page-cache buffer a crash could still lose. Returns
+/// `Ok(true)` when this call wrote the file, `Ok(false)` when `path` already existed
+/// (nothing written) — the CALLER decides what an existing path means: [`Cas::put`]
+/// verifies an existing object's bytes before reporting success (see
+/// [`CasError::Corrupt`]), and treats an existing sidecar as fine. Any other I/O
+/// failure (permissions, disk full, the parent directory missing) is propagated.
+/// There is no unlink, truncate, or rename anywhere in this
 /// function or its caller — an "edit" is always a new digest, never a mutation of an
 /// existing object.
 ///
@@ -753,17 +810,18 @@ impl MediaStore {
 /// window is exactly why verification on read ([`Cas::get`]) and on dedup ([`Cas::put`])
 /// exists as the actual backstop — fsync narrows how often corruption occurs, verification
 /// is what guarantees it is never handed back silently when it does.
-fn write_new_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+fn write_new_file(path: &Path, bytes: &[u8]) -> std::io::Result<bool> {
     use std::io::Write;
 
     let mut file = match std::fs::OpenOptions::new().write(true).create_new(true).open(path) // media-cas-write: blessed by the media CAS invariant amendment (AGENTS.md)
     {
         Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
         Err(e) => return Err(e),
     };
     file.write_all(bytes)?; // media-cas-write: blessed by the media CAS invariant amendment (AGENTS.md)
-    file.sync_all()
+    file.sync_all()?;
+    Ok(true)
 }
 
 /// Verify that `bytes` hashes to `digest`, consuming `bytes` into the `Ok` case so a
@@ -843,6 +901,21 @@ fn resolve_existing_ancestor(path: &Path) -> PathBuf {
         }
     }
     normalize(path)
+}
+
+/// The deepest existing path at-or-above `path` — `path` itself when it exists, else
+/// the nearest existing ancestor; `None` when nothing on the way up exists (an
+/// absolute path always bottoms out at `/`, so this is the degenerate relative case).
+/// Backs [`Cas::open`]'s structural check: whatever exists on the way to the root
+/// must be a directory, or no future write can succeed.
+fn first_existing_ancestor(path: &Path) -> Option<&Path> {
+    let mut cursor = path;
+    loop {
+        if cursor.exists() {
+            return Some(cursor);
+        }
+        cursor = cursor.parent()?;
+    }
 }
 
 /// Lexically clean a path (resolve `.` and `..` without touching the filesystem).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -213,6 +213,17 @@ pub struct CommonArgs {
     /// / the default ($XDG_STATE_HOME/kaibo/state.db).
     #[arg(long = "state-db", value_name = "FILE", global = true)]
     pub state_db: Option<PathBuf>,
+
+    /// Directory for the media CAS (generated artifacts). Overrides KAIBO_CAS_DIR /
+    /// [cas] dir / the default ($XDG_DATA_HOME/kaibo/cas).
+    #[arg(long = "cas-dir", value_name = "DIR", global = true)]
+    pub cas_dir: Option<PathBuf>,
+
+    /// Soft cap on total media-CAS size, in bytes. Unset means NO cap and no size
+    /// accounting; setting one makes every new write first sum the whole store.
+    /// Overrides KAIBO_CAS_MAX_BYTES / [cas] max_bytes.
+    #[arg(long = "cas-max-bytes", value_name = "BYTES", global = true)]
+    pub cas_max_bytes: Option<u64>,
 }
 
 /// The per-tool `--no-<tool>` gates — serve-only (they only make sense for the
@@ -510,6 +521,8 @@ fn load_config(common: &CommonArgs) -> anyhow::Result<Config> {
         common.user_context_file.clone(),
         common.no_persistence,
         common.state_db.clone(),
+        common.cas_dir.clone(),
+        common.cas_max_bytes,
     );
     Ok(config)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -977,7 +977,9 @@ pub fn run_config(common: CommonArgs) -> i32 {
     };
     // `active` reflects whether a real invocation would hold the store open — for a
     // one-shot `config` print we don't open it, but persistence being enabled is what
-    // a consult here would activate, so report that.
+    // a consult here would activate, so report that. The CAS mode is predicted from
+    // the same assumption, through the one shared derivation (`Config::cas_mode`).
+    let cas_mode = resolver.config.cas_mode(persistence_enabled);
     let body = render_config_resource(
         &resolver.config,
         resolver.allowed_trees(),
@@ -985,6 +987,7 @@ pub fn run_config(common: CommonArgs) -> i32 {
         resolver.default_root_inferred(),
         resolver.followed_worktrees(),
         persistence_enabled,
+        cas_mode,
     );
     println!("{body}");
     EXIT_OK
@@ -1789,7 +1792,12 @@ mod tests {
             long_help.contains("EXIT CODES"),
             "long --help should carry the exit-code table:\n{long_help}"
         );
-        for code in ["0  an answer", "2  usage error", "3  setup/containment", "4  the work ran"] {
+        for code in [
+            "0  an answer",
+            "2  usage error",
+            "3  setup/containment",
+            "4  the work ran",
+        ] {
             assert!(
                 long_help.contains(code),
                 "long --help should document exit code {code:?}:\n{long_help}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,6 +258,9 @@ pub struct ServeGates {
     /// Don't advertise the `list_models` tool.
     #[arg(long)]
     pub no_list_models: bool,
+    /// Don't advertise the `generate` tool (media generation).
+    #[arg(long)]
+    pub no_generate: bool,
 }
 
 impl ServeGates {
@@ -271,6 +274,7 @@ impl ServeGates {
             run_kaish: self.no_run_kaish,
             batch: self.no_batch,
             list_models: self.no_list_models,
+            generate: self.no_generate,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1579,15 +1579,19 @@ impl Config {
             // ROOT — rig's `ClientBuilder::base_url` appends its own versioned path
             // (`/v1beta/models/...` for Gemini) rather than taking one baked in; see
             // `GeminiBatch::base_url` (`batch.rs`) for the batch lane's matching
-            // reconciliation.
+            // reconciliation. `stability` takes one on the same optional host-root
+            // contract: kaibo's own facade appends `/v2beta/...` (`StabilityClient`),
+            // and unset dials the real https://api.stability.ai.
             if b.kind != ProviderKind::Openai
                 && b.kind != ProviderKind::Anthropic
                 && b.kind != ProviderKind::Gemini
+                && b.kind != ProviderKind::Stability
                 && b.base_url.is_some()
             {
                 bail!(
                     "backend {:?} (kind {:?}) sets base_url, but only the `openai`, \
-                     `anthropic`, and `gemini` kinds have a configurable endpoint",
+                     `anthropic`, `gemini`, and `stability` kinds have a configurable \
+                     endpoint",
                     b.name,
                     b.kind
                 );
@@ -2178,15 +2182,17 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
 /// casts; they drift — keep in sync with the source-of-truth pal configs
 /// (`provider-model-ids` memory).
 pub fn default_models(kind: ProviderKind) -> (&'static str, &'static str) {
-    match kind {
-        // Stability seeds no built-in cast: it staffs only the `image` slot, which no
-        // built-in carries, and it has no explorer/synth to name. Returning empty ids
-        // rather than plausible-looking ones keeps a mistaken caller loud — an empty
-        // model id fails at request time instead of silently dialing a wrong model.
-        ProviderKind::Stability => ("", ""),
-        ProviderKind::Anthropic => ("claude-haiku-4-5", "claude-sonnet-4-6"),
-        ProviderKind::DeepSeek => ("deepseek-v4-flash", "deepseek-v4-pro"),
-        ProviderKind::Gemini => ("gemini-flash-lite-latest", "gemini-3.5-flash"),
+    // A media kind seeds no built-in cast: it staffs only media slots, which no
+    // built-in carries, and it has no explorer/synth to name. Returning empty ids
+    // rather than plausible-looking ones keeps a mistaken caller loud — an empty
+    // model id fails at request time instead of silently dialing a wrong model.
+    let Some(wire) = kind.wire() else {
+        return ("", "");
+    };
+    match wire {
+        credentials::WireKind::Anthropic => ("claude-haiku-4-5", "claude-sonnet-4-6"),
+        credentials::WireKind::DeepSeek => ("deepseek-v4-flash", "deepseek-v4-pro"),
+        credentials::WireKind::Gemini => ("gemini-flash-lite-latest", "gemini-3.5-flash"),
         // OpenRouter's job here is a family we *can't* reach directly (we key
         // DeepSeek, Gemini, and Anthropic on their own backends), so the gateway
         // default is Qwen — a distinct lineage for a genuine cross-family read.
@@ -2198,8 +2204,8 @@ pub fn default_models(kind: ProviderKind) -> (&'static str, &'static str) {
         // which is text-only (hence the synth slot takes no vision pin below). If
         // you'd rather keep vision on the synth, swap in the multimodal plus tier
         // `qwen/qwen3.7-plus` (weaker reasoner, ~4.5× cheaper) and pin its vision on.
-        ProviderKind::OpenRouter => ("qwen/qwen3.6-flash", "qwen/qwen3.7-max"),
-        ProviderKind::Openai => ("Gemma-4-E4B-it-GGUF", "Gemma-4-26B-A4B-it-GGUF"),
+        credentials::WireKind::OpenRouter => ("qwen/qwen3.6-flash", "qwen/qwen3.7-max"),
+        credentials::WireKind::Openai => ("Gemma-4-E4B-it-GGUF", "Gemma-4-26B-A4B-it-GGUF"),
     }
 }
 
@@ -4636,7 +4642,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("only the `openai`, `anthropic`, and `gemini` kinds"),
+            err.contains("only the `openai`, `anthropic`, `gemini`, and `stability` kinds"),
             "got: {err}"
         );
     }
@@ -4654,6 +4660,20 @@ mod tests {
         .unwrap();
         let b = cfg.backends.get("anthropic").unwrap();
         assert_eq!(b.base_url.as_deref(), Some("http://ai.example.ts.net"));
+    }
+
+    /// The stability kind takes an optional base_url on the same host-root contract:
+    /// kaibo's own facade appends `/v2beta/...` (`StabilityClient`), so a gateway or a
+    /// test double in front of the real API is one config line. Unset still dials
+    /// api.stability.ai (`STABILITY_API_BASE`, applied in `MediaArm::from_slot`).
+    #[test]
+    fn stability_backend_accepts_a_base_url() {
+        let cfg = Config::from_toml_str(
+            "[backends.sd]\nkind = \"stability\"\nbase_url = \"http://sd.example.ts.net\"\n",
+        )
+        .unwrap();
+        let b = cfg.backends.get("sd").unwrap();
+        assert_eq!(b.base_url.as_deref(), Some("http://sd.example.ts.net"));
     }
 
     /// The gemini kind may also set base_url — for a Gemini-API-compatible

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,29 +170,55 @@ impl Default for Defaults {
 
 // --- Roles ------------------------------------------------------------------
 
-/// The roles a cast's model slots can serve: the two agent phases. Explorer does the
-/// fast sweeps; synth answers. There are no output/production roles — kaibo reasons
-/// over a codebase and renders nothing. Perception (image input, audio-in later) is a
-/// slot *capability* (`ModelCaps` / the `vision` pin), not a role. A cast may omit a
-/// role: an absent slot means the capability is absent, not an error (the four
-/// interactive built-in casts carry explorer+synth; the batch built-ins carry synth
-/// only).
+/// The roles a cast's model slots can serve.
+///
+/// Explorer does the fast sweeps and synth answers — the two *reasoning* phases, and for
+/// most of kaibo's life the only two. `Image` is deliberately different in kind: it is a
+/// **production** role, the one place kaibo emits rather than reasons, and it exists
+/// because Amy reopened image generation on 2026-07-25 with the media CAS as the write
+/// surface that makes it acceptable (see `src/cas.rs`'s module doc for why the CAS is
+/// safe by *shape* rather than by policy).
+///
+/// It lives here, on a cast slot, rather than as a config concept of its own. That was
+/// Amy's call (2026-07-30) over the alternative of a standalone `[image]` section keyed
+/// straight to a backend, and it earns its place: the staffing gate, the per-tool `cast`
+/// enum, and the per-call `cast` argument all keep working unchanged, so an image tool
+/// is one `CAST_ENUM_RULES` row rather than a parallel mechanism. The cost is that
+/// "cast" now names a team that may include a non-reasoning member; the benefit is that
+/// there is exactly one way to say "which models answer this call".
+///
+/// Perception stays a slot *capability* (`ModelCaps` / the `vision` pin), not a role —
+/// reading an image is part of a reasoning slot's input, not a job of its own.
+///
+/// A cast may omit any role: an absent slot means the capability is absent, not an error
+/// (the interactive built-ins carry explorer+synth; the batch built-ins carry synth
+/// only; none carries an image slot, so no built-in cast can staff an image tool).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ModelRole {
     Explorer,
     Synth,
+    Image,
 }
 
 impl ModelRole {
     /// Every role, in table order — the source for "known roles" error text.
-    pub const ALL: [ModelRole; 2] = [Self::Explorer, Self::Synth];
+    pub const ALL: [ModelRole; 3] = [Self::Explorer, Self::Synth, Self::Image];
 
     /// The role's config-table key (`[casts.<name>]`).
     pub fn key(self) -> &'static str {
         match self {
             Self::Explorer => "explorer",
             Self::Synth => "synth",
+            Self::Image => "image",
         }
+    }
+
+    /// Whether this role runs a *reasoning* phase — an agent turn with a preamble, a
+    /// tool loop, and a thinking budget. `Image` does not: it is one request to an image
+    /// API, so the request-shaping machinery (`ModelShape`, effort, thinking style, turn
+    /// caps) neither applies to it nor should be resolved for it.
+    pub fn is_reasoning(self) -> bool {
+        matches!(self, Self::Explorer | Self::Synth)
     }
 }
 
@@ -1386,6 +1412,35 @@ impl Config {
                         t.max_tokens
                     );
                 }
+                // The role and the backend KIND have to agree about what kind of wire
+                // this is. `stability` is an image-generation API driven through
+                // kaibo's own facade, not a rig completion model, so it can staff the
+                // `image` slot and nothing else; conversely an image slot pointed at a
+                // chat backend would ask a completion model to return pixels. Both are
+                // load errors here rather than a baffling failure at request time, when
+                // the operator would be reading a provider error instead of a config
+                // mistake. This is the config half of the guard `Arm::from_slot` bails
+                // on — if the two ever disagree, both refuse rather than improvise.
+                if kind == ProviderKind::Stability && role.is_reasoning() {
+                    bail!(
+                        "cast {name:?}: the {} slot points at backend {:?} (kind \
+                         `stability`), which generates images and has no completion \
+                         model to reason with — point {} at a chat backend, and put the \
+                         stability backend on this cast's `image` slot instead",
+                        role.key(),
+                        slot.backend,
+                        role.key(),
+                    );
+                }
+                if *role == ModelRole::Image && kind != ProviderKind::Stability {
+                    bail!(
+                        "cast {name:?}: the image slot points at backend {:?} (kind \
+                         `{}`), which is a chat/completion wire and cannot generate an \
+                         image — an image slot needs a backend of kind `stability`",
+                        slot.backend,
+                        kind.canonical_name(),
+                    );
+                }
                 // A slot's lane needs a fitting role and backend, caught here rather
                 // than as a baffling refusal or a 400 at submit/deliberate time. The
                 // explorer always runs interactively (a `deliberate` cast pairs it with
@@ -1788,6 +1843,11 @@ fn builtin_casts() -> BTreeMap<String, Cast> {
 /// (`provider-model-ids` memory).
 pub fn default_models(kind: ProviderKind) -> (&'static str, &'static str) {
     match kind {
+        // Stability seeds no built-in cast: it staffs only the `image` slot, which no
+        // built-in carries, and it has no explorer/synth to name. Returning empty ids
+        // rather than plausible-looking ones keeps a mistaken caller loud — an empty
+        // model id fails at request time instead of silently dialing a wrong model.
+        ProviderKind::Stability => ("", ""),
         ProviderKind::Anthropic => ("claude-haiku-4-5", "claude-sonnet-4-6"),
         ProviderKind::DeepSeek => ("deepseek-v4-flash", "deepseek-v4-pro"),
         ProviderKind::Gemini => ("gemini-flash-lite-latest", "gemini-3.5-flash"),
@@ -2116,6 +2176,8 @@ struct RawCast {
     batch: Option<bool>,
     explorer: Option<RawSlot>,
     synth: Option<RawSlot>,
+    /// The production slot — a text-to-image model. See [`ModelRole::Image`].
+    image: Option<RawSlot>,
 }
 
 impl RawCast {
@@ -2124,6 +2186,7 @@ impl RawCast {
         [
             (ModelRole::Explorer, &self.explorer),
             (ModelRole::Synth, &self.synth),
+            (ModelRole::Image, &self.image),
         ]
         .into_iter()
         .filter_map(|(role, slot)| slot.as_ref().map(|s| (role, s)))

--- a/src/config.rs
+++ b/src/config.rs
@@ -976,11 +976,20 @@ impl Default for PersistenceConfig {
 
 /// `[cas]` — the media content-addressed store where generated artifacts land.
 ///
-/// There is no `enabled` flag here on purpose: the CAS exists exactly when a tool that
-/// writes to it does, and those tools carry their own `--no-<tool>` gates plus the cast
-/// staffing gate. A second on/off switch would just be a way for the two to disagree.
+/// Lifecycle (Amy's ruling, 2026-08-03, reversing an earlier "no enabled flag" stance
+/// recorded here): the CAS is **on by default** and follows persistence — disk-backed at
+/// the fixed XDG data path while persistence is active, in-memory (artifacts lost on
+/// restart, warned LOUDLY at startup) while it is not. `enabled = false` is the explicit
+/// off switch, and it un-advertises every tool that needs the CAS — the same
+/// route-dropped posture the staffing gate takes, with the reason distinguishable in the
+/// startup warning and `kaibo://config` ("you disabled it" vs "nothing can staff it").
+/// The earlier stance ("the tool gates suffice") under-counted the modes: with disk /
+/// memory / off there are three states, and only an explicit flag makes "off" a choice
+/// rather than a side effect.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CasConfig {
+    /// The explicit off switch (`[cas] enabled = false`). Default `true`.
+    pub enabled: bool,
     /// Where artifacts live. Defaults to `$XDG_DATA_HOME/kaibo/cas`, else
     /// `~/.local/share/kaibo/cas` — the *data* dir, not the state dir the session db
     /// uses, because these are artifacts the user paid for and may never be able to
@@ -1001,8 +1010,63 @@ pub struct CasConfig {
 impl Default for CasConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             dir: crate::cas::default_cas_dir(),
             max_bytes: None,
+        }
+    }
+}
+
+/// Which media store a running server holds — the three-way state `kaibo://config`
+/// reports and `main` builds from. Derived in exactly one place
+/// ([`Config::cas_mode`]) so the store `main` constructs, the mode the resource
+/// renders, and the CLI's prediction can never disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CasMode {
+    /// Persistence is active and a CAS directory resolved: artifacts land on disk at
+    /// the fixed XDG data path, durable across restarts.
+    Disk,
+    /// The CAS is enabled but has nowhere durable to write (persistence inactive, or
+    /// no resolvable directory): artifacts are held in process memory for this run
+    /// only. Startup warns loudly; `kaibo://config` shows `mode = "memory"`.
+    Memory,
+    /// `[cas] enabled = false`: no store at all, and every tool that needs one is
+    /// un-advertised.
+    Off,
+}
+
+impl CasMode {
+    /// The word the `[cas]` render uses.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CasMode::Disk => "disk",
+            CasMode::Memory => "memory",
+            CasMode::Off => "off",
+        }
+    }
+}
+
+impl Config {
+    /// The media-store mode this config implies once `persistence_active` is known —
+    /// the ONE derivation of Amy's lifecycle ruling ("cas should be on when
+    /// persistence is, and ideally on but in memory only when it's not. but can be
+    /// disabled"). `main` builds the store from this; the `kaibo://config` render and
+    /// `kaibo config` report it; keeping one implementation is what stops the built
+    /// store and the reported mode from drifting.
+    ///
+    /// `persistence_active` is *runtime* truth, not `[persistence] enabled`: a store
+    /// that failed to open (the Windows `SingleProcessLocked` degrade) leaves this run
+    /// without durable state, and a CAS whose artifacts outlive the sessions that
+    /// name their digests would strand them — so the CAS degrades with it. A missing
+    /// directory (`dir = None`: neither `$XDG_DATA_HOME` nor `$HOME` resolvable) also
+    /// lands on `Memory` — loud in the startup warning, never a silently invented path.
+    pub fn cas_mode(&self, persistence_active: bool) -> CasMode {
+        if !self.cas.enabled {
+            CasMode::Off
+        } else if persistence_active && self.cas.dir.is_some() {
+            CasMode::Disk
+        } else {
+            CasMode::Memory
         }
     }
 }
@@ -1795,7 +1859,9 @@ impl Config {
                             lane.as_str()
                         );
                     }
-                    if lane == Lane::Batch && !crate::batch::batch_supported(&backends[&slot.backend]) {
+                    if lane == Lane::Batch
+                        && !crate::batch::batch_supported(&backends[&slot.backend])
+                    {
                         bail!(
                             "cast {name:?}: synth lane = \"batch\" but the synth backend \
                              {:?} ({}) has no batch API — a batch synth must sit on a \
@@ -2262,6 +2328,8 @@ struct RawPersistence {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawCas {
+    /// The explicit off switch — absent means on (see [`CasConfig::enabled`]).
+    enabled: Option<bool>,
     /// `$VAR`/`~`-expanded like `root`/`allow_paths`, so `$XDG_DATA_HOME/art` resolves
     /// per-environment rather than landing as a literal token.
     dir: Option<String>,
@@ -2478,9 +2546,9 @@ impl RawBackend {
                     b.kind
                 );
             }
-            b.data_collection = v.parse().with_context(|| {
-                format!("backend {:?} data_collection", b.name)
-            })?;
+            b.data_collection = v
+                .parse()
+                .with_context(|| format!("backend {:?} data_collection", b.name))?;
         }
         if let Some(v) = &self.wire {
             // The knob only exists on the openai kind — naming it anywhere else
@@ -2756,6 +2824,7 @@ fn merge_cas(raw: RawCas) -> Result<CasConfig> {
         );
     }
     Ok(CasConfig {
+        enabled: raw.enabled.unwrap_or(true),
         dir,
         max_bytes: raw.max_bytes,
     })
@@ -3277,7 +3346,11 @@ fn expand_env_vars(s: &str) -> anyhow::Result<String> {
                     // give — and so both reference forms agree on what a name is. (The
                     // braced form *is* an explicit expansion request, so a bad name is an
                     // error here, unlike a bare `$1` which is simply not a reference.)
-                    let ok = if name.is_empty() { is_start(nc) } else { is_continue(nc) };
+                    let ok = if name.is_empty() {
+                        is_start(nc)
+                    } else {
+                        is_continue(nc)
+                    };
                     if !ok {
                         bail!(
                             "path {s:?} has an invalid character {nc:?} in a ${{...}} \
@@ -3390,19 +3463,19 @@ mod tests {
         );
 
         for bad in [
-            format!("${unset}"),       // bare form, undefined
-            format!("${{{unset}}}"),   // braced form, undefined
+            format!("${unset}"),     // bare form, undefined
+            format!("${{{unset}}}"), // braced form, undefined
             "${UNTERMINATED".to_string(),
             "${}".to_string(),
             // The braced form is an explicit expansion request, so an invalid name is a
             // loud parse error (not the misleading "not set" the env lookup would give).
-            "${1bad}".to_string(),     // can't start with a digit
-            "${A/B}".to_string(),      // `/` is not a name char
+            "${1bad}".to_string(), // can't start with a digit
+            "${A/B}".to_string(),  // `/` is not a name char
             // A stray `$` that begins no reference is a typo in a boundary path, refused
             // rather than kept as a silent literal. Write `$$` for a real literal `$`.
-            "/a/$ b".to_string(),      // `$` followed by a space
-            "/cost/$100".to_string(),  // `$` followed by a digit
-            "trailing$".to_string(),   // `$` at end of string
+            "/a/$ b".to_string(),     // `$` followed by a space
+            "/cost/$100".to_string(), // `$` followed by a digit
+            "trailing$".to_string(),  // `$` at end of string
         ] {
             assert!(
                 expand_env_vars(&bad).is_err(),
@@ -3618,7 +3691,10 @@ mod tests {
         );
         assert_eq!((s.backend.as_str(), s.id.as_str()), ("openrouter", synth));
         assert_eq!(e.vision, Some(true), "explorer flash is multimodal-in");
-        assert_eq!(s.vision, None, "text-only synth leaves the classifier's false to stand");
+        assert_eq!(
+            s.vision, None,
+            "text-only synth leaves the classifier's false to stand"
+        );
 
         let b = cfg.resolve_backend("openrouter").unwrap();
         assert_eq!(b.kind, ProviderKind::OpenRouter);
@@ -5147,8 +5223,7 @@ mod tests {
         // and a bare containment check would keep passing after the knob's real
         // documentation vanished (gemini cross-family review, 2026-08-02).
         let mentions = |field: &str| {
-            let is_word =
-                |c: Option<char>| c.is_some_and(|c| c.is_alphanumeric() || c == '_');
+            let is_word = |c: Option<char>| c.is_some_and(|c| c.is_alphanumeric() || c == '_');
             template.match_indices(field).any(|(i, _)| {
                 !is_word(template[..i].chars().next_back())
                     && !is_word(template[i + field.len()..].chars().next())

--- a/src/config.rs
+++ b/src/config.rs
@@ -773,6 +773,39 @@ impl Default for PersistenceConfig {
     }
 }
 
+/// `[cas]` — the media content-addressed store where generated artifacts land.
+///
+/// There is no `enabled` flag here on purpose: the CAS exists exactly when a tool that
+/// writes to it does, and those tools carry their own `--no-<tool>` gates plus the cast
+/// staffing gate. A second on/off switch would just be a way for the two to disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CasConfig {
+    /// Where artifacts live. Defaults to `$XDG_DATA_HOME/kaibo/cas`, else
+    /// `~/.local/share/kaibo/cas` — the *data* dir, not the state dir the session db
+    /// uses, because these are artifacts the user paid for and may never be able to
+    /// reproduce (see `src/cas.rs`'s module doc). `None` only when neither
+    /// `$XDG_DATA_HOME` nor `$HOME` is set; a tool that needs the CAS then fails loudly
+    /// rather than inventing a path.
+    pub dir: Option<PathBuf>,
+    /// Optional soft cap on total store size. **Unset by default, and that is not the
+    /// same as a very large number**: a cap has to be enforced by summing every file in
+    /// the store on the write path, for every new object, over a store that by design
+    /// never deletes. That walk is O(objects) and only slows as the store fills, so an
+    /// operator who never asked for a ceiling pays nothing for it. Set it and you opt
+    /// into the accounting; leave it and disk-full is the backstop, with `find -mtime`
+    /// over the provenance sidecars as the cleanup story.
+    pub max_bytes: Option<u64>,
+}
+
+impl Default for CasConfig {
+    fn default() -> Self {
+        Self {
+            dir: crate::cas::default_cas_dir(),
+            max_bytes: None,
+        }
+    }
+}
+
 // --- The whole config ------------------------------------------------------
 
 /// kaibo's resolved configuration.
@@ -815,6 +848,8 @@ pub struct Config {
     pub telemetry: TelemetryConfig,
     /// Durable sessions + batch handles — on by default (see [`PersistenceConfig`]).
     pub persistence: PersistenceConfig,
+    /// `[cas]` — where generated media artifacts land, and an optional size ceiling.
+    pub cas: CasConfig,
     /// House-rules files spliced into each consultation tool's preamble (the
     /// `[context]` table). Defaults to reading `AGENTS.md` when present.
     pub context: ContextConfig,
@@ -1423,6 +1458,7 @@ impl Config {
         let infer_cwd = server.infer_cwd.unwrap_or(true);
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let persistence = merge_persistence(raw.persistence.unwrap_or_default())?;
+        let cas = merge_cas(raw.cas.unwrap_or_default())?;
         let context = merge_context(raw.context.unwrap_or_default())?;
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;
         let orientation = merge_orientation(raw.orientation.unwrap_or_default())?;
@@ -1454,6 +1490,7 @@ impl Config {
             defaults,
             telemetry,
             persistence,
+            cas,
             context,
             prompts,
             orientation,
@@ -1494,6 +1531,8 @@ impl Config {
         user_context_files: Vec<PathBuf>,
         disable_persistence: bool,
         state_db: Option<PathBuf>,
+        cas_dir: Option<PathBuf>,
+        cas_max_bytes: Option<u64>,
     ) {
         if let Some(root) = root {
             self.root = Some(root);
@@ -1507,6 +1546,16 @@ impl Config {
         // shell; a path arrives concrete). Overrides file/env/default.
         if let Some(path) = state_db {
             self.persistence.path = Some(path);
+        }
+        // `--cas-dir` / `--cas-max-bytes` are the top layer over env/file/default. Note
+        // there is no CLI way to *clear* a configured cap back to "no ceiling" — the
+        // absence of the flag means "don't override", the same grammar every other
+        // optional flag here uses. Omit `max_bytes` from the file to run uncapped.
+        if let Some(dir) = cas_dir {
+            self.cas.dir = Some(dir);
+        }
+        if let Some(max) = cas_max_bytes {
+            self.cas.max_bytes = Some(max);
         }
         // Mirrors the `--no-<tool>` discipline: the CLI can only turn the follow OFF,
         // never force it on over a `[server] follow_worktrees = false` in the file.
@@ -1769,6 +1818,7 @@ struct RawConfig {
     defaults: Option<RawDefaults>,
     telemetry: Option<RawTelemetry>,
     persistence: Option<RawPersistence>,
+    cas: Option<RawCas>,
     context: Option<RawContext>,
     prompts: Option<RawPrompts>,
     orientation: Option<RawOrientation>,
@@ -1804,6 +1854,16 @@ struct RawPersistence {
     /// `$VAR`/`~`-expanded like `root`/`allow_paths`, so `$XDG_STATE_HOME/kaibo.db` or
     /// `~/state.db` resolves per-environment rather than landing as a literal token.
     path: Option<String>,
+}
+
+/// `[cas]` as written in the file. `max_bytes` absent means *no cap* — see [`CasConfig`].
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawCas {
+    /// `$VAR`/`~`-expanded like `root`/`allow_paths`, so `$XDG_DATA_HOME/art` resolves
+    /// per-environment rather than landing as a literal token.
+    dir: Option<String>,
+    max_bytes: Option<u64>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -2266,6 +2326,29 @@ fn merge_persistence(raw: RawPersistence) -> Result<PersistenceConfig> {
     Ok(PersistenceConfig { enabled, path })
 }
 
+/// Resolve `[cas]`. A missing `dir` falls back to the XDG data default; a missing
+/// `max_bytes` means **no cap at all**, which is the deliberate default (see
+/// [`CasConfig::max_bytes`]). An explicit `max_bytes = 0` is a loud load error rather
+/// than a store that refuses every write — a zero ceiling is never what anyone means,
+/// and silently accepting it would produce a CAS that fails on first use with a
+/// capacity error nobody could explain.
+fn merge_cas(raw: RawCas) -> Result<CasConfig> {
+    let dir = match raw.dir {
+        Some(d) => Some(expand_path(&d)?),
+        None => crate::cas::default_cas_dir(),
+    };
+    if raw.max_bytes == Some(0) {
+        bail!(
+            "[cas] max_bytes must be > 0 — a zero ceiling refuses every write. Omit it \
+             entirely for no cap (the default), or set a real byte budget."
+        );
+    }
+    Ok(CasConfig {
+        dir,
+        max_bytes: raw.max_bytes,
+    })
+}
+
 /// Resolve `[context]`. A *missing* `project_files` keeps the built-in
 /// `["AGENTS.md"]` default (vendor-neutral, opt-out by an explicit empty list);
 /// `user_files` default to empty and are `$VAR`/`~`-expanded here (via `expand_path`,
@@ -2567,6 +2650,18 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if let Some(v) = get("KAIBO_STATE_DB") {
         persistence.path = Some(v);
+    }
+
+    // Media CAS: KAIBO_CAS_DIR / KAIBO_CAS_MAX_BYTES, straight from the naming rule
+    // (config key `foo_bar` ⇄ env `KAIBO_FOO_BAR`). There is no KAIBO_NO_CAS — the CAS
+    // isn't a capability you switch off, it's where an artifact-producing tool writes,
+    // and those tools carry their own `--no-<tool>` gates.
+    let cas = raw.cas.get_or_insert_with(Default::default);
+    if let Some(v) = get("KAIBO_CAS_DIR") {
+        cas.dir = Some(v);
+    }
+    if let Some(v) = get("KAIBO_CAS_MAX_BYTES") {
+        cas.max_bytes = Some(parse_env_int("KAIBO_CAS_MAX_BYTES", &v)?);
     }
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -403,6 +403,34 @@ impl ModelSlot {
             thinking_style: self.thinking_style.unwrap_or(defaults.thinking_style),
         }
     }
+
+    /// The reasoning tunables the operator wrote ON this slot's table, by knob name,
+    /// in the order the `kaibo://config` render lists inert knobs. This is the set a
+    /// non-reasoning (media) slot is judged by: an image slot sends one generation
+    /// request with no preamble, no tool loop, and no thinking budget (see
+    /// [`ModelRole::is_reasoning`]), so a reasoning knob written there never reaches a
+    /// request.
+    ///
+    /// Slot-written only, on purpose. A `[defaults]` effort or temperature states the
+    /// explorer/synth posture and merely falls back onto other roles, so inherited
+    /// values stay quiet here — the same rule that keeps the inherited built-in effort
+    /// quiet on toggle-less wires (see [`Defaults::explorer_effort_explicit`]).
+    pub fn written_reasoning_tunables(&self) -> Vec<&'static str> {
+        let mut written = Vec::new();
+        if self.thinking_budget.is_some() {
+            written.push("thinking_budget");
+        }
+        if self.effort.is_some() {
+            written.push("effort");
+        }
+        if self.temperature.is_some() {
+            written.push("temperature");
+        }
+        if self.thinking_style.is_some() {
+            written.push("thinking_style");
+        }
+        written
+    }
 }
 
 /// Where an operator wrote the `effort` that turned out to be inert.
@@ -497,6 +525,18 @@ pub struct EffortDiagnostic {
     /// The slot's `"backend/model-id"` ref, so the message names both halves.
     pub model: String,
     pub disposition: EffortDisposition,
+}
+
+/// One media (non-reasoning) cast slot carrying reasoning tunables the operator wrote
+/// on the slot table itself — see [`Config::media_tunable_diagnostics`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaTunableDiagnostic {
+    pub cast: String,
+    pub role: &'static str,
+    /// The slot's `"backend/model-id"` ref, so the message names both halves.
+    pub model: String,
+    /// The written knob names, in the `kaibo://config` render order.
+    pub tunables: Vec<&'static str>,
 }
 
 /// A slot's effective request-shaping knobs after the per-role fallback (see
@@ -1364,6 +1404,16 @@ impl Config {
         let mut out = Vec::new();
         for (cast_name, cast) in &self.casts {
             for (role, slot) in &cast.slots {
+                // A media slot runs no reasoning phase at all, so this scan covers
+                // reasoning roles only; its written knobs are reported by
+                // `media_tunable_diagnostics`. The distinction matters for the quiet
+                // half too: a `[defaults]` effort inheriting onto an image slot is a
+                // fallback artifact, not something the operator said about that slot,
+                // and reporting it here would warn on every image slot the moment
+                // anyone set `synth_effort`.
+                if !role.is_reasoning() {
+                    continue;
+                }
                 let Ok(disposition) = self.effort_disposition(slot, *role) else {
                     continue;
                 };
@@ -1375,6 +1425,41 @@ impl Config {
                     role: role.key(),
                     model: slot.qualified(),
                     disposition,
+                });
+            }
+        }
+        out
+    }
+
+    /// Every media (non-reasoning) cast slot where the operator *wrote* a reasoning
+    /// tunable on the slot table. An image slot sends one generation request with no
+    /// reasoning phase (see [`ModelRole::is_reasoning`]), so a reasoning knob there
+    /// never reaches a request; writing one usually means it landed on the wrong slot.
+    ///
+    /// Surfaced the way inert effort is surfaced — a startup warning plus
+    /// `inert_tunables` in `kaibo://config`, both reading this one rule — and
+    /// deliberately not a load error: the value is harmless, only silent, and the cure
+    /// is a message that names the slot and the knobs.
+    ///
+    /// Slot-written knobs only ([`ModelSlot::written_reasoning_tunables`]); inherited
+    /// `[defaults]` values stay quiet, the same rule that keeps the built-in effort
+    /// quiet on toggle-less wires ([`Self::effort_diagnostics`]).
+    pub fn media_tunable_diagnostics(&self) -> Vec<MediaTunableDiagnostic> {
+        let mut out = Vec::new();
+        for (cast_name, cast) in &self.casts {
+            for (role, slot) in &cast.slots {
+                if role.is_reasoning() {
+                    continue;
+                }
+                let tunables = slot.written_reasoning_tunables();
+                if tunables.is_empty() {
+                    continue;
+                }
+                out.push(MediaTunableDiagnostic {
+                    cast: cast_name.clone(),
+                    role: role.key(),
+                    model: slot.qualified(),
+                    tunables,
                 });
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1259,6 +1259,17 @@ impl Config {
             .is_some_and(|c| c.slot(ModelRole::Explorer).is_some())
     }
 
+    /// Whether canonical cast `name` can staff a `generate` call: it carries an
+    /// **image** slot — the media member, the only slot `generate` runs. Load
+    /// validation already pinned that slot to a media backend (kind `stability`), so
+    /// slot presence is the whole test here. Independent of the reasoning slots: a
+    /// cast may be image-only, and a full team's image slot is equally valid.
+    pub fn cast_can_generate(&self, name: &str) -> bool {
+        self.casts
+            .get(name)
+            .is_some_and(|c| c.slot(ModelRole::Image).is_some())
+    }
+
     /// Whether canonical cast `name` is the configured default — comparing against the
     /// *resolved* default, so an alias default (`server.cast = "claude"`) still matches
     /// its canonical cast (`anthropic`). The roster renderer (`casts_section`) gets
@@ -2052,6 +2063,9 @@ impl Config {
         if disable.list_models {
             self.tools.list_models = false;
         }
+        if disable.generate {
+            self.tools.generate = false;
+        }
         // Non-empty CLI allow_paths replaces lower layers (env/file).
         if !allow_paths.is_empty() {
             self.allow_paths = allow_paths;
@@ -2081,6 +2095,7 @@ pub struct ToolDisables {
     pub run_kaish: bool,
     pub batch: bool,
     pub list_models: bool,
+    pub generate: bool,
 }
 
 /// Register `alias → target` at one level (backend or cast), rejecting a clash
@@ -2461,6 +2476,7 @@ struct RawTools {
     run_kaish: Option<bool>,
     batch: Option<bool>,
     list_models: Option<bool>,
+    generate: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -2953,6 +2969,7 @@ fn merge_tools(raw: RawTools) -> ToolGating {
         run_kaish: raw.run_kaish.unwrap_or(d.run_kaish),
         batch: raw.batch.unwrap_or(d.batch),
         list_models: raw.list_models.unwrap_or(d.list_models),
+        generate: raw.generate.unwrap_or(d.generate),
     }
 }
 
@@ -3026,6 +3043,9 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if env_flag(get, "KAIBO_NO_LIST_MODELS") {
         tools.list_models = Some(false);
+    }
+    if env_flag(get, "KAIBO_NO_GENERATE") {
+        tools.generate = Some(false);
     }
 
     let defaults = raw.defaults.get_or_insert_with(Default::default);

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -29,7 +29,7 @@ use serde_json::{json, Value};
 use crate::attach::Attachment;
 use crate::completion_watch::{watched, CompletionLog, Watched};
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot};
-use crate::credentials::ProviderKind;
+use crate::credentials::WireKind;
 use crate::explorer::RunKaish;
 use crate::progress::{PhaseEvent, ProgressSink};
 use crate::sandbox::{KaishWorker, SandboxConfig};
@@ -366,20 +366,25 @@ impl Arm {
         // (the 2026-06-06 wedge; see the helper's doc). Injected via rig's `.http_client(..)`.
         let http = crate::tls::https_client(backend.request_timeout)?;
 
-        match backend.kind {
-            // A Stability backend has no completion model to build an arm from — it is
-            // an image API, reached through kaibo's own facade (`src/stability.rs`) on
-            // the `image` cast slot, never through rig. Config validation refuses a
-            // reasoning slot pointed at one, so this is the belt to that braces: if the
-            // two ever disagree, fail loudly here rather than construct a nonsense arm.
-            ProviderKind::Stability => anyhow::bail!(
-                "backend {:?} is kind `stability`, which generates images and cannot \
-                 staff a reasoning slot — point `explorer`/`synth` at a completion \
-                 backend, and use `image = \"{}/<model>\"` for generation",
+        // A media backend has no completion model to build an arm from — it is reached
+        // through the media seam (`crate::media::MediaArm`) on a media cast slot, never
+        // through rig. Config validation refuses a reasoning slot pointed at one, so
+        // this is the belt to those braces: if the two ever disagree, fail loudly here
+        // rather than construct a nonsense arm. Classifying up front also keeps the
+        // construction match below on `WireKind`, where a media arm cannot exist.
+        let wire = match backend.kind.class() {
+            crate::credentials::ProviderClass::Wire(w) => w,
+            crate::credentials::ProviderClass::Media(_) => anyhow::bail!(
+                "backend {:?} is kind `{}`, which generates media and cannot staff a \
+                 reasoning slot — point `explorer`/`synth` at a completion backend, \
+                 and use `image = \"{}/<model>\"` for generation",
                 backend.name,
+                backend.kind.canonical_name(),
                 backend.name
             ),
-            ProviderKind::Anthropic => {
+        };
+        match wire {
+            WireKind::Anthropic => {
                 // base_url is optional here (unlike the openai kind): unset dials
                 // rig's built-in https://api.anthropic.com; set, it points at an
                 // Anthropic-Messages-API-compatible gateway/proxy instead.
@@ -394,7 +399,7 @@ impl Arm {
                     .map_err(|e| anyhow!("anthropic client init: {e}"))?;
                 Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
             }
-            ProviderKind::DeepSeek => {
+            WireKind::DeepSeek => {
                 let key = backend.resolve_key()?;
                 let client = deepseek::Client::builder()
                     .api_key(&key)
@@ -403,7 +408,7 @@ impl Arm {
                     .map_err(|e| anyhow!("deepseek client init: {e}"))?;
                 Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
             }
-            ProviderKind::Gemini => {
+            WireKind::Gemini => {
                 // base_url is optional here (unlike the openai kind): unset dials
                 // rig's built-in https://generativelanguage.googleapis.com; set, it
                 // points at a Gemini-API-compatible gateway/proxy instead. Same
@@ -421,7 +426,7 @@ impl Arm {
                     .map_err(|e| anyhow!("gemini client init: {e}"))?;
                 Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))
             }
-            ProviderKind::OpenRouter => {
+            WireKind::OpenRouter => {
                 // A keyed gateway with a *fixed* endpoint (rig pins the base URL), so —
                 // unlike the openai kind — there is no base_url to resolve. `with_app_identity`
                 // stamps the X-OpenRouter-Title / HTTP-Referer headers so kaibo's traffic is
@@ -436,7 +441,7 @@ impl Arm {
                 let model = Self::openrouter_completion_model(&client, &slot.id);
                 Ok(Self::from_model(model, &slot.id, t.max_tokens, params, caps))
             }
-            ProviderKind::Openai => {
+            WireKind::Openai => {
                 // Any OpenAI-compatible endpoint, addressed by the backend's base
                 // URL. The key is optional for a keyless backend: `resolve_key`
                 // returns the configured key or a placeholder the server ignores.
@@ -2200,6 +2205,7 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
+    use crate::credentials::ProviderKind;
     use crate::session::{SessionStore, Sessions};
     use crate::test_support::{
         has_tool, is_finalize_turn, provider_error, reasoning_response, text_response,

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -297,6 +297,18 @@ impl Arm {
         let http = crate::tls::https_client(backend.request_timeout)?;
 
         match backend.kind {
+            // A Stability backend has no completion model to build an arm from — it is
+            // an image API, reached through kaibo's own facade (`src/stability.rs`) on
+            // the `image` cast slot, never through rig. Config validation refuses a
+            // reasoning slot pointed at one, so this is the belt to that braces: if the
+            // two ever disagree, fail loudly here rather than construct a nonsense arm.
+            ProviderKind::Stability => anyhow::bail!(
+                "backend {:?} is kind `stability`, which generates images and cannot \
+                 staff a reasoning slot — point `explorer`/`synth` at a completion \
+                 backend, and use `image = \"{}/<model>\"` for generation",
+                backend.name,
+                backend.name
+            ),
             ProviderKind::Anthropic => {
                 // base_url is optional here (unlike the openai kind): unset dials
                 // rig's built-in https://api.anthropic.com; set, it points at an

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -94,6 +94,11 @@ fn transport_supports_tool_result_images(kind: ProviderKind) -> bool {
         // Vision-blind on the wire; the value is unreached (no view_image attaches),
         // but "no tool-result image channel" is the honest answer.
         ProviderKind::DeepSeek => false,
+        // Never reached: `Stability` is an image-generation wire, not a completion
+        // wire — no reasoning slot may point at one, so no phase ever shapes a request
+        // for it. Answered explicitly rather than with a `_` arm so the next kind still
+        // has to make this choice consciously.
+        ProviderKind::Stability => false,
     }
 }
 
@@ -121,6 +126,11 @@ fn is_vision_capable(kind: ProviderKind, _model: &str) -> bool {
         // vision on, while its synth default (text-only `qwen3.7-max`) leaves the slot
         // `None` and lets this false stand.
         ProviderKind::OpenRouter => false,
+        // Never reached: no reasoning slot may point at a Stability backend (it is an
+        // image-generation wire, not a completion one), so nothing ever asks whether it
+        // can *read* an image. Stated rather than defaulted, so the next kind must
+        // choose consciously.
+        ProviderKind::Stability => false,
     }
 }
 
@@ -224,6 +234,10 @@ impl ModelShape {
             ProviderKind::DeepSeek => ThinkingStyle::DeepSeekEffort,
             ProviderKind::OpenRouter => ThinkingStyle::OpenRouterEffort,
             ProviderKind::Openai => ThinkingStyle::None,
+            // An image API has no reasoning channel to configure, and no reasoning slot
+            // can name a Stability backend, so this is unreachable — `None` is the
+            // truthful value rather than a convenient one.
+            ProviderKind::Stability => ThinkingStyle::None,
         };
         let (sampling_under_thinking, sampling_placement) = match kind {
             ProviderKind::Anthropic => (false, SamplingPlacement::TopLevel),
@@ -233,6 +247,10 @@ impl ModelShape {
             ProviderKind::DeepSeek | ProviderKind::OpenRouter | ProviderKind::Openai => {
                 (true, SamplingPlacement::TopLevel)
             }
+            // Unreachable for the same reason as `thinking` above: no completion request
+            // is ever shaped for this kind. Stability's own sampling knobs (cfg_scale,
+            // seed) live on `StabilityRequest`, not here.
+            ProviderKind::Stability => (true, SamplingPlacement::TopLevel),
         };
         Self {
             thinking,

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 
 use crate::config::DataCollection;
-use crate::credentials::ProviderKind;
+use crate::credentials::{ProviderKind, WireKind};
 
 /// Token budget for model "thinking"/reasoning, for the providers that expose a
 /// request-time toggle. Sized well under [`ConsultConfig`]'s `max_tokens` so the
@@ -122,10 +122,20 @@ impl ModelCaps {
     /// vision answer in both directions; `None` asks the classifier. The transport
     /// channel is a property of the wire protocol alone (`kind`), never overridden.
     pub fn resolve(kind: ProviderKind, model: &str, vision_override: Option<bool>) -> Self {
-        let vision = vision_override.unwrap_or_else(|| is_vision_capable(kind, model));
+        // Media kinds answered once, up front: a media backend answers no completion
+        // request, so it has nothing to see with and no tool-result channel — the
+        // per-wire classifiers below never need a media arm, and a stray `vision` pin
+        // on a media slot cannot conjure capabilities the wire doesn't have.
+        let Some(wire) = kind.wire() else {
+            return Self {
+                vision: false,
+                tool_result_images: false,
+            };
+        };
+        let vision = vision_override.unwrap_or_else(|| is_vision_capable(wire, model));
         Self {
             vision,
-            tool_result_images: transport_supports_tool_result_images(kind),
+            tool_result_images: transport_supports_tool_result_images(wire),
         }
     }
 }
@@ -138,10 +148,10 @@ impl ModelCaps {
 /// delivered as an `image_url` part on a **user** turn. DeepSeek is moot — vision-blind,
 /// so `view_image` never attaches. Branch the rewrite on *this*, not on `kind == Openai`:
 /// the next no-tool-result-image provider is a table entry, not a new `if`.
-fn transport_supports_tool_result_images(kind: ProviderKind) -> bool {
-    match kind {
-        ProviderKind::Anthropic | ProviderKind::Gemini => true,
-        ProviderKind::Openai => false,
+fn transport_supports_tool_result_images(wire: WireKind) -> bool {
+    match wire {
+        WireKind::Anthropic | WireKind::Gemini => true,
+        WireKind::Openai => false,
         // OpenRouter speaks the OpenAI wire but is *more* dangerous than a 400: rig's
         // converter silently rewrites a tool-result image to the placeholder text
         // "[Image content not supported in tool results]" (openrouter/completion.rs,
@@ -149,47 +159,37 @@ fn transport_supports_tool_result_images(kind: ProviderKind) -> bool {
         // quiet drop, the exact silent loss kaibo refuses. `false` routes a seen image
         // onto the user-turn channel (the break-rewrite-resume path) *before* it can
         // reach that converter, so the bytes actually arrive.
-        ProviderKind::OpenRouter => false,
+        WireKind::OpenRouter => false,
         // Vision-blind on the wire; the value is unreached (no view_image attaches),
         // but "no tool-result image channel" is the honest answer.
-        ProviderKind::DeepSeek => false,
-        // Never reached: `Stability` is an image-generation wire, not a completion
-        // wire — no reasoning slot may point at one, so no phase ever shapes a request
-        // for it. Answered explicitly rather than with a `_` arm so the next kind still
-        // has to make this choice consciously.
-        ProviderKind::Stability => false,
+        WireKind::DeepSeek => false,
     }
 }
 
 /// The built-in vision classifier. **Empirical — confirm by probe** (the discipline
 /// of [`is_anthropic_adaptive`]): boundaries reflect what the providers actually
 /// serve today, and a wrong guess fails loud at the provider, not silent here.
-fn is_vision_capable(kind: ProviderKind, _model: &str) -> bool {
-    match kind {
+fn is_vision_capable(wire: WireKind, _model: &str) -> bool {
+    match wire {
         // Every current Claude completion id is multimodal-in (vision shipped with
         // Claude 3; no text-only ids remain in the lineup).
-        ProviderKind::Anthropic => true,
+        WireKind::Anthropic => true,
         // The gemini-* completion line is natively multimodal across 2.x/3.x.
-        ProviderKind::Gemini => true,
+        WireKind::Gemini => true,
         // DeepSeek chat/reasoner are text-only on the wire (docs/issues.md, media
         // spine): images attached to a blind model must fail loud, not get dropped.
-        ProviderKind::DeepSeek => false,
+        WireKind::DeepSeek => false,
         // A generic OpenAI-compatible endpoint can front anything; vision is opt-in
         // per slot (`vision = true` in the role table) rather than guessed from an
         // arbitrary id.
-        ProviderKind::Openai => false,
+        WireKind::Openai => false,
         // OpenRouter fronts every model — vision-capable and text-only alike — so the
         // capability is a property of the pinned *model*, not the gateway. Opt in per
         // slot (`vision = true`), like the generic OpenAI kind. The built-in openrouter
         // cast splits by role: its explorer default (multimodal `qwen3.6-flash`) pins
         // vision on, while its synth default (text-only `qwen3.7-max`) leaves the slot
         // `None` and lets this false stand.
-        ProviderKind::OpenRouter => false,
-        // Never reached: no reasoning slot may point at a Stability backend (it is an
-        // image-generation wire, not a completion one), so nothing ever asks whether it
-        // can *read* an image. Stated rather than defaulted, so the next kind must
-        // choose consciously.
-        ProviderKind::Stability => false,
+        WireKind::OpenRouter => false,
     }
 }
 
@@ -271,8 +271,21 @@ pub struct ModelShape {
 impl ModelShape {
     /// Resolve the shape for `model` under `kind`, honoring an explicit override.
     pub fn resolve(kind: ProviderKind, model: &str, ovr: ThinkingStyleOverride) -> Self {
-        let thinking = match kind {
-            ProviderKind::Anthropic => {
+        // Media kinds answered once, up front: no completion request is ever shaped
+        // for one (a media backend is only reachable from a media cast slot, and the
+        // load guard refuses every other pairing), so the inert shape — no thinking
+        // style, nothing to sink a budget or an effort into — is the truthful value,
+        // and the per-wire matches below never need a media arm. A media provider's
+        // own knobs (cfg_scale, seed) ride its native request, not this shape.
+        let Some(wire) = kind.wire() else {
+            return Self {
+                thinking: ThinkingStyle::None,
+                sampling_under_thinking: true,
+                sampling_placement: SamplingPlacement::TopLevel,
+            };
+        };
+        let thinking = match wire {
+            WireKind::Anthropic => {
                 let adaptive = match ovr {
                     ThinkingStyleOverride::Auto => is_anthropic_adaptive(model),
                     ThinkingStyleOverride::Adaptive => true,
@@ -289,27 +302,19 @@ impl ModelShape {
             // 3-flash / 3.1-pro / 3.5-flash and drops `thinkingBudget` entirely — that
             // knob is the retired 2.5-era shape). So every Gemini id routes to level;
             // the per-role effort rides it. A pre-3.x id fails loud, not silent.
-            ProviderKind::Gemini => ThinkingStyle::GeminiLevel,
-            ProviderKind::DeepSeek => ThinkingStyle::DeepSeekEffort,
-            ProviderKind::OpenRouter => ThinkingStyle::OpenRouterEffort,
-            ProviderKind::Openai => ThinkingStyle::None,
-            // An image API has no reasoning channel to configure, and no reasoning slot
-            // can name a Stability backend, so this is unreachable — `None` is the
-            // truthful value rather than a convenient one.
-            ProviderKind::Stability => ThinkingStyle::None,
+            WireKind::Gemini => ThinkingStyle::GeminiLevel,
+            WireKind::DeepSeek => ThinkingStyle::DeepSeekEffort,
+            WireKind::OpenRouter => ThinkingStyle::OpenRouterEffort,
+            WireKind::Openai => ThinkingStyle::None,
         };
-        let (sampling_under_thinking, sampling_placement) = match kind {
-            ProviderKind::Anthropic => (false, SamplingPlacement::TopLevel),
-            ProviderKind::Gemini => (true, SamplingPlacement::GeminiGenerationConfig),
+        let (sampling_under_thinking, sampling_placement) = match wire {
+            WireKind::Anthropic => (false, SamplingPlacement::TopLevel),
+            WireKind::Gemini => (true, SamplingPlacement::GeminiGenerationConfig),
             // OpenRouter takes OpenAI-shaped sampling top-level and, being tolerant of
             // unsupported params (dropped per-model), keeps it under reasoning.
-            ProviderKind::DeepSeek | ProviderKind::OpenRouter | ProviderKind::Openai => {
+            WireKind::DeepSeek | WireKind::OpenRouter | WireKind::Openai => {
                 (true, SamplingPlacement::TopLevel)
             }
-            // Unreachable for the same reason as `thinking` above: no completion request
-            // is ever shaped for this kind. Stability's own sampling knobs (cfg_scale,
-            // seed) live on `StabilityRequest`, not here.
-            ProviderKind::Stability => (true, SamplingPlacement::TopLevel),
         };
         Self {
             thinking,
@@ -631,17 +636,17 @@ impl EffortWire {
         if responses_wire {
             return Self::OpenaiResponses;
         }
-        match kind {
-            ProviderKind::Gemini => Self::Gemini,
-            ProviderKind::Anthropic
-            | ProviderKind::DeepSeek
-            | ProviderKind::OpenRouter
-            | ProviderKind::Openai => Self::Passthrough,
-            // Never reached: effort belongs to reasoning arms, and the load-time
-            // guard refuses a reasoning slot on a Stability backend (it is an
-            // image-generation wire, no completion model). `Passthrough` is the
-            // do-nothing answer if that ever changes.
-            ProviderKind::Stability => Self::Passthrough,
+        // Media kinds carry no effort at all — no arm is ever built from one — so the
+        // do-nothing wire is the truthful answer, resolved once here instead of as an
+        // arm in the completion match below.
+        let Some(wire) = kind.wire() else {
+            return Self::Passthrough;
+        };
+        match wire {
+            WireKind::Gemini => Self::Gemini,
+            WireKind::Anthropic | WireKind::DeepSeek | WireKind::OpenRouter | WireKind::Openai => {
+                Self::Passthrough
+            }
         }
     }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -179,6 +179,73 @@ impl ProviderKind {
     pub fn key_file(self, home: &Path) -> PathBuf {
         home.join(self.key_file_name())
     }
+
+    /// Which side of the completion/media line this kind lives on — the structural
+    /// gate that keeps media kinds out of the completion-path machinery. Exhaustive
+    /// on purpose: a new `ProviderKind` variant fails to compile until it is
+    /// classified here, and that one decision is the *only* completion-vs-media
+    /// decision the new kind has to make. Everything downstream matches on
+    /// [`WireKind`] or [`MediaKind`] and never sees the other family.
+    pub fn class(self) -> ProviderClass {
+        match self {
+            ProviderKind::Anthropic => ProviderClass::Wire(WireKind::Anthropic),
+            ProviderKind::DeepSeek => ProviderClass::Wire(WireKind::DeepSeek),
+            ProviderKind::Gemini => ProviderClass::Wire(WireKind::Gemini),
+            ProviderKind::OpenRouter => ProviderClass::Wire(WireKind::OpenRouter),
+            ProviderKind::Openai => ProviderClass::Wire(WireKind::Openai),
+            ProviderKind::Stability => ProviderClass::Media(MediaKind::Stability),
+        }
+    }
+
+    /// The completion wire behind this kind, or `None` for a media kind — the
+    /// convenience form of [`class`](Self::class) for the completion entry points
+    /// (`ModelShape::resolve`, `ModelCaps::resolve`, `EffortWire::resolve`,
+    /// `batch_supported`), each of which answers the media case once at its top
+    /// instead of growing a media arm in every internal match.
+    pub fn wire(self) -> Option<WireKind> {
+        match self.class() {
+            ProviderClass::Wire(w) => Some(w),
+            ProviderClass::Media(_) => None,
+        }
+    }
+
+    /// Is this a media-generation kind (no completion model behind it)?
+    pub fn is_media(self) -> bool {
+        matches!(self.class(), ProviderClass::Media(_))
+    }
+}
+
+/// A completion wire protocol — the [`ProviderKind`] subset rig builds a
+/// `CompletionModel` for. The completion-path machinery (request shaping, effort
+/// wires, the vision/transport classifiers, batch eligibility, `Arm` construction)
+/// matches on THIS enum, so a media kind can never reach those matches and a new
+/// piece of completion machinery needs no media arm at all. Reached only through
+/// [`ProviderKind::class`]/[`ProviderKind::wire`], whose exhaustive match is where a
+/// new kind gets classified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireKind {
+    Anthropic,
+    DeepSeek,
+    Gemini,
+    OpenRouter,
+    Openai,
+}
+
+/// A media-generation API — a backend kaibo drives through its own facade and the
+/// [`crate::media::MediaModel`] seam, never through rig's completion machinery. Valid
+/// only on media cast slots (`image` today); the load-time role/kind guard in
+/// `config.rs` refuses every other pairing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaKind {
+    /// Stability AI's v2beta family, via `src/stability.rs`.
+    Stability,
+}
+
+/// The two families a [`ProviderKind`] can belong to — see [`ProviderKind::class`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderClass {
+    Wire(WireKind),
+    Media(MediaKind),
 }
 
 impl std::str::FromStr for ProviderKind {

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -49,9 +49,33 @@ pub enum ProviderKind {
     /// Any OpenAI-compatible endpoint, addressed by base URL; key optional.
     /// Defaults to a local keyless server (Gemma via an OpenAI-compatible host).
     Openai,
+    /// Stability AI's v2beta image family — the one **production** wire kaibo speaks,
+    /// and the odd one out here in a way worth stating: every other kind is a chat
+    /// completion API driven through `rig`, while this one is an image API driven
+    /// through kaibo's own facade (`src/stability.rs`). It is therefore only ever valid
+    /// on an `image` cast slot ([`crate::config::ModelRole::Image`]); a reasoning slot
+    /// pointed at a Stability backend is a load error, because there is no completion
+    /// model behind it to resolve.
+    ///
+    /// Deliberately NOT in the built-in backend list: image generation costs real money
+    /// per call and needs a key, so it appears only when an operator writes the stanza.
+    Stability,
 }
 
 impl ProviderKind {
+    /// Every kind, in declaration order. Drives the "expected one of…" error text so a
+    /// new kind can never be accepted by `FromStr` while staying unlisted in the message
+    /// a user actually reads — a hand-maintained list in that string had already drifted
+    /// once (`openrouter` shipped before it was named there).
+    pub const ALL: [ProviderKind; 6] = [
+        Self::Anthropic,
+        Self::DeepSeek,
+        Self::Gemini,
+        Self::OpenRouter,
+        Self::Openai,
+        Self::Stability,
+    ];
+
     /// Whether a missing credential is tolerated rather than a hard error. Only
     /// the OpenAI-compatible provider is: its default endpoint is a local keyless
     /// server, so an absent key falls back to a placeholder bearer token
@@ -84,7 +108,11 @@ impl ProviderKind {
             ProviderKind::Anthropic
             | ProviderKind::DeepSeek
             | ProviderKind::OpenRouter
-            | ProviderKind::Openai => PLACEHOLDER_OPENAI_KEY,
+            | ProviderKind::Openai
+            // Never reached: Stability is not `key_optional`, so a missing key is a
+            // hard error long before a stand-in is wanted. It is a header-bearer wire,
+            // so it takes the same shape as the others if that ever changes.
+            | ProviderKind::Stability => PLACEHOLDER_OPENAI_KEY,
         }
     }
 
@@ -100,6 +128,7 @@ impl ProviderKind {
             ProviderKind::Gemini => "gemini",
             ProviderKind::OpenRouter => "openrouter",
             ProviderKind::Openai => "openai",
+            ProviderKind::Stability => "stability",
         }
     }
 
@@ -125,6 +154,9 @@ impl ProviderKind {
             ProviderKind::Gemini => "GEMINI_API_KEY",
             ProviderKind::OpenRouter => "OPENROUTER_API_KEY",
             ProviderKind::Openai => "OPENAI_API_KEY",
+            // Reuses the constant `src/stability.rs` already resolves keys with, so the
+            // facade and the config layer can never disagree about which var to read.
+            ProviderKind::Stability => crate::stability::STABILITY_KEY_ENV_VAR,
         }
     }
 
@@ -138,6 +170,8 @@ impl ProviderKind {
             ProviderKind::Gemini => ".gemini-api-key",
             ProviderKind::OpenRouter => ".openrouter-key",
             ProviderKind::Openai => ".openai-key",
+            // Same constant `src/stability.rs` uses, for the same reason as `env_var`.
+            ProviderKind::Stability => crate::stability::STABILITY_KEY_FILE_NAME,
         }
     }
 
@@ -159,8 +193,14 @@ impl std::str::FromStr for ProviderKind {
             // The OpenAI-compatible endpoint. Also accept the names people reach
             // for when it points at the local keyless default (Gemma via Lemonade).
             "openai" | "local" | "lemonade" | "gemma" | "gemma4" => Ok(ProviderKind::Openai),
+            "stability" => Ok(ProviderKind::Stability),
             other => Err(anyhow!(
-                "unknown provider {other:?} (expected anthropic, deepseek, gemini, openrouter, or openai)"
+                "unknown provider {other:?} (expected one of: {})",
+                ProviderKind::ALL
+                    .iter()
+                    .map(|k| k.canonical_name())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             )),
         }
     }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -27,7 +27,7 @@ use serde_json::Value;
 
 use crate::batch::rfc3339_to_epoch;
 use crate::config::Backend;
-use crate::credentials::ProviderKind;
+use crate::credentials::WireKind;
 
 /// DeepSeek's models-list host. Mirrors rig's private `deepseek` provider constant —
 /// same drift-prone class as `config.rs::default_models`: if rig retargets its DeepSeek
@@ -111,20 +111,24 @@ pub fn discovery_endpoint(backend: &Backend) -> Result<DiscoveryRequest> {
 /// have no continuation — `cursor` is ignored for them, since [`discover_models`] never
 /// loops on those kinds anyway.
 pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Result<DiscoveryRequest> {
+    // A media kind publishes no model-listing endpoint in the `/models` shape this
+    // module speaks — Stability's model set is the small fixed route family
+    // (`generate/{core,ultra,sd3}`), documented rather than enumerable. Refusing
+    // loudly beats inventing a URL that would 404, and beats returning an empty
+    // list that would read as "this backend serves no models". Classified up front
+    // so the wire match below stays media-free.
+    let Some(wire) = backend.kind.wire() else {
+        anyhow::bail!(
+            "backend {:?} is kind `{}`, which publishes no model-listing endpoint — \
+             its models are the documented generate routes (core, ultra, sd3), not a \
+             discoverable list",
+            backend.name,
+            backend.kind.canonical_name()
+        )
+    };
     let key = backend.resolve_key()?;
-    match backend.kind {
-        // Stability publishes no model-listing endpoint in the `/models` shape this
-        // module speaks — its model set is the small fixed route family
-        // (`generate/{core,ultra,sd3}`), documented rather than enumerable. Refusing
-        // loudly beats inventing a URL that would 404, and beats returning an empty
-        // list that would read as "this backend serves no models".
-        ProviderKind::Stability => anyhow::bail!(
-            "backend {:?} is kind `stability`, which publishes no model-listing \
-             endpoint — its models are the documented generate routes (core, ultra, \
-             sd3), not a discoverable list",
-            backend.name
-        ),
-        ProviderKind::Openai => {
+    match wire {
+        WireKind::Openai => {
             let base = backend.resolved_base_url();
             let base = base.trim_end_matches('/');
             Ok(DiscoveryRequest {
@@ -133,17 +137,17 @@ pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Resul
                 query: Vec::new(),
             })
         }
-        ProviderKind::OpenRouter => Ok(DiscoveryRequest {
+        WireKind::OpenRouter => Ok(DiscoveryRequest {
             url: format!("{OPENROUTER_BASE}/models"),
             headers: vec![("Authorization".to_string(), format!("Bearer {key}"))],
             query: Vec::new(),
         }),
-        ProviderKind::DeepSeek => Ok(DiscoveryRequest {
+        WireKind::DeepSeek => Ok(DiscoveryRequest {
             url: format!("{DEEPSEEK_BASE}/models"),
             headers: vec![("Authorization".to_string(), format!("Bearer {key}"))],
             query: Vec::new(),
         }),
-        ProviderKind::Anthropic => {
+        WireKind::Anthropic => {
             let base = backend
                 .base_url
                 .as_deref()
@@ -166,7 +170,7 @@ pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Resul
                 query,
             })
         }
-        ProviderKind::Gemini => {
+        WireKind::Gemini => {
             let base = backend.base_url.as_deref().unwrap_or(GEMINI_DEFAULT_BASE);
             let base = base.trim_end_matches('/');
             // No auth header: Gemini authenticates `?key=` as a query param. A
@@ -361,12 +365,14 @@ pub async fn discover_models(
     backend: &Backend,
     fetcher: &impl ModelListFetcher,
 ) -> Result<Vec<DiscoveredModel>> {
-    match backend.kind {
-        // No listing endpoint — see `discovery_endpoint_page`. Same loud refusal, so
-        // `list_models` over a mixed backend set names the one it cannot enumerate
-        // instead of quietly omitting it.
-        ProviderKind::Stability => discovery_endpoint_page(backend, None).map(|_| Vec::new()),
-        ProviderKind::Anthropic => discover_paginated(
+    // A media kind has no listing endpoint — `discovery_endpoint_page` carries the
+    // loud refusal, so `list_models` over a mixed backend set names the one it
+    // cannot enumerate instead of quietly omitting it.
+    let Some(wire) = backend.kind.wire() else {
+        return discovery_endpoint_page(backend, None).map(|_| Vec::new());
+    };
+    match wire {
+        WireKind::Anthropic => discover_paginated(
             backend,
             fetcher,
             parse_anthropic_models,
@@ -378,7 +384,7 @@ pub async fn discover_models(
             },
         )
         .await,
-        ProviderKind::Gemini => discover_paginated(
+        WireKind::Gemini => discover_paginated(
             backend,
             fetcher,
             parse_gemini_models,
@@ -390,7 +396,7 @@ pub async fn discover_models(
             },
         )
         .await,
-        ProviderKind::Openai | ProviderKind::OpenRouter | ProviderKind::DeepSeek => {
+        WireKind::Openai | WireKind::OpenRouter | WireKind::DeepSeek => {
             let req = discovery_endpoint(backend)?;
             let body = fetcher.get_json(&req).await?;
             Ok(parse_openai_models(&body))
@@ -524,6 +530,7 @@ pub fn models_json_envelope(results: &BTreeMap<String, Result<Vec<DiscoveredMode
 mod tests {
     use super::*;
     use crate::config::{DataCollection, OpenaiWire};
+    use crate::credentials::ProviderKind;
     use std::sync::Mutex;
     use tempfile::TempDir;
 

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -113,6 +113,17 @@ pub fn discovery_endpoint(backend: &Backend) -> Result<DiscoveryRequest> {
 pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Result<DiscoveryRequest> {
     let key = backend.resolve_key()?;
     match backend.kind {
+        // Stability publishes no model-listing endpoint in the `/models` shape this
+        // module speaks — its model set is the small fixed route family
+        // (`generate/{core,ultra,sd3}`), documented rather than enumerable. Refusing
+        // loudly beats inventing a URL that would 404, and beats returning an empty
+        // list that would read as "this backend serves no models".
+        ProviderKind::Stability => anyhow::bail!(
+            "backend {:?} is kind `stability`, which publishes no model-listing \
+             endpoint — its models are the documented generate routes (core, ultra, \
+             sd3), not a discoverable list",
+            backend.name
+        ),
         ProviderKind::Openai => {
             let base = backend.resolved_base_url();
             let base = base.trim_end_matches('/');
@@ -351,6 +362,10 @@ pub async fn discover_models(
     fetcher: &impl ModelListFetcher,
 ) -> Result<Vec<DiscoveredModel>> {
     match backend.kind {
+        // No listing endpoint — see `discovery_endpoint_page`. Same loud refusal, so
+        // `list_models` over a mixed backend set names the one it cannot enumerate
+        // instead of quietly omitting it.
+        ProviderKind::Stability => discovery_endpoint_page(backend, None).map(|_| Vec::new()),
         ProviderKind::Anthropic => discover_paginated(
             backend,
             fetcher,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod explorer;
 pub mod jobs;
 pub mod kaish_syntax;
 pub mod mcp_log;
+pub mod media;
 pub mod orientation;
 pub mod progress;
 pub mod sandbox;

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
     // fallback) — with ONE narrow, deliberate carve-out below. The store is fed the handler's
     // resolved allowed set so its containment guard refuses a state db inside any project
     // tree. When persistence is off, the handler keeps its in-memory sessions unchanged.
-    let handler = if persistence.enabled {
+    let (handler, persistence_active) = if persistence.enabled {
         let path = persistence
             .path
             .expect("an enabled persistence store has a resolved path (validated at load)");
@@ -224,7 +224,7 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
                     state_db = %path.display(),
                     "persistence enabled — sessions and batch handles are durable across restarts"
                 );
-                handler.with_session_store(store)
+                (handler.with_session_store(store), true)
             }
             // THE ONE CARVE-OUT (Windows / single-process platforms only): another kaibo
             // already holds the db. MP-WAL is 64-bit-Unix-only, so a `SingleProcessLocked`
@@ -242,7 +242,7 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
                      kaibo://config shows persistence.active=false). Close the other kaibo, \
                      point --state-db elsewhere, or set --no-persistence to silence this."
                 );
-                handler
+                (handler, false)
             }
             // A special-cased arm, like `SingleProcessLocked` above: the generic message
             // below never mentions --root/--allow-path, which is actually the most natural
@@ -277,8 +277,13 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
             "persistence disabled — sessions are in-memory (lost on restart), \
              batch handles held nowhere"
         );
-        handler
+        (handler, false)
     };
+    // Settle the media CAS now that persistence's runtime truth is known: disk while
+    // persistence is active, in-memory (with a SEVERE warning) while it is not, off
+    // when the operator said `[cas] enabled = false`. A disk-open failure is fatal —
+    // crash over a silent fallback to memory, same posture as the store above.
+    let handler = handler.finalize_media_store(persistence_active)?;
     // Log the resolved (canonicalized) allowed set so the operator can verify the
     // containment boundary without inspecting config files.
     tracing::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,8 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
         common.user_context_file.clone(),
         common.no_persistence,
         common.state_db.clone(),
+        common.cas_dir.clone(),
+        common.cas_max_bytes,
     );
 
     // Logs MUST go to stderr; stdout carries the MCP protocol. RUST_LOG wins, else

--- a/src/media.rs
+++ b/src/media.rs
@@ -72,22 +72,32 @@ pub struct MediaArtifact {
 pub struct MediaJobId(pub String);
 
 /// One `generate` call's outcome. Sync operations resolve straight to `Complete`;
-/// a deferred operation's POST resolves to `Deferred`, and the artifact comes from
+/// a deferred operation's POST resolves to `Deferred`, and the artifacts come from
 /// [`MediaModel::poll`] later. Which shape a given operation has is the *provider's*
 /// declared fact (see `stability::Operation::shape`), never sniffed from a response.
+///
+/// `Complete` carries a **list**: many image models return several images per call
+/// (Amy's call, 2026-08-03), so one generation is one-to-many artifacts. Each artifact
+/// gets its own CAS digest and its own provenance sidecar downstream — a result is a
+/// list of digests, never a single blessed one. A provider that returns exactly one
+/// (Stability's ops today) hands back a one-element list; an *empty* list from a
+/// provider is that provider's bug to refuse at its own impl, not a shape this enum
+/// blesses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MediaOutcome {
-    Complete(MediaArtifact),
+    Complete(Vec<MediaArtifact>),
     Deferred(MediaJobId),
 }
 
 /// One poll's outcome: still running, or done. A poll is never itself deferred
 /// again — `Pending` means "ask again later", with the cadence owned by the caller
 /// (the tool lane brings its own deadline/backoff; this seam never sleeps).
+/// `Complete` is a list for the same one-to-many reason as
+/// [`MediaOutcome::Complete`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MediaPollOutcome {
     Pending,
-    Complete(MediaArtifact),
+    Complete(Vec<MediaArtifact>),
 }
 
 /// A media-generation model: one generate call plus one poll, both provider-neutral.
@@ -183,9 +193,9 @@ mod tests {
 
     /// A scripted model: answers `generate` with a fixed outcome and `poll` with a
     /// pending-then-complete sequence — enough to prove the trait dispatches as an
-    /// object and the arm forwards faithfully.
+    /// object and the arm forwards faithfully, artifact *lists* included.
     struct Scripted {
-        artifact: MediaArtifact,
+        artifacts: Vec<MediaArtifact>,
         polls: std::sync::Mutex<usize>,
     }
 
@@ -205,7 +215,7 @@ mod tests {
             if *n == 1 {
                 Ok(MediaPollOutcome::Pending)
             } else {
-                Ok(MediaPollOutcome::Complete(self.artifact.clone()))
+                Ok(MediaPollOutcome::Complete(self.artifacts.clone()))
             }
         }
     }
@@ -218,13 +228,23 @@ mod tests {
         }
     }
 
+    fn webp_artifact() -> MediaArtifact {
+        MediaArtifact {
+            bytes: b"RIFF....WEBP".to_vec(),
+            mime: "image/webp".to_string(),
+            seed: None,
+        }
+    }
+
     /// The deferred round trip through the trait object: generate hands back a job,
-    /// the first poll is pending, the second completes with the artifact intact.
+    /// the first poll is pending, the second completes with EVERY artifact intact and
+    /// in order — the one-to-many shape (many image models return several images per
+    /// call) the outcome enums exist to carry.
     #[tokio::test]
-    async fn deferred_generate_then_poll_round_trip() {
+    async fn deferred_generate_then_poll_round_trip_with_multiple_artifacts() {
         let arm = MediaArm::new(
             Arc::new(Scripted {
-                artifact: png_artifact(),
+                artifacts: vec![png_artifact(), webp_artifact()],
                 polls: std::sync::Mutex::new(0),
             }),
             "sd/core",
@@ -242,7 +262,10 @@ mod tests {
         };
         assert_eq!(arm.poll(&job).await.unwrap(), MediaPollOutcome::Pending);
         let done = arm.poll(&job).await.unwrap();
-        assert_eq!(done, MediaPollOutcome::Complete(png_artifact()));
+        assert_eq!(
+            done,
+            MediaPollOutcome::Complete(vec![png_artifact(), webp_artifact()])
+        );
     }
 
     /// A completion backend cannot staff a media arm: the mirror image of

--- a/src/media.rs
+++ b/src/media.rs
@@ -38,16 +38,20 @@ use crate::config::{Backend, ModelSlot};
 use crate::credentials::{MediaKind, ProviderClass};
 
 /// One generation request, provider-neutral. The prompt is the portable half; every
-/// provider-native knob (seed, aspect ratio, negative prompt, output format, an
-/// explicit `model` form field, ...) rides `fields` untyped — kaibo keeps no
-/// allowlist, the provider answers for its own knobs, the same passthrough posture
-/// `additional_params` takes on the completion side.
+/// provider-native knob (seed, aspect ratio, negative prompt, output format, ...)
+/// rides `fields` untyped — kaibo keeps no allowlist, the provider answers for its own
+/// knobs, the same passthrough posture `additional_params` takes on the completion
+/// side. (`prompt` and `model` never ride `fields`: the tool layer reserves both, so
+/// the recorded provenance always describes the request that ran.)
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MediaRequest {
     pub prompt: String,
-    /// `(name, value)` provider-native fields, order-preserving; a later entry with a
-    /// repeated name overrides the earlier one (Stability's `build_form_fields`
-    /// contract, adopted here as the neutral semantics).
+    /// `(name, value)` provider-native fields: **uniquely named**, in the order the
+    /// caller gave them (kept as a `Vec` because a provider may care about order —
+    /// the MCP face is a map, so duplicate names cannot arrive from a tool call). A
+    /// provider impl may seed its own defaults (Stability seeds `output_format`) and
+    /// lets a caller field of the same name replace the seeded default — that merge
+    /// is the provider's business, not a contract of this struct.
     pub fields: Vec<(String, String)>,
     /// Bytes of an input image, for the operations that take one (edit / upscale /
     /// image-to-image). `None` for text-to-image. Carried on the request now so the

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,0 +1,263 @@
+//! The media-generation seam: kaibo's counterpart of rig's `CompletionModel` for
+//! backends that produce artifacts instead of text.
+//!
+//! # Why a kaibo trait, when rig ships `ImageGenerationModel`
+//!
+//! rig's trait is one synchronous text-to-image call (`prompt`/`width`/`height`), with
+//! nowhere to hand a deferred job id — and Stability's v2beta family is bigger than
+//! that (deferred upscale/audio/3D operations whose POST returns only an id; see
+//! `src/stability.rs`'s module doc). kaibo's tool lane needs the deferred half as a
+//! first-class outcome: a sync operation answers in-call, a deferred one becomes a
+//! kaibo job the caller polls. So [`MediaModel`] carries both, the way
+//! [`crate::batch::BatchProvider`] carries submit *and* poll.
+//!
+//! The vocabulary here is deliberately provider-neutral (a [`MediaArtifact`] is bytes,
+//! a mime string, and a seed) — providers translate their native shapes at their own
+//! impl, exactly as rig providers translate into rig's completion types. The one live
+//! implementation today is Stability's (`src/stability.rs`).
+//!
+//! # The construction point
+//!
+//! [`MediaArm::from_slot`] is the single place a media backend becomes callable — the
+//! media mirror of `Arm::from_slot` (`consult/engine.rs`), and the enforcement seam
+//! for the completion/media split: it accepts only [`ProviderClass::Media`] kinds and
+//! bails loudly on a completion backend, the mirror image of `Arm::from_slot`'s
+//! media bail. Config validation (`config.rs`) refuses the mismatched pairings at
+//! load, so both bails are belts to those braces.
+//!
+//! Nothing here touches the filesystem: a [`MediaArtifact`]'s bytes live in memory
+//! until a caller hands them to the media CAS (`src/cas.rs`), which is one of the two
+//! blessed write surfaces and does its own containment checks.
+
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+
+use crate::config::{Backend, ModelSlot};
+use crate::credentials::{MediaKind, ProviderClass};
+
+/// One generation request, provider-neutral. The prompt is the portable half; every
+/// provider-native knob (seed, aspect ratio, negative prompt, output format, an
+/// explicit `model` form field, ...) rides `fields` untyped — kaibo keeps no
+/// allowlist, the provider answers for its own knobs, the same passthrough posture
+/// `additional_params` takes on the completion side.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MediaRequest {
+    pub prompt: String,
+    /// `(name, value)` provider-native fields, order-preserving; a later entry with a
+    /// repeated name overrides the earlier one (Stability's `build_form_fields`
+    /// contract, adopted here as the neutral semantics).
+    pub fields: Vec<(String, String)>,
+    /// Bytes of an input image, for the operations that take one (edit / upscale /
+    /// image-to-image). `None` for text-to-image. Carried on the request now so the
+    /// trait does not churn when those operations land.
+    pub input_image: Option<Vec<u8>>,
+}
+
+/// One generated artifact, provider-neutral: the bytes, the wire content type in the
+/// provider's own spelling (`"image/png"`), and the provider-reported seed when one
+/// exists — the reproduction handle the CAS provenance sidecar records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaArtifact {
+    pub bytes: Vec<u8>,
+    pub mime: String,
+    pub seed: Option<String>,
+}
+
+/// The id of one deferred generation, as the provider spelled it. Opaque: it
+/// round-trips through kaibo's job store as a string and only the provider's own
+/// poll route interprets it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaJobId(pub String);
+
+/// One `generate` call's outcome. Sync operations resolve straight to `Complete`;
+/// a deferred operation's POST resolves to `Deferred`, and the artifact comes from
+/// [`MediaModel::poll`] later. Which shape a given operation has is the *provider's*
+/// declared fact (see `stability::Operation::shape`), never sniffed from a response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MediaOutcome {
+    Complete(MediaArtifact),
+    Deferred(MediaJobId),
+}
+
+/// One poll's outcome: still running, or done. A poll is never itself deferred
+/// again — `Pending` means "ask again later", with the cadence owned by the caller
+/// (the tool lane brings its own deadline/backoff; this seam never sleeps).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MediaPollOutcome {
+    Pending,
+    Complete(MediaArtifact),
+}
+
+/// A media-generation model: one generate call plus one poll, both provider-neutral.
+/// Object-safe (`Arc<dyn MediaModel>`) so the tool lane and tests dispatch over the
+/// same seam — a scripted impl drives the lane offline, mirroring how
+/// [`crate::batch::BatchProvider`] is exercised against `ScriptedBatch`.
+#[async_trait]
+pub trait MediaModel: Send + Sync {
+    /// Run one generation request against the model this instance was built for.
+    async fn generate(&self, request: &MediaRequest) -> Result<MediaOutcome>;
+
+    /// Collect one deferred job's result. One shot, no retry loop — the caller owns
+    /// the cadence.
+    async fn poll(&self, job: &MediaJobId) -> Result<MediaPollOutcome>;
+}
+
+/// A staffed media slot, ready to call: the model behind an `image = "backend/id"`
+/// cast slot. The media mirror of the completion `Arm`.
+#[derive(Clone)]
+pub struct MediaArm {
+    model: Arc<dyn MediaModel>,
+    /// The slot's `"backend/model-id"` ref — provenance and error text.
+    slot_ref: String,
+}
+
+impl std::fmt::Debug for MediaArm {
+    /// Manual: `dyn MediaModel` carries no `Debug` bound, and the slot ref is the
+    /// arm's whole identity anyway.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MediaArm")
+            .field("slot_ref", &self.slot_ref)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MediaArm {
+    /// Wrap an already-built model — the seam tests inject a scripted [`MediaModel`]
+    /// through, mirroring `Arm::new` on the completion side. Production goes through
+    /// [`from_slot`](Self::from_slot).
+    pub fn new(model: Arc<dyn MediaModel>, slot_ref: impl Into<String>) -> Self {
+        Self {
+            model,
+            slot_ref: slot_ref.into(),
+        }
+    }
+
+    /// The single live construction point: resolve a media cast slot into a callable
+    /// arm. Only a [`ProviderClass::Media`] backend can staff one — a completion
+    /// backend is refused here with the same load-guard framing `Arm::from_slot` uses
+    /// for the mirror-image mistake.
+    pub fn from_slot(backend: &Backend, slot: &ModelSlot) -> Result<Self> {
+        match backend.kind.class() {
+            ProviderClass::Media(MediaKind::Stability) => {
+                let key = backend.resolve_key()?;
+                let base_url = backend
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| crate::stability::STABILITY_API_BASE.to_string());
+                let client =
+                    crate::stability::StabilityClient::new(key, base_url, backend.request_timeout)?;
+                let model = crate::stability::StabilityImageModel::from_parts(&client, &slot.id);
+                Ok(Self::new(Arc::new(model), slot.qualified()))
+            }
+            ProviderClass::Wire(_) => bail!(
+                "backend {:?} is kind `{}`, a completion wire — it cannot staff a media \
+                 slot. Point the `image` slot at a media backend (kind `stability`), \
+                 and use this backend on `explorer`/`synth` instead",
+                backend.name,
+                backend.kind.canonical_name()
+            ),
+        }
+    }
+
+    /// The `"backend/model-id"` this arm was staffed from.
+    pub fn slot_ref(&self) -> &str {
+        &self.slot_ref
+    }
+
+    /// Run one generation request on this arm.
+    pub async fn generate(&self, request: &MediaRequest) -> Result<MediaOutcome> {
+        self.model.generate(request).await
+    }
+
+    /// Collect one deferred job's result.
+    pub async fn poll(&self, job: &MediaJobId) -> Result<MediaPollOutcome> {
+        self.model.poll(job).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scripted model: answers `generate` with a fixed outcome and `poll` with a
+    /// pending-then-complete sequence — enough to prove the trait dispatches as an
+    /// object and the arm forwards faithfully.
+    struct Scripted {
+        artifact: MediaArtifact,
+        polls: std::sync::Mutex<usize>,
+    }
+
+    #[async_trait]
+    impl MediaModel for Scripted {
+        async fn generate(&self, request: &MediaRequest) -> Result<MediaOutcome> {
+            if request.prompt.is_empty() {
+                bail!("empty prompt");
+            }
+            Ok(MediaOutcome::Deferred(MediaJobId("job-1".to_string())))
+        }
+
+        async fn poll(&self, job: &MediaJobId) -> Result<MediaPollOutcome> {
+            assert_eq!(job.0, "job-1");
+            let mut n = self.polls.lock().unwrap();
+            *n += 1;
+            if *n == 1 {
+                Ok(MediaPollOutcome::Pending)
+            } else {
+                Ok(MediaPollOutcome::Complete(self.artifact.clone()))
+            }
+        }
+    }
+
+    fn png_artifact() -> MediaArtifact {
+        MediaArtifact {
+            bytes: vec![0x89, b'P', b'N', b'G'],
+            mime: "image/png".to_string(),
+            seed: Some("42".to_string()),
+        }
+    }
+
+    /// The deferred round trip through the trait object: generate hands back a job,
+    /// the first poll is pending, the second completes with the artifact intact.
+    #[tokio::test]
+    async fn deferred_generate_then_poll_round_trip() {
+        let arm = MediaArm::new(
+            Arc::new(Scripted {
+                artifact: png_artifact(),
+                polls: std::sync::Mutex::new(0),
+            }),
+            "sd/core",
+        );
+        assert_eq!(arm.slot_ref(), "sd/core");
+        let outcome = arm
+            .generate(&MediaRequest {
+                prompt: "a lighthouse".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let MediaOutcome::Deferred(job) = outcome else {
+            panic!("scripted generate is deferred, got {outcome:?}");
+        };
+        assert_eq!(arm.poll(&job).await.unwrap(), MediaPollOutcome::Pending);
+        let done = arm.poll(&job).await.unwrap();
+        assert_eq!(done, MediaPollOutcome::Complete(png_artifact()));
+    }
+
+    /// A completion backend cannot staff a media arm: the mirror image of
+    /// `Arm::from_slot`'s media bail, and the message names both the mistake and
+    /// the fix.
+    #[test]
+    fn from_slot_refuses_a_completion_backend() {
+        let cfg = crate::config::Config::builtin();
+        let backend = cfg.backends.get("anthropic").expect("built-in exists");
+        let slot = ModelSlot::bare("anthropic", "claude-sonnet-4-6");
+        let err = MediaArm::from_slot(backend, &slot).expect_err("wire kind must be refused");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("completion wire") && msg.contains("stability"),
+            "the error names the problem and the fix, got: {msg}"
+        );
+    }
+}

--- a/src/media.rs
+++ b/src/media.rs
@@ -187,6 +187,26 @@ impl MediaArm {
     }
 }
 
+/// How the generate lane turns a cast's `image` slot into a callable [`MediaArm`] —
+/// the injection seam, mirroring [`crate::batch::BatchProviderFactory`]: the handler
+/// holds an `Arc<dyn MediaArmFactory>`, production seeds [`LiveMediaArms`] (the real
+/// [`MediaArm::from_slot`] path), and tests swap in a factory returning a scripted
+/// [`MediaModel`] so the whole tool lane — CAS writes, job lane, rendering — runs
+/// offline with no network.
+pub trait MediaArmFactory: Send + Sync {
+    fn build(&self, backend: &Backend, slot: &ModelSlot) -> Result<MediaArm>;
+}
+
+/// The real construction path: [`MediaArm::from_slot`], the single live point where a
+/// media backend becomes callable.
+pub struct LiveMediaArms;
+
+impl MediaArmFactory for LiveMediaArms {
+    fn build(&self, backend: &Backend, slot: &ModelSlot) -> Result<MediaArm> {
+        MediaArm::from_slot(backend, slot)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -377,54 +377,67 @@ pub(crate) fn render_config_resource(
                     let backend = config
                         .resolve_backend(&slot.backend)
                         .expect("a loaded cast's slot backend resolves");
-                    // Resolve through `slot.tunables` — the same fallbacks the wire path
-                    // takes, so a `[defaults].thinking_style` (which the old
-                    // `unwrap_or_default()` here silently ignored) can't make the render
-                    // disagree with what actually ships.
-                    let t = slot.tunables(*role, &config.defaults);
-                    let shape = ModelShape::resolve(backend.kind, &slot.id, t.thinking_style);
-                    // Lane-aware: a `lane = "batch"` slot never builds an interactive arm.
-                    // Batch POSTs its own body and gates the Responses shape on the
-                    // endpoint-exact `is_hosted_openai`; the interactive arm follows the
-                    // configurable `uses_responses_wire` (a responses-wire gateway shapes
-                    // like Platform even though it isn't batch-eligible).
-                    let batch_lane = matches!(lane, Some(Lane::Batch));
-                    let responses_wire = if batch_lane {
-                        backend.is_hosted_openai()
+                    let inert_tunables = if role.is_reasoning() {
+                        // Resolve through `slot.tunables` — the same fallbacks the wire
+                        // path takes, so a `[defaults].thinking_style` (which the old
+                        // `unwrap_or_default()` here silently ignored) can't make the
+                        // render disagree with what actually ships.
+                        let t = slot.tunables(*role, &config.defaults);
+                        let shape = ModelShape::resolve(backend.kind, &slot.id, t.thinking_style);
+                        // Lane-aware: a `lane = "batch"` slot never builds an interactive
+                        // arm. Batch POSTs its own body and gates the Responses shape on
+                        // the endpoint-exact `is_hosted_openai`; the interactive arm
+                        // follows the configurable `uses_responses_wire` (a responses-wire
+                        // gateway shapes like Platform even though it isn't
+                        // batch-eligible).
+                        let batch_lane = matches!(lane, Some(Lane::Batch));
+                        let responses_wire = if batch_lane {
+                            backend.is_hosted_openai()
+                        } else {
+                            backend.uses_responses_wire()
+                        };
+                        let mut inert = Vec::new();
+                        // Whether the effort ships is a policy with exactly one
+                        // implementation — `Config::effort_disposition`. The render asks
+                        // it rather than re-deriving (drop? batch lift? off-switch?),
+                        // which is what keeps this and the startup warning from ever
+                        // telling an operator different stories about the same slot.
+                        let disposition = config
+                            .effort_disposition(slot, *role)
+                            .expect("a loaded cast's slot backend resolves");
+                        // Batch hands the provider no sampling at all (`None`/`None`), so
+                        // a `temperature` on a batch slot is inert regardless of the model.
+                        let sampling_sinks = if batch_lane {
+                            false
+                        } else if responses_wire {
+                            crate::consult::hosted_openai_accepts_sampling(&slot.id)
+                        } else {
+                            shape.sinks_sampling()
+                        };
+                        if thinking_budget.is_some() && !shape.sinks_thinking_budget() {
+                            inert.push("thinking_budget");
+                        }
+                        // The *effective* effort, not just a per-slot override: a
+                        // `[defaults]`/env effort lands on every cast, and one that lands
+                        // nowhere deserves the same flag. Inherited built-in defaults stay
+                        // quiet — see `Defaults::explorer_effort_explicit`.
+                        if disposition.explicit && !disposition.ships_as_configured() {
+                            inert.push("effort");
+                        }
+                        if temperature.is_some() && !sampling_sinks {
+                            inert.push("temperature");
+                        }
+                        inert
                     } else {
-                        backend.uses_responses_wire()
+                        // A media slot sends one generation request with no reasoning
+                        // phase, so every reasoning knob WRITTEN on the slot is inert —
+                        // and the request-shaping machinery (`ModelShape`,
+                        // `effort_disposition`) is deliberately not resolved for it (see
+                        // `ModelRole::is_reasoning`). Same single policy the startup
+                        // warning reads (`Config::media_tunable_diagnostics`); inherited
+                        // `[defaults]` values stay quiet.
+                        slot.written_reasoning_tunables()
                     };
-                    let mut inert_tunables = Vec::new();
-                    // Whether the effort ships is a policy with exactly one implementation
-                    // — `Config::effort_disposition`. The render asks it rather than
-                    // re-deriving (drop? batch lift? off-switch?), which is what keeps this
-                    // and the startup warning from ever telling an operator different
-                    // stories about the same slot.
-                    let disposition = config
-                        .effort_disposition(slot, *role)
-                        .expect("a loaded cast's slot backend resolves");
-                    // Batch hands the provider no sampling at all (`None`/`None`), so a
-                    // `temperature` on a batch slot is inert regardless of the model.
-                    let sampling_sinks = if batch_lane {
-                        false
-                    } else if responses_wire {
-                        crate::consult::hosted_openai_accepts_sampling(&slot.id)
-                    } else {
-                        shape.sinks_sampling()
-                    };
-                    if thinking_budget.is_some() && !shape.sinks_thinking_budget() {
-                        inert_tunables.push("thinking_budget");
-                    }
-                    // The *effective* effort, not just a per-slot override: a
-                    // `[defaults]`/env effort lands on every cast, and one that lands
-                    // nowhere deserves the same flag. Inherited built-in defaults stay
-                    // quiet — see `Defaults::explorer_effort_explicit`.
-                    if disposition.explicit && !disposition.ships_as_configured() {
-                        inert_tunables.push("effort");
-                    }
-                    if temperature.is_some() && !sampling_sinks {
-                        inert_tunables.push("temperature");
-                    }
                     (
                         role.key(),
                         SlotDoc {
@@ -774,6 +787,63 @@ mod tests {
             inert("gpt_chat", "synth"),
             vec!["thinking_budget", "effort"],
             "hosted GPT chat sinks sampling but rejects reasoning effort and budget"
+        );
+    }
+
+    /// An image slot never runs a reasoning phase, so the render judges it by what the
+    /// operator WROTE on the slot, not by any wire shape: every written reasoning knob
+    /// is flagged inert, and a bare image slot stays clean even when `[defaults]`
+    /// carries a written synth effort (inherited values are a fallback artifact, not a
+    /// statement about the image slot). Same rule as the startup warning
+    /// (`Config::media_tunable_diagnostics`) — one policy, two surfaces.
+    #[test]
+    fn config_render_flags_written_reasoning_knobs_on_an_image_slot() {
+        let config = Config::from_toml_str(
+            r#"
+            [defaults]
+            # Written, synth-side: lands on reasoning slots, must NOT flag image slots.
+            synth_effort = "medium"
+
+            [backends.sd]
+            kind = "stability"
+
+            # Knobs written on the image slot itself: all inert, all flagged.
+            [casts.noisy]
+            synth = "deepseek/deepseek-v4-pro"
+            image = { backend = "sd", id = "core", thinking_budget = 4096, effort = "high", temperature = 0.5, thinking_style = "adaptive" }
+
+            # A bare image slot: nothing written, nothing flagged.
+            [casts.clean]
+            synth = "deepseek/deepseek-v4-pro"
+            image = "sd/ultra"
+            "#,
+        )
+        .unwrap();
+        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
+        let inert = |cast: &str, role: &str| -> Vec<String> {
+            doc.get("casts")
+                .and_then(|c| c.get(cast))
+                .and_then(|c| c.get(role))
+                .and_then(|s| s.get("inert_tunables"))
+                .map(|a| {
+                    a.as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|v| v.as_str().unwrap().to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        assert_eq!(
+            inert("noisy", "image"),
+            vec!["thinking_budget", "effort", "temperature", "thinking_style"],
+            "every reasoning knob written on the image slot is flagged"
+        );
+        assert!(
+            inert("clean", "image").is_empty(),
+            "a bare image slot is clean; the written [defaults] synth effort does not \
+             leak onto it"
         );
     }
 

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -29,6 +29,7 @@ pub(crate) fn render_config_resource(
     default_root_inferred: bool,
     followed_worktrees: Vec<PathBuf>,
     persistence_active: bool,
+    cas_mode: crate::config::CasMode,
 ) -> String {
     use serde::Serialize;
     use std::collections::BTreeMap;
@@ -91,6 +92,9 @@ pub(crate) fn render_config_resource(
         /// Durable-store state (on by default): whether persistence is enabled, the
         /// resolved state-db path, and whether the store is actually open right now.
         persistence: PersistenceDoc,
+        /// The media CAS: the on/off knob, the runtime mode (disk / memory / off),
+        /// and where disk mode writes.
+        cas: CasDoc,
         /// alias → canonical backend name. Aliases are valid slot-ref prefixes
         /// and per-call backend overrides, so callers must be able to discover
         /// them here — built-in and file-declared both.
@@ -214,6 +218,21 @@ pub(crate) fn render_config_resource(
         active: bool,
     }
 
+    /// The media CAS as resolved. `mode` is runtime truth (`"disk"` / `"memory"` /
+    /// `"off"`) from the store the handler actually holds — `"memory"` is the loud
+    /// degraded state (artifacts do not survive a restart; startup already warned).
+    /// `dir` is the configured directory whether or not the current mode uses it, so
+    /// an operator diagnosing `"memory"` still sees where disk mode would write.
+    #[derive(Serialize)]
+    struct CasDoc {
+        enabled: bool,
+        mode: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dir: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_bytes: Option<u64>,
+    }
+
     #[derive(Serialize)]
     struct BackendDoc {
         kind: String,
@@ -327,11 +346,12 @@ pub(crate) fn render_config_resource(
                 api_key_file: api_key_file.clone(),
                 key_optional: *key_optional,
                 request_timeout_secs: request_timeout.as_secs(),
-                data_collection: (*kind == crate::credentials::ProviderKind::OpenRouter)
-                    .then_some(match data_collection {
+                data_collection: (*kind == crate::credentials::ProviderKind::OpenRouter).then_some(
+                    match data_collection {
                         crate::config::DataCollection::Deny => "deny",
                         crate::config::DataCollection::Allow => "allow",
-                    }),
+                    },
+                ),
                 // Resolved, not raw: an unset `wire` still has an effective shape
                 // (the endpoint-exact heuristic), so render what the backend will
                 // actually do, not just what was configured.
@@ -588,6 +608,12 @@ pub(crate) fn render_config_resource(
                 .map(|p| p.display().to_string()),
             active: persistence_active,
         },
+        cas: CasDoc {
+            enabled: config.cas.enabled,
+            mode: cas_mode.as_str().to_string(),
+            dir: config.cas.dir.as_ref().map(|p| p.display().to_string()),
+            max_bytes: config.cas.max_bytes,
+        },
         backend_aliases: config.backend_aliases().clone(),
         backends,
         cast_aliases: config.cast_aliases().clone(),
@@ -627,7 +653,15 @@ mod tests {
         let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp/the-repo")];
         let followed = vec![std::path::PathBuf::from("/tmp/the-repo-feature")];
-        let body = render_config_resource(&config, &allowed, None, false, followed, false);
+        let body = render_config_resource(
+            &config,
+            &allowed,
+            None,
+            false,
+            followed,
+            false,
+            crate::config::CasMode::Memory,
+        );
         assert!(
             body.contains("[runtime]") && body.contains("follow_worktrees = true"),
             "runtime section must echo the follow knob:\n{body}"
@@ -659,7 +693,15 @@ mod tests {
     /// confusing failure this reporting exists to prevent.
     #[test]
     fn config_resource_runtime_explains_a_tool_no_cast_can_staff() {
-        let body = render_config_resource(&Config::builtin(), &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &Config::builtin(),
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         let runtime = section(&body, "[runtime]");
         assert!(
             !runtime.contains("\"deliberate\""),
@@ -691,7 +733,15 @@ mod tests {
     fn config_resource_does_not_blame_casts_for_an_operator_disabled_tool() {
         let mut config = Config::builtin();
         config.tools.deliberate = false;
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         assert!(
             !section(&body, "[runtime.unstaffable_tools]").contains("deliberate"),
             "a flag-disabled tool belongs to [tools], not unstaffable_tools:\n{body}"
@@ -742,7 +792,15 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let inert = |cast: &str, role: &str| -> Vec<String> {
             doc.get("casts")
@@ -819,7 +877,15 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let inert = |cast: &str, role: &str| -> Vec<String> {
             doc.get("casts")
@@ -895,7 +961,15 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let inert = |cast: &str, role: &str| -> Vec<String> {
             doc.get("casts")
@@ -979,7 +1053,15 @@ mod tests {
         )
         .unwrap();
 
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let render_flags = |cast: &str, role: &str| -> bool {
             doc.get("casts")
@@ -1045,7 +1127,15 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let wire = |name: &str| -> Option<String> {
             doc.get("backends")
@@ -1084,7 +1174,15 @@ mod tests {
     fn config_resource_renders_expected_fields() {
         let config = Config::builtin();
         let allowed = vec![std::path::PathBuf::from("/tmp/test-allowed")];
-        let body = render_config_resource(&config, &allowed, None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &allowed,
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         // Structural presence checks — the resource is TOML or a document, not prose.
         for needle in [
             "allowed_paths",
@@ -1173,7 +1271,15 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         // The header NAME is discoverable…
         assert!(
             body.contains("authorization"),
@@ -1193,7 +1299,15 @@ mod tests {
         // Enabled (the default) with the store open.
         let config =
             Config::from_toml_str("[persistence]\npath = \"/var/lib/kaibo/state.db\"\n").unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], true);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            true,
+            crate::config::CasMode::Disk,
+        );
         let section = body
             .split_once("[persistence]")
             .expect("a [persistence] table renders")
@@ -1207,11 +1321,54 @@ mod tests {
 
         // Disabled: off and inactive.
         let off = Config::from_toml_str("[persistence]\nenabled = false\n").unwrap();
-        let body = render_config_resource(&off, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &off,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         let section = body.split_once("[persistence]").expect("table renders").1;
         assert!(
             section.contains("enabled = false") && section.contains("active = false"),
             "a disabled store renders off and inactive:\n{body}"
+        );
+    }
+
+    /// The media CAS renders its knob AND its runtime mode — the three-way state
+    /// (disk / memory / off) an operator needs to see, with `"memory"` the loud
+    /// degraded case (artifacts do not survive a restart) and `dir` shown even then
+    /// so a diagnosing operator sees where disk mode would write.
+    #[test]
+    fn config_resource_shows_cas_state_in_all_three_modes() {
+        use crate::config::CasMode;
+
+        let config = Config::from_toml_str("[cas]\ndir = \"/srv/art\"\n").unwrap();
+        let body = render_config_resource(&config, &[], None, false, vec![], true, CasMode::Disk);
+        let section = body.split_once("[cas]").expect("a [cas] table renders").1;
+        assert!(
+            section.contains("enabled = true")
+                && section.contains(r#"mode = "disk""#)
+                && section.contains("/srv/art"),
+            "disk mode must show on, the mode word, and the dir:\n{body}"
+        );
+
+        let body =
+            render_config_resource(&config, &[], None, false, vec![], false, CasMode::Memory);
+        let section = body.split_once("[cas]").expect("table renders").1;
+        assert!(
+            section.contains(r#"mode = "memory""#) && section.contains("/srv/art"),
+            "memory mode must render as memory and still show the configured dir:\n{body}"
+        );
+
+        let off = Config::from_toml_str("[cas]\nenabled = false\n").unwrap();
+        let body = render_config_resource(&off, &[], None, false, vec![], false, CasMode::Off);
+        let section = body.split_once("[cas]").expect("table renders").1;
+        assert!(
+            section.contains("enabled = false") && section.contains(r#"mode = "off""#),
+            "the explicit off switch renders as off:\n{body}"
         );
     }
 
@@ -1233,7 +1390,15 @@ mod tests {
             "#,
         )
         .unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], false);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         for needle in ["[backend_aliases]", "[cast_aliases]"] {
             assert!(body.contains(needle), "must render {needle}:\n{body}");
         }
@@ -1280,7 +1445,15 @@ mod tests {
             unsafe {
                 std::env::set_var(var_name, SENTINEL);
             }
-            let b = render_config_resource(&config, &allowed, None, false, vec![], false);
+            let b = render_config_resource(
+                &config,
+                &allowed,
+                None,
+                false,
+                vec![],
+                false,
+                crate::config::CasMode::Memory,
+            );
             #[allow(deprecated)]
             unsafe {
                 std::env::remove_var(var_name);
@@ -1306,7 +1479,15 @@ mod tests {
         let file_path = tmp.path().to_string_lossy().to_string();
         let toml2 = format!("[backends.anthropic]\napi_key_file = \"{file_path}\"\n");
         let config2 = Config::from_toml_str(&toml2).expect("valid config");
-        let body2 = render_config_resource(&config2, &allowed, None, false, vec![], false);
+        let body2 = render_config_resource(
+            &config2,
+            &allowed,
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         // The file path (source pointer) may appear, but not the file contents.
         assert!(
             !body2.contains(SENTINEL),

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -116,6 +116,7 @@ pub(crate) fn render_config_resource(
         run_kaish: bool,
         batch: bool,
         list_models: bool,
+        generate: bool,
     }
 
     /// Runtime-computed scope state. `follow_worktrees` echoes the knob;
@@ -490,6 +491,7 @@ pub(crate) fn render_config_resource(
         run_kaish,
         batch,
         list_models,
+        generate,
     } = &config.tools;
     let crate::sandbox::SandboxConfig {
         exec_timeout,
@@ -555,6 +557,7 @@ pub(crate) fn render_config_resource(
             run_kaish,
             batch,
             list_models,
+            generate,
         },
         sandbox: SandboxDoc {
             exec_timeout_secs: exec_timeout.as_secs(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -615,6 +615,8 @@ pub struct GenerateInput {
     /// Provider-native generation options passed through verbatim as string fields
     /// (Stability: aspect_ratio "16:9", output_format png|jpeg|webp, seed,
     /// negative_prompt, style_preset, ...). The provider validates its own knobs.
+    /// `prompt` and `model` are reserved: use the prompt parameter and the cast's
+    /// image slot.
     #[serde(default)]
     pub fields: Option<std::collections::BTreeMap<String, String>>,
 }
@@ -2471,8 +2473,9 @@ impl KaiboHandler {
             lists per-artifact digests — a kaibo://cas/<digest> resource URI, the mime, \
             the provider's seed, and the real file path when the store is on disk. \
             Provider-native options (aspect_ratio, output_format, seed, \
-            negative_prompt, style_preset, ...) pass through `fields` verbatim. A \
-            deferred operation returns a `job-N` handle for job_wait/job_get instead. \
+            negative_prompt, style_preset, ...) pass through `fields` verbatim. An \
+            operation the provider declares deferred returns a `job-N` handle for \
+            job_wait/job_get instead (today's Stability routes all answer in-call). \
             Provenance (prompt, model, cast, seed) is recorded beside every artifact."
     )]
     pub async fn generate(
@@ -2513,9 +2516,32 @@ impl KaiboHandler {
         let arm = self.media_arms.build(backend, slot).map_err(|e| {
             McpError::invalid_params(format!("cast `{}` image slot: {e:#}", cast.name), None)
         })?;
+        let fields: Vec<(String, String)> = input.fields.unwrap_or_default().into_iter().collect();
+        // Reserved keys: recorded provenance must describe the request that actually
+        // ran. `fields.prompt` would send prompt B while the sidecar records prompt A,
+        // and `fields.model` would reroute an SD3 call while the sidecar records the
+        // slot's model — so both are refused loudly, pointing at the real parameter.
+        for (key, param) in [
+            ("prompt", "the `prompt` parameter"),
+            (
+                "model",
+                "the cast's `image` slot (its model id picks the route/variant)",
+            ),
+        ] {
+            if fields.iter().any(|(name, _)| name == key) {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "`fields.{key}` is reserved — it would make the recorded \
+                         provenance disagree with the request that ran. Set it through \
+                         {param} instead."
+                    ),
+                    None,
+                ));
+            }
+        }
         let request = crate::media::MediaRequest {
             prompt: input.prompt.clone(),
-            fields: input.fields.unwrap_or_default().into_iter().collect(),
+            fields,
             input_image: None,
         };
         let span = tracing::info_span!("generate", cast = %cast.name, model = %arm.slot_ref());
@@ -2646,8 +2672,8 @@ impl KaiboHandler {
             }
             None => Err(McpError::invalid_params(
                 format!(
-                    "no consultation job `{}` — it may have finished and been evicted by \
-                     newer submits, been canceled, or never existed. Consult job ids look \
+                    "no background job `{}` — it may have finished and been evicted by \
+                     newer submits, been canceled, or never existed. Job ids look \
                      like `job-1` and live only for this server session.",
                     input.handle
                 ),
@@ -2683,16 +2709,18 @@ impl KaiboHandler {
             ))]));
         }
         self.ensure_consult_enabled(&input.handle)?;
+        // Producer-neutral wording throughout: a `job-N` may be a consultation, a
+        // deliberation, or a deferred generation — the handle doesn't say which.
         let msg = match self.jobs.cancel(&input.handle) {
-            CancelOutcome::Canceled => format!("Canceled consultation `{}`.", input.handle),
+            CancelOutcome::Canceled => format!("Canceled job `{}`.", input.handle),
             CancelOutcome::AlreadyFinished => format!(
-                "Consultation `{}` had already finished — `job_get` it for the answer.",
+                "Job `{}` had already finished — `job_get` it for the result.",
                 input.handle
             ),
             CancelOutcome::Unknown => {
                 return Err(McpError::invalid_params(
                     format!(
-                        "no consultation job `{}` to cancel — it may have finished and \
+                        "no background job `{}` to cancel — it may have finished and \
                          been evicted, or never existed.",
                         input.handle
                     ),
@@ -2716,9 +2744,11 @@ impl KaiboHandler {
     ) -> Result<CallToolResult, McpError> {
         let mut sections: Vec<String> = Vec::new();
 
-        // In-memory jobs first — this session. `consult_submit` AND `deliberate`'s direct
-        // lane both land here, so show the section when either produces jobs.
-        if self.config.tools.consult || self.config.tools.deliberate {
+        // In-memory jobs first — this session. `consult_submit`, `deliberate`'s direct
+        // lane, and deferred `generate` all land here, so the section shows whenever any
+        // producer is live — the same predicate the `job-N` collect guard uses
+        // (`job_producer_live`), so a server never accepts handles it won't list.
+        if self.job_producer_live() {
             sections.push(render_jobs_section(&self.jobs.list()));
         }
 
@@ -2968,18 +2998,25 @@ impl KaiboHandler {
         ))
     }
 
+    /// Whether any producer of in-memory `job-N` handles is live on this server:
+    /// `consult_submit`, `deliberate`'s direct lane, or a deferred `generate`. The ONE
+    /// predicate behind both the `job_list` in-memory section and the `job-N` collect
+    /// guard, so the section a server renders and the handles it accepts can't drift.
+    /// `generate` is judged by route liveness, not its bare flag: the flag defaults on
+    /// but the tool only mints a `job-N` when it is actually advertised (a cast can
+    /// staff it AND the media CAS is on), and a stock install has neither — the flag
+    /// alone would claim producers on servers where generate can't run.
+    fn job_producer_live(&self) -> bool {
+        self.config.tools.consult
+            || self.config.tools.deliberate
+            || self.tool_router.has_route("generate")
+    }
+
     /// Refuse a `job-N` handle only when no tool that produces one is enabled. A `job-N`
     /// comes from `consult_submit`, `deliberate`'s direct lane, OR a deferred `generate`,
     /// so any of the three keeps it collectible.
     fn ensure_consult_enabled(&self, handle: &str) -> Result<(), McpError> {
-        // `generate` is judged by route liveness, not its bare flag: the flag defaults
-        // on but the tool only mints a `job-N` when it is actually advertised (a cast
-        // can staff it AND the media CAS is on), and a stock install has neither — the
-        // flag alone would wave every handle through on servers where generate can't run.
-        if self.config.tools.consult
-            || self.config.tools.deliberate
-            || self.tool_router.has_route("generate")
-        {
+        if self.job_producer_live() {
             return Ok(());
         }
         Err(McpError::invalid_params(
@@ -3587,9 +3624,10 @@ kaibo's content-addressed store and you get its digest as a `kaibo://cas/<digest
 resource URI (read it as an MCP resource for the bytes), the mime, the provider's seed,
 and — when the store is on disk — the real file path. Provider-native options ride the
 `fields` object verbatim (Stability: `aspect_ratio` \"16:9\", `output_format`
-png|jpeg|webp, `seed`, `negative_prompt`, `style_preset`). A deferred operation hands
-back a `job-N` on the same collect verbs above. Every artifact gets a provenance sidecar
-(prompt, model, cast, timestamp, mime, seed) beside it in the store.
+png|jpeg|webp, `seed`, `negative_prompt`, `style_preset`). An operation the provider
+declares deferred hands back a `job-N` on the same collect verbs above — the lane is
+wired, though every Stability generate route today answers in-call. Every artifact gets
+a provenance sidecar (prompt, model, cast, timestamp, mime, seed) beside it in the store.
 
 ## Driving the read-only shell (`run_kaish`)
 
@@ -3778,6 +3816,15 @@ const GENERATE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// [`crate::media::MediaOutcome::Complete`] carrying a list). An empty list is refused:
 /// a provider reporting success with nothing attached is that provider's bug, surfaced
 /// loudly rather than rendered as an empty success.
+///
+/// The artifacts are paid for, so partial failure is handled in two layers (or-gpt
+/// review, 2026-08-03). First, the WHOLE list is prevalidated — every mime must map
+/// onto the store's closed on-disk set — before the first byte is written, so a list
+/// with one unstorable member stores *nothing* instead of storing some and then
+/// erroring with their digests discarded. Second, a store failure that can only occur
+/// mid-loop (I/O, the soft cap) returns an error that NAMES the digests already
+/// stored: they exist, they were paid for, and they stay retrievable by those
+/// addresses — an error that hid them would orphan them.
 fn store_generated_artifacts(
     store: &crate::cas::MediaStore,
     artifacts: &[crate::media::MediaArtifact],
@@ -3790,24 +3837,33 @@ fn store_generated_artifacts(
         !artifacts.is_empty(),
         "the provider reported a completed generation with zero artifacts"
     );
+    // Prevalidate every mime up front — an unknown format is refused rather than
+    // written under an invented extension (the same argument
+    // stability::MediaType::to_cas_extension records at length), and refusing BEFORE
+    // the first put is what keeps a mixed list all-or-nothing at this layer.
+    let exts: Vec<crate::cas::Extension> = artifacts
+        .iter()
+        .enumerate()
+        .map(|(i, artifact)| {
+            crate::cas::Extension::from_mime(&artifact.mime).ok_or_else(|| {
+                anyhow!(
+                    "artifact {} has mime {:?}, which the media store cannot name on \
+                     disk yet — refusing the whole result rather than storing it under \
+                     an invented extension; nothing was stored",
+                    i + 1,
+                    artifact.mime
+                )
+            })
+        })
+        .collect::<Result<_>>()?;
     let timestamp = now_epoch_secs();
     let mut lines = vec![format!(
         "Generated {} artifact{}:",
         artifacts.len(),
         if artifacts.len() == 1 { "" } else { "s" }
     )];
-    for (i, artifact) in artifacts.iter().enumerate() {
-        // The mime must map onto the CAS's closed on-disk set — an unknown format is
-        // refused rather than written under an invented extension (the same argument
-        // stability::MediaType::to_cas_extension records at length).
-        let ext = crate::cas::Extension::from_mime(&artifact.mime).ok_or_else(|| {
-            anyhow!(
-                "artifact {} has mime {:?}, which the media store cannot name on disk \
-                 yet — refusing to store it under an invented extension",
-                i + 1,
-                artifact.mime
-            )
-        })?;
+    let mut stored: Vec<String> = Vec::new();
+    for (i, (artifact, ext)) in artifacts.iter().zip(exts).enumerate() {
         let provenance = crate::cas::Provenance {
             prompt: prompt.to_string(),
             model: model.to_string(),
@@ -3816,9 +3872,29 @@ fn store_generated_artifacts(
             mime: artifact.mime.clone(),
             seed: artifact.seed.clone(),
         };
-        let digest = store
-            .put(&artifact.bytes, ext, &provenance)
-            .map_err(|e| anyhow!("storing artifact {}: {e}", i + 1))?;
+        let digest =
+            store
+                .put(&artifact.bytes, ext, &provenance)
+                .map_err(|e| match stored.is_empty() {
+                    true => anyhow!("storing artifact {}: {e} — nothing was stored", i + 1),
+                    false => anyhow!(
+                        "storing artifact {} of {}: {e}. The artifact{} stored before the \
+                     failure {} paid for and retrievable: {}",
+                        i + 1,
+                        artifacts.len(),
+                        if stored.len() == 1 { "" } else { "s" },
+                        if stored.len() == 1 {
+                            "remains"
+                        } else {
+                            "remain"
+                        },
+                        stored
+                            .iter()
+                            .map(|hex| format!("{CAS_RES_PREFIX}{hex}"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                })?;
         let hex = digest.to_hex();
         let mut line = format!("{}. {CAS_RES_PREFIX}{hex} ({}", i + 1, artifact.mime);
         if let Some(seed) = &artifact.seed {
@@ -3829,6 +3905,7 @@ fn store_generated_artifacts(
             line.push_str(&format!("\n   path: {}", path.display()));
         }
         lines.push(line);
+        stored.push(hex);
     }
     Ok(lines.join("\n"))
 }
@@ -4623,8 +4700,10 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn generate_deferred_returns_a_job_that_collects_digests() {
         let artifact = png(b"deferred-artifact");
+        let mut second = png(b"second-deferred-artifact");
+        second.mime = "image/webp".to_string();
         let h = media_handler(Arc::new(DeferredArtifacts {
-            artifacts: vec![artifact.clone()],
+            artifacts: vec![artifact.clone(), second.clone()],
             polls: std::sync::Mutex::new(0),
         }));
         let result = h
@@ -4670,6 +4749,226 @@ mod tests {
             h.media_store().unwrap().get(&digest).expect("readable"),
             Some((artifact.bytes.clone(), crate::cas::Extension::Png)),
             "the deferred artifact landed in the store"
+        );
+        // The one-to-many contract holds through the deferred lane too: the second
+        // artifact gets its own digest line and its own stored object.
+        let second_digest = crate::cas::Digest::of_bytes(&second.bytes);
+        assert!(
+            answer.contains(&format!("kaibo://cas/{}", second_digest.to_hex())),
+            "every artifact of a deferred completion is named:\n{answer}"
+        );
+        assert_eq!(
+            h.media_store()
+                .unwrap()
+                .get(&second_digest)
+                .expect("readable"),
+            Some((second.bytes.clone(), crate::cas::Extension::Webp)),
+            "the second deferred artifact landed in the store"
+        );
+    }
+
+    /// Recorded provenance must describe the request that ran (or-gpt review,
+    /// 2026-08-03): a caller who smuggles `prompt` or `model` through `fields` would
+    /// make the sidecar record the *other* prompt/model — so both keys are reserved
+    /// and refused loudly, naming the right parameter.
+    #[tokio::test]
+    async fn generate_refuses_reserved_field_keys() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![png(b"x")])));
+
+        let err = h
+            .generate(Parameters(GenerateInput {
+                prompt: "A".to_string(),
+                cast: Some("artist".to_string()),
+                fields: Some(
+                    [("prompt".to_string(), "B".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+            }))
+            .await
+            .expect_err("a fields.prompt override must be refused");
+        assert!(
+            err.message.contains("prompt") && err.message.contains("reserved"),
+            "the refusal names the reserved key, got: {}",
+            err.message
+        );
+
+        let err = h
+            .generate(Parameters(GenerateInput {
+                prompt: "A".to_string(),
+                cast: Some("artist".to_string()),
+                fields: Some(
+                    [("model".to_string(), "sd3.5-large".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+            }))
+            .await
+            .expect_err("a fields.model override must be refused");
+        assert!(
+            err.message.contains("model")
+                && err.message.contains("reserved")
+                && err.message.contains("image"),
+            "the refusal names the key and points at the image slot, got: {}",
+            err.message
+        );
+    }
+
+    /// A provider reporting success with an empty artifact list is that provider's
+    /// bug, surfaced as a loud tool error — never an empty success.
+    #[tokio::test]
+    async fn generate_refuses_an_empty_artifact_list() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let result = h
+            .generate(Parameters(GenerateInput {
+                prompt: "p".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect("a tool-result error, not a protocol error");
+        assert_eq!(result.is_error, Some(true));
+        assert!(
+            result_text(result).contains("zero artifacts"),
+            "the error names the empty completion"
+        );
+    }
+
+    /// Partial multi-artifact failure must not orphan paid artifacts silently
+    /// (or-gpt review, 2026-08-03). The cheap 90%: the WHOLE list is prevalidated —
+    /// every mime must map onto the store's on-disk set — before the first byte is
+    /// written, so [valid, unsupported] stores NOTHING instead of storing #1 and then
+    /// discarding its digest with the error.
+    #[tokio::test]
+    async fn generate_prevalidates_every_mime_before_storing_anything() {
+        let good = png(b"good-artifact");
+        let mut bad = png(b"unstorable-artifact");
+        bad.mime = "audio/mpeg".to_string();
+        let h = media_handler(Arc::new(SyncArtifacts(vec![good.clone(), bad])));
+        let result = h
+            .generate(Parameters(GenerateInput {
+                prompt: "p".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect("a tool-result error, not a protocol error");
+        assert_eq!(result.is_error, Some(true));
+        assert!(
+            result_text(result).contains("audio/mpeg"),
+            "the error names the unstorable mime"
+        );
+        let store = h.media_store().unwrap();
+        assert_eq!(
+            store
+                .get(&crate::cas::Digest::of_bytes(&good.bytes))
+                .expect("readable"),
+            None,
+            "prevalidation failed the call BEFORE the valid artifact was stored"
+        );
+    }
+
+    /// The residual 10%: a mid-loop store failure AFTER prevalidation (here the soft
+    /// cap refusing artifact #2) must return an error that NAMES the digests already
+    /// stored — the caller paid for them and they are retrievable; discarding their
+    /// addresses would orphan them.
+    #[tokio::test]
+    async fn generate_mid_loop_store_failure_names_the_digests_already_stored() {
+        let small = png(b"tiny");
+        let big = png(&[7u8; 4096]);
+        // A capped in-memory store: #1 fits, #2 breaches. Both mimes prevalidate.
+        let toml = format!("{MEDIA_CAST_TOML}\n[cas]\nmax_bytes = 64\n");
+        let h = hermetic_handler_from_toml(&toml).with_media_arms(Arc::new(ScriptedMediaArms(
+            Arc::new(SyncArtifacts(vec![small.clone(), big])),
+        )));
+        let result = h
+            .generate(Parameters(GenerateInput {
+                prompt: "p".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect("a tool-result error, not a protocol error");
+        assert_eq!(result.is_error, Some(true));
+        let text = result_text(result);
+        let stored = crate::cas::Digest::of_bytes(&small.bytes);
+        assert!(
+            text.contains(&stored.to_hex()),
+            "the error names the digest that DID land, so it isn't orphaned:\n{text}"
+        );
+        assert!(
+            h.media_store()
+                .unwrap()
+                .get(&stored)
+                .expect("readable")
+                .is_some(),
+            "and that artifact really is retrievable"
+        );
+    }
+
+    /// The deferred poll loop is bounded by [defaults] call_deadline: a provider job
+    /// that never completes fails the kaibo job with the PROVIDER id named, so the
+    /// operator can chase it on the provider's side.
+    #[tokio::test(start_paused = true)]
+    async fn generate_deferred_poll_deadline_fails_the_job_naming_the_provider_id() {
+        /// Defers, then reports Pending forever.
+        struct NeverDone;
+
+        #[async_trait::async_trait]
+        impl crate::media::MediaModel for NeverDone {
+            async fn generate(
+                &self,
+                _request: &crate::media::MediaRequest,
+            ) -> anyhow::Result<crate::media::MediaOutcome> {
+                Ok(crate::media::MediaOutcome::Deferred(
+                    crate::media::MediaJobId("prov-stuck-9".to_string()),
+                ))
+            }
+
+            async fn poll(
+                &self,
+                _job: &crate::media::MediaJobId,
+            ) -> anyhow::Result<crate::media::MediaPollOutcome> {
+                Ok(crate::media::MediaPollOutcome::Pending)
+            }
+        }
+
+        let h = media_handler(Arc::new(NeverDone));
+        let ack = result_text(
+            h.generate(Parameters(GenerateInput {
+                prompt: "p".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect("submit succeeds"),
+        );
+        let handle = ack
+            .split('`')
+            .nth(1)
+            .expect("backticked handle")
+            .to_string();
+
+        // Advance past the whole call_deadline budget (auto-advanced under start_paused)
+        // and collect the failure.
+        let deadline = h.config.defaults.call_deadline;
+        let mut failed = String::new();
+        for _ in 0..80 {
+            tokio::time::sleep(deadline / 8).await;
+            let r = h
+                .job_get(Parameters(HandleInput {
+                    handle: handle.clone(),
+                }))
+                .await
+                .expect("job_get answers");
+            if r.is_error == Some(true) {
+                failed = result_text(r);
+                break;
+            }
+        }
+        assert!(
+            failed.contains("prov-stuck-9") && failed.contains("still pending"),
+            "the timed-out job names the provider id so it can be chased:\n{failed}"
         );
     }
 
@@ -4722,6 +5021,83 @@ enabled = false
         assert!(
             !cas_off.advertised_tools().contains(&"generate".to_string()),
             "with the CAS off the tool has nowhere to store artifacts and must vanish"
+        );
+    }
+
+    /// A generate-ONLY server (consult, deliberate, and batch all disabled) still
+    /// lists, collects, and cancels the `job-N` handles its deferred generations mint.
+    /// The regression this pins (or-gpt review, 2026-08-03): `job_list`'s in-memory
+    /// section was keyed off `consult || deliberate` flags, so a generate-only server
+    /// advertised `job_list` yet returned no jobs section at all. And the shared job-N
+    /// wording said "Consultation" for every producer — it must stay producer-neutral.
+    #[tokio::test(start_paused = true)]
+    async fn generate_only_server_lists_collects_and_cancels_its_jobs() {
+        let toml = format!(
+            "{MEDIA_CAST_TOML}\n[server.tools]\nconsult = false\ndeliberate = false\nbatch = false\n"
+        );
+        let h = hermetic_handler_from_toml(&toml).with_media_arms(Arc::new(ScriptedMediaArms(
+            Arc::new(DeferredArtifacts {
+                artifacts: vec![png(b"listed-artifact")],
+                polls: std::sync::Mutex::new(0),
+            }),
+        )));
+        assert!(
+            h.advertised_tools().contains(&"job_list".to_string()),
+            "generate keeps the collect verbs alive"
+        );
+        let ack = result_text(
+            h.generate(Parameters(GenerateInput {
+                prompt: "p".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect("submit succeeds"),
+        );
+        let handle = ack
+            .split('`')
+            .nth(1)
+            .expect("backticked handle")
+            .to_string();
+
+        // job_list must show the in-memory jobs section with this job in it.
+        let listing = result_text(
+            h.job_list(Parameters(ListInput {
+                backend: None,
+                all: false,
+            }))
+            .await
+            .expect("job_list answers"),
+        );
+        assert!(
+            listing.contains(&handle),
+            "a generate-only server must list its own deferred job `{handle}`:\n{listing}"
+        );
+
+        // job_get while running: producer-neutral wording, never "Consultation".
+        let running = result_text(
+            h.job_get(Parameters(HandleInput {
+                handle: handle.clone(),
+            }))
+            .await
+            .expect("job_get answers"),
+        );
+        assert!(
+            !running.contains("Consultation"),
+            "job-N wording is shared by every producer and must stay neutral:\n{running}"
+        );
+
+        // job_cancel: same neutrality.
+        let canceled = result_text(
+            h.job_cancel(Parameters(HandleInput {
+                handle: handle.clone(),
+            }))
+            .await
+            .expect("job_cancel answers"),
+        );
+        assert!(
+            canceled.contains(&handle) && !canceled.contains("Consultation"),
+            "the cancel ack names the job without calling it a consultation:\n{canceled}"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -106,6 +106,14 @@ const CONFIG_GUIDE_URI: &str = "kaibo://config/guide";
 /// on demand, not in every agent's startup context (the AGENTS.md prompt-writing split:
 /// terse where it's always loaded, generous where it's pulled).
 const TOOLS_URI: &str = "kaibo://tools";
+/// Generated-artifact retrieval by content digest: `kaibo://cas/<sha256-hex>`.
+/// OPERATOR SURFACE ONLY (Amy's ruling, 2026-08-03): the MCP client and CLI read it;
+/// the inner model team never can — the CAS is not mounted into kaish and no
+/// cast-facing tool reads it, because kaibo state spans projects and a browsable CAS
+/// would let one project's team enumerate another's artifacts.
+const CAS_RES_PREFIX: &str = "kaibo://cas/";
+/// The RFC 6570 template `list_resource_templates` advertises for the CAS reads.
+const CAS_URI_TEMPLATE: &str = "kaibo://cas/{digest}";
 /// The system preambles kaibo hands each model-driven phase — explorer, consult
 /// driver, oneshot, and the offline batch/deliberate synth — rendered through the exact
 /// same [`resolve_phase_preamble`](crate::consult::resolve_phase_preamble) seam the live
@@ -202,6 +210,11 @@ pub struct ToolGating {
     /// model-driven tool: no cast, no tool loop, just a GET per backend. Its own gate,
     /// independent of the model-backed tools above.
     pub list_models: bool,
+    /// The `generate` tool (media generation through a cast's `image` slot) — its own
+    /// gate. Beyond this flag it also needs a cast that can staff it AND the media CAS
+    /// on (`[cas] enabled`), since artifacts must have somewhere to land — see
+    /// `live_tools`.
+    pub generate: bool,
 }
 
 impl Default for ToolGating {
@@ -214,6 +227,7 @@ impl Default for ToolGating {
             run_kaish: true,
             batch: true,
             list_models: true,
+            generate: true,
         }
     }
 }
@@ -235,6 +249,7 @@ impl ToolGating {
             "run_kaish" => self.run_kaish,
             "batch_submit" => self.batch,
             "list_models" => self.list_models,
+            "generate" => self.generate,
             _ => true,
         }
     }
@@ -248,6 +263,7 @@ impl ToolGating {
             && !self.run_kaish
             && !self.batch
             && !self.list_models
+            && !self.generate
     }
 }
 
@@ -582,6 +598,27 @@ pub struct ListModelsInput {
     pub backend: Option<String>,
 }
 
+/// Arguments to `generate`: media generation through the cast's `image` slot. No
+/// `path` — generation reads no project (the prompt is the whole input), so there is
+/// nothing to scope to an allowed tree.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GenerateInput {
+    /// What to generate, described in prose.
+    pub prompt: String,
+
+    /// Cast (model team) whose `image` slot generates. Optional — the server default
+    /// applies; the cast must carry an `image` slot (kaibo://config lists casts).
+    #[serde(default)]
+    pub cast: Option<String>,
+
+    /// Provider-native generation options passed through verbatim as string fields
+    /// (Stability: aspect_ratio "16:9", output_format png|jpeg|webp, seed,
+    /// negative_prompt, style_preset, ...). The provider validates its own knobs.
+    #[serde(default)]
+    pub fields: Option<std::collections::BTreeMap<String, String>>,
+}
+
 /// kaibo's MCP handler. Cheap to clone (rmcp clones it per request).
 #[derive(Clone)]
 pub struct KaiboHandler {
@@ -636,6 +673,11 @@ pub struct KaiboHandler {
     /// store once `main` knows whether persistence actually came up. `Arc` so
     /// per-request handler clones share one store.
     media_cas: Option<Arc<crate::cas::MediaStore>>,
+    /// How `generate` builds its media arm — the injection seam mirroring
+    /// `batch_providers`: production seeds [`crate::media::LiveMediaArms`]; tests swap
+    /// in a factory returning a scripted model via
+    /// [`with_media_arms`](Self::with_media_arms).
+    media_arms: Arc<dyn crate::media::MediaArmFactory>,
 }
 
 /// One `CAST_ENUM_RULES` entry: the tools sharing a cast eligibility, the predicate
@@ -699,6 +741,15 @@ const CAST_ENUM_RULES: &[CastEnumRule] = &[
         "a cast pairing an `explorer` slot with an OFFLINE synth (`lane = \"batch\"` or \
          `lane = \"direct\"`) — see the DELIBERATE casts in docs/config.example.toml",
     ),
+    // `generate` runs no reasoning slot at all: it needs the cast's media member. The
+    // media CAS gate ([cas] enabled) rides separately in `live_tools` — this rule is
+    // only the staffing half.
+    (
+        &["generate"],
+        Config::cast_can_generate,
+        "a cast with an `image` slot pointing at a media backend (kind `stability`) — \
+         see the image-slot example in docs/config.example.toml",
+    ),
 ];
 
 /// Inject `casts` as a JSON-Schema `enum` on the `cast` parameter of every
@@ -751,7 +802,7 @@ pub(crate) fn cast_requirement_for(name: &str) -> Option<&'static str> {
 /// Every `#[tool]` route name kaibo can advertise — the fixed universe [`live_tools`]
 /// filters. `KaiboHandler::new` asserts each really exists on the router, so a renamed
 /// tool method fails the build rather than leaving a gate quietly inert.
-pub(crate) const ALL_TOOL_NAMES: [&str; 12] = [
+pub(crate) const ALL_TOOL_NAMES: [&str; 13] = [
     "consult",
     "consult_submit",
     "explore",
@@ -759,6 +810,7 @@ pub(crate) const ALL_TOOL_NAMES: [&str; 12] = [
     "oneshot",
     "run_kaish",
     "batch_submit",
+    "generate",
     "job_get",
     "job_cancel",
     "job_list",
@@ -790,7 +842,12 @@ pub(crate) fn live_tools(config: &Config, usable: &[String]) -> Vec<&'static str
     let deliberate_live = gating.deliberate && can_staff("deliberate");
     let oneshot_live = gating.oneshot && can_staff("oneshot");
     let batch_live = gating.batch && can_staff("batch_submit");
-    let jobs_live = consult_live || batch_live || deliberate_live;
+    // `generate` needs its flag, a cast with an `image` slot, AND the media CAS on —
+    // an artifact-producing tool with nowhere to put artifacts is not advertised
+    // ([cas] enabled = false is the operator's explicit choice; the startup log and
+    // kaibo://config's [cas] section name it, distinct from the unstaffable warning).
+    let generate_live = gating.generate && can_staff("generate") && config.cas.enabled;
+    let jobs_live = consult_live || batch_live || deliberate_live || generate_live;
 
     [
         (consult_live, "consult"),
@@ -807,6 +864,9 @@ pub(crate) fn live_tools(config: &Config, usable: &[String]) -> Vec<&'static str
         // No cast, no model: the read-only shell is always staffable.
         (gating.run_kaish, "run_kaish"),
         (batch_live, "batch_submit"),
+        // Media generation through the cast's image slot; a deferred operation mints a
+        // `job-N`, so it is a job producer like the three above.
+        (generate_live, "generate"),
         // The collect verbs follow their producers — see the fn doc. "Live" folds the
         // flag AND staffing together, so a producer nothing can staff keeps them no more
         // than a producer the operator switched off does: neither mints a handle.
@@ -925,6 +985,19 @@ impl KaiboHandler {
             );
         }
 
+        // `generate` has a third gate beyond flag + staffing: the media CAS. When the
+        // operator's `[cas] enabled = false` is what holds it back, say that — it is a
+        // different answer than "nothing can staff it", and the [cas] section of
+        // kaibo://config carries the same fact for a live reader.
+        if gating.generate && !config.cas.enabled {
+            tracing::warn!(
+                tools = "generate",
+                "disabled: the media CAS is off ([cas] enabled = false) — an \
+                 artifact-producing tool needs somewhere to store artifacts. Remove the \
+                 flag and reconnect to bring it back."
+            );
+        }
+
         // Which tools actually survive: the operator's flags AND a cast that can staff
         // each. `live_tools` is the single source — `kaibo://config` reports the same
         // decision, so the resource can never describe a surface this router doesn't serve.
@@ -1023,6 +1096,7 @@ impl KaiboHandler {
             resolver,
             // The real network-client builders; tests swap in a scripted double.
             batch_providers: Arc::new(crate::batch::LiveBatchProviders),
+            media_arms: Arc::new(crate::media::LiveMediaArms),
         })
     }
 
@@ -1135,6 +1209,43 @@ impl KaiboHandler {
         self.media_cas.as_ref()
     }
 
+    /// Serve one `kaibo://cas/<digest>` read: the artifact's bytes as a base64 blob
+    /// stamped with its mime. The retrieval half of the `generate` contract — the tool
+    /// returns digests, this resource returns the bytes, and only to the operator
+    /// surface (the MCP client / CLI caller); the inner model team has no path here.
+    /// The digest is validated before it goes anywhere near a lookup
+    /// ([`crate::cas::Digest::from_hex`] — 64 lowercase hex or refused), a missing
+    /// object is a clean not-found, and a corrupt or unreadable object is a loud error,
+    /// never folded into "not found".
+    fn read_cas_resource(&self, hex: &str, uri: &str) -> Result<ReadResourceResponse, McpError> {
+        let Some(store) = &self.media_cas else {
+            return Err(McpError::resource_not_found(
+                "the media CAS is disabled ([cas] enabled = false); no artifacts are held"
+                    .to_string(),
+                None,
+            ));
+        };
+        let digest = crate::cas::Digest::from_hex(hex)
+            .map_err(|e| McpError::invalid_params(format!("{e} (in {uri})"), None))?;
+        match store.get(&digest) {
+            Ok(Some((bytes, ext))) => {
+                use base64::Engine as _;
+                let blob = base64::engine::general_purpose::STANDARD.encode(bytes);
+                Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
+                    vec![ResourceContents::blob(blob, uri).with_mime_type(ext.mime())],
+                )))
+            }
+            Ok(None) => Err(McpError::resource_not_found(
+                format!(
+                    "no artifact with digest {hex} — it was never generated on this \
+                     store, or (in memory mode) it did not survive a restart"
+                ),
+                None,
+            )),
+            Err(e) => Err(McpError::internal_error(format!("{e}"), None)),
+        }
+    }
+
     /// Swap in a batch-provider factory — the seam that lets tests drive the batch
     /// handlers (`batch_submit`, `deliberate`'s batch lane, the `job_*` batch arms) with a
     /// scripted double instead of real network clients. A builder, like
@@ -1145,6 +1256,16 @@ impl KaiboHandler {
         providers: Arc<dyn crate::batch::BatchProviderFactory>,
     ) -> Self {
         self.batch_providers = providers;
+        self
+    }
+
+    /// Swap in a media-arm factory — the seam that lets tests drive the `generate`
+    /// lane (sync store-and-answer, the deferred job, the CAS resource) with a
+    /// scripted [`crate::media::MediaModel`] instead of a real provider client. A
+    /// builder, like [`with_batch_providers`](Self::with_batch_providers).
+    #[cfg(test)]
+    pub fn with_media_arms(mut self, arms: Arc<dyn crate::media::MediaArmFactory>) -> Self {
+        self.media_arms = arms;
         self
     }
 
@@ -2344,6 +2465,146 @@ impl KaiboHandler {
     }
 
     #[tool(
+        description = "Generate an image from a text prompt with the cast's `image` \
+            model (a media backend, e.g. Stability). Bytes are never inlined: each \
+            artifact lands in kaibo's content-addressed media store and the result \
+            lists per-artifact digests — a kaibo://cas/<digest> resource URI, the mime, \
+            the provider's seed, and the real file path when the store is on disk. \
+            Provider-native options (aspect_ratio, output_format, seed, \
+            negative_prompt, style_preset, ...) pass through `fields` verbatim. A \
+            deferred operation returns a `job-N` handle for job_wait/job_get instead. \
+            Provenance (prompt, model, cast, seed) is recorded beside every artifact."
+    )]
+    pub async fn generate(
+        &self,
+        Parameters(input): Parameters<GenerateInput>,
+    ) -> Result<CallToolResult, McpError> {
+        // The route is dropped when the CAS is off, so this arm is a belt for a direct
+        // caller that bypasses the advertised list.
+        let Some(store) = self.media_cas.clone() else {
+            return Err(McpError::invalid_params(
+                "the media CAS is disabled ([cas] enabled = false), so `generate` has \
+                 nowhere to store artifacts. Re-enable it (or remove the flag) and \
+                 reconnect."
+                    .to_string(),
+                None,
+            ));
+        };
+        let cast = self.resolve_cast(input.cast)?;
+        let Some(slot) = cast.slot(ModelRole::Image) else {
+            return Err(McpError::invalid_params(
+                format!(
+                    "cast `{}` has no `image` slot — `generate` needs a cast whose \
+                     `image` slot points at a media backend (kind `stability`). \
+                     kaibo://config lists the configured casts and their slots.",
+                    cast.name
+                ),
+                None,
+            ));
+        };
+        // Slot backend refs are resolved at config load, so a miss here is kaibo's
+        // inconsistency, not the caller's parameter mistake.
+        let backend = self
+            .config
+            .resolve_backend(&slot.backend)
+            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+        // Building the arm resolves the provider key — a missing key is the operator's
+        // setup gap, reported cleanly with the cast and slot named.
+        let arm = self.media_arms.build(backend, slot).map_err(|e| {
+            McpError::invalid_params(format!("cast `{}` image slot: {e:#}", cast.name), None)
+        })?;
+        let request = crate::media::MediaRequest {
+            prompt: input.prompt.clone(),
+            fields: input.fields.unwrap_or_default().into_iter().collect(),
+            input_image: None,
+        };
+        let span = tracing::info_span!("generate", cast = %cast.name, model = %arm.slot_ref());
+        match arm.generate(&request).instrument(span).await {
+            Ok(crate::media::MediaOutcome::Complete(artifacts)) => {
+                let rendered = match store_generated_artifacts(
+                    &store,
+                    &artifacts,
+                    &input.prompt,
+                    arm.slot_ref(),
+                    &cast.name,
+                ) {
+                    Ok(text) => text,
+                    Err(e) => return Ok(consultation_failed("generate", &cast.name, e)),
+                };
+                Ok(CallToolResult::success(vec![ContentBlock::text(
+                    with_provenance(
+                        rendered,
+                        &cast.name,
+                        &[("image", arm.slot_ref())],
+                        &Usage::new(),
+                    ),
+                )]))
+            }
+            // The provider declared this operation deferred: hand back a `job-N` on the
+            // existing collect verbs, with a background task owning the poll cadence.
+            // The lane split follows the operation's DECLARED shape (see
+            // stability::Operation::shape), never a sniffed response.
+            Ok(crate::media::MediaOutcome::Deferred(provider_job)) => {
+                let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
+                let label = format!("generate · cast {} · image {}", cast.name, arm.slot_ref());
+                let prompt = input.prompt.clone();
+                let cast_name = cast.name.clone();
+                let slot_ref = arm.slot_ref().to_string();
+                let deadline = self.config.defaults.call_deadline;
+                let poll_arm = arm.clone();
+                let id = self.jobs.submit(label, progress_log, async move {
+                    let started = tokio::time::Instant::now();
+                    loop {
+                        match poll_arm.poll(&provider_job).await {
+                            Ok(crate::media::MediaPollOutcome::Complete(artifacts)) => {
+                                let text = store_generated_artifacts(
+                                    &store, &artifacts, &prompt, &slot_ref, &cast_name,
+                                )
+                                .map_err(|e| {
+                                    consultation_failure_text("generate", &cast_name, e)
+                                })?;
+                                return Ok(JobResult {
+                                    answer: with_provenance(
+                                        text,
+                                        &cast_name,
+                                        &[("image", &slot_ref)],
+                                        &Usage::new(),
+                                    ),
+                                    report: None,
+                                });
+                            }
+                            Ok(crate::media::MediaPollOutcome::Pending) => {
+                                if started.elapsed() > deadline {
+                                    return Err(format!(
+                                        "still pending after {}s (the call_deadline \
+                                         budget) — provider job id `{}` may still \
+                                         finish on the provider's side, but kaibo has \
+                                         stopped polling it",
+                                        deadline.as_secs(),
+                                        provider_job.0
+                                    ));
+                                }
+                                tokio::time::sleep(GENERATE_POLL_INTERVAL).await;
+                            }
+                            Err(e) => {
+                                return Err(consultation_failure_text("generate", &cast_name, e))
+                            }
+                        }
+                    }
+                });
+                Ok(CallToolResult::success(vec![ContentBlock::text(format!(
+                    "Deferred: `{id}` — the provider is generating in the background \
+                     (cast `{}`, image `{}`). Collect it with `job_get {id}` or park on \
+                     `job_wait`; stop it with `job_cancel {id}`.",
+                    cast.name,
+                    arm.slot_ref()
+                ))]))
+            }
+            Err(e) => Ok(consultation_failed("generate", &cast.name, e)),
+        }
+    }
+
+    #[tool(
         description = "Collect async work by handle — a batch (`backend/provider-id`) \
             or a background job (`job-N`). Returns a progress line while it runs, the \
             full result once done (batches: every item's answer, per-item failures \
@@ -2708,16 +2969,24 @@ impl KaiboHandler {
     }
 
     /// Refuse a `job-N` handle only when no tool that produces one is enabled. A `job-N`
-    /// comes from `consult_submit` OR `deliberate`'s direct lane, so either keeps it
-    /// collectible.
+    /// comes from `consult_submit`, `deliberate`'s direct lane, OR a deferred `generate`,
+    /// so any of the three keeps it collectible.
     fn ensure_consult_enabled(&self, handle: &str) -> Result<(), McpError> {
-        if self.config.tools.consult || self.config.tools.deliberate {
+        // `generate` is judged by route liveness, not its bare flag: the flag defaults
+        // on but the tool only mints a `job-N` when it is actually advertised (a cast
+        // can staff it AND the media CAS is on), and a stock install has neither — the
+        // flag alone would wave every handle through on servers where generate can't run.
+        if self.config.tools.consult
+            || self.config.tools.deliberate
+            || self.tool_router.has_route("generate")
+        {
             return Ok(());
         }
         Err(McpError::invalid_params(
             format!(
                 "`{handle}` looks like a background job (`job-N`), but nothing that \
-                 produces one is enabled on this server (--no-consult --no-deliberate)."
+                 produces one is enabled on this server (--no-consult --no-deliberate \
+                 --no-generate)."
             ),
             None,
         ))
@@ -2791,7 +3060,7 @@ impl rmcp::ServerHandler for KaiboHandler {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
         Ok(ListResourceTemplatesResult {
-            resource_templates: kaibo_resource_templates(),
+            resource_templates: kaibo_resource_templates(self.media_cas.is_some()),
             ..Default::default()
         })
     }
@@ -2801,6 +3070,12 @@ impl rmcp::ServerHandler for KaiboHandler {
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
+        // Generated-artifact reads by digest — handled here, not in the pure dispatch,
+        // because they need the handler's live media store. Operator surface only: MCP
+        // resources reach the client, never the inner model team.
+        if let Some(hex) = request.uri.strip_prefix(CAS_RES_PREFIX) {
+            return self.read_cas_resource(hex, &request.uri);
+        }
         // Compute the runtime-derived worktree set here (it needs the handler's
         // allowed_set and reflects worktrees that exist *now*); the renderer is a
         // pure function of its inputs, so it can't reach back for this itself.
@@ -3105,7 +3380,7 @@ pub(crate) fn configure_prompt_text_cli(goal: Option<&str>) -> String {
 
 /// The URI templates kaibo advertises: per-builtin help and per-cast prompts, each
 /// addressed by name.
-fn kaibo_resource_templates() -> Vec<rmcp::model::ResourceTemplate> {
+fn kaibo_resource_templates(cas_on: bool) -> Vec<rmcp::model::ResourceTemplate> {
     let builtin = ResourceTemplate::new(BUILTIN_URI_TEMPLATE, "kaish builtin help")
         .with_description(
             "Help for a single kaish builtin — parameters and examples. \
@@ -3118,7 +3393,20 @@ fn kaibo_resource_templates() -> Vec<rmcp::model::ResourceTemplate> {
              `preamble`s folded in as a live call resolves them. e.g. kaibo://prompts/deepseek",
         )
         .with_mime_type("text/markdown");
-    vec![builtin, prompts]
+    let mut templates = vec![builtin, prompts];
+    // Advertised only while a media store exists — a template whose every read would
+    // error is the resource-shaped version of the unstaffable-tool lie the staffing
+    // gate exists to prevent.
+    if cas_on {
+        templates.push(
+            ResourceTemplate::new(CAS_URI_TEMPLATE, "kaibo: generated artifact by digest")
+                .with_description(
+                    "One generated artifact's bytes, addressed by the content digest a \
+                     `generate` result returned (64 lowercase hex).",
+                ),
+        );
+    }
+    templates
 }
 
 /// Render the markdown body for a kaibo resource URI, or `None` if the URI isn't
@@ -3285,6 +3573,19 @@ This is a fire-and-forget lane. Submit, then go do other work — don't sit in a
 poll/sleep loop holding your turn open. `job_wait` when you're ready to spend a minute;
 `job_get`/`job_list` are the source of truth. Nothing here wakes you, and nothing is lost
 by waiting — the handles keep.
+
+## Generate media: `generate`
+
+`generate` turns a text prompt into an image through the cast's `image` slot (a media
+backend such as Stability). It is advertised only when a configured cast carries that
+slot and the media CAS is on. The result is never inline bytes: each artifact lands in
+kaibo's content-addressed store and you get its digest as a `kaibo://cas/<digest>`
+resource URI (read it as an MCP resource for the bytes), the mime, the provider's seed,
+and — when the store is on disk — the real file path. Provider-native options ride the
+`fields` object verbatim (Stability: `aspect_ratio` \"16:9\", `output_format`
+png|jpeg|webp, `seed`, `negative_prompt`, `style_preset`). A deferred operation hands
+back a `job-N` on the same collect verbs above. Every artifact gets a provenance sidecar
+(prompt, model, cast, timestamp, mime, seed) beside it in the store.
 
 ## Driving the read-only shell (`run_kaish`)
 
@@ -3459,6 +3760,73 @@ fn render_prompts_resource(config: &Config, cast: Option<&Cast>) -> String {
         out.push_str("\n```\n");
     }
     out
+}
+
+/// How often a deferred `generate` job re-polls its provider. The provider owns no
+/// cadence (`MediaModel::poll` is one shot by contract); this background job does,
+/// bounded overall by `[defaults] call_deadline`.
+const GENERATE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Store every artifact of one completed generation in the media store and render the
+/// per-artifact result lines: `kaibo://cas/<digest>`, the mime, the provider seed when
+/// reported, and the real file path in disk mode. One provenance sidecar per artifact
+/// (each has its own digest — the one-to-many consequence of
+/// [`crate::media::MediaOutcome::Complete`] carrying a list). An empty list is refused:
+/// a provider reporting success with nothing attached is that provider's bug, surfaced
+/// loudly rather than rendered as an empty success.
+fn store_generated_artifacts(
+    store: &crate::cas::MediaStore,
+    artifacts: &[crate::media::MediaArtifact],
+    prompt: &str,
+    model: &str,
+    cast: &str,
+) -> Result<String> {
+    use anyhow::{anyhow, ensure};
+    ensure!(
+        !artifacts.is_empty(),
+        "the provider reported a completed generation with zero artifacts"
+    );
+    let timestamp = now_epoch_secs();
+    let mut lines = vec![format!(
+        "Generated {} artifact{}:",
+        artifacts.len(),
+        if artifacts.len() == 1 { "" } else { "s" }
+    )];
+    for (i, artifact) in artifacts.iter().enumerate() {
+        // The mime must map onto the CAS's closed on-disk set — an unknown format is
+        // refused rather than written under an invented extension (the same argument
+        // stability::MediaType::to_cas_extension records at length).
+        let ext = crate::cas::Extension::from_mime(&artifact.mime).ok_or_else(|| {
+            anyhow!(
+                "artifact {} has mime {:?}, which the media store cannot name on disk \
+                 yet — refusing to store it under an invented extension",
+                i + 1,
+                artifact.mime
+            )
+        })?;
+        let provenance = crate::cas::Provenance {
+            prompt: prompt.to_string(),
+            model: model.to_string(),
+            cast: cast.to_string(),
+            timestamp,
+            mime: artifact.mime.clone(),
+            seed: artifact.seed.clone(),
+        };
+        let digest = store
+            .put(&artifact.bytes, ext, &provenance)
+            .map_err(|e| anyhow!("storing artifact {}: {e}", i + 1))?;
+        let hex = digest.to_hex();
+        let mut line = format!("{}. {CAS_RES_PREFIX}{hex} ({}", i + 1, artifact.mime);
+        if let Some(seed) = &artifact.seed {
+            line.push_str(&format!(", seed {seed}"));
+        }
+        line.push(')');
+        if let Some(path) = store.path_for(&digest) {
+            line.push_str(&format!("\n   path: {}", path.display()));
+        }
+        lines.push(line);
+    }
+    Ok(lines.join("\n"))
 }
 
 /// Read one kaibo resource by URI, with the runtime config and allowed set threaded
@@ -4070,6 +4438,343 @@ mod tests {
         );
     }
 
+    // --- The generate lane, driven offline through the media-arm seam -----------
+
+    /// A cast that can staff `generate`: a keyless (placeholder-credential) stability
+    /// backend plus an image-only cast. The scripted factory below never dials it.
+    const MEDIA_CAST_TOML: &str = r#"
+        [backends.sd]
+        kind = "stability"
+        key_optional = true
+
+        [casts.artist]
+        image = "sd/core"
+    "#;
+
+    /// A factory handing every build the same scripted [`crate::media::MediaModel`] —
+    /// the offline double for the whole generate lane (CAS writes, job lane, render).
+    struct ScriptedMediaArms(Arc<dyn crate::media::MediaModel>);
+
+    impl crate::media::MediaArmFactory for ScriptedMediaArms {
+        fn build(
+            &self,
+            _backend: &Backend,
+            slot: &ModelSlot,
+        ) -> anyhow::Result<crate::media::MediaArm> {
+            Ok(crate::media::MediaArm::new(
+                self.0.clone(),
+                slot.qualified(),
+            ))
+        }
+    }
+
+    /// Completes synchronously with a fixed artifact list.
+    struct SyncArtifacts(Vec<crate::media::MediaArtifact>);
+
+    #[async_trait::async_trait]
+    impl crate::media::MediaModel for SyncArtifacts {
+        async fn generate(
+            &self,
+            _request: &crate::media::MediaRequest,
+        ) -> anyhow::Result<crate::media::MediaOutcome> {
+            Ok(crate::media::MediaOutcome::Complete(self.0.clone()))
+        }
+
+        async fn poll(
+            &self,
+            _job: &crate::media::MediaJobId,
+        ) -> anyhow::Result<crate::media::MediaPollOutcome> {
+            unreachable!("a sync generation is never polled")
+        }
+    }
+
+    /// Defers on generate; the poll is pending once, then completes.
+    struct DeferredArtifacts {
+        artifacts: Vec<crate::media::MediaArtifact>,
+        polls: std::sync::Mutex<usize>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::media::MediaModel for DeferredArtifacts {
+        async fn generate(
+            &self,
+            _request: &crate::media::MediaRequest,
+        ) -> anyhow::Result<crate::media::MediaOutcome> {
+            Ok(crate::media::MediaOutcome::Deferred(
+                crate::media::MediaJobId("prov-77".to_string()),
+            ))
+        }
+
+        async fn poll(
+            &self,
+            job: &crate::media::MediaJobId,
+        ) -> anyhow::Result<crate::media::MediaPollOutcome> {
+            assert_eq!(job.0, "prov-77", "the provider id round-trips to the poll");
+            let mut n = self.polls.lock().unwrap();
+            *n += 1;
+            Ok(if *n == 1 {
+                crate::media::MediaPollOutcome::Pending
+            } else {
+                crate::media::MediaPollOutcome::Complete(self.artifacts.clone())
+            })
+        }
+    }
+
+    fn png(bytes: &[u8]) -> crate::media::MediaArtifact {
+        crate::media::MediaArtifact {
+            bytes: bytes.to_vec(),
+            mime: "image/png".to_string(),
+            seed: Some("42".to_string()),
+        }
+    }
+
+    fn media_handler(model: Arc<dyn crate::media::MediaModel>) -> KaiboHandler {
+        hermetic_handler_from_toml(MEDIA_CAST_TOML)
+            .with_media_arms(Arc::new(ScriptedMediaArms(model)))
+    }
+
+    /// The sync lane: a completed generation stores EVERY artifact in the media store
+    /// (its own digest and provenance each — the one-to-many contract) and answers with
+    /// per-artifact `kaibo://cas/<digest>` URIs, never inline bytes. Memory mode, so no
+    /// `path:` lines.
+    #[tokio::test]
+    async fn generate_stores_every_artifact_and_returns_digests() {
+        let a1 = png(b"first-artifact");
+        let mut a2 = png(b"second-artifact");
+        a2.mime = "image/webp".to_string();
+        a2.seed = None;
+        let h = media_handler(Arc::new(SyncArtifacts(vec![a1.clone(), a2.clone()])));
+        let result = h
+            .generate(Parameters(GenerateInput {
+                prompt: "a lighthouse at dusk".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect("generate succeeds");
+        assert_ne!(result.is_error, Some(true), "not a tool error");
+        let text = result_text(result);
+
+        let store = h.media_store().expect("cas on");
+        for (artifact, ext) in [
+            (&a1, crate::cas::Extension::Png),
+            (&a2, crate::cas::Extension::Webp),
+        ] {
+            let digest = crate::cas::Digest::of_bytes(&artifact.bytes);
+            assert!(
+                text.contains(&format!("kaibo://cas/{}", digest.to_hex())),
+                "the answer names each artifact's digest URI:\n{text}"
+            );
+            assert_eq!(
+                store.get(&digest).expect("readable"),
+                Some((artifact.bytes.clone(), ext)),
+                "the bytes are in the store under their own digest"
+            );
+        }
+        assert!(
+            text.contains("seed 42"),
+            "the provider seed is echoed:\n{text}"
+        );
+        assert!(
+            !text.contains("path:"),
+            "memory mode has no filesystem path to name:\n{text}"
+        );
+        assert!(
+            text.contains("cast `artist`") && text.contains("sd/core"),
+            "the provenance footer names the cast and image model:\n{text}"
+        );
+    }
+
+    /// Provenance sidecars are per-artifact: the prompt, the image slot ref, the cast,
+    /// the mime, and the provider seed all land beside the object.
+    #[tokio::test]
+    async fn generate_records_provenance_beside_each_artifact() {
+        let artifact = png(b"provenanced");
+        let h = media_handler(Arc::new(SyncArtifacts(vec![artifact.clone()])));
+        h.generate(Parameters(GenerateInput {
+            prompt: "a red door".to_string(),
+            cast: Some("artist".to_string()),
+            fields: None,
+        }))
+        .await
+        .expect("generate succeeds");
+
+        let digest = crate::cas::Digest::of_bytes(&artifact.bytes);
+        let Some(crate::cas::MediaStore::Memory(mem)) = h.media_store().map(Arc::as_ref) else {
+            panic!("test handler holds the in-memory store");
+        };
+        let prov = mem.provenance(&digest).expect("sidecar recorded");
+        assert_eq!(prov.prompt, "a red door");
+        assert_eq!(prov.model, "sd/core");
+        assert_eq!(prov.cast, "artist");
+        assert_eq!(prov.mime, "image/png");
+        assert_eq!(prov.seed.as_deref(), Some("42"));
+    }
+
+    /// The deferred lane: the declared-deferred outcome becomes a `job-N` on the
+    /// existing collect verbs; the background task owns the poll cadence
+    /// (pending → sleep → complete) and the finished job's answer carries the digest
+    /// URIs, with the artifacts landed in the store. `start_paused` auto-advances the
+    /// poll interval's sleep.
+    #[tokio::test(start_paused = true)]
+    async fn generate_deferred_returns_a_job_that_collects_digests() {
+        let artifact = png(b"deferred-artifact");
+        let h = media_handler(Arc::new(DeferredArtifacts {
+            artifacts: vec![artifact.clone()],
+            polls: std::sync::Mutex::new(0),
+        }));
+        let result = h
+            .generate(Parameters(GenerateInput {
+                prompt: "slow art".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect("submit succeeds");
+        let ack = result_text(result);
+        assert!(
+            ack.contains("job-") && ack.contains("job_get"),
+            "the ack hands back a job handle and the collect verb:\n{ack}"
+        );
+        let handle = ack
+            .split('`')
+            .nth(1)
+            .expect("the handle is backticked")
+            .to_string();
+
+        let digest = crate::cas::Digest::of_bytes(&artifact.bytes);
+        let mut answer = String::new();
+        for _ in 0..60 {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let r = h
+                .job_get(Parameters(HandleInput {
+                    handle: handle.clone(),
+                }))
+                .await
+                .expect("job_get answers");
+            let text = result_text(r);
+            if text.contains("kaibo://cas/") {
+                answer = text;
+                break;
+            }
+        }
+        assert!(
+            answer.contains(&format!("kaibo://cas/{}", digest.to_hex())),
+            "the finished job names the artifact's digest URI:\n{answer}"
+        );
+        assert_eq!(
+            h.media_store().unwrap().get(&digest).expect("readable"),
+            Some((artifact.bytes.clone(), crate::cas::Extension::Png)),
+            "the deferred artifact landed in the store"
+        );
+    }
+
+    /// A cast without an `image` slot is refused at call time with the requirement
+    /// named — the call-time mirror of the staffing rule.
+    #[tokio::test]
+    async fn generate_refuses_a_cast_without_an_image_slot() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![png(b"x")])));
+        let err = h
+            .generate(Parameters(GenerateInput {
+                prompt: "p".to_string(),
+                cast: Some("anthropic".to_string()),
+                fields: None,
+            }))
+            .await
+            .expect_err("no image slot must refuse");
+        assert!(
+            err.message.contains("image") && err.message.contains("anthropic"),
+            "the refusal names the missing slot and the cast, got: {}",
+            err.message
+        );
+    }
+
+    /// The advertisement gate, all three legs: no image-slot cast → dropped; staffable
+    /// → advertised (and the job verbs come alive with it, since a deferred generate
+    /// mints a `job-N`); staffable but `[cas] enabled = false` → dropped again, because
+    /// artifacts would have nowhere to land.
+    #[test]
+    fn generate_is_advertised_only_with_an_image_cast_and_the_cas_on() {
+        let bare = hermetic_handler_from_toml("");
+        assert!(
+            !bare.advertised_tools().contains(&"generate".to_string()),
+            "no built-in cast has an image slot, so a stock install must not advertise it"
+        );
+
+        let staffed = hermetic_handler_from_toml(MEDIA_CAST_TOML);
+        let tools = staffed.advertised_tools();
+        assert!(tools.contains(&"generate".to_string()));
+        assert!(
+            tools.contains(&"job_get".to_string()) && tools.contains(&"job_wait".to_string()),
+            "generate is a job producer, so the collect verbs follow it: {tools:?}"
+        );
+
+        let cas_off = hermetic_handler_from_toml(&format!(
+            "{MEDIA_CAST_TOML}
+[cas]
+enabled = false
+"
+        ));
+        assert!(
+            !cas_off.advertised_tools().contains(&"generate".to_string()),
+            "with the CAS off the tool has nowhere to store artifacts and must vanish"
+        );
+    }
+
+    /// The `kaibo://cas/<digest>` read: bytes come back base64 with the right mime, an
+    /// unknown digest is a clean not-found, and a malformed digest is refused before it
+    /// goes near a lookup. Operator surface — served straight off the handler's store.
+    #[tokio::test]
+    async fn cas_resource_serves_stored_bytes_and_validates_the_digest() {
+        use base64::Engine as _;
+        let h = media_handler(Arc::new(SyncArtifacts(vec![png(b"resource-bytes")])));
+        h.generate(Parameters(GenerateInput {
+            prompt: "p".to_string(),
+            cast: Some("artist".to_string()),
+            fields: None,
+        }))
+        .await
+        .expect("generate succeeds");
+
+        let digest = crate::cas::Digest::of_bytes(b"resource-bytes");
+        let hex = digest.to_hex();
+        let uri = format!("kaibo://cas/{hex}");
+        let ReadResourceResponse::Complete(result) = h
+            .read_cas_resource(&hex, &uri)
+            .expect("stored digest reads")
+        else {
+            panic!("expected a complete read");
+        };
+        let ResourceContents::BlobResourceContents {
+            blob, mime_type, ..
+        } = &result.contents[0]
+        else {
+            panic!("an artifact read is a blob, got {:?}", result.contents[0]);
+        };
+        assert_eq!(mime_type.as_deref(), Some("image/png"));
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(blob)
+                .expect("valid base64"),
+            b"resource-bytes"
+        );
+
+        let missing = crate::cas::Digest::of_bytes(b"never-generated").to_hex();
+        let err = h
+            .read_cas_resource(&missing, &format!("kaibo://cas/{missing}"))
+            .expect_err("unknown digest is not found");
+        assert!(err.message.contains("no artifact"), "got: {}", err.message);
+
+        let err = h
+            .read_cas_resource("../../etc/passwd", "kaibo://cas/../../etc/passwd")
+            .expect_err("a traversal-shaped digest is refused");
+        assert!(
+            err.message.contains("64 lowercase hex"),
+            "the refusal names the rule, got: {}",
+            err.message
+        );
+    }
+
     /// The joined text of a successful `CallToolResult` — for asserting on a handler's
     /// reply message.
     fn result_text(r: CallToolResult) -> String {
@@ -4306,6 +5011,13 @@ mod tests {
 
             [casts.mydirect_synthonly]                         # offline, no explorer → no tool
             synth    = { backend = "gem", id = "big", lane = "direct" }
+
+            [backends.sd]                                      # media backend for `generate`
+            kind = "stability"
+            key_optional = true
+
+            [casts.artist]                                     # image slot → `generate`
+            image    = "sd/core"
             "#,
         );
         let enum_of = |tool: &str| -> Vec<String> {
@@ -4335,6 +5047,9 @@ mod tests {
                 "explore" => true,
                 "batch_submit" => h.require_batch_cast(cast).is_ok(),
                 "deliberate" => h.require_deliberate_cast(cast).is_ok(),
+                // `generate`'s call-time gate is the image slot's presence — the same
+                // predicate the enum rule uses, checked here through the cast itself.
+                "generate" => cast.slot(crate::config::ModelRole::Image).is_some(),
                 other => panic!("unmapped cast-taking tool `{other}` — add its gate here"),
             }
         };
@@ -4699,6 +5414,7 @@ mod tests {
                 oneshot: true,
                 run_kaish: true,
                 list_models: true,
+                generate: false,
             };
             KaiboHandler::new(config).expect("handler builds")
         };
@@ -5364,7 +6080,7 @@ mod tests {
 
     #[test]
     fn advertises_the_per_builtin_template() {
-        let templates = kaibo_resource_templates();
+        let templates = kaibo_resource_templates(true);
         assert!(
             templates
                 .iter()
@@ -5797,7 +6513,7 @@ mod tests {
     /// message names the known casts (so a caller recovers to a real cast name).
     #[test]
     fn per_cast_prompts_template_advertised_and_unknown_cast_is_not_found() {
-        let templates: Vec<String> = kaibo_resource_templates()
+        let templates: Vec<String> = kaibo_resource_templates(true)
             .into_iter()
             .map(|t| t.uri_template)
             .collect();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,12 +21,13 @@ use rig_core::completion::Usage;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolResult, ContentBlock, GetPromptRequestParams, GetPromptResponse, Implementation,
-    JsonObject, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult, LoggingLevel,
-    MetaObject, PaginatedRequestParams, ProgressNotificationParam, ProgressToken, Prompt, PromptArgument,
-    PromptMessage, ProtocolVersion, ReadResourceRequestParams, ReadResourceResult,
-    ReadResourceResponse, RequestMetaObject, ResourceContents, Resource, ResourceTemplate, Role,
-    ServerCapabilities, ServerInfo, SetLevelRequestParams, GetPromptResult,
+    CallToolResult, ContentBlock, GetPromptRequestParams, GetPromptResponse, GetPromptResult,
+    Implementation, JsonObject, ListPromptsResult, ListResourceTemplatesResult,
+    ListResourcesResult, LoggingLevel, MetaObject, PaginatedRequestParams,
+    ProgressNotificationParam, ProgressToken, Prompt, PromptArgument, PromptMessage,
+    ProtocolVersion, ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult,
+    RequestMetaObject, Resource, ResourceContents, ResourceTemplate, Role, ServerCapabilities,
+    ServerInfo, SetLevelRequestParams,
 };
 use rmcp::schemars::{self, JsonSchema};
 use rmcp::service::{Peer, RequestContext};
@@ -628,6 +629,13 @@ pub struct KaiboHandler {
     /// [`with_batch_providers`](Self::with_batch_providers) to exercise the submit/poll
     /// handler wiring offline. `Arc<dyn …>` so the derived `Clone` shares one factory.
     batch_providers: Arc<dyn crate::batch::BatchProviderFactory>,
+    /// The media CAS, in whichever mode the lifecycle resolved (see
+    /// [`Config::cas_mode`]): `None` when `[cas] enabled = false`. `new` seeds the
+    /// in-memory store (mirroring how sessions start in-memory);
+    /// [`finalize_media_store`](Self::finalize_media_store) upgrades it to the disk
+    /// store once `main` knows whether persistence actually came up. `Arc` so
+    /// per-request handler clones share one store.
+    media_cas: Option<Arc<crate::cas::MediaStore>>,
 }
 
 /// One `CAST_ENUM_RULES` entry: the tools sharing a cast eligibility, the predicate
@@ -991,8 +999,18 @@ impl KaiboHandler {
         // same allocation) for its many `self.config` uses.
         let config = Arc::new(config);
         let resolver = Resolver::from_config(config.clone())?;
+        // The media CAS starts in-memory when enabled — the same posture sessions take
+        // (memory until `main` proves durable state is really available). `main` calls
+        // `finalize_media_store` to upgrade to disk / warn / keep it off; a handler
+        // built for a test that never finalizes holds a working in-memory store.
+        let media_cas = config.cas.enabled.then(|| {
+            Arc::new(crate::cas::MediaStore::Memory(crate::cas::MemoryCas::new(
+                config.cas.max_bytes,
+            )))
+        });
         Ok(Self {
             config,
+            media_cas,
             tool_router,
             tool_schemas: Arc::new(builtin_schemas()?),
             sessions,
@@ -1032,6 +1050,89 @@ impl KaiboHandler {
     pub fn with_session_store(mut self, store: crate::store::SessionStore) -> Self {
         self.sessions = Sessions::Persistent(store);
         self
+    }
+
+    /// Settle the media CAS into its final mode, once `main` knows whether persistence
+    /// actually came up — the runtime half of [`Config::cas_mode`]'s derivation
+    /// (Amy's lifecycle ruling: on and disk-backed while persistence is; on but
+    /// in-memory when it's not; `[cas] enabled = false` turns it off).
+    ///
+    /// - **Disk**: open the store at the fixed XDG data dir (never a model-suppliable
+    ///   path), containment-checked against the resolved allowed set. An open failure is
+    ///   a LOUD startup error — crash over a silent fallback to memory, mirroring the
+    ///   session store's posture.
+    /// - **Memory**: keep the in-memory store `new` seeded, and warn SEVERELY: the
+    ///   operator is paying provider credits for artifacts that will not survive a
+    ///   restart, and must hear that at startup, not discover it after one.
+    /// - **Off**: the operator's explicit choice; say so once at info, nothing to build.
+    pub fn finalize_media_store(mut self, persistence_active: bool) -> Result<Self> {
+        match self.config.cas_mode(persistence_active) {
+            crate::config::CasMode::Off => {
+                tracing::info!(
+                    "media CAS disabled ([cas] enabled = false) — artifact-producing tools \
+                     are not advertised"
+                );
+                self.media_cas = None;
+            }
+            crate::config::CasMode::Memory => {
+                let why = if self.config.cas.dir.is_none() {
+                    "no CAS directory resolves (neither $XDG_DATA_HOME nor $HOME is set)"
+                } else {
+                    "persistence is not active this run"
+                };
+                tracing::warn!(
+                    "MEDIA CAS IS IN-MEMORY ONLY: {why}. Generated artifacts are fetchable \
+                     by digest for THIS RUN ONLY and will NOT survive a restart — they cost \
+                     real provider credits and may not be reproducible. kaibo://config shows \
+                     [cas] mode = \"memory\". To store artifacts durably, run with \
+                     persistence enabled (and a resolvable $XDG_DATA_HOME or $HOME)."
+                );
+                // `new` already seeded the in-memory store; nothing to swap.
+            }
+            crate::config::CasMode::Disk => {
+                let dir = self
+                    .config
+                    .cas
+                    .dir
+                    .clone()
+                    .expect("CasMode::Disk implies a resolved dir");
+                let allowed = self.allowed_set();
+                let allowed_refs: Vec<&std::path::Path> =
+                    allowed.iter().map(PathBuf::as_path).collect();
+                let cas = crate::cas::Cas::open(&dir, &allowed_refs, self.config.cas.max_bytes)
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "failed to open the media CAS at {}: {e}\nkaibo never \
+                                 invents a different path and never falls back silently to \
+                                 memory. Point [cas] dir somewhere outside every allowed \
+                                 tree, or set [cas] enabled = false to run without it.",
+                            dir.display()
+                        )
+                    })?;
+                tracing::info!(
+                    cas_dir = %dir.display(),
+                    "media CAS on disk — generated artifacts are durable across restarts"
+                );
+                self.media_cas = Some(Arc::new(crate::cas::MediaStore::Disk(cas)));
+            }
+        }
+        Ok(self)
+    }
+
+    /// The mode the handler's media store is *actually* in right now — what the
+    /// `kaibo://config` render reports. Derived from the live field, not re-derived
+    /// from config, so the resource can never describe a store the handler doesn't hold.
+    fn live_cas_mode(&self) -> crate::config::CasMode {
+        match self.media_cas.as_deref() {
+            None => crate::config::CasMode::Off,
+            Some(crate::cas::MediaStore::Disk(_)) => crate::config::CasMode::Disk,
+            Some(crate::cas::MediaStore::Memory(_)) => crate::config::CasMode::Memory,
+        }
+    }
+
+    /// The live media store, if the CAS is enabled — for tests and diagnostics.
+    pub fn media_store(&self) -> Option<&Arc<crate::cas::MediaStore>> {
+        self.media_cas.as_ref()
     }
 
     /// Swap in a batch-provider factory — the seam that lets tests drive the batch
@@ -2003,9 +2104,9 @@ impl KaiboHandler {
             .await
             .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
 
-        Ok(CallToolResult::success(vec![ContentBlock::text(format_output(
-            &out,
-        ))]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(
+            format_output(&out),
+        )]))
     }
 
     #[tool(
@@ -2035,8 +2136,10 @@ impl KaiboHandler {
             None => self.config.backends.keys().cloned().collect(),
         };
 
-        let mut results: std::collections::BTreeMap<String, Result<Vec<crate::discover::DiscoveredModel>, String>> =
-            std::collections::BTreeMap::new();
+        let mut results: std::collections::BTreeMap<
+            String,
+            Result<Vec<crate::discover::DiscoveredModel>, String>,
+        > = std::collections::BTreeMap::new();
         for name in names {
             // A backend resolved above always resolves again here (nothing mutates
             // the registry mid-call); skip defensively rather than panic if that
@@ -2582,12 +2685,9 @@ impl KaiboHandler {
             batch_lines.push(line);
         }
 
-        Ok(CallToolResult::success(vec![ContentBlock::text(render_wait(
-            &records,
-            &batch_lines,
-            &self.jobs,
-            timeout,
-        ))]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(
+            render_wait(&records, &batch_lines, &self.jobs, timeout),
+        )]))
     }
 
     /// Refuse a batch-shaped handle only when *no tool that produces one* is enabled —
@@ -2643,8 +2743,7 @@ impl rmcp::ServerHandler for KaiboHandler {
         )
         // Identify as kaibo, not rmcp (from_build_env reports the rmcp crate).
         .with_server_info(
-            Implementation::new("kaibo", env!("CARGO_PKG_VERSION"))
-                .with_title("kaibo"),
+            Implementation::new("kaibo", env!("CARGO_PKG_VERSION")).with_title("kaibo"),
         )
         .with_protocol_version(ProtocolVersion::LATEST)
         // Judge provider usability from the live environment so a fresh install
@@ -2714,6 +2813,7 @@ impl rmcp::ServerHandler for KaiboHandler {
             self.resolver.default_root_inferred(),
             self.followed_worktrees(),
             self.sessions.store().is_some(),
+            self.live_cas_mode(),
         )
     }
 
@@ -2733,7 +2833,8 @@ impl rmcp::ServerHandler for KaiboHandler {
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<GetPromptResponse, McpError> {
-        kaibo_prompt_messages(&request.name, request.arguments.as_ref()).map(GetPromptResponse::Complete)
+        kaibo_prompt_messages(&request.name, request.arguments.as_ref())
+            .map(GetPromptResponse::Complete)
     }
 }
 
@@ -2948,12 +3049,14 @@ fn kaibo_prompt_messages(
             // Blank/whitespace-vs-absent is normalized in `append_configure_goal` (the
             // one gate both this MCP path and the CLI's `run_configure` go through), so
             // this just extracts the raw value.
-            let goal = arguments.and_then(|a| a.get("goal")).and_then(|v| v.as_str());
+            let goal = arguments
+                .and_then(|a| a.get("goal"))
+                .and_then(|v| v.as_str());
             Ok(GetPromptResult::new(vec![PromptMessage::new_text(
-                    Role::User,
-                    configure_prompt_text(goal),
-                )])
-                .with_description("Configure kaibo's models for this codebase"))
+                Role::User,
+                configure_prompt_text(goal),
+            )])
+            .with_description("Configure kaibo's models for this codebase"))
         }
         other => Err(McpError::invalid_params(
             format!("unknown prompt {other:?}; kaibo offers: {CONFIGURE_PROMPT_NAME}"),
@@ -3377,14 +3480,15 @@ fn read_kaibo_resource_with_config(
     default_root_inferred: bool,
     followed_worktrees: Vec<PathBuf>,
     persistence_active: bool,
+    cas_mode: crate::config::CasMode,
 ) -> Result<ReadResourceResponse, McpError> {
     if uri == PROMPTS_URI {
-        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(vec![
-            ResourceContents::text(
+        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
+            vec![ResourceContents::text(
                 render_prompts_resource(config, None),
                 uri,
-            ),
-        ])));
+            )],
+        )));
     }
     if let Some(name) = uri.strip_prefix(PROMPTS_CAST_PREFIX) {
         // `kaibo://prompts/<cast>` — the cast's resolved framing (name or alias). An
@@ -3393,12 +3497,12 @@ fn read_kaibo_resource_with_config(
         let cast = config
             .resolve_cast(name)
             .map_err(|e| McpError::resource_not_found(format!("{e:#} (in {uri})"), None))?;
-        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(vec![
-            ResourceContents::text(
+        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
+            vec![ResourceContents::text(
                 render_prompts_resource(config, Some(cast)),
                 uri,
-            ),
-        ])));
+            )],
+        )));
     }
     if uri == CONFIG_URI {
         let body = render_config_resource(
@@ -3408,22 +3512,23 @@ fn read_kaibo_resource_with_config(
             default_root_inferred,
             followed_worktrees,
             persistence_active,
+            cas_mode,
         );
-        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(vec![
-            ResourceContents::text(body, uri),
-        ])));
+        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
+            vec![ResourceContents::text(body, uri)],
+        )));
     }
     if uri == CONFIG_EXAMPLE_URI {
         // Static, config-independent — the embedded template verbatim.
-        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(vec![
-            ResourceContents::text(CONFIG_EXAMPLE_TOML, uri),
-        ])));
+        return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
+            vec![ResourceContents::text(CONFIG_EXAMPLE_TOML, uri)],
+        )));
     }
     let body = render_resource(uri, schemas)
         .ok_or_else(|| McpError::resource_not_found(format!("unknown resource: {uri}"), None))?;
-    Ok(ReadResourceResponse::Complete(ReadResourceResult::new(vec![
-        ResourceContents::text(body, uri),
-    ])))
+    Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
+        vec![ResourceContents::text(body, uri)],
+    )))
 }
 
 /// The MCP token the client attached for progress, if any. Per the spec, progress
@@ -3502,7 +3607,7 @@ impl ProgressSink for ProgressReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::{NumberOrString, ContentBlock};
+    use rmcp::model::{ContentBlock, NumberOrString};
     use rmcp::ServerHandler;
     use serde_json::json;
 
@@ -3900,11 +4005,69 @@ mod tests {
     /// want a usable cast declare a `key_optional = true` backend (no credential needed);
     /// everything else resolves to `Unconfigured` and drops out.
     fn hermetic_handler_from_toml(toml: &str) -> KaiboHandler {
-        KaiboHandler::new_with_env(
-            Config::from_toml_str(toml).expect("config parses"),
-            |_| None,
-        )
+        KaiboHandler::new_with_env(Config::from_toml_str(toml).expect("config parses"), |_| {
+            None
+        })
         .expect("handler builds")
+    }
+
+    /// The media-CAS lifecycle on the handler: `new` seeds the in-memory store when
+    /// the CAS is enabled (mirroring sessions-start-in-memory) and holds nothing when
+    /// `[cas] enabled = false`; `finalize_media_store` upgrades to disk exactly when
+    /// persistence is active, keeps memory when it is not, and refuses a CAS dir
+    /// inside an allowed tree the same way the session store does.
+    #[test]
+    fn media_store_lifecycle_memory_disk_and_off() {
+        use crate::config::CasMode;
+
+        // Enabled (default): a working in-memory store from construction.
+        let h = handler();
+        assert_eq!(h.live_cas_mode(), CasMode::Memory);
+        assert!(h.media_store().is_some());
+
+        // Explicitly disabled: no store at all.
+        let off = handler_from_toml("[cas]\nenabled = false\n");
+        assert_eq!(off.live_cas_mode(), CasMode::Off);
+        assert!(off.media_store().is_none());
+        // Finalize keeps it off even with persistence active — the off switch wins.
+        let off = off.finalize_media_store(true).expect("finalize");
+        assert_eq!(off.live_cas_mode(), CasMode::Off);
+
+        // Persistence inactive: finalize keeps the in-memory store (the warned mode).
+        let h = handler().finalize_media_store(false).expect("finalize");
+        assert_eq!(h.live_cas_mode(), CasMode::Memory);
+
+        // Persistence active + a dir outside every allowed tree: disk, rooted there.
+        let cas_dir = tempfile::tempdir().unwrap();
+        let toml = format!("[cas]\ndir = \"{}\"\n", cas_dir.path().display());
+        let h = handler_from_toml(&toml)
+            .finalize_media_store(true)
+            .expect("finalize opens the disk store");
+        assert_eq!(h.live_cas_mode(), CasMode::Disk);
+        assert_eq!(
+            h.media_store().unwrap().root().unwrap(),
+            cas_dir.path(),
+            "the disk store roots at the configured dir"
+        );
+    }
+
+    /// A CAS dir that resolves inside an allowed project tree is refused at finalize —
+    /// loudly, with the escape hatches named — never opened and never silently moved.
+    #[test]
+    fn media_store_refuses_a_cas_dir_inside_an_allowed_tree() {
+        let root = tempfile::tempdir().unwrap();
+        let toml = format!(
+            "[server]\nroot = \"{r}\"\n[cas]\ndir = \"{r}/cas\"\n",
+            r = root.path().display()
+        );
+        let Err(err) = handler_from_toml(&toml).finalize_media_store(true) else {
+            panic!("a CAS inside the project must be refused");
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("media CAS") && msg.contains("enabled = false"),
+            "the error names the store and an escape hatch, got: {msg}"
+        );
     }
 
     /// The joined text of a successful `CallToolResult` — for asserting on a handler's
@@ -5427,6 +5590,7 @@ mod tests {
             false,
             vec![],
             false,
+            crate::config::CasMode::Memory,
         )
         .expect("known uri must read");
         let result = match result {
@@ -5652,6 +5816,7 @@ mod tests {
             false,
             vec![],
             false,
+            crate::config::CasMode::Memory,
         )
         .expect_err("an unknown cast must be a not-found");
         assert!(
@@ -5681,6 +5846,7 @@ mod tests {
                 false,
                 vec![],
                 false,
+                crate::config::CasMode::Memory,
             )
             .is_err(),
             "an unregistered builtin must be a not-found error"
@@ -5701,6 +5867,7 @@ mod tests {
                 false,
                 vec![],
                 false,
+                crate::config::CasMode::Memory,
             )
             .is_err(),
             "an unknown URI must be a not-found error, not an empty success"
@@ -5732,6 +5899,7 @@ mod tests {
             false,
             vec![],
             false,
+            crate::config::CasMode::Memory,
         )
         .expect("example resource must be readable");
         let result = match result {
@@ -5826,7 +5994,15 @@ mod tests {
     fn read_kaibo_config_resource_is_readable() {
         let config = Config::builtin();
         let allowed = handler().allowed_set();
-        let body_str = render_config_resource(&config, &allowed, None, false, vec![], false);
+        let body_str = render_config_resource(
+            &config,
+            &allowed,
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
         // Sanity: the rendered document has something in it.
         assert!(
             !body_str.is_empty(),
@@ -5842,6 +6018,7 @@ mod tests {
             false,
             vec![],
             false,
+            crate::config::CasMode::Memory,
         );
         assert!(
             result.is_ok(),

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -178,14 +178,16 @@ fn running_beat(last_progress: &Option<(String, u64)>) -> String {
     }
 }
 
-/// Render an async consultation job for the unified `job_get`: a status line while it runs,
-/// the grounded answer (and optional report) when it's done, the stored failure text on
-/// error, or a canceled notice. Mirrors the synchronous `consult` result shape so an
-/// agent reads the same thing whether it asked synchronously or collected a job.
+/// Render an async background job for the unified `job_get`: a status line while it runs,
+/// the result (and optional report) when it's done, the stored failure text on
+/// error, or a canceled notice. Producer-neutral on purpose — a `job-N` may be a
+/// consultation, a deliberation, or a deferred generation, and this render serves all
+/// of them; the label carries the producer's own description. A finished consultation
+/// still mirrors the synchronous `consult` result shape.
 pub(super) fn render_job(id: &str, snap: JobSnapshot) -> CallToolResult {
     match snap.state {
         JobState::Running => CallToolResult::success(vec![ContentBlock::text(format!(
-            "Consultation `{id}` is still running — {} ({}s elapsed){}. No need to wait: go \
+            "Job `{id}` is still running — {} ({}s elapsed){}. No need to wait: go \
              do other work and `job_get` it again later.",
             snap.label,
             snap.age.as_secs(),
@@ -201,7 +203,7 @@ pub(super) fn render_job(id: &str, snap: JobSnapshot) -> CallToolResult {
         }
         JobState::Failed(text) => CallToolResult::error(vec![ContentBlock::text(text)]),
         JobState::Canceled => CallToolResult::success(vec![ContentBlock::text(format!(
-            "Consultation `{id}` was canceled."
+            "Job `{id}` was canceled."
         ))]),
     }
 }
@@ -348,9 +350,9 @@ pub(crate) fn batch_within_window(
 /// informative ("none"), so the section always renders.
 pub(super) fn render_jobs_section(jobs: &[(String, JobSnapshot)]) -> String {
     if jobs.is_empty() {
-        return "Consult jobs (this session): none.".to_string();
+        return "Background jobs (this session): none.".to_string();
     }
-    let mut s = String::from("Consult jobs (this session), newest first:");
+    let mut s = String::from("Background jobs (this session), newest first:");
     for (id, snap) in jobs {
         let state = match &snap.state {
             JobState::Running => {

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -179,6 +179,25 @@ impl Resolver {
             );
         }
 
+        // The media half of the same policy, from the same shared rule
+        // (`Config::media_tunable_diagnostics`, which the `kaibo://config` render also
+        // reads): reasoning tunables the operator WROTE on a slot that runs no
+        // reasoning phase. One line per slot, knobs named, so the fix needs no hunt.
+        // Inherited `[defaults]` values stay quiet, exactly like the effort scan above.
+        for d in config.media_tunable_diagnostics() {
+            tracing::warn!(
+                cast = %d.cast,
+                slot = %d.role,
+                model = %d.model,
+                tunables = %d.tunables.join(", "),
+                "reasoning tunables on the {} slot do nothing: this slot sends one \
+                 generation request with no reasoning phase, so these knobs are \
+                 dropped before any request is built. Move them to a reasoning slot \
+                 (explorer/synth) or remove them. See kaibo://config (inert_tunables).",
+                d.role
+            );
+        }
+
         Ok(Self {
             config,
             allowed_set: Arc::new(allowed),

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -669,6 +669,14 @@ pub struct Artifact {
 pub struct JobId(String);
 
 impl JobId {
+    /// Rebuild a job id from its string spelling. The id round-trips through kaibo's
+    /// job store (and the [`crate::media::MediaJobId`] seam) as a plain string, so
+    /// the poll path needs a way back in; the string stays opaque either way — only
+    /// Stability's own polling endpoints interpret it.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -1084,6 +1092,98 @@ impl RigImageGenerationModel for StabilityImageModel {
                 seed: artifact.seed,
             },
         })
+    }
+}
+
+impl StabilityImageModel {
+    /// Build directly from a client + model id — the non-rig constructor
+    /// [`crate::media::MediaArm::from_slot`] uses. Same shape as
+    /// [`RigImageGenerationModel::make`], available without importing rig's trait.
+    pub fn from_parts(client: &StabilityClient, model: impl Into<String>) -> Self {
+        Self {
+            client: client.clone(),
+            model: model.into(),
+        }
+    }
+
+    /// The request-side translation shared with [`from_rig_request`]: classify the
+    /// model id into a route, seed the sd3 `model` field and the explicit
+    /// `output_format = "png"` default, then let the caller's own fields override —
+    /// last write wins, the same contract [`build_form_fields`] applies again at
+    /// send time.
+    fn media_request(&self, request: &crate::media::MediaRequest) -> (Operation, StabilityRequest) {
+        let route = GenerateRoute::classify(&self.model);
+        let mut fields: Vec<(String, String)> = Vec::new();
+        if let GenerateRoute::Sd3 { model } = &route {
+            fields.push(("model".to_string(), model.clone()));
+        }
+        fields.push(("output_format".to_string(), "png".to_string()));
+        for (k, v) in &request.fields {
+            if let Some(existing) = fields.iter_mut().find(|(name, _)| name == k) {
+                existing.1 = v.clone();
+            } else {
+                fields.push((k.clone(), v.clone()));
+            }
+        }
+        (
+            Operation::Generate(route),
+            StabilityRequest {
+                prompt: request.prompt.clone(),
+                input_image: request.input_image.clone(),
+                // No derived ratio on this path: the neutral request has no
+                // width/height to bridge, and an `aspect_ratio` field from the caller
+                // rides `fields` verbatim.
+                aspect_ratio: None,
+                fields,
+            },
+        )
+    }
+}
+
+/// The [`crate::media::MediaModel`] impl — the neutral seam
+/// [`crate::media::MediaArm`] dispatches through. Thin on purpose:
+/// [`crate::media::MediaRequest::fields`] already speak Stability's `(name, value)`
+/// form-field shape, and the outcome enums mirror [`StabilityResponse`] /
+/// [`PollOutcome`] one-to-one — including the deferred half rig's trait cannot carry
+/// (see [`StabilityImageModel::image_generation`]'s forced error there).
+#[async_trait::async_trait]
+impl crate::media::MediaModel for StabilityImageModel {
+    async fn generate(
+        &self,
+        request: &crate::media::MediaRequest,
+    ) -> AnyResult<crate::media::MediaOutcome> {
+        let (op, stability_request) = self.media_request(request);
+        let response = self.client.call(&op, &stability_request).await?;
+        Ok(match response {
+            StabilityResponse::Complete(a) => {
+                crate::media::MediaOutcome::Complete(media_artifact(a))
+            }
+            StabilityResponse::Deferred(id) => crate::media::MediaOutcome::Deferred(
+                crate::media::MediaJobId(id.as_str().to_string()),
+            ),
+        })
+    }
+
+    async fn poll(
+        &self,
+        job: &crate::media::MediaJobId,
+    ) -> AnyResult<crate::media::MediaPollOutcome> {
+        let outcome = self.client.poll(&JobId::new(job.0.clone())).await?;
+        Ok(match outcome {
+            PollOutcome::Pending => crate::media::MediaPollOutcome::Pending,
+            PollOutcome::Complete(a) => crate::media::MediaPollOutcome::Complete(media_artifact(a)),
+        })
+    }
+}
+
+/// Lift this facade's [`Artifact`] into the neutral [`crate::media::MediaArtifact`]:
+/// the mime becomes the wire spelling ([`MediaType::as_str`]), bytes and seed carry
+/// verbatim.
+fn media_artifact(a: Artifact) -> crate::media::MediaArtifact {
+    crate::media::MediaArtifact {
+        mime: a.media_type.as_str().to_string(),
+        bytes: a.bytes,
+        seed: a.seed,
     }
 }
 

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -306,7 +306,9 @@ pub enum GenerateRoute {
     /// rides as the `model` form field — see [`from_rig_request`]. Passed through
     /// verbatim; Stability validates it, so an unrecognized variant still reaches the
     /// provider as a normal `400`, not a client-side guess.
-    Sd3 { model: String },
+    Sd3 {
+        model: String,
+    },
 }
 
 impl GenerateRoute {
@@ -527,7 +529,10 @@ impl std::fmt::Display for StabilityError {
                 write!(f, "invalid additional_params: {msg}")
             }
             StabilityError::InvalidDeferredBody(msg) => {
-                write!(f, "Stability's deferred response body didn't parse as {{\"id\": ...}}: {msg}")
+                write!(
+                    f,
+                    "Stability's deferred response body didn't parse as {{\"id\": ...}}: {msg}"
+                )
             }
             StabilityError::UnexpectedlyDeferred => write!(
                 f,
@@ -1155,8 +1160,11 @@ impl crate::media::MediaModel for StabilityImageModel {
         let (op, stability_request) = self.media_request(request);
         let response = self.client.call(&op, &stability_request).await?;
         Ok(match response {
+            // Stability's operations each return exactly one artifact, so it rides as a
+            // one-element list — the neutral outcome is a Vec because many image models
+            // return several per call, and the CAS story is per-artifact digests.
             StabilityResponse::Complete(a) => {
-                crate::media::MediaOutcome::Complete(media_artifact(a))
+                crate::media::MediaOutcome::Complete(vec![media_artifact(a)])
             }
             StabilityResponse::Deferred(id) => crate::media::MediaOutcome::Deferred(
                 crate::media::MediaJobId(id.as_str().to_string()),
@@ -1171,7 +1179,10 @@ impl crate::media::MediaModel for StabilityImageModel {
         let outcome = self.client.poll(&JobId::new(job.0.clone())).await?;
         Ok(match outcome {
             PollOutcome::Pending => crate::media::MediaPollOutcome::Pending,
-            PollOutcome::Complete(a) => crate::media::MediaPollOutcome::Complete(media_artifact(a)),
+            // One artifact per Stability poll, as a one-element list — see `generate`.
+            PollOutcome::Complete(a) => {
+                crate::media::MediaPollOutcome::Complete(vec![media_artifact(a)])
+            }
         })
     }
 }
@@ -1295,7 +1306,11 @@ mod tests {
     /// `#[non_exhaustive]`, so a struct literal isn't available outside rig's crate.
     /// Any `ImageGenerationModel` instance can mint the builder; a throwaway
     /// [`StabilityImageModel`] over a never-dialed client does the job with no network.
-    fn rig_request(width: u32, height: u32, additional_params: Option<Value>) -> ImageGenerationRequest {
+    fn rig_request(
+        width: u32,
+        height: u32,
+        additional_params: Option<Value>,
+    ) -> ImageGenerationRequest {
         let client = StabilityClient::new("test-key", "http://localhost", Duration::from_secs(1))
             .expect("client construction is pure config, no network");
         let model = StabilityImageModel::make(&client, "core");
@@ -1324,7 +1339,8 @@ mod tests {
 
     #[test]
     fn from_rig_request_sd3_variant_carries_model_field() {
-        let (op, req) = from_rig_request("sd3.5-large-turbo", &rig_request(1024, 1024, None)).unwrap();
+        let (op, req) =
+            from_rig_request("sd3.5-large-turbo", &rig_request(1024, 1024, None)).unwrap();
         assert_eq!(
             op,
             Operation::Generate(GenerateRoute::Sd3 {
@@ -1348,7 +1364,10 @@ mod tests {
         assert!(req.fields.iter().any(|(k, v)| k == "seed" && v == "42"));
         // output_format must not appear twice (override, not append).
         assert_eq!(
-            req.fields.iter().filter(|(k, _)| k == "output_format").count(),
+            req.fields
+                .iter()
+                .filter(|(k, _)| k == "output_format")
+                .count(),
             1
         );
     }
@@ -1486,7 +1505,11 @@ mod tests {
     /// `MediaType` section for why this refusal is a deliberate feature.
     #[test]
     fn media_type_to_cas_extension_refuses_audio_and_3d() {
-        for media_type in [MediaType::AudioMpeg, MediaType::AudioWav, MediaType::ModelGltfBinary] {
+        for media_type in [
+            MediaType::AudioMpeg,
+            MediaType::AudioWav,
+            MediaType::ModelGltfBinary,
+        ] {
             let err = media_type.to_cas_extension().unwrap_err();
             match err {
                 StabilityError::NoCasExtension { media_type: got } => {
@@ -1599,10 +1622,7 @@ mod tests {
         let body = br#"{"image":"AAAA","seed":1,"finish_reason":"SUCCESS"}"#;
         let err = handle_response(Shape::Sync, 200, Some("application/json"), None, None, body)
             .unwrap_err();
-        assert!(matches!(
-            err,
-            StabilityError::UnexpectedContentType { .. }
-        ));
+        assert!(matches!(err, StabilityError::UnexpectedContentType { .. }));
     }
 
     #[test]
@@ -1647,15 +1667,22 @@ mod tests {
 
     #[test]
     fn handle_response_200_empty_body_is_refused() {
-        let err = handle_response(Shape::Sync, 200, Some("image/png"), Some("SUCCESS"), None, b"")
-            .unwrap_err();
+        let err = handle_response(
+            Shape::Sync,
+            200,
+            Some("image/png"),
+            Some("SUCCESS"),
+            None,
+            b"",
+        )
+        .unwrap_err();
         assert_eq!(err, StabilityError::EmptyBody);
     }
 
     #[test]
     fn handle_response_200_missing_finish_reason_is_refused() {
-        let err = handle_response(Shape::Sync, 200, Some("image/png"), None, None, b"bytes")
-            .unwrap_err();
+        let err =
+            handle_response(Shape::Sync, 200, Some("image/png"), None, None, b"bytes").unwrap_err();
         assert_eq!(err, StabilityError::MissingFinishReason);
     }
 
@@ -1709,8 +1736,15 @@ mod tests {
     #[test]
     fn handle_response_deferred_200_with_id_is_deferred() {
         let body = br#"{"id":"job-abc-123"}"#;
-        let got = handle_response(Shape::Deferred, 200, Some("application/json"), None, None, body)
-            .expect("expected a deferred outcome");
+        let got = handle_response(
+            Shape::Deferred,
+            200,
+            Some("application/json"),
+            None,
+            None,
+            body,
+        )
+        .expect("expected a deferred outcome");
         match got {
             StabilityResponse::Deferred(id) => assert_eq!(id.as_str(), "job-abc-123"),
             StabilityResponse::Complete(_) => panic!("expected Deferred, got Complete"),
@@ -1720,8 +1754,15 @@ mod tests {
     #[test]
     fn handle_response_deferred_202_with_id_is_deferred() {
         let body = br#"{"id":"job-abc-123"}"#;
-        let got = handle_response(Shape::Deferred, 202, Some("application/json"), None, None, body)
-            .expect("expected a deferred outcome");
+        let got = handle_response(
+            Shape::Deferred,
+            202,
+            Some("application/json"),
+            None,
+            None,
+            body,
+        )
+        .expect("expected a deferred outcome");
         match got {
             StabilityResponse::Deferred(id) => assert_eq!(id.as_str(), "job-abc-123"),
             StabilityResponse::Complete(_) => panic!("expected Deferred, got Complete"),
@@ -1730,17 +1771,30 @@ mod tests {
 
     #[test]
     fn handle_response_deferred_invalid_json_is_refused() {
-        let err = handle_response(Shape::Deferred, 200, Some("application/json"), None, None, b"not json")
-            .unwrap_err();
+        let err = handle_response(
+            Shape::Deferred,
+            200,
+            Some("application/json"),
+            None,
+            None,
+            b"not json",
+        )
+        .unwrap_err();
         assert!(matches!(err, StabilityError::InvalidDeferredBody(_)));
     }
 
     #[test]
     fn handle_response_deferred_missing_id_field_is_refused() {
         let body = br#"{"status":"in_progress"}"#;
-        let err =
-            handle_response(Shape::Deferred, 200, Some("application/json"), None, None, body)
-                .unwrap_err();
+        let err = handle_response(
+            Shape::Deferred,
+            200,
+            Some("application/json"),
+            None,
+            None,
+            body,
+        )
+        .unwrap_err();
         assert!(matches!(err, StabilityError::InvalidDeferredBody(_)));
     }
 
@@ -1749,8 +1803,15 @@ mod tests {
         // Non-2xx handling is shape-agnostic — checked before the Sync/Deferred
         // dispatch — so a deferred route's 400 looks exactly like a sync route's.
         let body = br#"{"id":"abc123","name":"bad_request","errors":["missing field: prompt"]}"#;
-        let err = handle_response(Shape::Deferred, 400, Some("application/json"), None, None, body)
-            .unwrap_err();
+        let err = handle_response(
+            Shape::Deferred,
+            400,
+            Some("application/json"),
+            None,
+            None,
+            body,
+        )
+        .unwrap_err();
         assert!(matches!(err, StabilityError::Provider { status: 400, .. }));
     }
 
@@ -1789,8 +1850,14 @@ mod tests {
         let pending = handle_poll_response(202, None, None, None, b"{}").unwrap();
         assert_eq!(pending, PollOutcome::Pending);
 
-        let done = handle_poll_response(200, Some("audio/wav"), Some("SUCCESS"), None, b"RIFF....WAVEfmt ")
-            .unwrap();
+        let done = handle_poll_response(
+            200,
+            Some("audio/wav"),
+            Some("SUCCESS"),
+            None,
+            b"RIFF....WAVEfmt ",
+        )
+        .unwrap();
         match done {
             PollOutcome::Complete(artifact) => assert_eq!(artifact.media_type, MediaType::AudioWav),
             PollOutcome::Pending => panic!("expected Complete on the second poll"),
@@ -1800,7 +1867,8 @@ mod tests {
     #[test]
     fn handle_poll_response_404_expired_job_is_a_provider_error() {
         let body = br#"{"id":"abc123","name":"not_found","errors":["job id expired"]}"#;
-        let err = handle_poll_response(404, Some("application/json"), None, None, body).unwrap_err();
+        let err =
+            handle_poll_response(404, Some("application/json"), None, None, body).unwrap_err();
         assert!(matches!(err, StabilityError::Provider { status: 404, .. }));
     }
 

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -505,3 +505,97 @@ fn soft_cap_does_not_block_a_dedup_write_of_existing_content() {
     let d2 = cas.put(&bytes, Extension::Gif, &prov()).unwrap();
     assert_eq!(d1, d2);
 }
+
+// --- MemoryCas: same contract, no filesystem ---------------------------------
+
+use kaibo::cas::{MediaStore, MemoryCas};
+
+/// The in-memory store round-trips bytes by digest, with the extension (and thus
+/// the mime a resource read serves) intact — the degraded-mode contract for a run
+/// without persistence.
+#[test]
+fn memory_cas_put_then_get_round_trips_bytes_and_extension() {
+    let mem = MemoryCas::new(None);
+    let bytes = b"pretend-png".to_vec();
+    let digest = mem.put(&bytes, Extension::Png, &prov()).unwrap();
+    assert_eq!(digest, Digest::of_bytes(&bytes));
+    assert_eq!(mem.get(&digest), Some((bytes, Extension::Png)));
+    assert_eq!(mem.provenance(&digest).unwrap(), prov());
+}
+
+#[test]
+fn memory_cas_get_returns_none_for_unknown_digest() {
+    let mem = MemoryCas::new(None);
+    let missing = Digest::of_bytes(b"never stored");
+    assert_eq!(mem.get(&missing), None);
+}
+
+/// Identical content twice is one object and one digest — dedup, not accumulation.
+#[test]
+fn memory_cas_dedup_returns_the_same_digest() {
+    let mem = MemoryCas::new(None);
+    let d1 = mem.put(b"same", Extension::Webp, &prov()).unwrap();
+    let d2 = mem.put(b"same", Extension::Webp, &prov()).unwrap();
+    assert_eq!(d1, d2);
+}
+
+/// The soft cap keeps its meaning in memory: refuse loudly, never evict — and a
+/// dedup write of held content is exempt, exactly as on disk.
+#[test]
+fn memory_cas_cap_refuses_loudly_and_never_evicts() {
+    let mem = MemoryCas::new(Some(10));
+    let first = vec![1u8; 8];
+    let d1 = mem.put(&first, Extension::Png, &prov()).unwrap();
+    match mem.put(&[2u8; 100], Extension::Png, &prov()) {
+        Err(CasError::CapacityExceeded { max_bytes: 10, .. }) => {}
+        other => panic!("a write past the cap must be refused, got {other:?}"),
+    }
+    // Never evicts, and the dedup write of the held object still succeeds with no slack.
+    assert_eq!(mem.get(&d1).map(|(b, _)| b), Some(first.clone()));
+    assert_eq!(mem.put(&first, Extension::Png, &prov()).unwrap(), d1);
+}
+
+// --- MediaStore: one seam over both modes ------------------------------------
+
+/// Disk mode exposes the real filesystem path beside the digest; memory mode has no
+/// path at all (the kaibo://cas resource is its only retrieval channel). Both modes
+/// serve the same bytes+extension read.
+#[test]
+fn media_store_paths_exist_on_disk_and_not_in_memory() {
+    let (cas, _dir) = open_uncapped();
+    let disk = MediaStore::Disk(cas);
+    let mem = MediaStore::Memory(MemoryCas::new(None));
+
+    let bytes = b"artifact".to_vec();
+    let d_disk = disk.put(&bytes, Extension::Jpeg, &prov()).unwrap();
+    let d_mem = mem.put(&bytes, Extension::Jpeg, &prov()).unwrap();
+    assert_eq!(d_disk, d_mem, "the address is the content, mode-independent");
+
+    assert!(disk.path_for(&d_disk).is_some_and(|p| p.is_file()));
+    assert!(disk.root().is_some());
+    assert_eq!(disk.mode(), "disk");
+
+    assert_eq!(mem.path_for(&d_mem), None);
+    assert_eq!(mem.root(), None);
+    assert_eq!(mem.mode(), "memory");
+
+    assert_eq!(
+        disk.get(&d_disk).unwrap(),
+        Some((bytes.clone(), Extension::Jpeg))
+    );
+    assert_eq!(mem.get(&d_mem).unwrap(), Some((bytes, Extension::Jpeg)));
+}
+
+// --- Extension <-> mime -------------------------------------------------------
+
+/// The wire-mime mapping is closed and case/parameter-tolerant on parse (RFC 7231),
+/// canonical on render — and refuses anything the CAS cannot name on disk.
+#[test]
+fn extension_maps_mimes_both_ways_and_refuses_unknown() {
+    for ext in Extension::ALL {
+        assert_eq!(Extension::from_mime(ext.mime()), Some(ext));
+    }
+    assert_eq!(Extension::from_mime("IMAGE/PNG; charset=binary"), Some(Extension::Png));
+    assert_eq!(Extension::from_mime("audio/mpeg"), None);
+    assert_eq!(Extension::from_mime("model/gltf-binary"), None);
+}

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -52,12 +52,21 @@ fn provenance_round_trips_through_json_with_its_seed() {
     assert_eq!(back.seed.as_deref(), Some("9259671"));
 }
 
-/// A fresh CAS rooted under a temp dir plus the dir (kept alive by the caller), with a
-/// generous cap so most tests don't need to think about it.
+/// A fresh CAS rooted under a temp dir plus the dir (kept alive by the caller), capped
+/// at `max_bytes` — the tests that actually exercise the soft cap.
 fn open(max_bytes: u64) -> (Cas, TempDir) {
     let dir = TempDir::new().unwrap();
     let root = dir.path().join("cas");
-    let cas = Cas::open(&root, &[], max_bytes).expect("open cas");
+    let cas = Cas::open(&root, &[], Some(max_bytes)).expect("open cas");
+    (cas, dir)
+}
+
+/// A fresh UNCAPPED CAS — the default posture, and what most tests want: no cap means
+/// no size accounting at all, so they never have to think about a budget.
+fn open_uncapped() -> (Cas, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("cas");
+    let cas = Cas::open(&root, &[], None).expect("open cas");
     (cas, dir)
 }
 
@@ -134,7 +143,7 @@ fn digest_round_trips_through_hex() {
 fn open_refuses_path_inside_allowed_tree() {
     let project = TempDir::new().unwrap();
     let inside = project.path().join("sub/cas");
-    match Cas::open(&inside, &[project.path()], u64::MAX) {
+    match Cas::open(&inside, &[project.path()], None) {
         Err(CasError::PathInAllowedTree(_)) => {}
         Err(other) => panic!("wrong error: {other:?}"),
         Ok(_) => panic!("must refuse a cas dir inside an allowed tree"),
@@ -156,7 +165,7 @@ fn open_refuses_path_reaching_into_tree_via_symlink() {
     std::os::unix::fs::symlink(project.path().join("real"), &link).unwrap();
 
     let sneaky = link.join("cas");
-    match Cas::open(&sneaky, &[project.path()], u64::MAX) {
+    match Cas::open(&sneaky, &[project.path()], None) {
         Err(CasError::PathInAllowedTree(_)) => {}
         Err(other) => panic!("wrong error: {other:?}"),
         Ok(_) => panic!("must refuse a symlinked path that resolves inside an allowed tree"),
@@ -170,14 +179,14 @@ fn open_allows_path_outside_allowed_trees() {
     // Sanity: opening with an unrelated allowed tree present must not spuriously refuse.
     let dir = TempDir::new().unwrap();
     let root = dir.path().join("cas");
-    assert!(Cas::open(&root, &[project.path()], u64::MAX).is_ok());
+    assert!(Cas::open(&root, &[project.path()], None).is_ok());
 }
 
 /// A db-style equal-to-tree edge case: the cas root itself equals an allowed tree.
 #[test]
 fn open_refuses_path_equal_to_an_allowed_tree() {
     let project = TempDir::new().unwrap();
-    match Cas::open(project.path(), &[project.path()], u64::MAX) {
+    match Cas::open(project.path(), &[project.path()], None) {
         Err(CasError::PathInAllowedTree(_)) => {}
         Err(other) => panic!("wrong error: {other:?}"),
         Ok(_) => panic!("a cas dir equal to an allowed tree must be refused"),
@@ -213,7 +222,7 @@ fn open_refuses_relative_path_that_absolutizes_into_an_allowed_tree() {
     let canon = project.path().canonicalize().unwrap();
     let _cwd = CwdGuard::set(&canon);
 
-    match Cas::open(Path::new("nonexistent_dir/cas"), &[&canon], u64::MAX) {
+    match Cas::open(Path::new("nonexistent_dir/cas"), &[&canon], None) {
         Err(CasError::PathInAllowedTree(_)) => {}
         Err(other) => panic!("wrong error for a relative in-cwd path: {other:?}"),
         Ok(_) => panic!("a relative path resolving inside the cwd allowed tree must be refused"),
@@ -401,6 +410,68 @@ fn writing_the_same_content_twice_is_a_noop_not_a_rewrite() {
 }
 
 // --- Soft cap: refuse loudly, never evict ------------------------------------
+
+/// The cap is OPT-IN, and an uncapped store never measures itself.
+///
+/// This is the load-bearing property, not a convenience: enforcing a cap means summing
+/// every file in the store, and `put` does that on the write path — for every new object,
+/// forever, over a store that by design never deletes anything. Two-level sharding means
+/// that walk is up to 65,536 `readdir`s plus a `metadata` per object, and it only gets
+/// slower as the store fills. So an operator who sets no cap pays none of it. The proof
+/// here is behavioral: with the store's own size accounting made impossible (the shard
+/// tree is replaced by a file, so any attempt to walk it errors), an uncapped `put` still
+/// succeeds — it never looked.
+#[test]
+#[cfg(unix)]
+fn an_uncapped_cas_never_walks_the_store_to_size_it() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (cas, _d) = open_uncapped();
+    let first = cas
+        .put(&[1u8; 32], Extension::Png, &prov())
+        .expect("first put");
+    assert!(cas.get(&first).unwrap().is_some());
+
+    // Sabotage the size walk WITHOUT touching the shard any write needs: a sibling
+    // top-level shard directory that exists but cannot be read. `read_dir` on it fails
+    // with EACCES, so summing the store is impossible — while `create_dir_all` and the
+    // object write, which only ever touch their own digest's shard, are unaffected.
+    let root = cas.root().to_path_buf();
+    let unreadable = root.join("zz");
+    std::fs::create_dir_all(&unreadable).expect("create a sibling shard");
+    std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000))
+        .expect("make it unreadable");
+
+    // An uncapped put must not care, because it must never take the sizing path at all.
+    let second = cas
+        .put(&[2u8; 32], Extension::Png, &prov())
+        .expect("an uncapped put must not depend on being able to size the store");
+    assert_eq!(cas.get(&second).unwrap().unwrap(), vec![2u8; 32]);
+
+    // Prove the sabotage actually bites, so the success above means something: the SAME
+    // root opened WITH a cap must fail trying to walk it. Without this the test would
+    // still pass if `put` had simply stopped enforcing caps, or if the sabotage had
+    // quietly done nothing.
+    //
+    // The precondition is checked directly rather than by testing for uid 0: root (and
+    // anything holding CAP_DAC_OVERRIDE, or a filesystem mounted without permission
+    // enforcement) can still read the directory, and in that case there is no sabotage to
+    // observe. Asking whether the read actually fails is exact, needs no libc — which is
+    // a Linux-only dependency in this tree — and stays honest under every such case.
+    if std::fs::read_dir(&unreadable).is_err() {
+        let capped = Cas::open(&root, &[], Some(1 << 30)).expect("open the same root capped");
+        match capped.put(&[3u8; 32], Extension::Png, &prov()) {
+            Err(CasError::Io(msg)) => assert!(
+                msg.contains("scanning CAS size"),
+                "a capped put must fail IN the size walk, got: {msg}"
+            ),
+            other => panic!("the sabotage must break a capped put, got: {other:?}"),
+        }
+    }
+
+    // Leave the tree removable by the TempDir drop.
+    std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o755)).ok();
+}
 
 #[test]
 fn soft_cap_refuses_a_write_that_would_exceed_it() {

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -294,7 +294,10 @@ fn put_returns_corrupt_error_when_dedup_slot_is_poisoned() {
 
     // Poison the slot out-of-band, as if a prior crash left a truncated file there — before
     // any real `put` ever wrote to it.
-    let shard = cas.root().join(&digest.to_hex()[0..2]).join(&digest.to_hex()[2..4]);
+    let shard = cas
+        .root()
+        .join(&digest.to_hex()[0..2])
+        .join(&digest.to_hex()[2..4]);
     std::fs::create_dir_all(&shard).unwrap();
     let path = shard.join(format!("{}.png", digest.to_hex()));
     std::fs::write(&path, b"poisoned").unwrap();
@@ -363,7 +366,9 @@ fn path_for_uses_the_two_level_hex_shard_layout() {
     let rel = path.strip_prefix(cas.root()).unwrap();
     assert_eq!(
         rel,
-        Path::new(&hex[0..2]).join(&hex[2..4]).join(format!("{hex}.jpeg"))
+        Path::new(&hex[0..2])
+            .join(&hex[2..4])
+            .join(format!("{hex}.jpeg"))
     );
 }
 
@@ -376,7 +381,10 @@ fn put_writes_a_provenance_sidecar_next_to_the_object() {
 
     let obj_path = cas.path_for(&digest).unwrap();
     let sidecar_path = obj_path.with_extension("json");
-    assert!(sidecar_path.is_file(), "sidecar must exist next to the object");
+    assert!(
+        sidecar_path.is_file(),
+        "sidecar must exist next to the object"
+    );
 
     let raw = std::fs::read_to_string(&sidecar_path).unwrap();
     let parsed: Provenance = serde_json::from_str(&raw).unwrap();
@@ -475,8 +483,13 @@ fn an_uncapped_cas_never_walks_the_store_to_size_it() {
 
 #[test]
 fn soft_cap_refuses_a_write_that_would_exceed_it() {
-    let (cas, _d) = open(16); // 16 bytes total budget
+    // Budget for exactly one object-plus-sidecar footprint (admission counts both).
     let small = vec![1u8; 8];
+    let (probe, probe_dir) = open_uncapped();
+    probe.put(&small, Extension::Png, &prov()).unwrap();
+    let budget = dir_size(&probe_dir.path().join("cas"));
+
+    let (cas, _d) = open(budget);
     let d1 = cas.put(&small, Extension::Png, &prov()).unwrap();
 
     let too_big = vec![2u8; 100];
@@ -497,8 +510,13 @@ fn soft_cap_refuses_a_write_that_would_exceed_it() {
 /// because a naive "current + incoming" sum would look like it exceeds — it adds no bytes.
 #[test]
 fn soft_cap_does_not_block_a_dedup_write_of_existing_content() {
+    // Budget for exactly one footprint (object + sidecar): zero slack afterwards.
     let bytes = vec![7u8; 10];
-    let (cas, _d) = open(10); // exactly the size of one object, zero slack
+    let (probe, probe_dir) = open_uncapped();
+    probe.put(&bytes, Extension::Gif, &prov()).unwrap();
+    let budget = dir_size(&probe_dir.path().join("cas"));
+
+    let (cas, _d) = open(budget);
     let d1 = cas.put(&bytes, Extension::Gif, &prov()).unwrap();
     // Re-putting the identical bytes must still succeed even though the cap has no slack
     // left for "new" bytes — it isn't new, it's the same object.
@@ -569,7 +587,10 @@ fn media_store_paths_exist_on_disk_and_not_in_memory() {
     let bytes = b"artifact".to_vec();
     let d_disk = disk.put(&bytes, Extension::Jpeg, &prov()).unwrap();
     let d_mem = mem.put(&bytes, Extension::Jpeg, &prov()).unwrap();
-    assert_eq!(d_disk, d_mem, "the address is the content, mode-independent");
+    assert_eq!(
+        d_disk, d_mem,
+        "the address is the content, mode-independent"
+    );
 
     assert!(disk.path_for(&d_disk).is_some_and(|p| p.is_file()));
     assert!(disk.root().is_some());
@@ -595,7 +616,179 @@ fn extension_maps_mimes_both_ways_and_refuses_unknown() {
     for ext in Extension::ALL {
         assert_eq!(Extension::from_mime(ext.mime()), Some(ext));
     }
-    assert_eq!(Extension::from_mime("IMAGE/PNG; charset=binary"), Some(Extension::Png));
+    assert_eq!(
+        Extension::from_mime("IMAGE/PNG; charset=binary"),
+        Some(Extension::Png)
+    );
     assert_eq!(Extension::from_mime("audio/mpeg"), None);
     assert_eq!(Extension::from_mime("model/gltf-binary"), None);
+}
+
+// --- or-gpt review follow-ups (2026-08-03) ------------------------------------
+
+/// Sum of every file under `dir`, recursively — the store's true on-disk footprint.
+fn dir_size(dir: &Path) -> u64 {
+    fn walk(dir: &Path) -> u64 {
+        if !dir.is_dir() {
+            return 0;
+        }
+        std::fs::read_dir(dir)
+            .unwrap()
+            .map(|e| {
+                let e = e.unwrap();
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p)
+                } else {
+                    e.metadata().unwrap().len()
+                }
+            })
+            .sum()
+    }
+    walk(dir)
+}
+
+/// The cap admits an object only if the artifact AND its provenance sidecar both fit —
+/// the sidecar is real disk usage written by the same put, so an admission check that
+/// ignored it overshot the ceiling by the sidecar's size on every accepted write.
+#[test]
+fn soft_cap_admission_counts_the_provenance_sidecar() {
+    // Measure the true footprint of one put (object + sidecar) with no cap in the way.
+    let bytes = vec![9u8; 100];
+    let (probe, probe_dir) = open_uncapped();
+    probe.put(&bytes, Extension::Png, &prov()).unwrap();
+    let footprint = dir_size(&probe_dir.path().join("cas"));
+    assert!(
+        footprint > bytes.len() as u64,
+        "the sidecar adds real bytes beyond the artifact ({footprint})"
+    );
+
+    // One byte under the true footprint: refused up front, nothing written.
+    let (cas, d) = open(footprint - 1);
+    match cas.put(&bytes, Extension::Png, &prov()) {
+        Err(CasError::CapacityExceeded { .. }) => {}
+        other => panic!("a put whose sidecar would breach the cap must be refused, got {other:?}"),
+    }
+    assert_eq!(
+        dir_size(&d.path().join("cas")),
+        0,
+        "a refused put writes nothing at all"
+    );
+
+    // Exactly the footprint: accepted, and the real directory size respects the cap.
+    let (cas, d) = open(footprint);
+    cas.put(&bytes, Extension::Png, &prov()).unwrap();
+    assert_eq!(dir_size(&d.path().join("cas")), footprint);
+}
+
+/// A `create_new` that loses to something already sitting at the object path must
+/// verify what is there before reporting success — the doc contract says an existing
+/// object is a VERIFIED no-op. The deterministic stand-in for the concurrent race: a
+/// dangling symlink at the object path passes the `is_file()` pre-check as "nothing
+/// here" (it follows the link), then `O_EXCL` refuses with `AlreadyExists` — the exact
+/// post-pre-check appearance the race produces. Reporting Ok there would claim bytes
+/// were stored when nothing readable exists at the address.
+#[cfg(unix)]
+#[test]
+fn put_losing_create_new_after_the_precheck_still_verifies() {
+    let (cas, _d) = open_uncapped();
+    let bytes = b"raced-content".to_vec();
+    let digest = Digest::of_bytes(&bytes);
+    let hex = digest.to_hex();
+    let shard = cas.root().join(&hex[0..2]).join(&hex[2..4]);
+    std::fs::create_dir_all(&shard).unwrap();
+    std::os::unix::fs::symlink(
+        "/nonexistent-kaibo-cas-target",
+        shard.join(format!("{hex}.png")),
+    )
+    .unwrap();
+
+    match cas.put(&bytes, Extension::Png, &prov()) {
+        Ok(_) => panic!(
+            "put must not report success when the path was claimed by something it \
+             could not verify"
+        ),
+        Err(CasError::Io(_) | CasError::Corrupt { .. }) => {}
+        Err(other) => panic!("unexpected error kind: {other:?}"),
+    }
+}
+
+/// Two concurrent puts of identical new content, on clones sharing one store: both
+/// callers return success only once a verified object AND its sidecar exist. `Cas`
+/// serializes its write path (handler clones share one `Arc<MediaStore>`, so
+/// concurrent MCP calls really do land here), and the dedup arm verifies rather than
+/// trusts — so whichever caller loses the race still speaks the truth when it
+/// reports success.
+#[test]
+fn concurrent_identical_puts_both_return_verified() {
+    let (cas, _d) = open_uncapped();
+    for round in 0u32..32 {
+        let bytes = format!("round-{round}-content").into_bytes();
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let digests: Vec<Digest> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..2)
+                .map(|_| {
+                    let cas = cas.clone();
+                    let bytes = bytes.clone();
+                    let barrier = barrier.clone();
+                    scope.spawn(move || {
+                        barrier.wait();
+                        cas.put(&bytes, Extension::Png, &prov())
+                            .expect("put succeeds")
+                    })
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+        assert_eq!(digests[0], digests[1]);
+        // Both returned: the object must be present, verified, with its sidecar.
+        assert_eq!(
+            cas.get(&digests[0]).expect("verified read"),
+            Some(bytes.clone()),
+            "round {round}: the bytes both callers vouched for must be there, intact"
+        );
+        let hex = digests[0].to_hex();
+        let sidecar = cas
+            .root()
+            .join(&hex[0..2])
+            .join(&hex[2..4])
+            .join(format!("{hex}.json"));
+        assert!(
+            sidecar.is_file(),
+            "round {round}: the sidecar must exist once success was reported"
+        );
+    }
+}
+
+/// `Cas::open` refuses a root that structurally cannot become a store directory: an
+/// existing FILE at the root, or a file where an ancestor directory would have to be.
+/// Without this, startup passes and the failure surfaces only on the first PAID
+/// generation — the guide promises structural path errors fail at open.
+#[test]
+fn open_refuses_a_file_at_the_root_or_in_its_ancestry() {
+    let dir = TempDir::new().unwrap();
+
+    // A file sitting exactly at the requested root.
+    let file_root = dir.path().join("occupied");
+    std::fs::write(&file_root, b"not a directory").unwrap();
+    match Cas::open(&file_root, &[], None) {
+        Ok(_) => panic!("a file at the CAS root must be refused at open"),
+        Err(e) => assert!(
+            format!("{e}").contains("not a directory"),
+            "the error names the problem, got: {e}"
+        ),
+    }
+
+    // A file where an ancestor of the (not-yet-created) root would have to be a dir.
+    let nested = file_root.join("cas");
+    match Cas::open(&nested, &[], None) {
+        Ok(_) => panic!("a file in the root's ancestry must be refused at open"),
+        Err(e) => assert!(
+            format!("{e}").contains("not a directory"),
+            "the error names the problem, got: {e}"
+        ),
+    }
+
+    // A plain directory (or a path whose ancestors are dirs) still opens fine.
+    Cas::open(&dir.path().join("fresh").join("cas"), &[], None).expect("clean path opens");
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2052,6 +2052,41 @@ fn cas_defaults_to_the_xdg_data_dir_and_no_cap() {
     );
 }
 
+/// `[cas] enabled = false` is the explicit off switch (Amy, 2026-08-03); on is the
+/// default, so an empty config runs with the CAS available.
+#[test]
+fn cas_enabled_defaults_true_and_the_file_can_turn_it_off() {
+    let c = Config::from_toml_str("").unwrap();
+    assert!(c.cas.enabled, "the CAS is on by default");
+    let off = Config::from_toml_str("[cas]\nenabled = false\n").unwrap();
+    assert!(!off.cas.enabled);
+}
+
+/// The one derivation of the CAS lifecycle: disabled wins over everything; otherwise
+/// the CAS follows *runtime* persistence truth — disk while a durable store is open,
+/// memory while it is not (including the degrade path where `[persistence]` is enabled
+/// but the store failed to open) or when no directory resolves.
+#[test]
+fn cas_mode_follows_persistence_and_the_off_switch_wins() {
+    use kaibo::config::CasMode;
+    let c = Config::from_toml_str("").unwrap();
+    assert_eq!(c.cas_mode(true), CasMode::Disk);
+    assert_eq!(
+        c.cas_mode(false),
+        CasMode::Memory,
+        "no durable persistence means an in-memory CAS, not a stranded disk store"
+    );
+
+    let off = Config::from_toml_str("[cas]\nenabled = false\n").unwrap();
+    assert_eq!(off.cas_mode(true), CasMode::Off);
+    assert_eq!(off.cas_mode(false), CasMode::Off);
+
+    // No resolvable dir: enabled + persistence-active still cannot mean disk.
+    let mut no_dir = Config::from_toml_str("").unwrap();
+    no_dir.cas.dir = None;
+    assert_eq!(no_dir.cas_mode(true), CasMode::Memory);
+}
+
 /// The file layer sets both knobs, and `$VAR`/`~` in `dir` expand like every other path.
 #[test]
 fn cas_file_layer_sets_dir_and_cap() {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -626,7 +626,7 @@ fn base_url_on_a_keyed_backend_is_rejected() {
     let msg = format!("{err:#}");
     assert!(msg.contains("base_url"), "got: {msg}");
     assert!(
-        msg.contains("only the `openai`, `anthropic`, and `gemini` kinds"),
+        msg.contains("only the `openai`, `anthropic`, `gemini`, and `stability` kinds"),
         "got: {msg}"
     );
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1957,6 +1957,72 @@ fn no_builtin_cast_carries_an_image_slot() {
     }
 }
 
+/// Reasoning tunables WRITTEN on an image slot are diagnosed, not load errors: an image
+/// slot sends one generation request with no reasoning phase, so a `thinking_budget` /
+/// `effort` / `temperature` / `thinking_style` written there never reaches a request.
+/// The diagnostic rides the same shared machinery as inert effort (startup warning +
+/// `inert_tunables` in kaibo://config), and it names the cast, the slot, and each knob.
+#[test]
+fn written_reasoning_tunables_on_an_image_slot_are_diagnosed() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.sd]
+        kind = "stability"
+
+        [casts.artist]
+        explorer = "deepseek/deepseek-v4-flash"
+        synth    = "deepseek/deepseek-v4-pro"
+        image    = { backend = "sd", id = "core", thinking_budget = 4096, effort = "high", temperature = 0.5, thinking_style = "adaptive" }
+        "#,
+    )
+    .expect("reasoning knobs on an image slot load fine; they are diagnosed, not refused");
+    let diags = c.media_tunable_diagnostics();
+    assert_eq!(diags.len(), 1, "exactly the one image slot is reported");
+    let d = &diags[0];
+    assert_eq!(d.cast, "artist");
+    assert_eq!(d.role, "image");
+    assert_eq!(d.model, "sd/core");
+    assert_eq!(
+        d.tunables,
+        vec!["thinking_budget", "effort", "temperature", "thinking_style"],
+        "every written reasoning knob is named, in render order"
+    );
+}
+
+/// The quiet half: INHERITED defaults never flag an image slot. A `[defaults]`
+/// synth-side effort states the synth posture and merely falls back onto other roles,
+/// so a bare image slot stays silent in both scans — `media_tunable_diagnostics`
+/// (nothing written on the slot) and `effort_diagnostics` (media roles are covered by
+/// the media scan, so a defaults effort can't warn on every image slot the moment
+/// someone sets `synth_effort`).
+#[test]
+fn inherited_defaults_stay_quiet_on_an_image_slot() {
+    let c = Config::from_toml_str(
+        r#"
+        [defaults]
+        synth_effort = "medium"
+
+        [backends.sd]
+        kind = "stability"
+
+        [casts.artist]
+        explorer = "deepseek/deepseek-v4-flash"
+        synth    = "deepseek/deepseek-v4-pro"
+        image    = "sd/core"
+        "#,
+    )
+    .unwrap();
+    assert!(
+        c.media_tunable_diagnostics().is_empty(),
+        "a bare image slot has nothing written, so nothing is reported"
+    );
+    assert!(
+        !c.effort_diagnostics().iter().any(|d| d.role == "image"),
+        "the effort scan covers reasoning roles only; an image slot inheriting a \
+         defaults effort is a fallback artifact, not an operator statement"
+    );
+}
+
 // --- [cas]: the media content-addressed store -------------------------------
 
 /// The default posture: a dir under XDG *data* (not state — these are artifacts the user

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -917,7 +917,9 @@ fn cli_cast_wins_over_env_and_file() {
         vec![], // no --project-context-file flags
         vec![], // no --user-context-file flags
         false,  // --no-persistence not passed
-        None,   // no --state-db
+        None,   // no --state-db,
+        None, // --cas-dir
+        None, // --cas-max-bytes
     );
     assert_eq!(c.default_cast, "deepseek", "--cast beats env and file");
     assert_eq!(c.root.as_deref(), Some(std::path::Path::new("/tmp/proj")));
@@ -950,6 +952,8 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
         vec![],
         false,
         None,
+        None, // --cas-dir
+        None, // --cas-max-bytes
     );
     // The env/file-layer value must survive.
     assert!(
@@ -1836,6 +1840,117 @@ fn persistence_env_disables_and_overrides_path() {
     );
 }
 
+// --- [cas]: the media content-addressed store -------------------------------
+
+/// The default posture: a dir under XDG *data* (not state — these are artifacts the user
+/// paid for), and **no size cap**. The absent cap is the load-bearing default, not an
+/// oversight: enforcing one means summing every file in the store on every write, over a
+/// store that never deletes.
+#[test]
+fn cas_defaults_to_the_xdg_data_dir_and_no_cap() {
+    let c = Config::from_toml_str("").unwrap();
+    assert_eq!(
+        c.cas.max_bytes, None,
+        "the CAS ships uncapped — a cap costs an O(objects) walk per write, so it is opt-in"
+    );
+    let dir = c.cas.dir.expect("a default CAS dir resolves from XDG_DATA_HOME or HOME");
+    assert!(
+        dir.ends_with("kaibo/cas"),
+        "the default CAS dir is <data>/kaibo/cas, got {}",
+        dir.display()
+    );
+    assert!(
+        !dir.to_string_lossy().contains("/state/"),
+        "the CAS belongs in the DATA dir, not beside the disposable state db: {}",
+        dir.display()
+    );
+}
+
+/// The file layer sets both knobs, and `$VAR`/`~` in `dir` expand like every other path.
+#[test]
+fn cas_file_layer_sets_dir_and_cap() {
+    let c = Config::from_toml_str(
+        "[cas]\ndir = \"/srv/art\"\nmax_bytes = 1024\n",
+    )
+    .unwrap();
+    assert_eq!(c.cas.dir.unwrap(), std::path::PathBuf::from("/srv/art"));
+    assert_eq!(c.cas.max_bytes, Some(1024));
+}
+
+/// A zero ceiling is a loud load error, not a store that refuses every write. Nobody
+/// means "refuse everything" by `max_bytes = 0`; accepting it would produce a CAS that
+/// fails on first use with a capacity error no operator could explain.
+#[test]
+fn cas_zero_max_bytes_is_a_loud_load_error() {
+    let err = Config::from_toml_str("[cas]\nmax_bytes = 0\n")
+        .expect_err("max_bytes = 0 must be refused");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("max_bytes") && msg.contains("> 0"),
+        "the error must name the knob and the rule, got: {msg}"
+    );
+    assert!(
+        msg.contains("Omit"),
+        "and it must say how to get the uncapped default, got: {msg}"
+    );
+}
+
+/// An unknown key under `[cas]` is refused — `deny_unknown_fields`, like every other
+/// section, so a typo'd knob is never silently ignored.
+#[test]
+fn cas_unknown_key_is_refused() {
+    assert!(
+        Config::from_toml_str("[cas]\nmax_size = 10\n").is_err(),
+        "a typo'd [cas] key must be a loud load error, not a silently-ignored knob"
+    );
+}
+
+/// Env overrides the file, per the standard naming rule (`max_bytes` ⇄ KAIBO_CAS_MAX_BYTES).
+#[test]
+fn cas_env_overrides_the_file() {
+    let env: HashMap<&str, &str> = [
+        ("KAIBO_CAS_DIR", "/from/env"),
+        ("KAIBO_CAS_MAX_BYTES", "4096"),
+    ]
+    .into_iter()
+    .collect();
+    let c = Config::load_with(None, None, |k| env.get(k).map(|s| s.to_string())).unwrap();
+    assert_eq!(c.cas.dir.unwrap(), std::path::PathBuf::from("/from/env"));
+    assert_eq!(c.cas.max_bytes, Some(4096));
+}
+
+/// The CLI is the top layer, and an ABSENT flag never clobbers a lower layer — the same
+/// grammar every other optional flag here uses.
+#[test]
+fn cas_cli_wins_and_absent_flags_do_not_clobber() {
+    let mut c =
+        Config::from_toml_str("[cas]\ndir = \"/from/file\"\nmax_bytes = 111\n").unwrap();
+    c.apply_cli(
+        None,
+        None,
+        ToolDisables::default(),
+        vec![],
+        false,
+        false,
+        vec![],
+        vec![],
+        false,
+        None,
+        Some(std::path::PathBuf::from("/from/cli")), // --cas-dir
+        None,                                       // --cas-max-bytes NOT passed
+    );
+    assert_eq!(
+        c.cas.dir.unwrap(),
+        std::path::PathBuf::from("/from/cli"),
+        "--cas-dir wins over the file"
+    );
+    assert_eq!(
+        c.cas.max_bytes,
+        Some(111),
+        "an absent --cas-max-bytes must leave the file's value alone, not reset it"
+    );
+}
+
 /// The CLI is the top layer: `--no-persistence` and `--state-db` win over file/env.
 #[test]
 fn persistence_cli_wins_over_lower_layers() {
@@ -1853,6 +1968,8 @@ fn persistence_cli_wins_over_lower_layers() {
         vec![],
         true,                                           // --no-persistence
         Some(std::path::PathBuf::from("/from/cli.db")), // --state-db
+        None,                                           // --cas-dir
+        None,                                           // --cas-max-bytes
     );
     assert!(!c.persistence.enabled, "--no-persistence wins");
     assert_eq!(

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1840,6 +1840,96 @@ fn persistence_env_disables_and_overrides_path() {
     );
 }
 
+// --- the image role and the stability kind ----------------------------------
+
+/// An `image` slot parses and lands on the cast. Until this change `image = …` was a
+/// loud `deny_unknown_fields` error (986806f reduced the role set to explorer+synth);
+/// reviving it is what lets a cast staff an artifact-producing tool.
+#[test]
+fn a_cast_can_carry_an_image_slot() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.sd]
+        kind = "stability"
+
+        [casts.artist]
+        explorer = "deepseek/deepseek-v4-flash"
+        synth    = "deepseek/deepseek-v4-pro"
+        image    = "sd/core"
+        "#,
+    )
+    .expect("an image slot must parse");
+    let cast = c.resolve_cast("artist").expect("cast resolves");
+    let slot = cast
+        .slot(kaibo::config::ModelRole::Image)
+        .expect("the image slot is present");
+    assert_eq!(slot.backend, "sd");
+    assert_eq!(slot.id, "core");
+}
+
+/// A REASONING slot pointed at a Stability backend is a loud LOAD error. There is no
+/// completion model behind an image API, so an arm built from one could only fail at
+/// request time — and by then the operator is reading a provider error instead of being
+/// told their config is wrong. Refuse at load, and name the fix.
+#[test]
+fn a_reasoning_slot_cannot_point_at_a_stability_backend() {
+    for role in ["explorer", "synth"] {
+        let toml = format!(
+            r#"
+            [backends.sd]
+            kind = "stability"
+
+            [casts.broken]
+            {role} = "sd/core"
+            "#
+        );
+        let err = Config::from_toml_str(&toml)
+            .expect_err("a {role} slot on a stability backend must be refused at load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(role) && msg.contains("stability"),
+            "the error must name the offending slot and the kind, got: {msg}"
+        );
+        assert!(
+            msg.contains("image"),
+            "and it must point at the fix (the image slot), got: {msg}"
+        );
+    }
+}
+
+/// The mirror: an `image` slot on a chat backend is refused too. Asking a completion
+/// model to return pixels fails just as surely, and just as confusingly, at request time.
+#[test]
+fn an_image_slot_cannot_point_at_a_completion_backend() {
+    let err = Config::from_toml_str(
+        r#"
+        [casts.broken]
+        image = "deepseek/deepseek-v4-pro"
+        "#,
+    )
+    .expect_err("an image slot on a chat backend must be refused at load");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("image") && msg.contains("stability"),
+        "the error must name the slot and the kind it needs, got: {msg}"
+    );
+}
+
+/// No BUILT-IN cast carries an image slot, so a stock install can staff no image tool —
+/// the staffing gate then keeps that tool off the wire entirely, at zero resident cost
+/// for every user who never configures one. Pins the premise that argument rests on.
+#[test]
+fn no_builtin_cast_carries_an_image_slot() {
+    let c = Config::builtin();
+    for (name, cast) in &c.casts {
+        assert!(
+            cast.slot(kaibo::config::ModelRole::Image).is_none(),
+            "built-in cast {name:?} must not carry an image slot — image generation \
+             costs real money per call and has to be configured deliberately"
+        );
+    }
+}
+
 // --- [cas]: the media content-addressed store -------------------------------
 
 /// The default posture: a dir under XDG *data* (not state — these are artifacts the user

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -594,6 +594,8 @@ fn allow_paths_cli_replaces_env_and_file() {
         vec![],
         false,
         None,
+        None, // --cas-dir
+        None, // --cas-max-bytes
     );
     assert_eq!(c.allow_paths.len(), 2);
     assert!(c

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -14,12 +14,13 @@ use kaibo::server::{KaiboHandler, ToolGating};
 /// and stay advertised as long as either capability is on, so they belong to neither
 /// flag. `list_models` is its own gate — a read-only operator/config tool, no model in
 /// the loop, independent of everything else here.
-const ALL_TOOLS: [&str; 12] = [
+const ALL_TOOLS: [&str; 13] = [
     "batch_submit",
     "consult",
     "consult_submit",
     "deliberate",
     "explore",
+    "generate",
     "job_cancel",
     "job_get",
     "job_list",
@@ -56,9 +57,14 @@ const FULLY_STAFFED: &str = r#"
     kind = "gemini"
     key_optional = true
 
+    [backends.sd]
+    kind = "stability"
+    key_optional = true
+
     [casts.inter]
     explorer = "gem/lite"
     synth    = "gem/flash"
+    image    = "sd/core"
 
     [casts.deep]
     explorer = "gem/lite"
@@ -109,6 +115,11 @@ fn a_stock_install_does_not_advertise_deliberate() {
          not be advertised on a stock install; got {tools:?}"
     );
     assert!(
+        !tools.contains(&"generate".to_string()),
+        "no built-in cast carries an `image` slot, so `generate` must not be advertised \
+         on a stock install; got {tools:?}"
+    );
+    assert!(
         tools.contains(&"consult".to_string()),
         "the rest of the surface must survive — this is a targeted drop, not a shutdown; \
          got {tools:?}"
@@ -121,7 +132,7 @@ fn each_flag_removes_exactly_its_own_tools() {
     // `job_get`/`job_cancel`/`job_list` belong to neither flag alone — gating one
     // capability leaves them because the other still needs them — so they appear in no
     // row's removed-set and are covered by the "every other tool remains" check below.
-    let cases: [(&[&str], ToolGating); 7] = [
+    let cases: [(&[&str], ToolGating); 8] = [
         (
             // `--no-consult` drops the blocking `consult` and the async `consult_submit`;
             // `job_get`/`job_cancel`/`job_list` stay (batch still uses them).
@@ -181,6 +192,15 @@ fn each_flag_removes_exactly_its_own_tools() {
                 ..Default::default()
             },
         ),
+        (
+            // `--no-generate` drops only `generate`; the collect verbs stay (the other
+            // producers still mint handles).
+            &["generate"],
+            ToolGating {
+                generate: false,
+                ..Default::default()
+            },
+        ),
     ];
     for (disabled, gating) in cases {
         let tools = advertised(gating);
@@ -202,19 +222,54 @@ fn each_flag_removes_exactly_its_own_tools() {
 
 /// The shared collect verbs (`job_get`/`job_cancel`/`job_list`/`job_wait`) are gated by
 /// *any handle producer*: `consult_submit` and `batch_submit` — and `deliberate`, which
-/// produces both a `job-N` (direct lane) and a `backend/provider-id` (batch lane). They
-/// stay while any of the three is on, and drop only when all are off. A gate that knew
-/// only batch+consult would strand a `deliberate`-only server's handles.
+/// produces both a `job-N` (direct lane) and a `backend/provider-id` (batch lane) —
+/// and `generate`, whose deferred operations mint a `job-N`. They stay while any of
+/// the four is on, and drop only when all are off. A gate that knew only batch+consult
+/// would strand a `deliberate`-only (or `generate`-only) server's handles.
 #[test]
 fn shared_collect_verbs_track_all_handle_producers() {
     const VERBS: [&str; 4] = ["job_get", "job_cancel", "job_list", "job_wait"];
 
     // Each producer alone must keep the verbs — its handles need collecting.
     for (label, only) in [
-        ("consult", ToolGating { batch: false, deliberate: false, ..Default::default() }),
-        ("batch", ToolGating { consult: false, deliberate: false, ..Default::default() }),
+        (
+            "consult",
+            ToolGating {
+                batch: false,
+                deliberate: false,
+                generate: false,
+                ..Default::default()
+            },
+        ),
+        (
+            "batch",
+            ToolGating {
+                consult: false,
+                deliberate: false,
+                generate: false,
+                ..Default::default()
+            },
+        ),
         // deliberate alone: it's the case the old batch+consult gate would have stranded.
-        ("deliberate", ToolGating { batch: false, consult: false, ..Default::default() }),
+        (
+            "deliberate",
+            ToolGating {
+                batch: false,
+                consult: false,
+                generate: false,
+                ..Default::default()
+            },
+        ),
+        // generate alone: a deferred generation is collected through the same verbs.
+        (
+            "generate",
+            ToolGating {
+                batch: false,
+                consult: false,
+                deliberate: false,
+                ..Default::default()
+            },
+        ),
     ] {
         let tools = advertised(only);
         for v in VERBS {
@@ -225,18 +280,19 @@ fn shared_collect_verbs_track_all_handle_producers() {
         }
     }
 
-    // All three producers off — nothing to collect, so the verbs drop. (run_kaish/oneshot
+    // All four producers off — nothing to collect, so the verbs drop. (run_kaish/oneshot
     // keep the server a valid, non-empty surface.)
     let none = advertised(ToolGating {
         batch: false,
         consult: false,
         deliberate: false,
+        generate: false,
         ..Default::default()
     });
     for v in VERBS {
         assert!(
             !none.contains(&v.to_string()),
-            "{v} must drop when every handle producer (batch/consult/deliberate) is off"
+            "{v} must drop when every handle producer (batch/consult/deliberate/generate) is off"
         );
     }
 }
@@ -251,6 +307,7 @@ fn all_disabled_is_detected() {
         run_kaish: false,
         batch: false,
         list_models: false,
+        generate: false,
     };
     assert!(none_on.all_disabled());
     // Any single tool on means it's a usable server, not the refused state.


### PR DESCRIPTION
Completes the media-cas arc on the four decisions Amy made in-session (2026-08-02/03):

1. **Trait shape approved, widened first**: `MediaOutcome::Complete` and `MediaPollOutcome::Complete` carry `Vec<MediaArtifact>` — Amy: "pretty sure many of the image gen models do multiple returns". One digest + one provenance sidecar per artifact; an empty list is a provider bug to refuse, never a blessed shape.
2. **Retrieval is operator-surface only**: the new `kaibo://cas/{digest}` resource serves bytes (base64, correct mime) to the calling client. The inner model team never sees the CAS — no kaish mount, no cast-facing read path — so one project's team can't enumerate another project's artifacts. Cross-agent sharing is deliberately deferred. Amy's framing: "cas should be a way for the kaibo agents to get stuff to the client efficiently."
3. **Lifecycle follows persistence**: disk CAS while persistence is active; in-memory with a severe startup warning when it isn't (artifacts don't survive restart); `[cas] enabled = false` turns it off and un-advertises dependent tools. One derivation (`Config::cas_mode`) feeds main, `kaibo://config`, and the CLI.
4. **Lane split by declared shape**: sync operations answer in-call; provider-declared deferred operations return `job-N` on the existing job verbs. The tool returns digests + URIs (+ real path in disk mode), never inline bytes.

The `generate` tool is the eighth capability flag, staffed via the cast's `image` slot through `CAST_ENUM_RULES`, with a third liveness gate: the CAS must be on. Stock installs (no image cast) drop the route — pinned in `tests/gating.rs`.

**Write-surface discipline held**: `tests/no_write_path.rs` pinned count is 4 before and after — `MemoryCas` touches no filesystem and the tool writes only through `Cas::put`'s existing blessed sites. No destination-path parameter exists anywhere; `src/sandbox.rs` is untouched.

Judgment calls flagged for review (details in commits):
- A HOME-less environment (no resolvable CAS dir) lands on memory mode with the severe warn naming the reason, rather than a fatal error.
- Deferred polling reuses `[defaults] call_deadline` as its budget (10s cadence) instead of a new knob.
- AGENTS.md's "produces no output artifacts" opening was rewritten — the change `docs/issues.md` explicitly required to land with the first artifact-producing tool.

888 tests green (baseline 868 after merging main), clippy silent. Patch by a Claude subagent from the in-session decision brief; cross-family reviews (DeepSeek + Gemini) to follow as PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)