### PR TITLE
feat(media): openai-images — one kind for hosted gpt-image and a local sd-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ record. Each later release appends a new section at the top.
 - **A second media kind: `openai-images`.** One backend kind covers hosted OpenAI
   image generation (gpt-image-1) *and* a local stable-diffusion.cpp `sd-server`,
   which speaks the same `/v1/images/generations` shape — `base_url` picks the
-  target (unset dials hosted OpenAI), keys ride the same `OPENAI_API_KEY` /
-  `~/.openai-key` sources as the `openai` kind, and the keyless local case works
-  with no credential at all. A single `generate` call can now return several
-  images (the `n` field), each stored under its own digest.
+  target (unset dials hosted OpenAI, so the key is required by default), keys ride
+  the same `OPENAI_API_KEY` / `~/.openai-key` sources as the `openai` kind, and a
+  keyless local server opts in with `key_optional = true`. A single `generate`
+  call can now return several images (the `n` field), each stored under its own
+  digest — and `fields` values keep their JSON types (`n` as a number, `user` as
+  a string) all the way to the provider, on every media kind.
 
 - **kaibo can now generate images.** A new `generate` tool turns a text prompt into
   artifacts through the cast's new `image` slot — a media backend (Stability's v2beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **A second media kind: `openai-images`.** One backend kind covers hosted OpenAI
+  image generation (gpt-image-1) *and* a local stable-diffusion.cpp `sd-server`,
+  which speaks the same `/v1/images/generations` shape — `base_url` picks the
+  target (unset dials hosted OpenAI), keys ride the same `OPENAI_API_KEY` /
+  `~/.openai-key` sources as the `openai` kind, and the keyless local case works
+  with no credential at all. A single `generate` call can now return several
+  images (the `n` field), each stored under its own digest.
+
 - **kaibo can now generate images.** A new `generate` tool turns a text prompt into
   artifacts through the cast's new `image` slot — a media backend (Stability's v2beta
   `core`/`ultra`/SD3.5 family) riding beside the reasoning slots, e.g.

--- a/README.md
+++ b/README.md
@@ -475,11 +475,12 @@ the box with environment variables and built-in defaults, so a missing config fi
 not an error. `$XDG_CONFIG_HOME/kaibo/config.toml` lets you wire your own roster. The
 config has three concepts for configuring models:
 
-- **backend** — a *connection*: which wire protocol (`anthropic` | `deepseek` |
-  `gemini` | `openrouter` | `openai`), base URL, and where its key comes from. Secrets
-  never live in the TOML — only the *name* of an env var or the path to a key file.
-  `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every major
-  model family, reasoning on by default via its unified `effort` param.
+- **backend** — a *connection*: which wire protocol (the completion kinds `anthropic`
+  | `deepseek` | `gemini` | `openrouter` | `openai`, or the media kinds `stability` |
+  `openai-images` behind the `image` role), base URL, and where its key comes from.
+  Secrets never live in the TOML — only the *name* of an env var or the path to a key
+  file. `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every
+  major model family, reasoning on by default via its unified `effort` param.
 - **role** — a *job* a model does: `explorer` (fast sweeps), `synth` (the voice that
   answers), and `image` (the media member behind `generate`). A reasoning slot that
   reads images carries a `vision` pin (see [`docs/casts.md`](docs/casts.md)).

--- a/README.md
+++ b/README.md
@@ -452,7 +452,9 @@ review: there's no diff, because nothing it runs can change your tree.
 ### `generate` — images through the cast's media member
 
 kaibo's first artifact-*producing* tool: a text prompt in, generated images out —
-through a cast's `image` slot (a Stability backend today). The bytes never inline into
+through a cast's `image` slot. Image generation spans Stability's v2beta family and
+OpenAI-compatible image endpoints (hosted gpt-image, or a local stable-diffusion.cpp
+`sd-server` speaking the same `/v1/images/generations` shape). The bytes never inline into
 your context: each artifact lands in kaibo's content-addressed media store with a
 provenance sidecar (prompt, model, cast, seed), and the result lists per-artifact
 digests as `kaibo://cas/<digest>` resource URIs — plus the real file path when the

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -435,8 +435,8 @@ wire = "responses"
 # `deep-dive`) so it can route by name without reading this file.
 #
 # Roles: explorer, synth (the reasoning phases), and image (the media member — it
-# points at a stability backend and staffs `generate`; see the image-slot example
-# below). A typo'd role is a loud load
+# points at a media backend, kind stability or openai-images, and staffs `generate`;
+# see the image-slot examples below). A typo'd role is a loud load
 # error. A cast may omit roles — the tool that needs a missing role fails at call time,
 # naming the gap ("cast `notes` has no synth slot"); absent = capability absent.
 #
@@ -496,20 +496,23 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 # image    = "sd/core"            # core | ultra | an sd3.5 variant (e.g. sd3.5-large)
 
 # --- The openai-images kind covers two shapes with one wire. Hosted OpenAI: no
-#     base_url (unset dials api.openai.com/v1) and key_optional = false, so a
-#     missing OPENAI_API_KEY / ~/.openai-key fails loudly instead of sending the
-#     placeholder. Local stable-diffusion.cpp sd-server: base_url through /v1 and
-#     no key at all — key_optional defaults true on this kind, exactly for this
-#     case. Provider knobs (size, quality, n, output_format, ...) ride the
-#     `generate` tool's fields, not the config. ---
+#     base_url (unset dials api.openai.com/v1); the key is required — the seeded
+#     default, so a missing OPENAI_API_KEY / ~/.openai-key fails loudly instead of
+#     sending a placeholder bearer to a paid endpoint. Local stable-diffusion.cpp
+#     sd-server: base_url through /v1 plus key_optional = true — keyless is an
+#     explicit opt-in on this kind, stated beside the local endpoint it belongs to.
+#     Provider knobs (size, quality, n, output_format, ...) ride the `generate`
+#     tool's fields, not the config; output_format is checked before the call and
+#     must be png, jpeg, or webp (the set kaibo's media store can name on disk). ---
 
 # [backends.oai-images]
-# kind = "openai-images"          # key: OPENAI_API_KEY / ~/.openai-key
-# key_optional = false            # hosted OpenAI needs a real key
+# kind = "openai-images"          # key: OPENAI_API_KEY / ~/.openai-key (required —
+#                                 # the default; a missing key fails at call setup)
 
 # [backends.sdcpp]
 # kind = "openai-images"
-# base_url = "http://localhost:1234/v1"   # keyless local sd-server
+# base_url = "http://localhost:1234/v1"   # local sd-server...
+# key_optional = true                     # ...which needs no key: explicit opt-in
 
 # [casts.hosted-artist]
 # image = "oai-images/gpt-image-1"        # the request's `model` field

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -313,18 +313,19 @@ scratch_limit_bytes = 67108864
 # ---------------------------------------------------------------------------
 # [backends.<name>] — CONNECTIONS only: `kind` picks the wire and its client. The
 # completion wires (anthropic | deepseek | gemini | openrouter | openai) serve the
-# reasoning slots; the media wire (stability) serves `image` slots only. The rest
-# describes the wire (endpoint, key source, per-request deadline). Models live on
-# cast slots, never here.
+# reasoning slots; the media kinds (stability | openai-images) serve `image` slots
+# only. The rest describes the wire (endpoint, key source, per-request deadline).
+# Models live on cast slots, never here.
 #
 # Keys are referenced, never inlined: api_key_env names an env var, api_key_file a
 # path (~ ok). env wins over file. key_optional=true falls back to a placeholder
 # bearer token (keyless local servers). base_url is legal on the openai kind
 # (required for a new backend), the anthropic and gemini kinds (optional —
 # unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com),
-# and the stability kind (optional — unset dials api.stability.ai); set it to point
-# the same wire at a compatible gateway/proxy instead — a HOST ROOT in every case,
-# since the client appends its own versioned path. Every other keyed kind rejects
+# and the media kinds (optional — unset dials api.stability.ai for stability,
+# api.openai.com/v1 for openai-images); set it to point the same wire at a
+# compatible gateway/proxy (or a local server) instead — a ROOT in every case,
+# since the client appends its own path. Every other keyed kind rejects
 # base_url at load (rig fixes those endpoints).
 # ---------------------------------------------------------------------------
 
@@ -480,10 +481,11 @@ explorer = "llama/qwen2.5-coder-7b"                              # bare ref: jus
 synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 # --- The `image` slot: a MEDIA member on the team. It points at a media backend
-#     (kind = "stability") and produces artifacts instead of text, so the reasoning
-#     tunables (effort, thinking_budget, temperature, ...) do not apply to it —
-#     writing one there is inert and kaibo://config flags it. A cast carries it
-#     beside its reasoning slots; a cast without one cannot staff the media tools. ---
+#     (kind = "stability" or "openai-images") and produces artifacts instead of
+#     text, so the reasoning tunables (effort, thinking_budget, temperature, ...)
+#     do not apply to it — writing one there is inert and kaibo://config flags it.
+#     A cast carries it beside its reasoning slots; a cast without one cannot staff
+#     the media tools. ---
 
 # [backends.sd]
 # kind = "stability"              # key: STABILITY_API_KEY / ~/.stability-key.txt
@@ -492,6 +494,28 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 # explorer = "deepseek/deepseek-v4-flash"
 # synth    = "deepseek/deepseek-v4-pro"
 # image    = "sd/core"            # core | ultra | an sd3.5 variant (e.g. sd3.5-large)
+
+# --- The openai-images kind covers two shapes with one wire. Hosted OpenAI: no
+#     base_url (unset dials api.openai.com/v1) and key_optional = false, so a
+#     missing OPENAI_API_KEY / ~/.openai-key fails loudly instead of sending the
+#     placeholder. Local stable-diffusion.cpp sd-server: base_url through /v1 and
+#     no key at all — key_optional defaults true on this kind, exactly for this
+#     case. Provider knobs (size, quality, n, output_format, ...) ride the
+#     `generate` tool's fields, not the config. ---
+
+# [backends.oai-images]
+# kind = "openai-images"          # key: OPENAI_API_KEY / ~/.openai-key
+# key_optional = false            # hosted OpenAI needs a real key
+
+# [backends.sdcpp]
+# kind = "openai-images"
+# base_url = "http://localhost:1234/v1"   # keyless local sd-server
+
+# [casts.hosted-artist]
+# image = "oai-images/gpt-image-1"        # the request's `model` field
+
+# [casts.local-artist]
+# image = "sdcpp/sd3.5-large"             # whatever the local server loaded
 
 # --- The table form, part 2: per-slot tunables. Each overrides its [defaults]
 #     per-role value for THIS slot only; knobs you omit fall back. Available:

--- a/docs/config.md
+++ b/docs/config.md
@@ -59,7 +59,7 @@ Connection settings only. Models are never declared here.
 | `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
 | `api_key_env` | env var *name* | seeded from `kind` | env source, checked first |
 | `api_key_file` | path | seeded from `kind` | file source, checked second |
-| `key_optional` | bool | `true` for `openai` and `openai-images`, else `false` | allows a placeholder token |
+| `key_optional` | bool | `true` for `openai`, else `false` | allows a placeholder token |
 | `data_collection` | `deny` \| `allow` | `deny` | `kind = "openrouter"` only; load error elsewhere |
 | `request_timeout_secs` | integer > 0 | `[defaults]` value (900) | per-single-completion ceiling |
 
@@ -86,11 +86,14 @@ by re-declaration.
 - **`kind = "openai-images"`** — optional. Unset dials hosted OpenAI
   (`https://api.openai.com/v1`). Set, it points the same wire at any server speaking
   `/v1/images/generations` — a local stable-diffusion.cpp `sd-server`
-  (`base_url = "http://localhost:1234/v1"`) is the expected local case. Key posture
-  mirrors the `openai` kind, not `stability`: the same `OPENAI_API_KEY` /
-  `~/.openai-key` sources, and `key_optional` defaults **true** (the keyless local
-  server case) — set `key_optional = false` on a backend aimed at hosted OpenAI so a
-  missing key fails loudly instead of sending the placeholder.
+  (`base_url = "http://localhost:1234/v1"`) is the expected local case. Key sources
+  are shared with the `openai` kind (the same `OPENAI_API_KEY` / `~/.openai-key`),
+  but the key is **required by default**: the default endpoint is hosted, so a
+  keyless seed would send a placeholder bearer to a paid API and 401 on the first
+  call instead of failing loudly at setup. A keyless local `sd-server` backend sets
+  `key_optional = true` beside its local `base_url`. The `generate` tool's
+  `output_format` field for this kind must be `png`, `jpeg`, or `webp` — checked
+  before the call, since it names the stored artifact's on-disk format.
 - **Every other kind** — a load error. rig fixes those endpoints.
 
 The value is a root the client versions itself, never a full endpoint path. rig's

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,7 +20,7 @@ of backends and casts. A missing file at the default path is not an error.
 
 ```
 ProviderKind = anthropic | deepseek | gemini | openrouter | openai   (completion wires)
-             | stability                                             (media wire)
+             | stability | openai-images                             (media kinds)
 Backend      = { name, kind, base_url?, key source, request_timeout }
 Cast         = { name, role → ModelSlot }                  (freely spans backends)
 ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
@@ -32,13 +32,14 @@ Each concept owns one idea:
   selects the client and the request shape), `base_url`, a key source, and
   `request_timeout`. Answers "how do I reach Gemini". Kinds divide into two classes:
   the completion wires (everything through rig's completion clients) and the media
-  wire (`stability`, an image-generation API with no completion surface).
+  kinds (`stability`, `openai-images` — image-generation APIs with no completion
+  surface).
 - **role** — a *job* a model serves. Three exist: `explorer` and `synth`, the two
   reasoning phases, and `image`, the media member that staffs the `generate` tool.
   A reasoning role takes a completion backend; the `image` role takes a media backend
-  (kind `stability`) — pairing either with the wrong class is a load error naming the
-  fix. Image *input* is a slot capability (the `vision` pin on a reasoning slot), not
-  a role.
+  (kind `stability` or `openai-images`) — pairing either with the wrong class is a
+  load error naming the fix. Image *input* is a slot capability (the `vision` pin on
+  a reasoning slot), not a role.
 - **cast** — a *composition*. A named assignment of models to roles. This is what the
   `cast` call parameter selects.
 
@@ -53,12 +54,12 @@ Connection settings only. Models are never declared here.
 
 | key | type | default | notes |
 |---|---|---|---|
-| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` | required on a new backend | closed enum; selects client + request shape (`stability` is the media wire — image slots only) |
-| `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini`/`stability`; load error elsewhere |
+| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` | required on a new backend | closed enum; selects client + request shape (`stability` and `openai-images` are the media kinds — image slots only) |
+| `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini` and the media kinds; load error elsewhere |
 | `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
 | `api_key_env` | env var *name* | seeded from `kind` | env source, checked first |
 | `api_key_file` | path | seeded from `kind` | file source, checked second |
-| `key_optional` | bool | `true` for `openai`, else `false` | allows a placeholder token |
+| `key_optional` | bool | `true` for `openai` and `openai-images`, else `false` | allows a placeholder token |
 | `data_collection` | `deny` \| `allow` | `deny` | `kind = "openrouter"` only; load error elsewhere |
 | `request_timeout_secs` | integer > 0 | `[defaults]` value (900) | per-single-completion ceiling |
 
@@ -82,12 +83,22 @@ by re-declaration.
 - **`kind = "stability"`** — optional, same contract: unset dials
   `https://api.stability.ai`; set, it points the media wire at a compatible
   gateway or proxy.
+- **`kind = "openai-images"`** — optional. Unset dials hosted OpenAI
+  (`https://api.openai.com/v1`). Set, it points the same wire at any server speaking
+  `/v1/images/generations` — a local stable-diffusion.cpp `sd-server`
+  (`base_url = "http://localhost:1234/v1"`) is the expected local case. Key posture
+  mirrors the `openai` kind, not `stability`: the same `OPENAI_API_KEY` /
+  `~/.openai-key` sources, and `key_optional` defaults **true** (the keyless local
+  server case) — set `key_optional = false` on a backend aimed at hosted OpenAI so a
+  missing key fails loudly instead of sending the placeholder.
 - **Every other kind** — a load error. rig fixes those endpoints.
 
-The value is a **host root**, not a versioned path. rig's `ClientBuilder` appends the
-provider-specific path (Gemini's `/v1beta/models/...`), and the batch lane's
-`GeminiBatch` versions a configured host root with `/v1beta` the same way, so one
-address serves both the interactive and batch paths.
+The value is a root the client versions itself, never a full endpoint path. rig's
+`ClientBuilder` appends the provider-specific path (Gemini's `/v1beta/models/...`),
+the batch lane's `GeminiBatch` versions a configured host root with `/v1beta` the
+same way, and the media clients append their own route (`/v2beta/...` for
+`stability`; `/images/generations` for `openai-images`, so give that one a URL
+through `/v1`).
 
 #### `wire`
 
@@ -205,8 +216,10 @@ synth    = "claude/claude-sonnet-4-6"       # the model that answers
 
 **Roles.** `explorer`, `synth`, and `image`. A misspelled role, or a misspelled
 per-slot key, is a load error rather than a silent no-op. The `image` slot is the
-media member: it points at a `stability`-kind backend (its model id picks the route —
-`core`, `ultra`, or an SD3.5 variant) and staffs the `generate` tool. It sends one
+media member: it points at a media-kind backend and staffs the `generate` tool. Its
+model id means what that kind says it means — for `stability` it picks the route
+(`core`, `ultra`, or an SD3.5 variant); for `openai-images` it is the `model` field
+(`gpt-image-1` hosted, or whatever a local sd-server loaded). It sends one
 generation request, not a reasoning loop, so the reasoning tunables (`effort`,
 `thinking_budget`, `temperature`, ...) written on it are inert — `kaibo://config`
 flags them under `inert_tunables`.
@@ -637,7 +650,7 @@ Which cast shape staffs which tool:
 | `explore` | a cast with an `explorer` slot |
 | `batch_submit` | a cast whose synth runs on `lane = "batch"` (or the `batch = true` sugar) |
 | `deliberate` | a cast with an `explorer` **and** an offline synth (`lane = "batch"` or `lane = "direct"`) |
-| `generate` | a cast with an `image` slot (a media backend, kind `stability`) — plus `[cas]` on |
+| `generate` | a cast with an `image` slot (a media backend: kind `stability` or `openai-images`) — plus `[cas]` on |
 | `job_get`, `job_cancel`, `job_list`, `job_wait` | at least one live handle *producer*; they follow whatever survives above |
 | `run_kaish`, `list_models` | no cast at all; advertised whenever their flag is on |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -733,6 +733,11 @@ impl Backend {
     /// `base_url` wins; otherwise fall back to `OPENAI_BASE_URL` (back-compat) or the
     /// built-in default. Read at use-time, not construction, so backend *building*
     /// stays pure (see [`Config::from_toml_str`]).
+    ///
+    /// COMPLETION-WIRE ONLY: the fallback default here is the local keyless server, the
+    /// `openai` kind's home. A media backend (`openai-images`) defaults to the *hosted*
+    /// endpoint instead, resolved in `MediaArm::from_slot` — a call site reaching this
+    /// method for a media backend would silently dial localhost.
     pub fn resolved_base_url(&self) -> String {
         self.base_url
             .clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1261,7 +1261,7 @@ impl Config {
 
     /// Whether canonical cast `name` can staff a `generate` call: it carries an
     /// **image** slot — the media member, the only slot `generate` runs. Load
-    /// validation already pinned that slot to a media backend (kind `stability`), so
+    /// validation already pinned that slot to a media-class backend, so
     /// slot presence is the whole test here. Independent of the reasoning slots: a
     /// cast may be image-only, and a full team's image slot is equally valid.
     pub fn cast_can_generate(&self, name: &str) -> bool {
@@ -1646,27 +1646,31 @@ impl Config {
                     b.name
                 );
             }
-            // A base_url on a keyed kind: rig fixes those endpoints — except Anthropic
-            // and Gemini, which also accept one (for an Anthropic/Gemini-API-compatible
-            // gateway/proxy in front of the real backend), optionally: unset still
-            // dials rig's built-in https://api.anthropic.com /
-            // https://generativelanguage.googleapis.com. Both contracts are a HOST
-            // ROOT — rig's `ClientBuilder::base_url` appends its own versioned path
-            // (`/v1beta/models/...` for Gemini) rather than taking one baked in; see
-            // `GeminiBatch::base_url` (`batch.rs`) for the batch lane's matching
-            // reconciliation. `stability` takes one on the same optional host-root
-            // contract: kaibo's own facade appends `/v2beta/...` (`StabilityClient`),
-            // and unset dials the real https://api.stability.ai.
-            if b.kind != ProviderKind::Openai
-                && b.kind != ProviderKind::Anthropic
-                && b.kind != ProviderKind::Gemini
-                && b.kind != ProviderKind::Stability
-                && b.base_url.is_some()
-            {
+            // A base_url on a keyed completion kind: rig fixes those endpoints —
+            // except Anthropic and Gemini, which also accept one (for an
+            // Anthropic/Gemini-API-compatible gateway/proxy in front of the real
+            // backend), optionally: unset still dials rig's built-in
+            // https://api.anthropic.com / https://generativelanguage.googleapis.com.
+            // Both contracts are a ROOT the client versions itself — rig's
+            // `ClientBuilder::base_url` appends its own path (`/v1beta/models/...`
+            // for Gemini) rather than taking one baked in; see `GeminiBatch::base_url`
+            // (`batch.rs`) for the batch lane's matching reconciliation. EVERY
+            // media-class kind takes one on the same client-appends-its-path
+            // contract: kaibo's own facades append their route (`/v2beta/...` for
+            // stability, `/images/generations` for openai-images), and unset dials
+            // each kind's real hosted endpoint (api.stability.ai /
+            // api.openai.com/v1). Class-based on the media side so a new media kind
+            // never has to join a hand-maintained list here.
+            let base_url_legal = matches!(b.kind.class(), credentials::ProviderClass::Media(_))
+                || matches!(
+                    b.kind,
+                    ProviderKind::Openai | ProviderKind::Anthropic | ProviderKind::Gemini
+                );
+            if !base_url_legal && b.base_url.is_some() {
                 bail!(
                     "backend {:?} (kind {:?}) sets base_url, but only the `openai`, \
-                     `anthropic`, `gemini`, and `stability` kinds have a configurable \
-                     endpoint",
+                     `anthropic`, and `gemini` completion kinds and the media kinds \
+                     have a configurable endpoint",
                     b.name,
                     b.kind
                 );
@@ -1820,31 +1824,39 @@ impl Config {
                         t.max_tokens
                     );
                 }
-                // The role and the backend KIND have to agree about what kind of wire
-                // this is. `stability` is an image-generation API driven through
-                // kaibo's own facade, not a rig completion model, so it can staff the
-                // `image` slot and nothing else; conversely an image slot pointed at a
-                // chat backend would ask a completion model to return pixels. Both are
-                // load errors here rather than a baffling failure at request time, when
-                // the operator would be reading a provider error instead of a config
-                // mistake. This is the config half of the guard `Arm::from_slot` bails
-                // on — if the two ever disagree, both refuse rather than improvise.
-                if kind == ProviderKind::Stability && role.is_reasoning() {
+                // The role and the backend kind's CLASS have to agree. A media-class
+                // kind (stability, openai-images, ...) is driven through kaibo's own
+                // facade, not a rig completion model, so it can staff the `image`
+                // slot and nothing else; conversely an image slot pointed at a
+                // completion wire would ask a chat model to return pixels. Both are
+                // load errors here rather than a baffling failure at request time,
+                // when the operator would be reading a provider error instead of a
+                // config mistake. Class-based on purpose (`ProviderKind::class`), so
+                // a new media kind is covered the moment it is classified and the
+                // error text never carries a kind list that goes stale. This is the
+                // config half of the guard `Arm::from_slot` / `MediaArm::from_slot`
+                // bail on — if the two ever disagree, both refuse rather than
+                // improvise.
+                let is_media = matches!(kind.class(), credentials::ProviderClass::Media(_));
+                if is_media && role.is_reasoning() {
                     bail!(
                         "cast {name:?}: the {} slot points at backend {:?} (kind \
-                         `stability`), which generates images and has no completion \
-                         model to reason with — point {} at a chat backend, and put the \
-                         stability backend on this cast's `image` slot instead",
+                         `{}`, a media kind), which generates artifacts and has no \
+                         completion model to reason with — point {} at a completion \
+                         backend, and put backend {:?} on this cast's `image` slot \
+                         instead",
                         role.key(),
                         slot.backend,
+                        kind.canonical_name(),
                         role.key(),
+                        slot.backend,
                     );
                 }
-                if *role == ModelRole::Image && kind != ProviderKind::Stability {
+                if *role == ModelRole::Image && !is_media {
                     bail!(
                         "cast {name:?}: the image slot points at backend {:?} (kind \
-                         `{}`), which is a chat/completion wire and cannot generate an \
-                         image — an image slot needs a backend of kind `stability`",
+                         `{}`, a completion wire), which cannot generate an image — \
+                         an image slot needs a media-kind backend",
                         slot.backend,
                         kind.canonical_name(),
                     );
@@ -4791,7 +4803,10 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("only the `openai`, `anthropic`, `gemini`, and `stability` kinds"),
+            err.contains(
+                "only the `openai`, `anthropic`, and `gemini` completion kinds and the \
+                 media kinds"
+            ),
             "got: {err}"
         );
     }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -63,12 +63,14 @@ pub enum ProviderKind {
     /// OpenAI's Images API (`POST {base}/images/generations`) — the second media kind,
     /// via `src/openai_images.rs`. One kind covers two real targets: hosted OpenAI
     /// image generation (the gpt-image-1 family) and any local server speaking the
-    /// same endpoint shape (stable-diffusion.cpp's sd-server). Its key posture
-    /// mirrors [`ProviderKind::Openai`], not Stability: the same `OPENAI_API_KEY` /
-    /// `~/.openai-key` sources, and `key_optional` by default because the local
-    /// sd-server case is keyless — an operator pointing at hosted OpenAI sets
-    /// `key_optional = false` explicitly. Like Stability, it is not in the built-in
-    /// backend list and staffs only `image` cast slots.
+    /// same endpoint shape (stable-diffusion.cpp's sd-server). Its key SOURCES
+    /// mirror [`ProviderKind::Openai`] (the same `OPENAI_API_KEY` / `~/.openai-key`
+    /// — one OpenAI credential, not two to maintain), but the key is REQUIRED by
+    /// default: this kind's default endpoint is hosted OpenAI, so a keyless seed
+    /// would 401 on the first paid call instead of failing at load (see
+    /// [`ProviderKind::key_optional`]). A keyless local sd-server backend sets
+    /// `key_optional = true` beside its explicit local `base_url`. Like Stability,
+    /// it is not in the built-in backend list and staffs only `image` cast slots.
     OpenAiImages,
 }
 
@@ -87,15 +89,18 @@ impl ProviderKind {
         Self::OpenAiImages,
     ];
 
-    /// Whether a missing credential is tolerated rather than a hard error. The two
-    /// OpenAI-shaped kinds are: the completion kind's default endpoint is a local
-    /// keyless server, and the images kind covers the keyless local sd-server case
-    /// with the same reasoning — an absent key falls back to a placeholder bearer
-    /// token ([`PLACEHOLDER_OPENAI_KEY`]), and an operator pointing either at hosted
-    /// OpenAI sets `key_optional = false` on the backend explicitly. The keyed
-    /// providers must fail loudly on a missing key.
+    /// Whether a missing credential is tolerated rather than a hard error. Only the
+    /// OpenAI-compatible *completion* provider is: its default endpoint is a local
+    /// keyless server, so an absent key coherently falls back to a placeholder
+    /// bearer token ([`PLACEHOLDER_OPENAI_KEY`]). The images kind shares its key
+    /// sources but seeds key-REQUIRED, because its default endpoint is hosted
+    /// OpenAI: a keyless seed there would let a minimal stanza load clean, staff
+    /// `generate`, and then send `Bearer no-auth` to api.openai.com — a 401 on the
+    /// first paid call instead of a loud load-time gap. A keyless local sd-server
+    /// backend opts in with `key_optional = true` explicitly, beside its explicit
+    /// local `base_url`. The keyed providers must fail loudly on a missing key.
     pub fn key_optional(self) -> bool {
-        matches!(self, ProviderKind::Openai | ProviderKind::OpenAiImages)
+        matches!(self, ProviderKind::Openai)
     }
 
     /// The stand-in credential a `key_optional` backend sends when no real key is
@@ -123,7 +128,8 @@ impl ProviderKind {
             | ProviderKind::DeepSeek
             | ProviderKind::OpenRouter
             | ProviderKind::Openai
-            // The keyless local sd-server case: header-bearer shaped, value ignored.
+            // Reached only when an operator sets `key_optional = true` for a local
+            // sd-server: header-bearer shaped, value ignored by such a server.
             | ProviderKind::OpenAiImages
             // Never reached: Stability is not `key_optional`, so a missing key is a
             // hard error long before a stand-in is wanted. It is a header-bearer wire,
@@ -271,6 +277,20 @@ pub enum MediaKind {
 pub enum ProviderClass {
     Wire(WireKind),
     Media(MediaKind),
+}
+
+/// The media-class kinds as a display list (``"`stability`, `openai-images`"``) —
+/// derived from [`ProviderKind::ALL`] through [`ProviderKind::class`], so guidance
+/// text built at format time never carries a hand-maintained kind list that goes
+/// stale when a media kind lands. (Text that must live in a `const` still names the
+/// kinds literally; this helper serves every site that formats at runtime.)
+pub fn media_kinds_list() -> String {
+    ProviderKind::ALL
+        .iter()
+        .filter(|k| k.is_media())
+        .map(|k| format!("`{}`", k.canonical_name()))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 impl std::str::FromStr for ProviderKind {

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -60,6 +60,16 @@ pub enum ProviderKind {
     /// Deliberately NOT in the built-in backend list: image generation costs real money
     /// per call and needs a key, so it appears only when an operator writes the stanza.
     Stability,
+    /// OpenAI's Images API (`POST {base}/images/generations`) — the second media kind,
+    /// via `src/openai_images.rs`. One kind covers two real targets: hosted OpenAI
+    /// image generation (the gpt-image-1 family) and any local server speaking the
+    /// same endpoint shape (stable-diffusion.cpp's sd-server). Its key posture
+    /// mirrors [`ProviderKind::Openai`], not Stability: the same `OPENAI_API_KEY` /
+    /// `~/.openai-key` sources, and `key_optional` by default because the local
+    /// sd-server case is keyless — an operator pointing at hosted OpenAI sets
+    /// `key_optional = false` explicitly. Like Stability, it is not in the built-in
+    /// backend list and staffs only `image` cast slots.
+    OpenAiImages,
 }
 
 impl ProviderKind {
@@ -67,21 +77,25 @@ impl ProviderKind {
     /// new kind can never be accepted by `FromStr` while staying unlisted in the message
     /// a user actually reads — a hand-maintained list in that string had already drifted
     /// once (`openrouter` shipped before it was named there).
-    pub const ALL: [ProviderKind; 6] = [
+    pub const ALL: [ProviderKind; 7] = [
         Self::Anthropic,
         Self::DeepSeek,
         Self::Gemini,
         Self::OpenRouter,
         Self::Openai,
         Self::Stability,
+        Self::OpenAiImages,
     ];
 
-    /// Whether a missing credential is tolerated rather than a hard error. Only
-    /// the OpenAI-compatible provider is: its default endpoint is a local keyless
-    /// server, so an absent key falls back to a placeholder bearer token
-    /// ([`PLACEHOLDER_OPENAI_KEY`]). The keyed providers must fail loudly on a missing key.
+    /// Whether a missing credential is tolerated rather than a hard error. The two
+    /// OpenAI-shaped kinds are: the completion kind's default endpoint is a local
+    /// keyless server, and the images kind covers the keyless local sd-server case
+    /// with the same reasoning — an absent key falls back to a placeholder bearer
+    /// token ([`PLACEHOLDER_OPENAI_KEY`]), and an operator pointing either at hosted
+    /// OpenAI sets `key_optional = false` on the backend explicitly. The keyed
+    /// providers must fail loudly on a missing key.
     pub fn key_optional(self) -> bool {
-        matches!(self, ProviderKind::Openai)
+        matches!(self, ProviderKind::Openai | ProviderKind::OpenAiImages)
     }
 
     /// The stand-in credential a `key_optional` backend sends when no real key is
@@ -109,6 +123,8 @@ impl ProviderKind {
             | ProviderKind::DeepSeek
             | ProviderKind::OpenRouter
             | ProviderKind::Openai
+            // The keyless local sd-server case: header-bearer shaped, value ignored.
+            | ProviderKind::OpenAiImages
             // Never reached: Stability is not `key_optional`, so a missing key is a
             // hard error long before a stand-in is wanted. It is a header-bearer wire,
             // so it takes the same shape as the others if that ever changes.
@@ -129,6 +145,7 @@ impl ProviderKind {
             ProviderKind::OpenRouter => "openrouter",
             ProviderKind::Openai => "openai",
             ProviderKind::Stability => "stability",
+            ProviderKind::OpenAiImages => "openai-images",
         }
     }
 
@@ -153,7 +170,10 @@ impl ProviderKind {
             ProviderKind::DeepSeek => "DEEPSEEK_API_KEY",
             ProviderKind::Gemini => "GEMINI_API_KEY",
             ProviderKind::OpenRouter => "OPENROUTER_API_KEY",
-            ProviderKind::Openai => "OPENAI_API_KEY",
+            // The images kind shares the completion kind's key sources on purpose:
+            // both talk to the same OpenAI account when hosted, and both cover a
+            // keyless local server when not — one credential, not two to maintain.
+            ProviderKind::Openai | ProviderKind::OpenAiImages => "OPENAI_API_KEY",
             // Reuses the constant `src/stability.rs` already resolves keys with, so the
             // facade and the config layer can never disagree about which var to read.
             ProviderKind::Stability => crate::stability::STABILITY_KEY_ENV_VAR,
@@ -169,7 +189,8 @@ impl ProviderKind {
             ProviderKind::DeepSeek => ".deepseek-key",
             ProviderKind::Gemini => ".gemini-api-key",
             ProviderKind::OpenRouter => ".openrouter-key",
-            ProviderKind::Openai => ".openai-key",
+            // Shared with the images kind — see `env_var`.
+            ProviderKind::Openai | ProviderKind::OpenAiImages => ".openai-key",
             // Same constant `src/stability.rs` uses, for the same reason as `env_var`.
             ProviderKind::Stability => crate::stability::STABILITY_KEY_FILE_NAME,
         }
@@ -194,6 +215,7 @@ impl ProviderKind {
             ProviderKind::OpenRouter => ProviderClass::Wire(WireKind::OpenRouter),
             ProviderKind::Openai => ProviderClass::Wire(WireKind::Openai),
             ProviderKind::Stability => ProviderClass::Media(MediaKind::Stability),
+            ProviderKind::OpenAiImages => ProviderClass::Media(MediaKind::OpenAiImages),
         }
     }
 
@@ -239,6 +261,9 @@ pub enum WireKind {
 pub enum MediaKind {
     /// Stability AI's v2beta family, via `src/stability.rs`.
     Stability,
+    /// OpenAI's Images API shape (`/v1/images/generations`), via
+    /// `src/openai_images.rs` — hosted OpenAI or a local sd-server.
+    OpenAiImages,
 }
 
 /// The two families a [`ProviderKind`] can belong to — see [`ProviderKind::class`].
@@ -261,6 +286,7 @@ impl std::str::FromStr for ProviderKind {
             // for when it points at the local keyless default (Gemma via Lemonade).
             "openai" | "local" | "lemonade" | "gemma" | "gemma4" => Ok(ProviderKind::Openai),
             "stability" => Ok(ProviderKind::Stability),
+            "openai-images" => Ok(ProviderKind::OpenAiImages),
             other => Err(anyhow!(
                 "unknown provider {other:?} (expected one of: {})",
                 ProviderKind::ALL

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -119,16 +119,26 @@ pub fn discovery_endpoint(backend: &Backend) -> Result<DiscoveryRequest> {
 /// loops on those kinds anyway.
 pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Result<DiscoveryRequest> {
     // A media kind publishes no model-listing endpoint in the `/models` shape this
-    // module speaks — Stability's model set is the small fixed route family
-    // (`generate/{core,ultra,sd3}`), documented rather than enumerable. Refusing
-    // loudly beats inventing a URL that would 404, and beats returning an empty
-    // list that would read as "this backend serves no models". Classified up front
-    // so the wire match below stays media-free.
+    // module speaks. Refusing loudly beats inventing a URL that would 404, and
+    // beats returning an empty list that would read as "this backend serves no
+    // models". Classified up front so the wire match below stays media-free; the
+    // hint is per media kind, since where a model id comes from differs by kind.
     let Some(wire) = backend.kind.wire() else {
+        let hint = match backend.kind.class() {
+            crate::credentials::ProviderClass::Media(crate::credentials::MediaKind::Stability) => {
+                "the documented generate routes: core, ultra, or an sd3.5 variant"
+            }
+            crate::credentials::ProviderClass::Media(
+                crate::credentials::MediaKind::OpenAiImages,
+            ) => "the endpoint's own model names, e.g. gpt-image-1 hosted or whatever a \
+                  local sd-server has loaded",
+            // The `else` above already proved this kind has no completion wire.
+            crate::credentials::ProviderClass::Wire(_) => unreachable!("wire() was None"),
+        };
         anyhow::bail!(
-            "backend {:?} is kind `{}`, which publishes no model-listing endpoint — \
-             its models are the documented generate routes (core, ultra, sd3), not a \
-             discoverable list",
+            "backend {:?} is kind `{}`, a media kind — it publishes no model-listing \
+             endpoint in the `/models` shape this tool speaks. Its models are named on \
+             a cast's `image` slot: {hint}",
             backend.name,
             backend.kind.canonical_name()
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod jobs;
 pub mod kaish_syntax;
 pub mod mcp_log;
 pub mod media;
+pub mod openai_images;
 pub mod orientation;
 pub mod progress;
 pub mod sandbox;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,16 @@
 //! sub-agent, all driving a read-only [`kaish`] kernel via `run_kaish(script)` (`cat`,
 //! `grep`, `find`, `jq`, pipelines, the lot). The `consult` and toolless `oneshot` tools
 //! are both costumes over one primitive, [`consult::run_phase`]. The team *perceives*
-//! what fuses into its reasoning (image input today, via `view_image`); it produces no
-//! output artifacts — kaibo reasons over code, it doesn't render or emit.
+//! what fuses into its reasoning (image input today, via `view_image`); when kaibo
+//! *produces* (the `generate` tool, via [`media`]), the artifacts land only in the
+//! content-addressed media store ([`cas`]) — an individually-gated mediated surface at
+//! a fixed XDG path no model steers, never a general write path.
 //!
-//! The load-bearing safety property lives in [`sandbox`]: kaibo can read the project but
-//! cannot mutate it (read-only is *unconditional* — no write path of any kind), and
-//! cannot shell out to external commands.
+//! The load-bearing safety property lives in [`sandbox`]: kaibo can read the project
+//! but cannot mutate it — the project is untouchable from every path (the model-facing
+//! shell has no write mount; kaibo's own two blessed write surfaces, the persistence
+//! store and the media CAS, refuse to resolve into any allowed tree) — and cannot
+//! shell out to external commands.
 
 pub mod attach;
 pub mod batch;

--- a/src/media.rs
+++ b/src/media.rs
@@ -165,10 +165,30 @@ impl MediaArm {
                 let model = crate::stability::StabilityImageModel::from_parts(&client, &slot.id);
                 Ok(Self::new(Arc::new(model), slot.qualified()))
             }
+            ProviderClass::Media(MediaKind::OpenAiImages) => {
+                // Key posture mirrors the `openai` completion kind: `resolve_key`
+                // hands back the placeholder for a keyless local sd-server
+                // (`key_optional`, the seeded default) and a real key otherwise.
+                let key = backend.resolve_key()?;
+                // Unset dials hosted OpenAI — a root through /v1; the client appends
+                // its own /images/generations. A local sd-server sets base_url.
+                let base_url = backend
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| crate::credentials::HOSTED_OPENAI_BASE_URL.to_string());
+                let client = crate::openai_images::OpenAiImagesClient::new(
+                    key,
+                    base_url,
+                    backend.request_timeout,
+                )?;
+                let model =
+                    crate::openai_images::OpenAiImagesModel::from_parts(&client, &slot.id);
+                Ok(Self::new(Arc::new(model), slot.qualified()))
+            }
             ProviderClass::Wire(_) => bail!(
                 "backend {:?} is kind `{}`, a completion wire — it cannot staff a media \
-                 slot. Point the `image` slot at a media backend (kind `stability`), \
-                 and use this backend on `explorer`/`synth` instead",
+                 slot. Point the `image` slot at a media backend, and use this backend \
+                 on `explorer`/`synth` instead",
                 backend.name,
                 backend.kind.canonical_name()
             ),
@@ -303,8 +323,47 @@ mod tests {
         let err = MediaArm::from_slot(backend, &slot).expect_err("wire kind must be refused");
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("completion wire") && msg.contains("stability"),
+            msg.contains("completion wire") && msg.contains("media backend"),
             "the error names the problem and the fix, got: {msg}"
         );
+    }
+
+    /// An openai-images backend staffs an image slot — and the keyless default
+    /// (`key_optional` seeds true for this kind) resolves to the placeholder, so a
+    /// local sd-server backend needs no credential at all. Construction only; no
+    /// network.
+    #[test]
+    fn from_slot_staffs_an_openai_images_backend_keylessly() {
+        let cfg = crate::config::Config::from_toml_str(
+            r#"
+            [backends.sdcpp]
+            kind = "openai-images"
+            base_url = "http://localhost:1234/v1"
+            api_key_file = "/nonexistent-kaibo-test/openai"
+            "#,
+        )
+        .expect("config parses");
+        let backend = cfg.backends.get("sdcpp").expect("backend exists");
+        let slot = ModelSlot::bare("sdcpp", "sd3.5-large");
+        let arm = MediaArm::from_slot(backend, &slot).expect("an openai-images backend staffs");
+        assert_eq!(arm.slot_ref(), "sdcpp/sd3.5-large");
+    }
+
+    /// The Stability arm still staffs — the sibling-kind regression guard for the
+    /// `from_slot` match growing a second media arm.
+    #[test]
+    fn from_slot_still_staffs_a_stability_backend() {
+        let cfg = crate::config::Config::from_toml_str(
+            r#"
+            [backends.sd]
+            kind = "stability"
+            key_optional = true
+            "#,
+        )
+        .expect("config parses");
+        let backend = cfg.backends.get("sd").expect("backend exists");
+        let slot = ModelSlot::bare("sd", "core");
+        let arm = MediaArm::from_slot(backend, &slot).expect("a stability backend staffs");
+        assert_eq!(arm.slot_ref(), "sd/core");
     }
 }

--- a/src/media.rs
+++ b/src/media.rs
@@ -13,8 +13,10 @@
 //!
 //! The vocabulary here is deliberately provider-neutral (a [`MediaArtifact`] is bytes,
 //! a mime string, and a seed) — providers translate their native shapes at their own
-//! impl, exactly as rig providers translate into rig's completion types. The one live
-//! implementation today is Stability's (`src/stability.rs`).
+//! impl, exactly as rig providers translate into rig's completion types. Two live
+//! implementations today: Stability's (`src/stability.rs`, multipart form wire, sync
+//! and deferred shapes) and OpenAI Images (`src/openai_images.rs`, JSON body wire,
+//! sync only).
 //!
 //! # The construction point
 //!
@@ -37,22 +39,88 @@ use async_trait::async_trait;
 use crate::config::{Backend, ModelSlot};
 use crate::credentials::{MediaKind, ProviderClass};
 
+/// One provider-native field value, carrying the caller's JSON type end to end. The
+/// caller said string, number, or bool at the tool face; guessing the type back out
+/// of a string is unsound in both directions (the Images API's `user` field is a
+/// string — `user = "123"` re-typed to the number `123` is a provider 400), so the
+/// stated type rides through instead. Each provider serializes it for its own wire:
+/// a JSON-body provider (openai-images) sends it verbatim as the JSON scalar it is;
+/// a form-field provider (Stability) stringifies via
+/// [`to_wire_string`](Self::to_wire_string), which is lossless there because its
+/// multipart wire is all-string anyway.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldValue {
+    Str(String),
+    /// `serde_json::Number`, not `f64`: it keeps integers integral (`n = 2` must
+    /// serialize as `2`, never `2.0` — the Images API type-checks it) and carries
+    /// the full u64/i64/f64 range a caller can write in JSON.
+    Num(serde_json::Number),
+    Bool(bool),
+}
+
+impl FieldValue {
+    /// The value as the JSON scalar the caller stated — what a JSON-body provider
+    /// sends verbatim.
+    pub fn to_json(&self) -> serde_json::Value {
+        match self {
+            FieldValue::Str(s) => serde_json::Value::String(s.clone()),
+            FieldValue::Num(n) => serde_json::Value::Number(n.clone()),
+            FieldValue::Bool(b) => serde_json::Value::Bool(*b),
+        }
+    }
+
+    /// The value as wire text — what a form-field provider sends. Numbers and bools
+    /// render in their JSON spelling (`2`, `1.5`, `true`), so nothing is lost on an
+    /// all-string wire.
+    pub fn to_wire_string(&self) -> String {
+        match self {
+            FieldValue::Str(s) => s.clone(),
+            FieldValue::Num(n) => n.to_string(),
+            FieldValue::Bool(b) => b.to_string(),
+        }
+    }
+
+    /// The string inside a `Str`, or `None` — for the fields a provider itself must
+    /// read (an `output_format` name), where a number or bool is the caller's
+    /// mistake to surface, not a value to coerce.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            FieldValue::Str(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl From<&str> for FieldValue {
+    fn from(s: &str) -> Self {
+        FieldValue::Str(s.to_string())
+    }
+}
+
+impl From<String> for FieldValue {
+    fn from(s: String) -> Self {
+        FieldValue::Str(s)
+    }
+}
+
 /// One generation request, provider-neutral. The prompt is the portable half; every
 /// provider-native knob (seed, aspect ratio, negative prompt, output format, ...)
-/// rides `fields` untyped — kaibo keeps no allowlist, the provider answers for its own
-/// knobs, the same passthrough posture `additional_params` takes on the completion
-/// side. (`prompt` and `model` never ride `fields`: the tool layer reserves both, so
-/// the recorded provenance always describes the request that ran.)
+/// rides `fields` with no allowlist — kaibo passes them through, the provider answers
+/// for its own knobs, the same passthrough posture `additional_params` takes on the
+/// completion side. (`prompt` and `model` never ride `fields`: the tool layer
+/// reserves both, so the recorded provenance always describes the request that ran.)
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MediaRequest {
     pub prompt: String,
     /// `(name, value)` provider-native fields: **uniquely named**, in the order the
     /// caller gave them (kept as a `Vec` because a provider may care about order —
-    /// the MCP face is a map, so duplicate names cannot arrive from a tool call). A
-    /// provider impl may seed its own defaults (Stability seeds `output_format`) and
-    /// lets a caller field of the same name replace the seeded default — that merge
-    /// is the provider's business, not a contract of this struct.
-    pub fields: Vec<(String, String)>,
+    /// the MCP face is a map, so duplicate names cannot arrive from a tool call).
+    /// Values are typed ([`FieldValue`]) so the caller's JSON type survives to the
+    /// provider's wire. A provider impl may seed its own defaults (Stability seeds
+    /// `output_format`) and lets a caller field of the same name replace the seeded
+    /// default — that merge is the provider's business, not a contract of this
+    /// struct.
+    pub fields: Vec<(String, FieldValue)>,
     /// Bytes of an input image, for the operations that take one (edit / upscale /
     /// image-to-image). `None` for text-to-image. Carried on the request now so the
     /// trait does not churn when those operations land.
@@ -166,9 +234,10 @@ impl MediaArm {
                 Ok(Self::new(Arc::new(model), slot.qualified()))
             }
             ProviderClass::Media(MediaKind::OpenAiImages) => {
-                // Key posture mirrors the `openai` completion kind: `resolve_key`
-                // hands back the placeholder for a keyless local sd-server
-                // (`key_optional`, the seeded default) and a real key otherwise.
+                // Key sources are shared with the `openai` completion kind, but the
+                // key is required by default (the default endpoint is hosted OpenAI
+                // — see `ProviderKind::key_optional`); a keyless local sd-server
+                // backend sets `key_optional = true` and resolves the placeholder.
                 let key = backend.resolve_key()?;
                 // Unset dials hosted OpenAI — a root through /v1; the client appends
                 // its own /images/generations. A local sd-server sets base_url.
@@ -328,10 +397,10 @@ mod tests {
         );
     }
 
-    /// An openai-images backend staffs an image slot — and the keyless default
-    /// (`key_optional` seeds true for this kind) resolves to the placeholder, so a
-    /// local sd-server backend needs no credential at all. Construction only; no
-    /// network.
+    /// An openai-images backend staffs an image slot. The local sd-server shape —
+    /// explicit `base_url` plus explicit `key_optional = true` (the kind seeds
+    /// key-REQUIRED, because its default endpoint is hosted OpenAI) — resolves the
+    /// placeholder and needs no credential. Construction only; no network.
     #[test]
     fn from_slot_staffs_an_openai_images_backend_keylessly() {
         let cfg = crate::config::Config::from_toml_str(
@@ -339,6 +408,7 @@ mod tests {
             [backends.sdcpp]
             kind = "openai-images"
             base_url = "http://localhost:1234/v1"
+            key_optional = true
             api_key_file = "/nonexistent-kaibo-test/openai"
             "#,
         )

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -1,0 +1,771 @@
+//! The OpenAI Images API — kaibo's second media kind (`ProviderKind::OpenAiImages`),
+//! a sibling of `src/stability.rs`, not a redesign of it.
+//!
+//! # One kind, two real targets
+//!
+//! `POST {base}/images/generations` is spoken by two things kaibo cares about:
+//! hosted OpenAI image generation (the gpt-image-1 family, at
+//! `https://api.openai.com/v1`) and local stable-diffusion.cpp's `sd-server`, which
+//! implements the same endpoint shape on a keyless local port. That is why this is
+//! ONE kind with a configurable `base_url` (default the hosted endpoint) and an
+//! optional key (`key_optional` seeds true — the sd-server case; an operator dialing
+//! hosted OpenAI sets `key_optional = false` explicitly), mirroring the `openai`
+//! completion kind's posture rather than Stability's.
+//!
+//! # Sync-only, and b64 or error
+//!
+//! Every operation here is synchronous: the POST returns the artifacts in-call, so
+//! [`crate::media::MediaModel::generate`] always resolves to
+//! [`crate::media::MediaOutcome::Complete`] and `poll` is unreachable (it bails
+//! loudly — see its doc). The `n` field makes several artifacts per call the NORMAL
+//! case, the first real exerciser of the outcome's `Vec` widening: order is
+//! preserved, one [`crate::media::MediaArtifact`] per `data` entry.
+//!
+//! Artifacts must arrive as base64 (`b64_json`). gpt-image-1 always returns b64 and
+//! rejects the `response_format` parameter outright; older families (dall-e-2/3)
+//! default to URLs unless asked. So [`build_request_body`] seeds
+//! `response_format = "b64_json"` for every model family EXCEPT gpt-image-1's, and
+//! [`parse_response`] refuses a URL-only entry loudly — kaibo never fetches artifact
+//! URLs (a second network hop to an address the provider chose is a different trust
+//! shape than decoding bytes already in hand).
+//!
+//! # Mime: from the request, not the response
+//!
+//! Unlike Stability, the response carries no artifact content-type — `b64_json` is
+//! bytes in a JSON envelope. The format is whatever the request's `output_format`
+//! field asked for (`png` | `jpeg` | `webp`, gpt-image-1's set), default `png`
+//! (gpt-image-1's own default). [`OutputFormat`] is that closed set; it maps into
+//! the CAS's closed [`crate::cas::Extension`], and an unknown value is a loud error
+//! at request build — before any credits are spent — rather than a wrong extension
+//! on disk. The response's `revised_prompt` field (dall-e-3 rewrites prompts) is
+//! deliberately ignored for now: the provenance sidecar records the operator's
+//! prompt, the request that *ran*.
+//!
+//! # Fields ride verbatim, scalars typed
+//!
+//! The passthrough posture is unchanged from Stability: `size`, `quality`, `n`,
+//! `style`, `output_format`, `background`, ... ride [`crate::media::MediaRequest::fields`]
+//! and the provider validates its own knobs; `prompt` and `model` stay reserved at
+//! the tool layer. The one wire difference: this API takes a JSON body, not a
+//! multipart form, and OpenAI type-checks it (`n` must be a JSON integer, not
+//! `"2"`). So [`field_value`] sends a field whose string parses as a bare JSON
+//! number or bool as that scalar, and everything else as a string — `n = "2"`
+//! becomes `2`, `size = "1024x1024"` stays a string. That is a wire-shape
+//! translation, not an allowlist: every field still goes through, kaibo still
+//! validates none of them.
+//!
+//! # Credentials
+//!
+//! Shared with the `openai` completion kind (`OPENAI_API_KEY` / `~/.openai-key`,
+//! placeholder when `key_optional`) — resolution lives on `Backend::resolve_key`;
+//! this module takes an already-resolved key. The base URL default is
+//! [`crate::credentials::HOSTED_OPENAI_BASE_URL`] — a root *through* `/v1`, to which
+//! this client appends its own `/images/generations`, the same
+//! client-appends-its-path contract every configurable base URL in kaibo follows.
+
+use std::time::Duration;
+
+use anyhow::Result as AnyResult;
+use base64::Engine as _;
+use reqwest::header::AUTHORIZATION;
+use serde_json::{Map, Value};
+
+use crate::media::{MediaArtifact, MediaJobId, MediaOutcome, MediaPollOutcome, MediaRequest};
+
+// --- Output format -----------------------------------------------------------
+
+/// The closed set of image formats the Images API can be asked for
+/// (`output_format`, gpt-image-1's parameter) — and, just as important, the closed
+/// set of extensions the CAS can name the bytes under. Parsed case-insensitively;
+/// anything else is a loud [`OpenAiImagesError::UnknownOutputFormat`] at request
+/// build, before the call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Png,
+    Jpeg,
+    Webp,
+}
+
+impl OutputFormat {
+    /// Parse a caller's `output_format` field value. The accepted spellings are
+    /// exactly the API's own (`png` | `jpeg` | `webp`), case-insensitive; `"jpg"` is
+    /// not among them — OpenAI rejects it too, so accepting it here would build a
+    /// request the provider refuses.
+    pub fn parse(value: &str) -> Result<Self, OpenAiImagesError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "png" => Ok(OutputFormat::Png),
+            "jpeg" => Ok(OutputFormat::Jpeg),
+            "webp" => Ok(OutputFormat::Webp),
+            other => Err(OpenAiImagesError::UnknownOutputFormat(other.to_string())),
+        }
+    }
+
+    /// The wire mime for artifacts of this format — what
+    /// [`crate::media::MediaArtifact::mime`] carries.
+    pub fn mime(self) -> &'static str {
+        match self {
+            OutputFormat::Png => "image/png",
+            OutputFormat::Jpeg => "image/jpeg",
+            OutputFormat::Webp => "image/webp",
+        }
+    }
+
+    /// The CAS extension the bytes are stored under. Total, unlike Stability's
+    /// `MediaType::to_cas_extension`: this enum was drawn to fit inside
+    /// [`crate::cas::Extension`] from the start.
+    pub fn to_cas_extension(self) -> crate::cas::Extension {
+        match self {
+            OutputFormat::Png => crate::cas::Extension::Png,
+            OutputFormat::Jpeg => crate::cas::Extension::Jpeg,
+            OutputFormat::Webp => crate::cas::Extension::Webp,
+        }
+    }
+}
+
+// --- Errors ------------------------------------------------------------------
+
+/// Everything that can go wrong building or interpreting an Images API call. Own
+/// type for the same reason `StabilityError` is: [`build_request_body`] and
+/// [`parse_response`] stay pure and unit-testable with no reqwest types in the
+/// loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenAiImagesError {
+    /// The HTTP request itself failed (DNS, connect, TLS, a dropped connection) —
+    /// message pre-rendered so this stays `Clone`/`PartialEq`.
+    Transport(String),
+    /// A non-2xx response. `body` is OpenAI's `{error: {message, ...}}` rendered
+    /// readably when it parses; the raw text otherwise (a local sd-server or a
+    /// gateway may not speak OpenAI's error shape, and the real bytes beat
+    /// swallowing them).
+    Provider { status: u16, body: String },
+    /// A 2xx whose body didn't parse as the documented `{data: [...]}` envelope.
+    InvalidBody(String),
+    /// A 2xx with an empty `data` array — a provider bug this module refuses at its
+    /// own impl rather than handing an empty artifact list downstream (see
+    /// `MediaOutcome::Complete`'s contract).
+    EmptyData,
+    /// A `data` entry with no `b64_json`. `has_url` distinguishes the real-world
+    /// case (an older model family defaulted to URLs) from a malformed entry, so
+    /// the message can name the fix.
+    MissingB64 { index: usize, has_url: bool },
+    /// A `b64_json` value that didn't decode as base64.
+    InvalidB64 { index: usize, detail: String },
+    /// An `output_format` field naming a format outside the closed
+    /// [`OutputFormat`] set — refused at request build, before the call.
+    UnknownOutputFormat(String),
+}
+
+impl std::fmt::Display for OpenAiImagesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OpenAiImagesError::Transport(msg) => {
+                write!(f, "Images API request failed: {msg}")
+            }
+            OpenAiImagesError::Provider { status, body } => {
+                write!(f, "Images API returned {status}: {body}")
+            }
+            OpenAiImagesError::InvalidBody(msg) => write!(
+                f,
+                "Images API 2xx body didn't parse as {{\"data\": [...]}}: {msg}"
+            ),
+            OpenAiImagesError::EmptyData => write!(
+                f,
+                "Images API returned an empty `data` array — zero artifacts is never \
+                 treated as a successful generation"
+            ),
+            OpenAiImagesError::MissingB64 { index, has_url } => {
+                if *has_url {
+                    write!(
+                        f,
+                        "Images API data[{index}] carries a URL instead of `b64_json` — \
+                         kaibo never fetches artifact URLs; artifacts must arrive as \
+                         base64. This model family defaults to URLs and appears to have \
+                         ignored (or been overridden on) `response_format = \"b64_json\"`"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Images API data[{index}] has no `b64_json` — artifacts must \
+                         arrive as base64, and this entry carries none"
+                    )
+                }
+            }
+            OpenAiImagesError::InvalidB64 { index, detail } => write!(
+                f,
+                "Images API data[{index}].b64_json is not valid base64: {detail}"
+            ),
+            OpenAiImagesError::UnknownOutputFormat(v) => write!(
+                f,
+                "output_format {v:?} is not one this kind can name on disk — expected \
+                 png, jpeg, or webp (the Images API's own set)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for OpenAiImagesError {}
+
+// --- Request building (pure) -------------------------------------------------
+
+/// A field value as the JSON scalar the API type-checks for: a string that parses
+/// as a bare JSON number or bool goes typed (`"2"` → `2`, `"true"` → `true`);
+/// everything else stays a string (`"1024x1024"`, `"high"`). See the module doc —
+/// this is wire-shape translation, not validation.
+fn field_value(raw: &str) -> Value {
+    match serde_json::from_str::<Value>(raw) {
+        Ok(v @ (Value::Number(_) | Value::Bool(_))) => v,
+        _ => Value::String(raw.to_string()),
+    }
+}
+
+/// True for the model family that always returns base64 and REJECTS the
+/// `response_format` parameter (gpt-image-1, gpt-image-1-mini, and successors under
+/// the same prefix). Everything else — dall-e-2/3, and local sd-server models under
+/// arbitrary ids — takes the parameter, so it gets seeded.
+fn always_b64(model: &str) -> bool {
+    model.trim().to_ascii_lowercase().starts_with("gpt-image")
+}
+
+/// Build the JSON body for one generation call, and resolve the format its
+/// artifacts will be in. Pure.
+///
+/// - `model` and `prompt` come from the slot and the tool parameter (the tool layer
+///   reserves both field names, so they cannot arrive in `request.fields`).
+/// - `response_format = "b64_json"` is seeded for every model family except
+///   gpt-image-1's (which rejects the parameter and always returns b64) — a caller
+///   field of the same name replaces the seed, the same last-write-wins merge
+///   Stability's `output_format` seed follows. Overriding it to `"url"` just moves
+///   the failure to [`parse_response`]'s loud b64 refusal.
+/// - Every `request.fields` entry rides through [`field_value`], in order.
+/// - The artifact format is the request's `output_format` field when present
+///   ([`OutputFormat::parse`] — unknown is a loud error here, before the call),
+///   else png.
+pub fn build_request_body(
+    model: &str,
+    request: &MediaRequest,
+) -> Result<(Value, OutputFormat), OpenAiImagesError> {
+    let mut body = Map::new();
+    body.insert("model".to_string(), Value::String(model.to_string()));
+    body.insert("prompt".to_string(), Value::String(request.prompt.clone()));
+    if !always_b64(model) {
+        body.insert(
+            "response_format".to_string(),
+            Value::String("b64_json".to_string()),
+        );
+    }
+
+    let mut format = OutputFormat::Png;
+    for (name, value) in &request.fields {
+        if name == "output_format" {
+            format = OutputFormat::parse(value)?;
+        }
+        // Map insert: a caller field replaces a seeded default of the same name
+        // (fields are uniquely named by the tool layer's map face).
+        body.insert(name.clone(), field_value(value));
+    }
+    Ok((Value::Object(body), format))
+}
+
+// --- Response handling (pure) ------------------------------------------------
+
+/// OpenAI's error body, when it is OpenAI's — rendered readably, with the raw text
+/// as the fallback for anything else in front of (or instead of) the real API.
+fn provider_error(status: u16, body: &[u8]) -> OpenAiImagesError {
+    #[derive(serde::Deserialize)]
+    struct ErrorBody {
+        error: ErrorDetail,
+    }
+    #[derive(serde::Deserialize)]
+    struct ErrorDetail {
+        message: String,
+        #[serde(rename = "type")]
+        kind: Option<String>,
+    }
+    let rendered = match serde_json::from_slice::<ErrorBody>(body) {
+        Ok(e) => match e.error.kind {
+            Some(kind) => format!("{} ({kind})", e.error.message),
+            None => e.error.message,
+        },
+        Err(_) => String::from_utf8_lossy(body).trim().to_string(),
+    };
+    OpenAiImagesError::Provider {
+        status,
+        body: rendered,
+    }
+}
+
+/// Interpret one HTTP response as the artifact list. A non-2xx is always a provider
+/// error. A 2xx must carry `{data: [...]}` with at least one entry, every entry
+/// carrying decodable `b64_json` — order preserved, one artifact per entry, each
+/// stamped with `format`'s mime. The API reports no seed, so every artifact's
+/// `seed` is `None`. (`data[].revised_prompt` may be present; ignored — see the
+/// module doc.)
+pub fn parse_response(
+    status: u16,
+    body: &[u8],
+    format: OutputFormat,
+) -> Result<Vec<MediaArtifact>, OpenAiImagesError> {
+    if !(200..300).contains(&status) {
+        return Err(provider_error(status, body));
+    }
+    let v: Value =
+        serde_json::from_slice(body).map_err(|e| OpenAiImagesError::InvalidBody(e.to_string()))?;
+    let Some(data) = v.get("data").and_then(Value::as_array) else {
+        return Err(OpenAiImagesError::InvalidBody(
+            "no `data` array in the response".to_string(),
+        ));
+    };
+    if data.is_empty() {
+        return Err(OpenAiImagesError::EmptyData);
+    }
+    let mut artifacts = Vec::with_capacity(data.len());
+    for (index, entry) in data.iter().enumerate() {
+        let Some(b64) = entry.get("b64_json").and_then(Value::as_str) else {
+            return Err(OpenAiImagesError::MissingB64 {
+                index,
+                has_url: entry.get("url").and_then(Value::as_str).is_some(),
+            });
+        };
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .map_err(|e| OpenAiImagesError::InvalidB64 {
+                index,
+                detail: e.to_string(),
+            })?;
+        artifacts.push(MediaArtifact {
+            bytes,
+            mime: format.mime().to_string(),
+            // The Images API reports no seed — there is nothing to record for
+            // reproduction, so the provenance sidecar's seed stays empty.
+            seed: None,
+        });
+    }
+    Ok(artifacts)
+}
+
+// --- The HTTP client ---------------------------------------------------------
+
+/// An Images API connection: the `reqwest::Client` (ring-installed —
+/// [`crate::tls::https_client`] is the one build site in this codebase), the
+/// resolved key, and the base URL (a root through `/v1`; this client appends
+/// `/images/generations`).
+#[derive(Clone)]
+pub struct OpenAiImagesClient {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl OpenAiImagesClient {
+    /// Build a client from an already-resolved key (see `Backend::resolve_key` —
+    /// the placeholder for the keyless local case arrives here like any other key;
+    /// a local server ignores the bearer value).
+    pub fn new(
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+        request_timeout: Duration,
+    ) -> AnyResult<Self> {
+        Ok(Self {
+            http: crate::tls::https_client(request_timeout)?,
+            api_key: api_key.into(),
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Run one generation call: build the JSON body ([`build_request_body`]), POST
+    /// it, and hand the response through [`parse_response`]. The one
+    /// side-effecting wrapper over this module's pure functions.
+    pub async fn generate(
+        &self,
+        model: &str,
+        request: &MediaRequest,
+    ) -> Result<Vec<MediaArtifact>, OpenAiImagesError> {
+        let (body, format) = build_request_body(model, request)?;
+        let url = format!("{}/images/generations", self.base_url.trim_end_matches('/'));
+        let resp = self
+            .http
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| OpenAiImagesError::Transport(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| OpenAiImagesError::Transport(e.to_string()))?;
+        parse_response(status, &bytes, format)
+    }
+}
+
+// --- The MediaModel impl -----------------------------------------------------
+
+/// The [`crate::media::MediaModel`] behind an `image = "backend/model-id"` slot on
+/// an `openai-images` backend — built by `MediaArm::from_slot` (`src/media.rs`).
+#[derive(Clone)]
+pub struct OpenAiImagesModel {
+    client: OpenAiImagesClient,
+    model: String,
+}
+
+impl OpenAiImagesModel {
+    /// Build from a client + model id — the constructor `MediaArm::from_slot` uses,
+    /// mirroring `StabilityImageModel::from_parts`.
+    pub fn from_parts(client: &OpenAiImagesClient, model: impl Into<String>) -> Self {
+        Self {
+            client: client.clone(),
+            model: model.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::media::MediaModel for OpenAiImagesModel {
+    /// Always resolves to [`MediaOutcome::Complete`] — the Images API is
+    /// synchronous, and `n` makes a multi-artifact list the normal shape.
+    async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
+        let artifacts = self.client.generate(&self.model, request).await?;
+        Ok(MediaOutcome::Complete(artifacts))
+    }
+
+    /// Unreachable in practice: `generate` above never returns
+    /// [`MediaOutcome::Deferred`], so no caller ever holds a job id to poll this
+    /// kind with. It bails loudly rather than pretending — a poll arriving here
+    /// means some caller invented a job id or a future change broke the sync-only
+    /// declaration, and either deserves a crash over a silent `Pending` forever.
+    async fn poll(&self, _job: &MediaJobId) -> AnyResult<MediaPollOutcome> {
+        anyhow::bail!(
+            "openai-images declares no deferred operations — every generation \
+             completes in-call, so there is no provider job to poll"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    fn request(fields: &[(&str, &str)]) -> MediaRequest {
+        MediaRequest {
+            prompt: "a lighthouse at dusk".to_string(),
+            fields: fields
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            input_image: None,
+        }
+    }
+
+    // --- OutputFormat -----------------------------------------------------
+
+    /// The closed set, its mimes, and its CAS extensions — the mapping the stored
+    /// artifact's on-disk name rides on.
+    #[test]
+    fn output_format_maps_to_mime_and_cas_extension() {
+        for (raw, format, mime, ext) in [
+            (
+                "png",
+                OutputFormat::Png,
+                "image/png",
+                crate::cas::Extension::Png,
+            ),
+            (
+                "jpeg",
+                OutputFormat::Jpeg,
+                "image/jpeg",
+                crate::cas::Extension::Jpeg,
+            ),
+            (
+                "webp",
+                OutputFormat::Webp,
+                "image/webp",
+                crate::cas::Extension::Webp,
+            ),
+            // Case-insensitive, like every media-type comparison in this codebase.
+            (
+                "PNG",
+                OutputFormat::Png,
+                "image/png",
+                crate::cas::Extension::Png,
+            ),
+        ] {
+            assert_eq!(OutputFormat::parse(raw), Ok(format), "input {raw:?}");
+            assert_eq!(format.mime(), mime);
+            assert_eq!(format.to_cas_extension(), ext);
+        }
+    }
+
+    /// An unknown output_format is a loud error naming the value and the accepted
+    /// set — including `jpg`, which OpenAI itself rejects, so accepting it here
+    /// would only move the failure to the provider.
+    #[test]
+    fn output_format_unknown_fails_loudly() {
+        for raw in ["gif", "avif", "jpg", ""] {
+            let err = OutputFormat::parse(raw).unwrap_err();
+            assert!(
+                matches!(err, OpenAiImagesError::UnknownOutputFormat(_)),
+                "input {raw:?} got {err:?}"
+            );
+        }
+        let msg = OutputFormat::parse("gif").unwrap_err().to_string();
+        assert!(
+            msg.contains("gif") && msg.contains("png"),
+            "the message names what arrived and the accepted set, got: {msg}"
+        );
+    }
+
+    // --- build_request_body -----------------------------------------------
+
+    /// The dall-e-and-local families get `response_format = "b64_json"` seeded —
+    /// they default to URLs, which kaibo never fetches.
+    #[test]
+    fn request_body_seeds_b64_response_format_for_url_defaulting_families() {
+        for model in ["dall-e-3", "dall-e-2", "sd3.5-large", "whatever-local"] {
+            let (body, format) = build_request_body(model, &request(&[])).unwrap();
+            assert_eq!(
+                body.get("response_format").and_then(Value::as_str),
+                Some("b64_json"),
+                "model {model:?}"
+            );
+            assert_eq!(body.get("model").and_then(Value::as_str), Some(model));
+            assert_eq!(
+                body.get("prompt").and_then(Value::as_str),
+                Some("a lighthouse at dusk")
+            );
+            assert_eq!(format, OutputFormat::Png, "png is the default format");
+        }
+    }
+
+    /// The gpt-image family always returns b64 and REJECTS the parameter — seeding
+    /// it there would fail every hosted call.
+    #[test]
+    fn request_body_omits_response_format_for_gpt_image_family() {
+        for model in ["gpt-image-1", "gpt-image-1-mini", "GPT-IMAGE-2"] {
+            let (body, _) = build_request_body(model, &request(&[])).unwrap();
+            assert!(
+                body.get("response_format").is_none(),
+                "model {model:?} must not carry response_format, got {body}"
+            );
+        }
+    }
+
+    /// Fields ride through verbatim in value, with bare JSON scalars typed the way
+    /// the API type-checks them: `n = "2"` must go as the integer 2 (OpenAI rejects
+    /// the string), `size` stays a string. A caller's `response_format` replaces
+    /// the seeded default rather than duplicating it.
+    #[test]
+    fn request_body_types_scalars_and_lets_fields_override_seeds() {
+        let (body, format) = build_request_body(
+            "dall-e-3",
+            &request(&[
+                ("n", "2"),
+                ("size", "1024x1024"),
+                ("quality", "high"),
+                ("output_format", "webp"),
+                ("response_format", "b64_json"),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(body.get("n"), Some(&Value::from(2)), "n goes typed");
+        assert_eq!(
+            body.get("size").and_then(Value::as_str),
+            Some("1024x1024"),
+            "size stays a string"
+        );
+        assert_eq!(body.get("quality").and_then(Value::as_str), Some("high"));
+        assert_eq!(format, OutputFormat::Webp, "output_format drives the mime");
+        assert_eq!(
+            body.get("response_format").and_then(Value::as_str),
+            Some("b64_json"),
+            "one response_format, not two"
+        );
+    }
+
+    /// An unknown output_format fails at request build — before any credits are
+    /// spent — not after the provider generated under a format the CAS can't name.
+    #[test]
+    fn request_body_refuses_unknown_output_format_before_the_call() {
+        let err =
+            build_request_body("gpt-image-1", &request(&[("output_format", "avif")])).unwrap_err();
+        assert_eq!(
+            err,
+            OpenAiImagesError::UnknownOutputFormat("avif".to_string())
+        );
+    }
+
+    // --- parse_response ----------------------------------------------------
+
+    /// One image: one artifact, bytes decoded, mime from the request's format,
+    /// seed None (the API reports none).
+    #[test]
+    fn parse_response_single_image() {
+        let body = serde_json::json!({
+            "created": 1_722_000_000u64,
+            "data": [{ "b64_json": b64(b"png-bytes") }],
+        });
+        let artifacts =
+            parse_response(200, body.to_string().as_bytes(), OutputFormat::Png).unwrap();
+        assert_eq!(
+            artifacts,
+            vec![MediaArtifact {
+                bytes: b"png-bytes".to_vec(),
+                mime: "image/png".to_string(),
+                seed: None,
+            }]
+        );
+    }
+
+    /// `n > 1`: every artifact lands, in the provider's order — the first real
+    /// exerciser of the outcome's Vec widening.
+    #[test]
+    fn parse_response_multi_image_preserves_order() {
+        let body = serde_json::json!({
+            "data": [
+                { "b64_json": b64(b"first") },
+                { "b64_json": b64(b"second"), "revised_prompt": "a nicer lighthouse" },
+                { "b64_json": b64(b"third") },
+            ],
+        });
+        let artifacts =
+            parse_response(200, body.to_string().as_bytes(), OutputFormat::Webp).unwrap();
+        assert_eq!(
+            artifacts
+                .iter()
+                .map(|a| a.bytes.clone())
+                .collect::<Vec<_>>(),
+            vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()],
+            "one artifact per data entry, order preserved"
+        );
+        assert!(
+            artifacts.iter().all(|a| a.mime == "image/webp"),
+            "every artifact carries the request's format"
+        );
+    }
+
+    /// A URL-only entry is refused loudly, naming the b64 requirement — kaibo never
+    /// fetches artifact URLs.
+    #[test]
+    fn parse_response_url_only_entry_is_refused_naming_b64() {
+        let body = serde_json::json!({
+            "data": [
+                { "b64_json": b64(b"fine") },
+                { "url": "https://oaidalleapi.example/img.png" },
+            ],
+        });
+        let err = parse_response(200, body.to_string().as_bytes(), OutputFormat::Png).unwrap_err();
+        assert_eq!(
+            err,
+            OpenAiImagesError::MissingB64 {
+                index: 1,
+                has_url: true
+            }
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("b64_json") && msg.contains("never fetches"),
+            "the message names the b64 requirement and the no-URL-fetch stance, got: {msg}"
+        );
+    }
+
+    /// An entry with neither b64 nor URL is the malformed sibling — same refusal,
+    /// different rendering.
+    #[test]
+    fn parse_response_entry_with_no_b64_and_no_url_is_refused() {
+        let body = serde_json::json!({ "data": [{ "revised_prompt": "only this" }] });
+        let err = parse_response(200, body.to_string().as_bytes(), OutputFormat::Png).unwrap_err();
+        assert_eq!(
+            err,
+            OpenAiImagesError::MissingB64 {
+                index: 0,
+                has_url: false
+            }
+        );
+    }
+
+    /// Invalid base64 is a loud error naming the entry, never truncated-or-empty
+    /// bytes handed on as an artifact.
+    #[test]
+    fn parse_response_invalid_base64_is_refused() {
+        let body = serde_json::json!({ "data": [{ "b64_json": "not!!valid@@base64" }] });
+        let err = parse_response(200, body.to_string().as_bytes(), OutputFormat::Png).unwrap_err();
+        assert!(
+            matches!(err, OpenAiImagesError::InvalidB64 { index: 0, .. }),
+            "got {err:?}"
+        );
+    }
+
+    /// Zero artifacts is never a success.
+    #[test]
+    fn parse_response_empty_data_is_refused() {
+        let body = serde_json::json!({ "data": [] });
+        let err = parse_response(200, body.to_string().as_bytes(), OutputFormat::Png).unwrap_err();
+        assert_eq!(err, OpenAiImagesError::EmptyData);
+    }
+
+    /// A 2xx that isn't the documented envelope at all — a proxy page, a bare
+    /// string — is refused as an invalid body, not sniffed.
+    #[test]
+    fn parse_response_non_envelope_body_is_refused() {
+        for body in [&b"<html>gateway</html>"[..], b"{}", b"{\"data\": \"nope\"}"] {
+            let err = parse_response(200, body, OutputFormat::Png).unwrap_err();
+            assert!(
+                matches!(err, OpenAiImagesError::InvalidBody(_)),
+                "body {:?} got {err:?}",
+                String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    /// A non-2xx renders OpenAI's own error shape readably, and falls back to the
+    /// raw text for anything else in front of the API.
+    #[test]
+    fn parse_response_provider_error_renders_openai_shape_and_raw_fallback() {
+        let openai = serde_json::json!({
+            "error": { "message": "Billing hard limit reached", "type": "invalid_request_error" }
+        });
+        let err =
+            parse_response(400, openai.to_string().as_bytes(), OutputFormat::Png).unwrap_err();
+        assert_eq!(
+            err,
+            OpenAiImagesError::Provider {
+                status: 400,
+                body: "Billing hard limit reached (invalid_request_error)".to_string()
+            }
+        );
+
+        let err = parse_response(502, b"Bad Gateway", OutputFormat::Png).unwrap_err();
+        assert_eq!(
+            err,
+            OpenAiImagesError::Provider {
+                status: 502,
+                body: "Bad Gateway".to_string()
+            }
+        );
+    }
+
+    // --- the MediaModel seam ----------------------------------------------
+
+    /// `poll` bails loudly: this kind declares no deferred operations, so a poll
+    /// arriving at all is a caller inventing a job id or a broken sync-only
+    /// declaration — crash over a silent forever-Pending.
+    #[tokio::test]
+    async fn poll_bails_loudly() {
+        let client =
+            OpenAiImagesClient::new("test-key", "http://localhost:1", Duration::from_secs(1))
+                .expect("client construction is pure config, no network");
+        let model = OpenAiImagesModel::from_parts(&client, "gpt-image-1");
+        let err = crate::media::MediaModel::poll(&model, &MediaJobId("job-x".to_string()))
+            .await
+            .expect_err("poll must refuse");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no deferred operations"),
+            "the refusal names the declaration, got: {msg}"
+        );
+    }
+}

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -41,18 +41,20 @@
 //! deliberately ignored for now: the provenance sidecar records the operator's
 //! prompt, the request that *ran*.
 //!
-//! # Fields ride verbatim, scalars typed
+//! # Fields ride verbatim, typed by the caller
 //!
 //! The passthrough posture is unchanged from Stability: `size`, `quality`, `n`,
 //! `style`, `output_format`, `background`, ... ride [`crate::media::MediaRequest::fields`]
 //! and the provider validates its own knobs; `prompt` and `model` stay reserved at
-//! the tool layer. The one wire difference: this API takes a JSON body, not a
-//! multipart form, and OpenAI type-checks it (`n` must be a JSON integer, not
-//! `"2"`). So [`field_value`] sends a field whose string parses as a bare JSON
-//! number or bool as that scalar, and everything else as a string — `n = "2"`
-//! becomes `2`, `size = "1024x1024"` stays a string. That is a wire-shape
-//! translation, not an allowlist: every field still goes through, kaibo still
-//! validates none of them.
+//! the tool layer. This API takes a JSON body that OpenAI type-checks (`n` must be
+//! a JSON integer, `user` must be a string), so the caller's stated JSON type
+//! rides through verbatim — [`crate::media::FieldValue`] carries string vs number
+//! vs bool from the tool face to the wire, with no re-typing in between (guessing
+//! from the text would turn a legitimate `user = "123"` into the number `123` and
+//! a provider 400). Two fields get provider-side treatment: `output_format` must
+//! name a format this kind can store (validated before the call, canonical
+//! spelling sent), and `response_format` is refused outright — kaibo owns it (see
+//! above).
 //!
 //! # Credentials
 //!
@@ -97,6 +99,16 @@ impl OutputFormat {
             "jpeg" => Ok(OutputFormat::Jpeg),
             "webp" => Ok(OutputFormat::Webp),
             other => Err(OpenAiImagesError::UnknownOutputFormat(other.to_string())),
+        }
+    }
+
+    /// The canonical lowercase wire spelling — what [`build_request_body`] sends,
+    /// regardless of how leniently [`parse`](Self::parse) read the caller's value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OutputFormat::Png => "png",
+            OutputFormat::Jpeg => "jpeg",
+            OutputFormat::Webp => "webp",
         }
     }
 
@@ -150,9 +162,19 @@ pub enum OpenAiImagesError {
     MissingB64 { index: usize, has_url: bool },
     /// A `b64_json` value that didn't decode as base64.
     InvalidB64 { index: usize, detail: String },
+    /// A `b64_json` that decoded to ZERO bytes — the empty string is valid base64,
+    /// so without this check it would sail through as a zero-byte artifact and land
+    /// in the CAS under a real digest. Never treated as success.
+    EmptyArtifact { index: usize },
     /// An `output_format` field naming a format outside the closed
     /// [`OutputFormat`] set — refused at request build, before the call.
     UnknownOutputFormat(String),
+    /// The caller put `response_format` in `fields`. kaibo owns that parameter:
+    /// artifacts must arrive as base64, and `url` in particular would spend real
+    /// credits generating artifacts kaibo then refuses to fetch. Refused at request
+    /// build, before the call — any value, even a redundant `"b64_json"`, so the
+    /// contract stays one-sided.
+    CallerResponseFormat,
 }
 
 impl std::fmt::Display for OpenAiImagesError {
@@ -194,10 +216,22 @@ impl std::fmt::Display for OpenAiImagesError {
                 f,
                 "Images API data[{index}].b64_json is not valid base64: {detail}"
             ),
+            OpenAiImagesError::EmptyArtifact { index } => write!(
+                f,
+                "Images API data[{index}].b64_json decoded to zero bytes — never \
+                 treated as a successful empty artifact"
+            ),
             OpenAiImagesError::UnknownOutputFormat(v) => write!(
                 f,
                 "output_format {v:?} is not one this kind can name on disk — expected \
                  png, jpeg, or webp (the Images API's own set)"
+            ),
+            OpenAiImagesError::CallerResponseFormat => write!(
+                f,
+                "`fields.response_format` is owned by kaibo — artifacts must arrive \
+                 as base64 (`url` would spend credits on artifacts kaibo refuses to \
+                 fetch), and kaibo already sends the right value per model family. \
+                 Omit the field"
             ),
         }
     }
@@ -206,17 +240,6 @@ impl std::fmt::Display for OpenAiImagesError {
 impl std::error::Error for OpenAiImagesError {}
 
 // --- Request building (pure) -------------------------------------------------
-
-/// A field value as the JSON scalar the API type-checks for: a string that parses
-/// as a bare JSON number or bool goes typed (`"2"` → `2`, `"true"` → `true`);
-/// everything else stays a string (`"1024x1024"`, `"high"`). See the module doc —
-/// this is wire-shape translation, not validation.
-fn field_value(raw: &str) -> Value {
-    match serde_json::from_str::<Value>(raw) {
-        Ok(v @ (Value::Number(_) | Value::Bool(_))) => v,
-        _ => Value::String(raw.to_string()),
-    }
-}
 
 /// True for the model family that always returns base64 and REJECTS the
 /// `response_format` parameter (gpt-image-1, gpt-image-1-mini, and successors under
@@ -231,15 +254,19 @@ fn always_b64(model: &str) -> bool {
 ///
 /// - `model` and `prompt` come from the slot and the tool parameter (the tool layer
 ///   reserves both field names, so they cannot arrive in `request.fields`).
-/// - `response_format = "b64_json"` is seeded for every model family except
-///   gpt-image-1's (which rejects the parameter and always returns b64) — a caller
-///   field of the same name replaces the seed, the same last-write-wins merge
-///   Stability's `output_format` seed follows. Overriding it to `"url"` just moves
-///   the failure to [`parse_response`]'s loud b64 refusal.
-/// - Every `request.fields` entry rides through [`field_value`], in order.
-/// - The artifact format is the request's `output_format` field when present
-///   ([`OutputFormat::parse`] — unknown is a loud error here, before the call),
-///   else png.
+/// - `response_format = "b64_json"` is sent for every model family except
+///   gpt-image-1's (which rejects the parameter and always returns b64). The
+///   parameter is kaibo's alone: a caller `response_format` field is refused
+///   outright ([`OpenAiImagesError::CallerResponseFormat`]) — `url` would spend
+///   credits on artifacts kaibo then refuses, so the field never rides through.
+/// - Every other `request.fields` entry rides through verbatim as the JSON scalar
+///   the caller stated ([`crate::media::FieldValue::to_json`]) — no re-typing, the
+///   provider validates its own knobs.
+/// - The artifact format is the request's `output_format` field when present —
+///   which must be a *string* naming one of [`OutputFormat`]'s set (unknown, or a
+///   non-string value, is a loud error here, before the call) — else png. The
+///   parsed format's canonical lowercase spelling is what reaches the wire, so
+///   `" PNG "` is sent as `png`, not forwarded raw for the provider to refuse.
 pub fn build_request_body(
     model: &str,
     request: &MediaRequest,
@@ -256,12 +283,25 @@ pub fn build_request_body(
 
     let mut format = OutputFormat::Png;
     for (name, value) in &request.fields {
-        if name == "output_format" {
-            format = OutputFormat::parse(value)?;
+        match name.as_str() {
+            "response_format" => return Err(OpenAiImagesError::CallerResponseFormat),
+            "output_format" => {
+                // Must be a string naming a format this kind can store; a number or
+                // bool here is the caller's mistake, surfaced with its wire spelling.
+                let raw = value.as_str().ok_or_else(|| {
+                    OpenAiImagesError::UnknownOutputFormat(value.to_wire_string())
+                })?;
+                format = OutputFormat::parse(raw)?;
+                // The canonical spelling goes on the wire, not the raw value —
+                // `parse` was lenient (case, whitespace) so the wire can be exact.
+                body.insert(name.clone(), Value::String(format.as_str().to_string()));
+            }
+            _ => {
+                // Map insert: uniquely named by the tool layer's map face; the
+                // caller's stated JSON type rides verbatim.
+                body.insert(name.clone(), value.to_json());
+            }
         }
-        // Map insert: a caller field replaces a seeded default of the same name
-        // (fields are uniquely named by the tool layer's map face).
-        body.insert(name.clone(), field_value(value));
     }
     Ok((Value::Object(body), format))
 }
@@ -332,6 +372,12 @@ pub fn parse_response(
                 index,
                 detail: e.to_string(),
             })?;
+        // The empty string is VALID base64, so a decode success is not yet an
+        // artifact — zero bytes under a real digest is the silent-garbage shape
+        // this module refuses everywhere else.
+        if bytes.is_empty() {
+            return Err(OpenAiImagesError::EmptyArtifact { index });
+        }
         artifacts.push(MediaArtifact {
             bytes,
             mime: format.mime().to_string(),
@@ -451,11 +497,20 @@ mod tests {
     }
 
     fn request(fields: &[(&str, &str)]) -> MediaRequest {
+        typed_request(
+            &fields
+                .iter()
+                .map(|(k, v)| (*k, crate::media::FieldValue::from(*v)))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn typed_request(fields: &[(&str, crate::media::FieldValue)]) -> MediaRequest {
         MediaRequest {
             prompt: "a lighthouse at dusk".to_string(),
             fields: fields
                 .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .map(|(k, v)| (k.to_string(), v.clone()))
                 .collect(),
             input_image: None,
         }
@@ -554,40 +609,74 @@ mod tests {
         }
     }
 
-    /// Fields ride through verbatim in value, with bare JSON scalars typed the way
-    /// the API type-checks them: `n = "2"` must go as the integer 2 (OpenAI rejects
-    /// the string), `size` stays a string. A caller's `response_format` replaces
-    /// the seeded default rather than duplicating it.
+    /// The caller's stated JSON type rides through verbatim — no re-typing in
+    /// either direction. `n` passed as a number arrives as the integer `2` (never
+    /// `2.0`, never `"2"`); `user = "123"` passed as a STRING stays the string
+    /// `"123"` (the or-gpt review's case: value-based guessing would re-type it to
+    /// a number and draw a provider 400); a boolean survives typed.
     #[test]
-    fn request_body_types_scalars_and_lets_fields_override_seeds() {
+    fn request_body_carries_the_callers_stated_types_verbatim() {
+        use crate::media::FieldValue;
         let (body, format) = build_request_body(
             "dall-e-3",
-            &request(&[
-                ("n", "2"),
-                ("size", "1024x1024"),
-                ("quality", "high"),
-                ("output_format", "webp"),
-                ("response_format", "b64_json"),
+            &typed_request(&[
+                ("n", FieldValue::Num(serde_json::Number::from(2))),
+                ("size", FieldValue::Str("1024x1024".to_string())),
+                ("user", FieldValue::Str("123".to_string())),
+                ("transparent", FieldValue::Bool(true)),
+                ("output_format", FieldValue::Str("webp".to_string())),
             ]),
         )
         .unwrap();
-        assert_eq!(body.get("n"), Some(&Value::from(2)), "n goes typed");
+        assert_eq!(
+            body.get("n"),
+            Some(&Value::from(2)),
+            "a caller number is the JSON integer 2, not \"2\" or 2.0"
+        );
         assert_eq!(
             body.get("size").and_then(Value::as_str),
             Some("1024x1024"),
-            "size stays a string"
+            "a caller string stays a string"
         );
-        assert_eq!(body.get("quality").and_then(Value::as_str), Some("high"));
-        assert_eq!(format, OutputFormat::Webp, "output_format drives the mime");
         assert_eq!(
-            body.get("response_format").and_then(Value::as_str),
-            Some("b64_json"),
-            "one response_format, not two"
+            body.get("user"),
+            Some(&Value::String("123".to_string())),
+            "a numeric-LOOKING caller string is still a string — never re-typed"
+        );
+        assert_eq!(
+            body.get("transparent"),
+            Some(&Value::Bool(true)),
+            "a caller bool survives typed"
+        );
+        assert_eq!(format, OutputFormat::Webp, "output_format drives the mime");
+    }
+
+    /// A caller-supplied `response_format` is refused before the call, whatever the
+    /// value — kaibo owns that parameter (`url` would spend credits on artifacts
+    /// kaibo then refuses; even a redundant `b64_json` is rejected so the contract
+    /// stays one-sided), and the error says why.
+    #[test]
+    fn request_body_refuses_a_caller_response_format() {
+        for value in ["url", "b64_json"] {
+            let err = build_request_body("dall-e-3", &request(&[("response_format", value)]))
+                .expect_err("caller response_format must be refused");
+            assert_eq!(
+                err,
+                OpenAiImagesError::CallerResponseFormat,
+                "value {value:?}"
+            );
+        }
+        let msg = OpenAiImagesError::CallerResponseFormat.to_string();
+        assert!(
+            msg.contains("owned by kaibo") && msg.contains("base64"),
+            "the refusal explains the ownership and the b64 contract, got: {msg}"
         );
     }
 
     /// An unknown output_format fails at request build — before any credits are
     /// spent — not after the provider generated under a format the CAS can't name.
+    /// A non-string value there is the same refusal, rendered via its wire
+    /// spelling.
     #[test]
     fn request_body_refuses_unknown_output_format_before_the_call() {
         let err =
@@ -595,6 +684,30 @@ mod tests {
         assert_eq!(
             err,
             OpenAiImagesError::UnknownOutputFormat("avif".to_string())
+        );
+        let err = build_request_body(
+            "gpt-image-1",
+            &typed_request(&[(
+                "output_format",
+                crate::media::FieldValue::Num(serde_json::Number::from(3)),
+            )]),
+        )
+        .unwrap_err();
+        assert_eq!(err, OpenAiImagesError::UnknownOutputFormat("3".to_string()));
+    }
+
+    /// `parse` is lenient (case, whitespace) but the WIRE gets the canonical
+    /// spelling: `" PNG "` is sent as `png`, never forwarded raw for the provider
+    /// to refuse.
+    #[test]
+    fn request_body_sends_canonical_output_format_spelling() {
+        let (body, format) =
+            build_request_body("gpt-image-1", &request(&[("output_format", " PNG ")])).unwrap();
+        assert_eq!(format, OutputFormat::Png);
+        assert_eq!(
+            body.get("output_format").and_then(Value::as_str),
+            Some("png"),
+            "the canonical lowercase spelling reaches the wire"
         );
     }
 
@@ -697,6 +810,18 @@ mod tests {
             matches!(err, OpenAiImagesError::InvalidB64 { index: 0, .. }),
             "got {err:?}"
         );
+    }
+
+    /// The empty string is VALID base64, so decode success alone would wave a
+    /// zero-byte artifact into the CAS under a real digest — refused by its own
+    /// name instead.
+    #[test]
+    fn parse_response_empty_b64_is_refused_not_a_zero_byte_artifact() {
+        let body = serde_json::json!({
+            "data": [{ "b64_json": b64(b"real") }, { "b64_json": "" }],
+        });
+        let err = parse_response(200, body.to_string().as_bytes(), OutputFormat::Png).unwrap_err();
+        assert_eq!(err, OpenAiImagesError::EmptyArtifact { index: 1 });
     }
 
     /// Zero artifacts is never a success.

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -340,7 +340,7 @@ pub(crate) fn render_config_resource(
                 base_url.clone()
             };
             let doc = BackendDoc {
-                kind: format!("{:?}", kind).to_lowercase(),
+                kind: kind.canonical_name().to_string(),
                 base_url: rendered_base_url,
                 // KEY SOURCE ONLY — env var name or file path, never the value.
                 api_key_env: api_key_env.clone(),
@@ -672,6 +672,37 @@ mod tests {
         assert!(
             body.contains("/tmp/the-repo-feature"),
             "runtime section must list the followed worktree:\n{body}"
+        );
+    }
+
+    /// A backend's `kind` renders as its canonical (hyphenated) name, the spelling an
+    /// operator writes in config — a Debug-derived lowercase would collapse
+    /// `openai-images` into `openaiimages`, a name that round-trips into a load error.
+    #[test]
+    fn config_resource_renders_kind_by_canonical_name() {
+        let config = Config::from_toml_str(
+            r#"
+            [backends.imggen]
+            kind = "openai-images"
+            "#,
+        )
+        .unwrap();
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
+        assert!(
+            body.contains(r#"kind = "openai-images""#),
+            "the kind must render in its canonical spelling:\n{body}"
+        );
+        assert!(
+            !body.contains("openaiimages"),
+            "a Debug-lowercased kind name must not appear:\n{body}"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -612,14 +612,39 @@ pub struct GenerateInput {
     #[serde(default)]
     pub cast: Option<String>,
 
-    /// Provider-native generation options passed through verbatim as string fields
-    /// (Stability: aspect_ratio "16:9", output_format png|jpeg|webp, seed,
-    /// negative_prompt, style_preset, ...; OpenAI-compatible images endpoints: size
-    /// "1024x1024", n, quality, output_format, ...). The provider validates its own
+    /// Provider-native generation options passed through verbatim — each value's
+    /// JSON type (string | number | boolean) is the type the provider receives, so
+    /// pass `n` as a number and ids like `user` as strings. (Stability:
+    /// aspect_ratio "16:9", output_format png|jpeg|webp, seed, negative_prompt,
+    /// style_preset, ...; OpenAI-compatible images endpoints: size "1024x1024", n,
+    /// quality, output_format png|jpeg|webp, ...). The provider validates its own
     /// knobs. `prompt` and `model` are reserved: use the prompt parameter and the
     /// cast's image slot.
     #[serde(default)]
-    pub fields: Option<std::collections::BTreeMap<String, String>>,
+    pub fields: Option<std::collections::BTreeMap<String, GenerateFieldValue>>,
+}
+
+/// One `generate` field value, as typed JSON: the schema face of
+/// [`crate::media::FieldValue`]. Untagged, so a caller writes plain JSON scalars
+/// (`{"n": 2, "size": "1024x1024", "transparent": true}`) and the stated type — not
+/// a guess re-derived from text — rides through to the provider's wire.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum GenerateFieldValue {
+    Bool(bool),
+    /// `serde_json::Number` keeps integers integral end to end (`2`, never `2.0`).
+    Num(serde_json::Number),
+    Str(String),
+}
+
+impl GenerateFieldValue {
+    fn into_field_value(self) -> crate::media::FieldValue {
+        match self {
+            GenerateFieldValue::Str(s) => crate::media::FieldValue::Str(s),
+            GenerateFieldValue::Num(n) => crate::media::FieldValue::Num(n),
+            GenerateFieldValue::Bool(b) => crate::media::FieldValue::Bool(b),
+        }
+    }
 }
 
 /// kaibo's MCP handler. Cheap to clone (rmcp clones it per request).
@@ -2476,7 +2501,8 @@ impl KaiboHandler {
             kaibo://cas/<digest> resource URI, the mime, the provider's seed when \
             reported, and the real file path when the store is on disk. \
             Provider-native options (aspect_ratio, size, n, output_format, seed, \
-            negative_prompt, style_preset, ...) pass through `fields` verbatim. An \
+            negative_prompt, style_preset, ...) pass through `fields` verbatim, each \
+            value's JSON type (string | number | boolean) preserved to the wire. An \
             operation the provider declares deferred returns a `job-N` handle for \
             job_wait/job_get instead (every route wired today answers in-call). \
             Provenance (prompt, model, cast, seed) is recorded beside every artifact."
@@ -2501,10 +2527,10 @@ impl KaiboHandler {
             return Err(McpError::invalid_params(
                 format!(
                     "cast `{}` has no `image` slot — `generate` needs a cast whose \
-                     `image` slot points at a media backend (kind `stability` or \
-                     `openai-images`). kaibo://config lists the configured casts and \
-                     their slots.",
-                    cast.name
+                     `image` slot points at a media backend (kind {}). kaibo://config \
+                     lists the configured casts and their slots.",
+                    cast.name,
+                    crate::credentials::media_kinds_list(),
                 ),
                 None,
             ));
@@ -2520,7 +2546,12 @@ impl KaiboHandler {
         let arm = self.media_arms.build(backend, slot).map_err(|e| {
             McpError::invalid_params(format!("cast `{}` image slot: {e:#}", cast.name), None)
         })?;
-        let fields: Vec<(String, String)> = input.fields.unwrap_or_default().into_iter().collect();
+        let fields: Vec<(String, crate::media::FieldValue)> = input
+            .fields
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(name, value)| (name, value.into_field_value()))
+            .collect();
         // Reserved keys: recorded provenance must describe the request that actually
         // ran. `fields.prompt` would send prompt B while the sidecar records prompt A,
         // and `fields.model` would reroute the call (Stability's SD3 route, the
@@ -3622,17 +3653,21 @@ by waiting — the handles keep.
 
 ## Generate media: `generate`
 
-`generate` turns a text prompt into an image through the cast's `image` slot (a media
-backend such as Stability). It is advertised only when a configured cast carries that
-slot and the media CAS is on. The result is never inline bytes: each artifact lands in
-kaibo's content-addressed store and you get its digest as a `kaibo://cas/<digest>`
-resource URI (read it as an MCP resource for the bytes), the mime, the provider's seed,
-and — when the store is on disk — the real file path. Provider-native options ride the
-`fields` object verbatim (Stability: `aspect_ratio` \"16:9\", `output_format`
-png|jpeg|webp, `seed`, `negative_prompt`, `style_preset`). An operation the provider
-declares deferred hands back a `job-N` on the same collect verbs above — the lane is
-wired, though every Stability generate route today answers in-call. Every artifact gets
-a provenance sidecar (prompt, model, cast, timestamp, mime, seed) beside it in the store.
+`generate` turns a text prompt into images through the cast's `image` slot — a media
+backend: Stability's v2beta family, or an OpenAI-compatible images endpoint (hosted
+gpt-image, or a local stable-diffusion.cpp sd-server; one call may return several
+images via `n`). It is advertised only when a configured cast carries that slot and
+the media CAS is on. The result is never inline bytes: each artifact lands in kaibo's
+content-addressed store and you get its digest as a `kaibo://cas/<digest>` resource
+URI (read it as an MCP resource for the bytes), the mime, the provider's seed when
+reported, and — when the store is on disk — the real file path. Provider-native
+options ride the `fields` object verbatim, each value's JSON type preserved
+(Stability: `aspect_ratio` \"16:9\", `output_format` png|jpeg|webp, `seed`,
+`negative_prompt`, `style_preset`; OpenAI-compatible: `size` \"1024x1024\", `n`,
+`quality`, `output_format` png|jpeg|webp). An operation the provider declares
+deferred hands back a `job-N` on the same collect verbs above — the lane is wired,
+though every route wired today answers in-call. Every artifact gets a provenance
+sidecar (prompt, model, cast, timestamp, mime, seed) beside it in the store.
 
 ## Driving the read-only shell (`run_kaish`)
 
@@ -4785,9 +4820,12 @@ mod tests {
                 prompt: "A".to_string(),
                 cast: Some("artist".to_string()),
                 fields: Some(
-                    [("prompt".to_string(), "B".to_string())]
-                        .into_iter()
-                        .collect(),
+                    [(
+                        "prompt".to_string(),
+                        GenerateFieldValue::Str("B".to_string()),
+                    )]
+                    .into_iter()
+                    .collect(),
                 ),
             }))
             .await
@@ -4803,9 +4841,12 @@ mod tests {
                 prompt: "A".to_string(),
                 cast: Some("artist".to_string()),
                 fields: Some(
-                    [("model".to_string(), "sd3.5-large".to_string())]
-                        .into_iter()
-                        .collect(),
+                    [(
+                        "model".to_string(),
+                        GenerateFieldValue::Str("sd3.5-large".to_string()),
+                    )]
+                    .into_iter()
+                    .collect(),
                 ),
             }))
             .await

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -614,9 +614,10 @@ pub struct GenerateInput {
 
     /// Provider-native generation options passed through verbatim as string fields
     /// (Stability: aspect_ratio "16:9", output_format png|jpeg|webp, seed,
-    /// negative_prompt, style_preset, ...). The provider validates its own knobs.
-    /// `prompt` and `model` are reserved: use the prompt parameter and the cast's
-    /// image slot.
+    /// negative_prompt, style_preset, ...; OpenAI-compatible images endpoints: size
+    /// "1024x1024", n, quality, output_format, ...). The provider validates its own
+    /// knobs. `prompt` and `model` are reserved: use the prompt parameter and the
+    /// cast's image slot.
     #[serde(default)]
     pub fields: Option<std::collections::BTreeMap<String, String>>,
 }
@@ -749,8 +750,8 @@ const CAST_ENUM_RULES: &[CastEnumRule] = &[
     (
         &["generate"],
         Config::cast_can_generate,
-        "a cast with an `image` slot pointing at a media backend (kind `stability`) — \
-         see the image-slot example in docs/config.example.toml",
+        "a cast with an `image` slot pointing at a media backend (kind `stability` or \
+         `openai-images`) — see the image-slot examples in docs/config.example.toml",
     ),
 ];
 
@@ -2467,15 +2468,17 @@ impl KaiboHandler {
     }
 
     #[tool(
-        description = "Generate an image from a text prompt with the cast's `image` \
-            model (a media backend, e.g. Stability). Bytes are never inlined: each \
-            artifact lands in kaibo's content-addressed media store and the result \
-            lists per-artifact digests — a kaibo://cas/<digest> resource URI, the mime, \
-            the provider's seed, and the real file path when the store is on disk. \
-            Provider-native options (aspect_ratio, output_format, seed, \
+        description = "Generate images from a text prompt with the cast's `image` \
+            model (a media backend: Stability, or an OpenAI-compatible images \
+            endpoint — hosted gpt-image or a local stable-diffusion.cpp sd-server). \
+            Bytes are never inlined: each artifact lands in kaibo's content-addressed \
+            media store and the result lists per-artifact digests — a \
+            kaibo://cas/<digest> resource URI, the mime, the provider's seed when \
+            reported, and the real file path when the store is on disk. \
+            Provider-native options (aspect_ratio, size, n, output_format, seed, \
             negative_prompt, style_preset, ...) pass through `fields` verbatim. An \
             operation the provider declares deferred returns a `job-N` handle for \
-            job_wait/job_get instead (today's Stability routes all answer in-call). \
+            job_wait/job_get instead (every route wired today answers in-call). \
             Provenance (prompt, model, cast, seed) is recorded beside every artifact."
     )]
     pub async fn generate(
@@ -2498,8 +2501,9 @@ impl KaiboHandler {
             return Err(McpError::invalid_params(
                 format!(
                     "cast `{}` has no `image` slot — `generate` needs a cast whose \
-                     `image` slot points at a media backend (kind `stability`). \
-                     kaibo://config lists the configured casts and their slots.",
+                     `image` slot points at a media backend (kind `stability` or \
+                     `openai-images`). kaibo://config lists the configured casts and \
+                     their slots.",
                     cast.name
                 ),
                 None,
@@ -2519,13 +2523,14 @@ impl KaiboHandler {
         let fields: Vec<(String, String)> = input.fields.unwrap_or_default().into_iter().collect();
         // Reserved keys: recorded provenance must describe the request that actually
         // ran. `fields.prompt` would send prompt B while the sidecar records prompt A,
-        // and `fields.model` would reroute an SD3 call while the sidecar records the
-        // slot's model — so both are refused loudly, pointing at the real parameter.
+        // and `fields.model` would reroute the call (Stability's SD3 route, the
+        // Images API's model field) while the sidecar records the slot's model — so
+        // both are refused loudly, pointing at the real parameter.
         for (key, param) in [
             ("prompt", "the `prompt` parameter"),
             (
                 "model",
-                "the cast's `image` slot (its model id picks the route/variant)",
+                "the cast's `image` slot (its model id picks the provider model/route)",
             ),
         ] {
             if fields.iter().any(|(name, _)| name == key) {

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -1124,10 +1124,15 @@ impl StabilityImageModel {
         }
         fields.push(("output_format".to_string(), "png".to_string()));
         for (k, v) in &request.fields {
+            // Typed neutral values land on Stability's all-string multipart wire via
+            // their wire spelling — lossless here (`seed = 42` was always the text
+            // `42` on this wire), and the caller's stated type still reached the
+            // provider that cares (see `media::FieldValue`).
+            let v = v.to_wire_string();
             if let Some(existing) = fields.iter_mut().find(|(name, _)| name == k) {
-                existing.1 = v.clone();
+                existing.1 = v;
             } else {
-                fields.push((k.clone(), v.clone()));
+                fields.push((k.clone(), v));
             }
         }
         (
@@ -1298,6 +1303,34 @@ mod tests {
             ],
             "an explicit fields entry must win over the derived aspect_ratio, not duplicate it"
         );
+    }
+
+    /// Typed neutral field values land on Stability's all-string multipart wire in
+    /// their wire spelling — `seed = 42` (a caller number) becomes the text `42`,
+    /// a bool becomes `true` — losslessly, since this wire was always text. The
+    /// stringify half of the `media::FieldValue` contract (the typed half lands on
+    /// openai-images' JSON wire; see that module's tests).
+    #[test]
+    fn media_request_stringifies_typed_fields_for_the_form_wire() {
+        use crate::media::FieldValue;
+        let client = StabilityClient::new("k", "http://localhost", Duration::from_secs(1)).unwrap();
+        let model = StabilityImageModel::from_parts(&client, "core");
+        let (_, req) = model.media_request(&crate::media::MediaRequest {
+            prompt: "p".to_string(),
+            fields: vec![
+                ("seed".to_string(), FieldValue::Num(serde_json::Number::from(42))),
+                ("tiling".to_string(), FieldValue::Bool(true)),
+                ("style_preset".to_string(), FieldValue::Str("anime".to_string())),
+            ],
+            input_image: None,
+        });
+        for (name, wire) in [("seed", "42"), ("tiling", "true"), ("style_preset", "anime")] {
+            assert!(
+                req.fields.iter().any(|(k, v)| k == name && v == wire),
+                "{name} must reach the form fields as the text {wire:?}, got {:?}",
+                req.fields
+            );
+        }
     }
 
     // --- from_rig_request --------------------------------------------------------

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1969,9 +1969,13 @@ fn an_image_slot_cannot_point_at_a_completion_backend() {
 // --- the openai-images kind ---------------------------------------------------
 
 /// The `openai-images` kind parses from TOML and seeds its defaults: the same key
-/// sources as the `openai` completion kind (`OPENAI_API_KEY` / `~/.openai-key`) and
-/// `key_optional = true` — the keyless local sd-server case is the seeded posture,
-/// and an operator dialing hosted OpenAI turns key_optional off explicitly.
+/// sources as the `openai` completion kind (`OPENAI_API_KEY` / `~/.openai-key`),
+/// but the key is REQUIRED. This kind's default endpoint is hosted OpenAI, so a
+/// keyless seed would let a minimal stanza load clean, staff `generate`, and then
+/// send `Bearer no-auth` to api.openai.com — a 401 on the first paid call instead
+/// of a loud config gap (the or-gpt cross-family review's posture reversal,
+/// 2026-08-03). A keyless local sd-server opts in with `key_optional = true`
+/// beside its explicit local `base_url`.
 #[test]
 fn openai_images_backend_parses_and_seeds_openai_key_sources() {
     let c = Config::from_toml_str(
@@ -1990,34 +1994,38 @@ fn openai_images_backend_parses_and_seeds_openai_key_sources() {
         b.api_key_file
     );
     assert!(
-        b.key_optional,
-        "key_optional seeds true — the keyless local sd-server case"
+        !b.key_optional,
+        "key_optional seeds FALSE — the default endpoint is hosted, so a missing \
+         key must fail loudly at resolve; a local sd-server opts in explicitly"
     );
 }
 
 /// base_url is optional on an openai-images backend, unlike a new `openai`
 /// completion backend (which must say where it points): unset means hosted OpenAI
 /// (`https://api.openai.com/v1`, resolved at arm construction), set points the same
-/// wire at a local sd-server. Both shapes load.
+/// wire at a local sd-server (which also sets `key_optional = true` — keyless is an
+/// explicit opt-in on this kind). Both shapes load.
 #[test]
 fn openai_images_base_url_is_optional_default_hosted() {
     let c = Config::from_toml_str(
         r#"
         [backends.hosted-imgs]
         kind = "openai-images"
-        key_optional = false
 
         [backends.sdcpp]
         kind = "openai-images"
         base_url = "http://localhost:1234/v1"
+        key_optional = true
         "#,
     )
     .expect("both the hosted (no base_url) and local shapes load");
     assert_eq!(c.backends["hosted-imgs"].base_url, None);
+    assert!(!c.backends["hosted-imgs"].key_optional);
     assert_eq!(
         c.backends["sdcpp"].base_url.as_deref(),
         Some("http://localhost:1234/v1")
     );
+    assert!(c.backends["sdcpp"].key_optional);
 }
 
 /// An openai-images backend staffs an image slot — the config half of the

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -643,7 +643,10 @@ fn base_url_on_a_keyed_backend_is_rejected() {
     let msg = format!("{err:#}");
     assert!(msg.contains("base_url"), "got: {msg}");
     assert!(
-        msg.contains("only the `openai`, `anthropic`, `gemini`, and `stability` kinds"),
+        msg.contains(
+            "only the `openai`, `anthropic`, and `gemini` completion kinds and the \
+             media kinds"
+        ),
         "got: {msg}"
     );
 }
@@ -1957,9 +1960,115 @@ fn an_image_slot_cannot_point_at_a_completion_backend() {
     .expect_err("an image slot on a chat backend must be refused at load");
     let msg = format!("{err:#}");
     assert!(
-        msg.contains("image") && msg.contains("stability"),
-        "the error must name the slot and the kind it needs, got: {msg}"
+        msg.contains("image") && msg.contains("completion wire") && msg.contains("media-kind"),
+        "the error names the slot, the offending class, and the class it needs — \
+         never a kind list that goes stale, got: {msg}"
     );
+}
+
+// --- the openai-images kind ---------------------------------------------------
+
+/// The `openai-images` kind parses from TOML and seeds its defaults: the same key
+/// sources as the `openai` completion kind (`OPENAI_API_KEY` / `~/.openai-key`) and
+/// `key_optional = true` — the keyless local sd-server case is the seeded posture,
+/// and an operator dialing hosted OpenAI turns key_optional off explicitly.
+#[test]
+fn openai_images_backend_parses_and_seeds_openai_key_sources() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.imgs]
+        kind = "openai-images"
+        "#,
+    )
+    .expect("the openai-images kind must parse");
+    let b = c.backends.get("imgs").expect("backend exists");
+    assert_eq!(b.kind, kaibo::credentials::ProviderKind::OpenAiImages);
+    assert_eq!(b.api_key_env.as_deref(), Some("OPENAI_API_KEY"));
+    assert!(
+        b.api_key_file.as_deref().is_some_and(|f| f.ends_with("/.openai-key")),
+        "the key file mirrors the openai completion kind's, got: {:?}",
+        b.api_key_file
+    );
+    assert!(
+        b.key_optional,
+        "key_optional seeds true — the keyless local sd-server case"
+    );
+}
+
+/// base_url is optional on an openai-images backend, unlike a new `openai`
+/// completion backend (which must say where it points): unset means hosted OpenAI
+/// (`https://api.openai.com/v1`, resolved at arm construction), set points the same
+/// wire at a local sd-server. Both shapes load.
+#[test]
+fn openai_images_base_url_is_optional_default_hosted() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.hosted-imgs]
+        kind = "openai-images"
+        key_optional = false
+
+        [backends.sdcpp]
+        kind = "openai-images"
+        base_url = "http://localhost:1234/v1"
+        "#,
+    )
+    .expect("both the hosted (no base_url) and local shapes load");
+    assert_eq!(c.backends["hosted-imgs"].base_url, None);
+    assert_eq!(
+        c.backends["sdcpp"].base_url.as_deref(),
+        Some("http://localhost:1234/v1")
+    );
+}
+
+/// An openai-images backend staffs an image slot — the config half of the
+/// class-based pairing, exercised for the second media kind.
+#[test]
+fn an_image_slot_can_point_at_an_openai_images_backend() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.imgs]
+        kind = "openai-images"
+        base_url = "http://localhost:1234/v1"
+
+        [casts.artist]
+        image = "imgs/sd3.5-large"
+        "#,
+    )
+    .expect("an image slot on an openai-images backend loads");
+    let cast = c.resolve_cast("artist").expect("cast resolves");
+    let slot = cast
+        .slot(kaibo::config::ModelRole::Image)
+        .expect("the image slot is present");
+    assert_eq!(slot.backend, "imgs");
+    assert_eq!(slot.id, "sd3.5-large");
+}
+
+/// A reasoning slot pointed at an openai-images backend is refused at load with the
+/// class-based error — proof the guard generalized instead of hardcoding stability.
+#[test]
+fn a_reasoning_slot_cannot_point_at_an_openai_images_backend() {
+    for role in ["explorer", "synth"] {
+        let toml = format!(
+            r#"
+            [backends.imgs]
+            kind = "openai-images"
+
+            [casts.broken]
+            {role} = "imgs/gpt-image-1"
+            "#
+        );
+        let err = Config::from_toml_str(&toml)
+            .expect_err("a reasoning slot on an openai-images backend must be refused at load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(role) && msg.contains("openai-images") && msg.contains("media kind"),
+            "the error names the slot, the kind, and its class, got: {msg}"
+        );
+        assert!(
+            msg.contains("image"),
+            "and it points at the fix (the image slot), got: {msg}"
+        );
+    }
 }
 
 /// No BUILT-IN cast carries an image slot, so a stock install can staff no image tool —

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -126,6 +126,34 @@ fn a_stock_install_does_not_advertise_deliberate() {
     );
 }
 
+/// An `image` slot on an `openai-images` backend staffs `generate` exactly the way a
+/// stability one does — the staffing gate is class-based, not stability-shaped. The
+/// keyless local sd-server posture (base_url set, no key anywhere) is the config
+/// under test, since it is the shape that must work with zero credentials.
+#[test]
+fn an_openai_images_cast_staffs_generate() {
+    let mut config = Config::from_toml_str(
+        r#"
+        [backends.sdcpp]
+        kind = "openai-images"
+        base_url = "http://localhost:1234/v1"
+        api_key_file = "/nonexistent-kaibo-test/openai"
+
+        [casts.artist]
+        image = "sdcpp/sd3.5-large"
+        "#,
+    )
+    .expect("fixture config parses");
+    config.tools = ToolGating::default();
+    let tools = KaiboHandler::new_with_env(config, |_| None)
+        .expect("handler builds")
+        .advertised_tools();
+    assert!(
+        tools.contains(&"generate".to_string()),
+        "an openai-images image slot must staff `generate`; got {tools:?}"
+    );
+}
+
 #[test]
 fn each_flag_removes_exactly_its_own_tools() {
     // Each flag and the tool route(s) it drops *exclusively*. The shared collect verbs

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -128,7 +128,8 @@ fn a_stock_install_does_not_advertise_deliberate() {
 
 /// An `image` slot on an `openai-images` backend staffs `generate` exactly the way a
 /// stability one does — the staffing gate is class-based, not stability-shaped. The
-/// keyless local sd-server posture (base_url set, no key anywhere) is the config
+/// keyless local sd-server posture (base_url set, `key_optional = true` explicit —
+/// the kind seeds key-required since its default endpoint is hosted) is the config
 /// under test, since it is the shape that must work with zero credentials.
 #[test]
 fn an_openai_images_cast_staffs_generate() {
@@ -137,6 +138,7 @@ fn an_openai_images_cast_staffs_generate() {
         [backends.sdcpp]
         kind = "openai-images"
         base_url = "http://localhost:1234/v1"
+        key_optional = true
         api_key_file = "/nonexistent-kaibo-test/openai"
 
         [casts.artist]

--- a/tests/openai_images_live.rs
+++ b/tests/openai_images_live.rs
@@ -1,0 +1,75 @@
+//! Live OpenAI Images API probe — `#[ignore]`d, following the precedent of
+//! `tests/stability_live.rs` and the live provider probes in `tests/consult.rs`:
+//! never run by `cargo test`, run by hand with `--ignored` once a real credential
+//! is present. Spends real OpenAI credits (one gpt-image-1 generation at the
+//! cheapest quality/size) — deliberate, and the only test in this module that
+//! touches the network.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kaibo::media::MediaRequest;
+use kaibo::openai_images::OpenAiImagesClient;
+
+/// The same key sources the `openai-images` kind seeds (`OPENAI_API_KEY` /
+/// `~/.openai-key`, env wins) — resolved directly because this probe targets the
+/// hosted API, where a key is mandatory even though the kind is `key_optional`.
+fn hosted_key() -> anyhow::Result<String> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("$HOME is not set; cannot locate the key-file"))?;
+    let env_value = std::env::var("OPENAI_API_KEY").ok();
+    kaibo::credentials::resolve(env_value.as_deref(), &home.join(".openai-key"))
+}
+
+#[tokio::test]
+#[ignore = "hits the OpenAI Images API (gpt-image-1, low quality, real money); run with \
+            --ignored and ~/.openai-key or OPENAI_API_KEY present"]
+async fn gpt_image_1_returns_real_png_bytes() {
+    let key = match hosted_key() {
+        Ok(k) => k,
+        Err(e) => panic!("no OpenAI credential for live test: {e}"),
+    };
+    let client = OpenAiImagesClient::new(
+        key,
+        kaibo::credentials::HOSTED_OPENAI_BASE_URL,
+        Duration::from_secs(120),
+    )
+    .expect("client construction");
+
+    let request = MediaRequest {
+        prompt: "a small lighthouse on a rocky cliff, watercolor".to_string(),
+        input_image: None,
+        // The cheapest hosted shape; output_format png is gpt-image-1's default,
+        // stated explicitly so the mime derivation is exercised end to end.
+        fields: vec![
+            ("size".to_string(), "1024x1024".to_string()),
+            ("quality".to_string(), "low".to_string()),
+            ("output_format".to_string(), "png".to_string()),
+        ],
+    };
+
+    let artifacts = client
+        .generate("gpt-image-1", &request)
+        .await
+        .expect("a live gpt-image-1 call should succeed");
+
+    eprintln!(
+        "=== OPENAI IMAGES LIVE: {} artifact(s), first {} bytes, mime {} ===",
+        artifacts.len(),
+        artifacts[0].bytes.len(),
+        artifacts[0].mime
+    );
+
+    assert_eq!(artifacts.len(), 1, "no `n` field, so exactly one artifact");
+    let image = &artifacts[0];
+    assert!(!image.bytes.is_empty(), "must return non-empty image bytes");
+    // PNG magic bytes — confirms the b64 envelope really decoded to an image.
+    assert_eq!(
+        &image.bytes[..8],
+        b"\x89PNG\r\n\x1a\n",
+        "expected PNG magic bytes"
+    );
+    assert_eq!(image.mime, "image/png");
+    assert_eq!(image.seed, None, "the Images API reports no seed");
+}

--- a/tests/openai_images_live.rs
+++ b/tests/openai_images_live.rs
@@ -43,9 +43,9 @@ async fn gpt_image_1_returns_real_png_bytes() {
         // The cheapest hosted shape; output_format png is gpt-image-1's default,
         // stated explicitly so the mime derivation is exercised end to end.
         fields: vec![
-            ("size".to_string(), "1024x1024".to_string()),
-            ("quality".to_string(), "low".to_string()),
-            ("output_format".to_string(), "png".to_string()),
+            ("size".to_string(), "1024x1024".into()),
+            ("quality".to_string(), "low".into()),
+            ("output_format".to_string(), "png".into()),
         ],
     };
 

--- a/tests/openai_images_transport.rs
+++ b/tests/openai_images_transport.rs
@@ -1,0 +1,253 @@
+//! The openai-images client driven end to end over a real socket, offline — the
+//! transport truths the pure-function tests cannot see and the paid live probe
+//! should not be the only witness to: the URL the client actually dials, the
+//! bearer header it sends, the JSON body as serialized on the wire, and the
+//! response walking back into `Vec<MediaArtifact>`.
+//!
+//! Pattern precedent: `tests/llm_timeout.rs` stands up a local `TcpListener` to
+//! exercise a real client with no network and no key. This file's listener goes
+//! one step further: it reads the one request, hands back a canned response, and
+//! surrenders the captured request for assertions.
+
+use std::time::Duration;
+
+use base64::Engine as _;
+use kaibo::media::{FieldValue, MediaRequest};
+use kaibo::openai_images::OpenAiImagesClient;
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// One captured HTTP request: the head (request line + headers, as raw text) and
+/// the body parsed as JSON.
+struct Captured {
+    head: String,
+    body: Value,
+}
+
+impl Captured {
+    /// The request line, e.g. `POST /v1/images/generations HTTP/1.1`.
+    fn request_line(&self) -> &str {
+        self.head.lines().next().unwrap_or("")
+    }
+
+    /// A header's value, name matched case-insensitively.
+    fn header(&self, name: &str) -> Option<String> {
+        let want = format!("{}:", name.to_ascii_lowercase());
+        self.head.lines().find_map(|line| {
+            line.to_ascii_lowercase()
+                .starts_with(&want)
+                .then(|| line[want.len()..].trim().to_string())
+        })
+    }
+}
+
+/// Serve exactly one HTTP exchange: accept a connection, read the request (head,
+/// then `Content-Length` bytes of body), answer with `status` + a JSON `body`,
+/// and hand the captured request back through the returned receiver. Returns the
+/// base URL to dial (through `/v1`, the shape the client contract wants).
+async fn one_shot_server(
+    status: u16,
+    response_body: String,
+) -> (String, tokio::sync::oneshot::Receiver<Captured>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        // Read until the end of the head, then exactly Content-Length body bytes.
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-request");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+        let content_length: usize = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse().unwrap())
+            })
+            .expect("a JSON POST always declares Content-Length");
+        while buf.len() < head_end + content_length {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-body");
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body: Value =
+            serde_json::from_slice(&buf[head_end..head_end + content_length]).unwrap();
+
+        let response = format!(
+            "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\n\
+             content-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+            response_body.len(),
+        );
+        sock.write_all(response.as_bytes()).await.unwrap();
+        sock.shutdown().await.ok();
+        tx.send(Captured { head, body }).ok();
+    });
+    (format!("http://{addr}/v1"), rx)
+}
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// The URL-defaulting family (dall-e-3), full round trip: the client POSTs to
+/// exactly `{base}/images/generations`, authenticates with the bearer it was
+/// built with, serializes the body with the caller's stated JSON types intact
+/// (`n` an integer, `user` a string that LOOKS numeric, a bool typed), seeds
+/// `response_format = "b64_json"` — and a multi-image response walks back into an
+/// ordered `Vec<MediaArtifact>`.
+#[tokio::test]
+async fn dall_e_round_trip_sends_typed_body_and_collects_ordered_artifacts() {
+    let response = serde_json::json!({
+        "created": 1_722_000_000u64,
+        "data": [
+            { "b64_json": b64(b"first-image") },
+            { "b64_json": b64(b"second-image") },
+        ],
+    });
+    let (base_url, captured) = one_shot_server(200, response.to_string()).await;
+
+    let client = OpenAiImagesClient::new("test-key-123", base_url, Duration::from_secs(5))
+        .expect("client builds offline");
+    let artifacts = client
+        .generate(
+            "dall-e-3",
+            &MediaRequest {
+                prompt: "two lighthouses".to_string(),
+                fields: vec![
+                    (
+                        "n".to_string(),
+                        FieldValue::Num(serde_json::Number::from(2)),
+                    ),
+                    ("user".to_string(), FieldValue::Str("123".to_string())),
+                    ("transparent".to_string(), FieldValue::Bool(true)),
+                    ("size".to_string(), FieldValue::Str("1024x1024".to_string())),
+                ],
+                input_image: None,
+            },
+        )
+        .await
+        .expect("the canned 200 parses into artifacts");
+
+    let req = captured.await.expect("the server captured one request");
+    assert_eq!(
+        req.request_line(),
+        "POST /v1/images/generations HTTP/1.1",
+        "the client appends its own route to the /v1 root"
+    );
+    assert_eq!(
+        req.header("authorization").as_deref(),
+        Some("Bearer test-key-123"),
+        "the resolved key rides as a bearer"
+    );
+    assert_eq!(
+        req.body.get("model").and_then(Value::as_str),
+        Some("dall-e-3")
+    );
+    assert_eq!(
+        req.body.get("prompt").and_then(Value::as_str),
+        Some("two lighthouses")
+    );
+    assert_eq!(
+        req.body.get("n"),
+        Some(&Value::from(2)),
+        "a caller number is a JSON integer on the wire"
+    );
+    assert_eq!(
+        req.body.get("user"),
+        Some(&Value::String("123".to_string())),
+        "a numeric-looking caller string stays a string on the wire"
+    );
+    assert_eq!(req.body.get("transparent"), Some(&Value::Bool(true)));
+    assert_eq!(
+        req.body.get("response_format").and_then(Value::as_str),
+        Some("b64_json"),
+        "the URL-defaulting family gets the b64 contract stated"
+    );
+
+    assert_eq!(
+        artifacts
+            .iter()
+            .map(|a| a.bytes.clone())
+            .collect::<Vec<_>>(),
+        vec![b"first-image".to_vec(), b"second-image".to_vec()],
+        "both images land, in the provider's order"
+    );
+    assert!(artifacts.iter().all(|a| a.mime == "image/png"));
+    assert!(artifacts.iter().all(|a| a.seed.is_none()));
+}
+
+/// The gpt-image family: `response_format` is ABSENT from the wire (the API
+/// rejects the parameter; the family always returns b64), and a trailing slash on
+/// the configured base URL still dials the exact same path.
+#[tokio::test]
+async fn gpt_image_omits_response_format_and_joins_a_trailing_slash_base() {
+    let response = serde_json::json!({ "data": [{ "b64_json": b64(b"img") }] });
+    let (base_url, captured) = one_shot_server(200, response.to_string()).await;
+
+    let client = OpenAiImagesClient::new(
+        "k",
+        format!("{base_url}/"), // trailing slash: joining must not double it
+        Duration::from_secs(5),
+    )
+    .expect("client builds offline");
+    client
+        .generate(
+            "gpt-image-1",
+            &MediaRequest {
+                prompt: "p".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("the canned 200 parses");
+
+    let req = captured.await.expect("captured");
+    assert_eq!(
+        req.request_line(),
+        "POST /v1/images/generations HTTP/1.1",
+        "a trailing-slash base joins to the same exact path"
+    );
+    assert!(
+        req.body.get("response_format").is_none(),
+        "gpt-image never carries response_format, got {}",
+        req.body
+    );
+}
+
+/// A provider error over the real transport surfaces as the rendered provider
+/// error, not a parse panic — the wire half of `parse_response`'s non-2xx arm.
+#[tokio::test]
+async fn provider_401_surfaces_readably_over_the_wire() {
+    let response = serde_json::json!({
+        "error": { "message": "Incorrect API key provided", "type": "invalid_request_error" }
+    });
+    let (base_url, _captured) = one_shot_server(401, response.to_string()).await;
+
+    let client = OpenAiImagesClient::new("bad-key", base_url, Duration::from_secs(5)).unwrap();
+    let err = client
+        .generate(
+            "gpt-image-1",
+            &MediaRequest {
+                prompt: "p".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("a 401 is a provider error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("401") && msg.contains("Incorrect API key"),
+        "the status and the provider's message both surface, got: {msg}"
+    );
+}


### PR DESCRIPTION
The second media kind on the #121 spine, approved by Amy in-session ("let's get the openai-images PR rolling"). One kind covers two real targets because they speak the same endpoint: hosted OpenAI image generation (gpt-image-1 family) and a local stable-diffusion.cpp sd-server (`/v1/images/generations`).

Design decided in-session:

- **`ProviderKind::OpenAiImages`** (canonical `openai-images`), `class()` → `Media(MediaKind::OpenAiImages)`. The #121 class-funnel claim held structurally: after adding the variant, the only non-exhaustive match in the tree was `MediaArm::from_slot` — no completion path needed an arm.
- **Key posture mirrors the `openai` completion kind, not Stability**: `OPENAI_API_KEY` / `~/.openai-key`, `key_optional` seeds true (the keyless local sd-server case); hosted use sets `key_optional = false` + the key file explicitly, exactly like `[backends.gpt]`. `base_url` optional, defaulting to hosted; a host root — the client appends its own path.
- **Sync-only**: `generate` returns `Complete(Vec<MediaArtifact>)` — `n` makes multi-artifact the normal case, the first real exerciser of #121's Vec widening. `response_format = "b64_json"` is seeded for URL-defaulting families and omitted for gpt-image (which rejects the parameter and always returns b64); URL-only responses are refused loudly. `poll` bails — unreachable by construction, said in its doc.
- **Mime** from the request's `output_format` (png|jpeg|webp, default png) into the CAS's closed `Extension`; unknown format errors before the paid call. No seed on this wire → `None`.
- **Config validation generalized to class-based**: image-slot-on-wire and reasoning-slot-on-media both bail naming the kind's class, so the error text can't go stale as kinds accumulate (the docs-drift lesson from #121's review).

Agent judgment calls: scalar typing in `fields` (the Images API type-checks its body — `n` must be a JSON integer; bare numbers/bools go typed, documented as wire-shape translation, not an allowlist); the key file matches the `openai` kind's `.openai-key` so both kinds share one credential.

920 tests green (+22 offline, fixture-driven; +1 `#[ignore]`d hosted live probe mirroring `stability_live.rs`), clippy silent, `cargo tree -i aws-lc-rs` empty (client builds through `src/tls.rs`), `no_write_path` untouched. Mutation checks proved the b64-refusal and class-validation tests can fail.

Docs: guide kind/base_url/staffing tables, template with both hosted and keyless-local shapes, README, short CHANGELOG entry.

Patch by a Claude subagent from the in-session design brief; cross-family reviews to follow as PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)