### PR TITLE
feat(artifact): save_artifact — a one-way delivery tunnel from the model team to the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,12 @@ record. Each later release appends a new section at the top.
   write a generated corpus, a long inventory, or a fixture into kaibo's media store;
   the answer names each `kaibo://cas/<digest>` and you choose what to read. Off
   unless an operator turns it on — `[artifacts] enabled = true`,
-  `KAIBO_ARTIFACTS_ENABLED`, or `--allow-save-artifact` — which makes it kaibo's
-  first opt-in capability rather than a `--no-<tool>` gate. Limits are fixed (1 MiB
-  per artifact, 8 artifacts and 8 MiB per call) and a save past one is refused
-  rather than truncated, naming the limit it hit. Every saved artifact's provenance
-  sidecar records that a model wrote it, which cast and model, and the model's own
-  description, because the contents may be run.
+  `KAIBO_ARTIFACTS_ENABLED`, or `--allow-save-artifact` (serve only) — which makes it
+  kaibo's first opt-in capability rather than a `--no-<tool>` gate. Limits are fixed
+  (1 MiB per artifact, 8 artifacts and 8 MiB per call) and a save past one is refused
+  rather than truncated, naming the limit it hit. A consult that saved and then failed
+  still reports the digests, and a call with a `session_id` keeps them beside the
+  conversation.
 
 - **A second media kind: `openai-images`.** One backend kind covers hosted OpenAI
   image generation (gpt-image-1) *and* a local stable-diffusion.cpp `sd-server`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **A consult can hand you bulk output as an artifact instead of spending your
+  context on it.** Ask with `save_artifacts: true` and the investigating model can
+  write a generated corpus, a long inventory, or a fixture into kaibo's media store;
+  the answer names each `kaibo://cas/<digest>` and you choose what to read. Off
+  unless an operator turns it on — `[artifacts] enabled = true`,
+  `KAIBO_ARTIFACTS_ENABLED`, or `--allow-save-artifact` — which makes it kaibo's
+  first opt-in capability rather than a `--no-<tool>` gate. Limits are fixed (1 MiB
+  per artifact, 8 artifacts and 8 MiB per call) and a save past one is refused
+  rather than truncated, naming the limit it hit. Every saved artifact's provenance
+  sidecar records that a model wrote it, which cast and model, and the model's own
+  description, because the contents may be run.
+
 - **A second media kind: `openai-images`.** One backend kind covers hosted OpenAI
   image generation (gpt-image-1) *and* a local stable-diffusion.cpp `sd-server`,
   which speaks the same `/v1/images/generations` shape — `base_url` picks the

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -311,6 +311,30 @@ scratch_limit_bytes = 67108864
 #                                          # 0 is a load error, not "refuse everything".
 
 # ---------------------------------------------------------------------------
+# [artifacts] — may the model team save what it writes? OFF by default.
+#
+# kaibo's one inverted switch. Every knob in [tools] is on until you turn it off; this
+# one is off until you turn it on, because it is the only surface where a MODEL decides
+# that bytes become durable. Turning it on grants standing permission, not automatic
+# behavior: the call must also pass `save_artifacts`, and [cas] above must be live. All
+# three, or the model never sees the tool.
+#
+# What it buys: a consult producing bulk output (a generated corpus, a long inventory, a
+# fixture) writes it into the CAS and names the digest in its answer, instead of
+# spending your context window on material you may only want to keep. You read it at
+# kaibo://cas/<digest>, or you do not.
+#
+# Limits are fixed, not configurable: 1 MiB per artifact, 8 artifacts and 8 MiB per
+# call. A save past a limit is refused and stores nothing. Every saved artifact records
+# its author in the provenance sidecar (tool, cast, model, slot, the model's own label),
+# because the contents are model-written and something downstream may run them.
+# Env: KAIBO_ARTIFACTS_ENABLED. CLI: --allow-save-artifact (serve only).
+# ---------------------------------------------------------------------------
+
+# [artifacts]
+# enabled = false                          # true lets a consult that ASKS save artifacts
+
+# ---------------------------------------------------------------------------
 # [backends.<name>] — CONNECTIONS only: `kind` picks the wire and its client. The
 # completion wires (anthropic | deepseek | gemini | openrouter | openai) serve the
 # reasoning slots; the media kinds (stability | openai-images) serve `image` slots

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -289,9 +289,11 @@ scratch_limit_bytes = 67108864
 # not every operation has one). A backup tool should carry them.
 #
 # NO GC, on purpose. kaibo never prunes this store and never rewrites an object — the
-# address IS the content hash, so an "edit" is a new object. Every artifact gets a
-# <hex>.json sidecar (prompt, model, cast, timestamp, mime, seed) precisely so YOU can
-# prune intelligently: `find -mtime`, jq over the sidecars, restic. A TTL may come later.
+# address IS the content hash, so an "edit" is a new object and an address you hold never
+# goes stale. Every artifact gets a <hex>.json sidecar (prompt, model, cast, timestamp,
+# mime, seed, producing tool) beside it, so an object reached BY ITS ADDRESS describes
+# itself. That is the access pattern: by digest, one lookup. Sweeping the store to survey
+# it does not scale and is not what this is for.
 #
 # max_bytes is OPT-IN, and unset is not the same as a huge number. Enforcing a ceiling
 # means summing every file in the store, on the write path, for EVERY new object — over
@@ -324,11 +326,14 @@ scratch_limit_bytes = 67108864
 # spending your context window on material you may only want to keep. You read it at
 # kaibo://cas/<digest>, or you do not.
 #
-# Limits are fixed, not configurable: 1 MiB per artifact, 8 artifacts and 8 MiB per
-# call. A save past a limit is refused and stores nothing. Every saved artifact records
-# its author in the provenance sidecar (tool, cast, model, slot, the model's own label),
-# because the contents are model-written and something downstream may run them.
-# Env: KAIBO_ARTIFACTS_ENABLED. CLI: --allow-save-artifact (serve only).
+# Limits are fixed, not configurable: 1 MiB per artifact, 8 artifacts and 8 MiB per call,
+# and a one-line label of at most 200 bytes. A save past a limit is refused and stores
+# nothing. The answer names every artifact it saved; a call with a session_id also
+# persists those digests beside the conversation.
+#
+# Env: KAIBO_ARTIFACTS_ENABLED (accepts only 1/true/yes and 0/false/no — this flag will
+# not guess, so `off` or a typo is a startup error rather than a silent enable).
+# CLI: --allow-save-artifact (serve only).
 # ---------------------------------------------------------------------------
 
 # [artifacts]

--- a/docs/config.md
+++ b/docs/config.md
@@ -928,10 +928,13 @@ see the server's posture before asking.
 | artifacts per MCP call | 8 |
 | bytes per MCP call | 8 MiB |
 | label | one line, 200 bytes |
-| formats | `text`, `jsonl` |
+| formats | `text`, `jsonl`, `markdown` — a hint; anything else stores as text |
 
 A save past a limit is **refused and stores nothing**; the refusal names the limit, the
-actual size, and the way forward. Nothing is ever truncated — a digest handed back for
+actual size, and the way forward. The format is the one non-gate: the content arrives as
+a JSON string, so it is UTF-8 text by construction — source code, a config, a log all
+ship as `text` — and an unknown format name stores as `text/plain` with the coercion
+stated in the tool result, never refused. Binary artifacts come only from `generate`. Nothing is ever truncated — a digest handed back for
 content that is not what the model wrote would be silent corruption. The per-artifact
 limit is a backstop rather than a working ceiling: the content rides in tool-call
 arguments, so the model's own `max_tokens` binds first. The label is bounded and must be a

--- a/docs/config.md
+++ b/docs/config.md
@@ -864,6 +864,71 @@ ancestors must be a directory. Write errors that only a real write can reveal
 opening the store writes nothing, so it cannot probe for them. Memory mode is the one
 warned degrade, mirroring the persistence posture it follows.
 
+## Saving artifacts: `[artifacts]`
+
+**Off by default.** This is the only switch in kaibo whose default is off. Everything in
+`[tools]` is advertised unless you disable it; this one is disabled unless you enable it,
+because it is the only surface where a *model* decides that bytes become durable.
+
+`save_artifact` is a tool injected into the `consult` driver's own toolset. The model
+hands kaibo bulk content it wrote and gets back a digest; the answer's footer names each
+`kaibo://cas/<digest>` and you decide whether to read it. The point is your context
+window: a consult asked to produce a generated corpus, a long inventory, or a fixture no
+longer has to spend the answer on material you may only want to store.
+
+```toml
+[artifacts]
+enabled = false                             # default false; true grants standing permission
+```
+
+CLI/env: `--allow-save-artifact` (serve only) / `KAIBO_ARTIFACTS_ENABLED`. Unlike the
+`KAIBO_NO_*` flags, the env var sets the knob either way and the CLI flag *enables* — the
+built-in default is the conservative end of the range, so a layer that could only disable
+would have nothing to say.
+
+**Three conditions, all required.** The tool is absent from the model's toolset unless
+every one holds:
+
+| condition | surface | who decides |
+|---|---|---|
+| `[artifacts] enabled = true` | config / env / CLI | the operator, standing |
+| `save_artifacts: true` on the call | the `consult` tool argument | the calling agent, per call |
+| the media CAS is live | `[cas] enabled`, above | the operator |
+
+A call that passes `save_artifacts` on a server missing either of the other two is
+**refused**, with a message naming which one — never answered quietly without the
+artifacts it asked for. `kaibo://config` reports `[artifacts] enabled`, so a caller can
+see the server's posture before asking.
+
+**Limits are fixed and not configurable.**
+
+| limit | value |
+|---|---|
+| bytes per artifact | 1 MiB |
+| artifacts per MCP call | 8 |
+| bytes per MCP call | 8 MiB |
+| formats | `text`, `jsonl` |
+
+A save past a limit is **refused and stores nothing**; the refusal names the limit, the
+actual size, and the way forward. Nothing is ever truncated — a digest handed back for
+content that is not what the model wrote would be silent corruption. The per-artifact
+limit is a backstop rather than a working ceiling: the content rides in tool-call
+arguments, so the model's own `max_tokens` binds first.
+
+**What the model cannot do.** It can write and it can never read. There is no list verb,
+no read verb, and no `kaibo://cas` access from inside the loop. The result of a save is a
+digest and nothing else: it never reports whether the content was already in the store,
+because that answer would let one project's model team probe another's artifacts. Only
+the `consult` driver loop gets the tool; delegated explorer sweeps never do.
+
+**Authorship is recorded.** Each saved artifact's `<hex>.json` sidecar carries
+`tool = "save_artifact"` plus the cast, the model, the slot, the session, and the model's
+own one-line label, alongside the fields a `generate` sidecar has. The contents are
+model-written and something downstream may run them, so the sidecar is the trust record.
+
+Retention is yours, as with everything in the CAS: kaibo never prunes, and this tool
+makes minting cheap. See the `[cas]` section above.
+
 ## House rules: `[context]`
 
 kaibo's models work for other agents, so they benefit from inheriting the calling agent's

--- a/docs/config.md
+++ b/docs/config.md
@@ -820,9 +820,11 @@ explicit. Every other open failure stays fatal.
 
 ## Media CAS: `[cas]`
 
-**On by default, and it follows persistence.** The CAS is the content-addressed store
-where an artifact-producing tool (image generation) writes what it made. Its lifecycle
-has three states, reported as `mode` in `kaibo://config`'s `[cas]` section:
+**On by default, and it follows persistence.** The CAS is the content-addressed store an
+artifact-producing tool writes into. Two produce today: `generate` (images a provider
+rendered) and `save_artifact` (bulk text a consult's model wrote, see `[artifacts]`
+below). Its lifecycle has three states, reported as `mode` in `kaibo://config`'s `[cas]`
+section:
 
 | mode | when | what it means |
 |---|---|---|
@@ -842,9 +844,24 @@ CLI/env: `--cas-dir` / `KAIBO_CAS_DIR` move the store; `--cas-max-bytes` /
 
 **The address is the content.** Every object's filename is the SHA-256 of its bytes, so
 nothing (model or operator) can aim a write at a chosen path, and identical content is
-stored once. Objects are written once and never rewritten, unlinked, or evicted. Each
-object gets a `<hex>.json` provenance sidecar (prompt, model, cast, timestamp, mime,
-seed) so you can prune by hand with `find`/`jq`/`restic` — kaibo ships no GC.
+stored once. Objects are written once and never rewritten, unlinked, or evicted — which
+is why kaibo ships no GC: an object at a given digest stays that object forever, so no
+address anyone holds goes stale.
+
+Each object gets a `<hex>.json` provenance sidecar (prompt, model, cast, timestamp, mime,
+seed, and which tool produced it). It makes an object self-describing **to whoever holds
+its address**: one lookup by digest says what the bytes are and what format to serve them
+as. Read it that way. The store is not built to be swept — a survey means walking 65,536
+shards and parsing a file per object, and it only gets slower as the store fills. Operator
+inventory verbs are tracked in `docs/issues.md` and want an index kaibo maintains, not a
+scan.
+
+The sidecar is **first-writer-wins**: it records the first write of a given content and is
+never rewritten. Save bytes the store already holds and the record stays the original
+one — which may name a different call, a different cast, or `generate`. It is metadata for
+an operator, not an audit trail, and a content-addressed store that never rewrites cannot
+be one. For a durable per-call record, kaibo's answers are the tool-call telemetry each
+save emits and the session the answer was recorded into.
 
 **Retrieval is operator-surface only.** A generation result returns each artifact's
 digest, a `kaibo://cas/<digest>` resource URI, and (in disk mode) the real filesystem
@@ -854,7 +871,10 @@ projects and a browsable CAS would let one project's team enumerate another's ar
 
 **`max_bytes` refuses, never evicts.** A write that would pass the cap fails loudly and
 nothing is deleted to make room. The cap is opt-in because enforcing it costs an
-O(objects) walk of the store per new write.
+O(objects) walk of the store per new write. When a cap is set, *every* write is admitted
+the same way, including one whose content the store already holds: exempting those would
+let a full store answer "is this content already here?" by succeeding for held bytes and
+refusing for new ones, across every project this kaibo has served.
 
 **Failure is loud.** In disk mode, a structurally unusable CAS path fails startup with
 an error naming the escape hatches: a dir that resolves inside an allowed project tree
@@ -907,27 +927,40 @@ see the server's posture before asking.
 | bytes per artifact | 1 MiB |
 | artifacts per MCP call | 8 |
 | bytes per MCP call | 8 MiB |
+| label | one line, 200 bytes |
 | formats | `text`, `jsonl` |
 
 A save past a limit is **refused and stores nothing**; the refusal names the limit, the
 actual size, and the way forward. Nothing is ever truncated — a digest handed back for
 content that is not what the model wrote would be silent corruption. The per-artifact
 limit is a backstop rather than a working ceiling: the content rides in tool-call
-arguments, so the model's own `max_tokens` binds first.
+arguments, so the model's own `max_tokens` binds first. The label is bounded and must be a
+single line because it is rendered into the answer's footer, where a line break could
+forge entries the caller would read as real artifacts.
 
 **What the model cannot do.** It can write and it can never read. There is no list verb,
 no read verb, and no `kaibo://cas` access from inside the loop. The result of a save is a
 digest and nothing else: it never reports whether the content was already in the store,
-because that answer would let one project's model team probe another's artifacts. Only
-the `consult` driver loop gets the tool; delegated explorer sweeps never do.
+because that answer would let one project's model team probe another's artifacts. Refusals
+are sanitized for the same reason — the model is told what to do next, never the store's
+path or how full it is. Only the `consult` driver loop gets the tool; delegated explorer
+sweeps never do.
 
-**Authorship is recorded.** Each saved artifact's `<hex>.json` sidecar carries
-`tool = "save_artifact"` plus the cast, the model, the slot, the session, and the model's
-own one-line label, alongside the fields a `generate` sidecar has. The contents are
-model-written and something downstream may run them, so the sidecar is the trust record.
+**Where the digests are written down.** The answer's footer names every artifact this call
+saved, with its mime, size, label, and (in disk mode) its path. A consult that saved and
+then *failed* reports them too, in the failure text — the bytes are durable either way,
+and a result without their addresses would strand them. A call carrying a `session_id`
+also persists the footer with the answer, so the digests sit in kaibo's state db beside
+the conversation that produced them.
 
-Retention is yours, as with everything in the CAS: kaibo never prunes, and this tool
-makes minting cheap. See the `[cas]` section above.
+One gap, stated plainly: **cancelling a running `consult_submit` job aborts it mid-flight,
+so anything it had already saved is not reported.** Those artifacts exist and are readable
+by digest, but the digests are gone unless the call also carried a `session_id`. Avoid it
+by threading a session, or by letting a job finish.
+
+The provenance sidecar beside each object is housekeeping metadata, first-writer-wins —
+see the `[cas]` section above for what it does and does not claim. Retention is yours:
+kaibo never prunes, and this tool makes minting cheap.
 
 ## House rules: `[context]`
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -63,6 +63,26 @@ is resident tool cost and curation. `MediaType::to_cas_extension` already refuse
 and `model/gltf-binary` loudly so that adding one forces a deliberate naming decision rather
 than silently writing bytes nobody can open.
 
+### CAS retention changed character with `save_artifact` — the store wants operator verbs and a GC story
+
+The no-GC stance was honest while `generate` was the only producer: every artifact cost a
+paid provider call, so minting was rare and self-limiting, and `find -mtime` over the
+sidecars was proportionate cleanup. `save_artifact` (shipped 2026-08-05) breaks that
+assumption — a consult can mint eight artifacts a call for the price of tokens it was
+already spending, against an append-only store that never unlinks. XDG data grows without
+bound and the operator's only tools are shell commands over a two-level sharded tree.
+
+What it wants, roughly in order: `kaibo cas ls` / `kaibo cas du` (list and size by sidecar
+metadata — cast, tool, age, label — so an operator can *see* what accumulated without
+learning the shard layout), then a pruning story. Pruning is the hard half, and a real
+design question rather than a missing command: the store's safety argument is that it
+never unlinks (`src/cas.rs`'s module doc), so a GC verb is a new mutation surface needing
+its own justification, its own containment check, and probably its own blessed line in
+`tests/no_write_path.rs`. A TTL sweep, an explicit `kaibo cas rm <digest>`, and "the
+operator prunes by hand, with better visibility" are three answers with different blast
+radii. Not blocking; the sidecars already carry enough metadata (authorship included) that
+the ls/du half is straightforward whenever we want it.
+
 ### Someday: the CAS as kaish's egress gateway (design note, not scheduled)
 Amy's direction 2026-07-25, explicitly *"need to think about it more"* — recorded so the
 reasoning survives, not to be built. The shape she wants: kaish can **read** from the CAS

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -72,16 +72,32 @@ assumption — a consult can mint eight artifacts a call for the price of tokens
 already spending, against an append-only store that never unlinks. XDG data grows without
 bound and the operator's only tools are shell commands over a two-level sharded tree.
 
-What it wants, roughly in order: `kaibo cas ls` / `kaibo cas du` (list and size by sidecar
-metadata — cast, tool, age, label — so an operator can *see* what accumulated without
-learning the shard layout), then a pruning story. Pruning is the hard half, and a real
-design question rather than a missing command: the store's safety argument is that it
-never unlinks (`src/cas.rs`'s module doc), so a GC verb is a new mutation surface needing
-its own justification, its own containment check, and probably its own blessed line in
-`tests/no_write_path.rs`. A TTL sweep, an explicit `kaibo cas rm <digest>`, and "the
-operator prunes by hand, with better visibility" are three answers with different blast
-radii. Not blocking; the sidecars already carry enough metadata (authorship included) that
-the ls/du half is straightforward whenever we want it.
+What it wants, roughly in order: `kaibo cas ls` / `kaibo cas du`, so an operator can *see*
+what accumulated without learning the shard layout — then a pruning story.
+
+**Neither should be built on a filesystem sweep.** The sidecar is metadata for an object
+you already have the address of; it is not an index. Surveying the store by walking it
+means 65,536 shards and a read-plus-parse per object, and it degrades exactly as the store
+grows — which is the condition that makes anyone want `ls` in the first place. The shape
+these verbs want is an index kaibo maintains as it writes (its own persistence store is
+the obvious home: it is already open, already at a fixed XDG path no model steers, and
+already the place kaibo records what it did). That also makes `du` an O(1) read instead of
+a full walk, and would let the `[cas] max_bytes` admission stop walking the store on every
+capped write.
+
+Pruning is the harder half and a real design question rather than a missing command: the
+store's safety argument is that it never unlinks (`src/cas.rs`'s module doc), so a GC verb
+is a new mutation surface needing its own justification, its own containment check, and
+probably its own blessed line in `tests/no_write_path.rs`. A TTL sweep, an explicit
+`kaibo cas rm <digest>`, and "the operator prunes by hand, with better visibility" are
+three answers with different blast radii.
+
+Related gap worth folding in when this is picked up: **cancelling a `consult_submit` job
+aborts the future, so artifacts it saved before the cancel are never reported** — they are
+durable and readable by digest, but their addresses are lost unless the call carried a
+`session_id` (whose persisted answer keeps the footer). Surfacing them would mean the job
+record carrying the call's artifact sink, which touches every producer's `jobs.rs`
+signature; documented in `docs/config.md` rather than papered over.
 
 ### Someday: the CAS as kaish's egress gateway (design note, not scheduled)
 Amy's direction 2026-07-25, explicitly *"need to think about it more"* — recorded so the

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -108,10 +108,24 @@ fn format_names() -> Vec<&'static str> {
     FORMATS.iter().map(|(name, _)| *name).collect()
 }
 
+/// The most bytes a `label` may carry, and it is not a courtesy limit.
+///
+/// The label is the one model-authored string that reaches the caller *outside* the
+/// content — it is rendered into the structured footer beside a URI. Two things follow.
+/// Unbounded, it is metadata that rides around the byte caps: a model could deliver
+/// kilobytes per save in a field nothing counts. And unvalidated, it is an injection
+/// surface: a newline lets a model forge extra numbered entries or a `path:` line in the
+/// footer, so the caller reads artifacts kaibo never wrote. Hence a modest ceiling and a
+/// hard refusal of any control character, checked before anything touches the store.
+///
+/// 200 bytes is a full descriptive sentence and nowhere near a payload.
+pub const MAX_LABEL_BYTES: usize = 200;
+
 /// Who authored an artifact, resolved once per MCP call from the cast and slot actually
-/// running. Recorded into every sidecar this call writes, so a later reader can tell a
-/// model's writing from a provider's render — the trust record that matters when
-/// somebody decides whether to *execute* an artifact's contents.
+/// running. Recorded into the sidecar the *first* write of a given content produces —
+/// housekeeping metadata that makes an object self-describing when an operator reaches
+/// it **by address**. See [`ArtifactSink::save`] on what that record does and does not
+/// claim.
 #[derive(Debug, Clone)]
 pub struct ArtifactAuthor {
     /// The question this consult is answering. Recorded as the sidecar's `prompt`, the
@@ -133,12 +147,24 @@ pub struct ArtifactAuthor {
 pub struct SavedArtifact {
     /// The address: 64 lowercase hex, the content's own SHA-256.
     pub digest: String,
-    /// The mime the `kaibo://cas/<digest>` resource will stamp on these bytes.
+    /// The mime the `kaibo://cas/<digest>` resource will stamp on these bytes — read
+    /// back from the **store** after the write, never the format this save asked for.
+    /// The two can differ: identical bytes saved as `jsonl` when they are already held
+    /// as `txt` land at the same address, and the store's answer is `txt`. Rendering the
+    /// request instead would advertise a mime the resource will not serve and a path
+    /// that does not exist. See [`MediaStore::extension_for`].
     pub mime: &'static str,
     /// Size of the content, in bytes.
     pub bytes: usize,
-    /// The model's own one-line description.
+    /// The model's one-line description, validated (bounded, no control characters —
+    /// see [`MAX_LABEL_BYTES`]) before it reaches this struct, because it is rendered
+    /// into the structured footer.
     pub label: String,
+    /// True when the bytes are durably stored but their provenance sidecar could not be
+    /// written ([`crate::cas::CasError::ProvenanceNotRecorded`]). The artifact still
+    /// belongs in the footer — it is real and retrievable — so the ledger carries it and
+    /// the footer says the record is missing rather than pretending it is there.
+    pub provenance_missing: bool,
 }
 
 /// A refusal, always loud, always naming the way out. Every variant carries the cap it
@@ -161,8 +187,26 @@ pub enum SaveError {
     /// `label` came in blank. The label is what the caller reads beside the URI, so an
     /// artifact with no description is one the caller cannot act on.
     MissingLabel,
-    /// The store itself refused (capacity, I/O, a corrupt object at this address).
-    Store(String),
+    /// `label` is past [`MAX_LABEL_BYTES`], or carries a control character (a newline
+    /// especially — see that constant for why the footer cannot take one).
+    BadLabel { cap: usize, actual: usize },
+    /// The bytes are stored and reachable, but their provenance sidecar is not — the
+    /// store's own [`crate::cas::CasError::ProvenanceNotRecorded`]. An error, because
+    /// the housekeeping record the operator prunes by is missing, but emphatically NOT
+    /// "nothing was saved": the digest names durable content and rides the footer.
+    StoredWithoutProvenance { digest: String },
+    /// The store refused the write (capacity, I/O, a corrupt object at this address).
+    ///
+    /// Holds the **typed** error rather than its rendered text, because the two audiences
+    /// need opposite things from it. The operator wants everything — the CAS path, the
+    /// store's current usage, the OS error — and gets it on the tracing log at the sink.
+    /// The model gets a sanitized sentence, because [`crate::cas::CasError`]'s own
+    /// `Display` carries filesystem paths (kaibo's XDG data dir, which the model has no
+    /// business learning) and, for a capacity refusal, `current_bytes` of a store shared
+    /// across every project this kaibo has served. That number is a side channel: it
+    /// tells a model how much other projects' work is sitting in the store, and watching
+    /// it move across calls tells it more.
+    Store(crate::cas::CasError),
 }
 
 impl std::fmt::Display for SaveError {
@@ -198,10 +242,33 @@ impl std::fmt::Display for SaveError {
                  the artifact's URI, so give one short line saying what this artifact \
                  holds, and save again."
             ),
-            SaveError::Store(e) => write!(
+            SaveError::BadLabel { cap, actual } => write!(
                 f,
-                "kaibo's artifact store refused this write: {e}. Nothing was saved. Report \
-                 what you found in your answer instead."
+                "`label` is {actual} bytes and must be one single line of at most {cap} \
+                 bytes, with no line breaks. Nothing was saved. Shorten it to one plain \
+                 sentence naming what this artifact holds, and save again. Put the detail \
+                 in your answer, where there is room for it."
+            ),
+            SaveError::StoredWithoutProvenance { digest } => write!(
+                f,
+                "The artifact WAS saved and the caller will receive it at {}{digest}. \
+                 kaibo could not record its housekeeping metadata beside it, so name the \
+                 URI in your answer and describe what the artifact covers, so the caller \
+                 knows what it holds.",
+                crate::cas::CAS_URI_PREFIX
+            ),
+            // Sanitized on purpose — see `SaveError::Store`. Two kinds, because they call
+            // for different next moves, and neither carries a number or a path.
+            SaveError::Store(crate::cas::CasError::CapacityExceeded { .. }) => write!(
+                f,
+                "kaibo's artifact store has no room for this artifact, so nothing was \
+                 saved. A smaller artifact may still fit. Report what you found in your \
+                 answer instead, and say that saving was refused for lack of room."
+            ),
+            SaveError::Store(_) => write!(
+                f,
+                "kaibo's artifact store refused this write, so nothing was saved. Report \
+                 what you found in your answer instead, and say that saving was refused."
             ),
         }
     }
@@ -276,6 +343,26 @@ impl ArtifactSink {
     ///
     /// The return value is the digest and nothing more. Whether these bytes were already
     /// in the store is deliberately unobservable — see the module doc.
+    ///
+    /// # The sidecar is first-writer-wins, and it is housekeeping, not an audit trail
+    ///
+    /// The provenance sidecar is written with `create_new` and an existing one is left
+    /// alone, so the record beside a given content describes its **first** write. Save
+    /// content another call already stored and the sidecar keeps that call's cast, model,
+    /// label, and session — or names `generate`, if a provider rendered those exact bytes
+    /// first. This save still enters *this* call's ledger and this call's footer, so the
+    /// caller sees the label it was given; only the on-disk record is the older one.
+    ///
+    /// That is fine because of what the sidecar is for: **housekeeping metadata that
+    /// makes an object self-describing to whoever holds its address**. It is read the way
+    /// everything in this store is read — by digest, one lookup — and it is what lets
+    /// [`crate::cas::Cas::entry_for`] name an object's format in a single stat. It is
+    /// deliberately not a per-save audit record and must not be described as one: a
+    /// content-addressed store that never rewrites structurally cannot hold one write's
+    /// worth of metadata per save. Where a durable per-call record is wanted, the honest
+    /// sources are the tool-call telemetry every save emits (a traced `save_artifact`
+    /// span) and the session the answer was recorded into, whose persisted text carries
+    /// this call's digests.
     pub fn save(
         &self,
         label: &str,
@@ -285,6 +372,15 @@ impl ArtifactSink {
         let label = label.trim();
         if label.is_empty() {
             return Err(SaveError::MissingLabel);
+        }
+        // Bounded and single-line, checked before the store is touched: the label is
+        // rendered into the structured footer, so a newline forges footer entries and an
+        // unbounded one is payload the byte caps never see. See `MAX_LABEL_BYTES`.
+        if label.len() > MAX_LABEL_BYTES || label.chars().any(char::is_control) {
+            return Err(SaveError::BadLabel {
+                cap: MAX_LABEL_BYTES,
+                actual: label.len(),
+            });
         }
         let asked = format
             .map(str::trim)
@@ -331,18 +427,57 @@ impl ArtifactSink {
             label: Some(label.to_string()),
             session: self.author.session.clone(),
         };
-        let digest = self
-            .store
-            .put(bytes, ext, &provenance)
-            .map_err(|e| SaveError::Store(e.to_string()))?;
+        // Three outcomes, not two. The middle one — bytes stored, provenance not — is
+        // still a save, so it enters the ledger and rides the footer; denying it would
+        // orphan durable content behind a message claiming nothing happened.
+        let (digest, provenance_missing) = match self.store.put(bytes, ext, &provenance) {
+            Ok(digest) => (digest, false),
+            Err(crate::cas::CasError::ProvenanceNotRecorded { digest, cause }) => {
+                tracing::warn!(
+                    digest = %digest,
+                    cause = %cause,
+                    "artifact stored without its provenance sidecar — the bytes are \
+                     durable and retrievable, the housekeeping record is not"
+                );
+                let parsed = crate::cas::Digest::from_hex(&digest)
+                    .expect("the store renders its own digests in canonical hex");
+                (parsed, true)
+            }
+            Err(e) => {
+                // The operator gets the whole typed error, paths and usage included; the
+                // model gets `SaveError`'s sanitized rendering. See `SaveError::Store`.
+                tracing::warn!(error = %e, "artifact store refused a save_artifact write");
+                return Err(SaveError::Store(e));
+            }
+        };
+
+        // What the artifact IS, per the store — not what this save asked for. They differ
+        // whenever identical content is already held under another container format, and
+        // the footer must agree with the resource read and the on-disk path. A `None`
+        // here is not reachable through a successful put; treat it as loud-but-recoverable
+        // rather than panicking on the caller's paid-for save.
+        let stored_ext = self.store.extension_for(&digest).unwrap_or_else(|| {
+            tracing::warn!(
+                digest = %digest.to_hex(),
+                "artifact stored but the store cannot name its format — falling back to \
+                 the requested one for the footer"
+            );
+            ext
+        });
 
         ledger.total_bytes += bytes.len();
         ledger.saved.push(SavedArtifact {
             digest: digest.to_hex(),
-            mime: ext.mime(),
+            mime: stored_ext.mime(),
             bytes: bytes.len(),
             label: label.to_string(),
+            provenance_missing,
         });
+        if provenance_missing {
+            return Err(SaveError::StoredWithoutProvenance {
+                digest: digest.to_hex(),
+            });
+        }
         Ok(digest)
     }
 }
@@ -416,7 +551,8 @@ impl Tool for SaveArtifact {
              Limits for one call: {per_artifact_bytes} bytes per artifact, \
              {artifacts_per_call} artifacts, {total_bytes_per_call} bytes in total. A \
              save past a limit is refused and stores nothing, and the refusal says which \
-             limit it hit. Split large content into several artifacts to stay inside them."
+             limit it hit. Split large content into several artifacts to stay inside \
+             them. Write `label` as one single line of at most {MAX_LABEL_BYTES} bytes."
         )
     }
 
@@ -426,7 +562,7 @@ impl Tool for SaveArtifact {
             "properties": {
                 "label": {
                     "type": "string",
-                    "description": "one short line saying what this artifact holds; the \
+                    "description": "one single line saying what this artifact holds; the \
                                     caller reads it beside the artifact's URI"
                 },
                 "content": {
@@ -504,6 +640,12 @@ fn artifact_footer(saved: &[SavedArtifact], store: &MediaStore) -> String {
             .and_then(|d| store.path_for(&d))
         {
             out.push_str(&format!("\n   path: {}", path.display()));
+        }
+        if a.provenance_missing {
+            out.push_str(
+                "\n   note: kaibo could not write this artifact's housekeeping metadata \
+                 beside it; the content itself is stored and readable at the URI above.",
+            );
         }
     }
     out

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -107,9 +107,28 @@ pub const FORMATS: &[(&str, Extension)] = &[
     ("markdown", Extension::Md),
 ];
 
-/// The format names, for a schema `enum` and for error text.
+/// The format names, for the schema description and the coercion note.
 fn format_names() -> Vec<&'static str> {
     FORMATS.iter().map(|(name, _)| *name).collect()
+}
+
+/// Resolve a `format` ask to a container. **Assume text**: a name outside [`FORMATS`]
+/// resolves to [`Extension::Txt`] rather than refusing — the content arrived as a JSON
+/// string, so it IS UTF-8 text whatever the model called it, and `text/plain` is a true
+/// label where a refusal would burn the whole payload's output tokens to enforce a mime
+/// vocabulary. `format` is a hint, not a gate; the binary paths belong to `generate`.
+/// `None` when the ask was unknown lets the caller *state* the coercion in its result —
+/// stated, never silent.
+pub fn resolve_format(asked: Option<&str>) -> (Extension, Option<String>) {
+    let asked = asked.map(str::trim).filter(|f| !f.is_empty());
+    match asked {
+        None => (Extension::Txt, None),
+        Some(name) => FORMATS
+            .iter()
+            .find(|(known, _)| known.eq_ignore_ascii_case(name))
+            .map(|(_, ext)| (*ext, None))
+            .unwrap_or((Extension::Txt, Some(name.to_string()))),
+    }
 }
 
 /// The most bytes a `label` may carry, and it is not a courtesy limit.
@@ -186,8 +205,6 @@ pub enum SaveError {
         used: usize,
         actual: usize,
     },
-    /// `format` names something outside [`FORMATS`].
-    UnknownFormat { asked: String },
     /// `label` came in blank. The label is what the caller reads beside the URI, so an
     /// artifact with no description is one the caller cannot act on.
     MissingLabel,
@@ -233,12 +250,6 @@ impl std::fmt::Display for SaveError {
                 "This call has saved {used} bytes and this artifact adds {actual} more, \
                  which is past the limit of {cap} bytes for one call. Nothing was saved. \
                  Save a smaller selection, and report the rest in your answer."
-            ),
-            SaveError::UnknownFormat { asked } => write!(
-                f,
-                "`format` was {asked:?}. The formats available are {}. Nothing was saved. \
-                 Choose one of those and save again.",
-                format_names().join(" and ")
             ),
             SaveError::MissingLabel => write!(
                 f,
@@ -386,17 +397,10 @@ impl ArtifactSink {
                 actual: label.len(),
             });
         }
-        let asked = format
-            .map(str::trim)
-            .filter(|f| !f.is_empty())
-            .unwrap_or("text");
-        let ext = FORMATS
-            .iter()
-            .find(|(name, _)| name.eq_ignore_ascii_case(asked))
-            .map(|(_, ext)| *ext)
-            .ok_or_else(|| SaveError::UnknownFormat {
-                asked: asked.to_string(),
-            })?;
+        // Assume text: an unknown format name resolves to Txt instead of refusing —
+        // see `resolve_format` for the argument. The coercion is surfaced by the tool's
+        // `call`, which runs the same resolution to build its note.
+        let (ext, _coerced) = resolve_format(format);
         let bytes = content.as_bytes();
         if bytes.len() > self.caps.per_artifact_bytes {
             return Err(SaveError::TooLarge {
@@ -512,7 +516,7 @@ pub struct SaveArtifactArgs {
     pub label: String,
     /// The bytes themselves.
     pub content: String,
-    /// `text` or `jsonl`; `text` when omitted.
+    /// A format hint (`text`, `jsonl`, `markdown`); anything else, or nothing, is text.
     #[serde(default)]
     pub format: Option<String>,
 }
@@ -550,8 +554,10 @@ impl Tool for SaveArtifact {
              one or two representative entries where they illustrate the coverage. The \
              full content reaches the caller through the artifact.\n\n\
              Use this for material the caller wants to keep or to run: a generated \
-             corpus, a long inventory, a fixture. Reach for it when the content is bulk. \
-             Keep your reasoning and your conclusions in the answer itself.\n\n\
+             corpus, a long inventory, a report, a source file, a fixture. Any UTF-8 \
+             content ships as text unless `jsonl` or `markdown` fits it better. Reach \
+             for it when the content is bulk. Keep your reasoning and your conclusions \
+             in the answer itself.\n\n\
              Limits for one call: {per_artifact_bytes} bytes per artifact, \
              {artifacts_per_call} artifacts, {total_bytes_per_call} bytes in total. A \
              save past a limit is refused and stores nothing, and the refusal says which \
@@ -575,8 +581,11 @@ impl Tool for SaveArtifact {
                 },
                 "format": {
                     "type": "string",
-                    "enum": format_names(),
-                    "description": "the shape of the content; `text` when omitted"
+                    "description": format!(
+                        "a hint for the stored mime: {}; anything else, or nothing, \
+                         stores as text",
+                        format_names().join(" | ")
+                    )
                 }
             },
             "required": ["label", "content"]
@@ -594,8 +603,20 @@ impl Tool for SaveArtifact {
         // Exactly this line for exactly these bytes, every time. A word about whether the
         // content was new would answer "is this already in the store?" for arbitrary bytes,
         // across every project this kaibo serves — see the module doc's existence-oracle note.
+        // The coercion note depends only on the *request*, never on store state, so it
+        // keeps that property.
+        let (_, coerced) = resolve_format(args.format.as_deref());
+        let note = match coerced {
+            Some(asked) => format!(
+                " (`format` {:?} is not a name kaibo knows, so it stored as text/plain — \
+                 the formats are {})",
+                asked,
+                format_names().join(", ")
+            ),
+            None => String::new(),
+        };
         Ok(format!(
-            "Saved. The caller will receive this artifact with your answer, at \
+            "Saved{note}. The caller will receive this artifact with your answer, at \
              {}{}. Name that URI in your answer and describe what the artifact covers.",
             crate::cas::CAS_URI_PREFIX,
             digest.to_hex()

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -1,0 +1,559 @@
+//! `save_artifact` — a one-way delivery tunnel from the inner model team to the caller.
+//!
+//! The problem it solves: a `consult` that produces *bulk* output (a corpus of shell
+//! commands to fuzz a parser with, a per-file inventory, a generated fixture) has only
+//! one channel today — the answer text. That channel is the caller's context window,
+//! and a driver that dumps ten kilobytes into it has spent the caller's budget on
+//! material the caller may only want to *store*.
+//!
+//! So the model gets a second channel: hand kaibo the bytes, get back a digest. The
+//! caller sees footer lines naming each `kaibo://cas/<digest>` and **chooses** whether
+//! to read them. One way, by construction: the model can write into the store and can
+//! never read, list, or probe it (see "What the model cannot do" below).
+//!
+//! # Why this does not weaken the read-only invariant
+//!
+//! The invariant text (`AGENTS.md`) already carves the shape this fills: "anything
+//! further that must *record* or *emit* is its own individually-gated mediated tool,
+//! never a general filesystem escape hatch." This is that tool, and it holds the line
+//! the same way [`crate::cas`] does — by *shape*, not policy:
+//!
+//! - **The write is unaimable.** The tool's whole input is `content` (the bytes) plus a
+//!   `label` and a `format`. There is no `path`, no `from`, no destination of any kind,
+//!   and there never will be: the address is the content's own hash. A parameter naming
+//!   a filesystem location was designed, argued, and **dropped permanently** (2026-08-05)
+//!   — inline `content` is the only input path this tool ever gets.
+//! - **It reaches disk only through [`crate::cas::Cas::put`]**, the existing blessed
+//!   write surface. No new `std::fs` call site exists in this module, so
+//!   `tests/no_write_path.rs` stays pinned at its four blessed lines.
+//! - **kaish is untouched.** The shell the model drives has no new builtin, no mount, no
+//!   knowledge that this store exists. `src/sandbox.rs` did not change.
+//!
+//! # What the model cannot do
+//!
+//! The tool returns one digest and nothing else. It never says whether the content was
+//! new or already present, because that difference is an **existence oracle**: the CAS
+//! spans every project this kaibo has ever served, so "was this already here?" answered
+//! for arbitrary bytes would let one project's model team probe another's artifacts.
+//! Same content in, same line out. There is no read verb, no list verb, and no
+//! `kaibo://cas` access from inside the loop — retrieval is operator surface only.
+//!
+//! # Caps refuse; they never truncate
+//!
+//! A rejected call has already cost the caller the output tokens for the whole payload,
+//! so every limit is stated in the tool's own description (from these constants, never a
+//! hand-copied number that can drift) and every refusal names the cap, the actual size,
+//! and the way out. Truncating instead would hand back a digest for content that is not
+//! what the model wrote, which is the silent corruption this codebase refuses.
+//!
+//! The per-call ledger lives on one [`ArtifactSink`], built per MCP call, so "8 artifacts
+//! per call" means the call the caller made — not per turn, and not per sweep.
+
+use std::sync::{Arc, Mutex};
+
+use rig_agent::tool::{Tool, ToolExecutionError};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::cas::{Digest, Extension, MediaStore, Provenance};
+
+/// The most bytes one artifact may carry.
+///
+/// A backstop, not a working limit: `content` rides in tool-call arguments, which are
+/// completion tokens, so a synth's `max_tokens` binds long before this does (a 32K
+/// output budget is roughly 100 KB of text at best). It exists so a model that somehow
+/// can emit more cannot land a megabyte-plus object in one call.
+pub const MAX_ARTIFACT_BYTES: usize = 1 << 20;
+
+/// The most artifacts one MCP call may save. Counted across the whole call, so a driver
+/// cannot spread a flood over many turns.
+pub const MAX_ARTIFACTS_PER_CALL: usize = 8;
+
+/// The most bytes one MCP call may save in total, across every artifact.
+pub const MAX_TOTAL_BYTES_PER_CALL: usize = 1 << 23;
+
+/// One call's limits. Ships as [`Caps::default`] — the three constants above — and is a
+/// field on the sink rather than three `const` reads scattered through the checks, so the
+/// refusals, the tool description, and the admission logic all read the *same* numbers.
+/// That is also what lets a test drive a boundary without allocating megabytes
+/// (mirroring `ViewImage::with_max_bytes`); it is deliberately not an operator knob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Caps {
+    pub per_artifact_bytes: usize,
+    pub artifacts_per_call: usize,
+    pub total_bytes_per_call: usize,
+}
+
+impl Default for Caps {
+    fn default() -> Self {
+        Self {
+            per_artifact_bytes: MAX_ARTIFACT_BYTES,
+            artifacts_per_call: MAX_ARTIFACTS_PER_CALL,
+            total_bytes_per_call: MAX_TOTAL_BYTES_PER_CALL,
+        }
+    }
+}
+
+/// The formats a model may ask for, and the on-disk container each maps to. Kept as a
+/// table rather than a `match` so the tool description, the schema `enum`, and the
+/// refusal message all render from the same list and cannot drift apart.
+///
+/// This is a *serving* concern, not a safety boundary — a model can put anything inside
+/// a `.txt`, and the byte caps are the real limit. What it buys is a retrieval that says
+/// something true about the bytes: `kaibo://cas/<digest>` stamps a mime from this table.
+pub const FORMATS: &[(&str, Extension)] = &[("text", Extension::Txt), ("jsonl", Extension::Jsonl)];
+
+/// The format names, for a schema `enum` and for error text.
+fn format_names() -> Vec<&'static str> {
+    FORMATS.iter().map(|(name, _)| *name).collect()
+}
+
+/// Who authored an artifact, resolved once per MCP call from the cast and slot actually
+/// running. Recorded into every sidecar this call writes, so a later reader can tell a
+/// model's writing from a provider's render — the trust record that matters when
+/// somebody decides whether to *execute* an artifact's contents.
+#[derive(Debug, Clone)]
+pub struct ArtifactAuthor {
+    /// The question this consult is answering. Recorded as the sidecar's `prompt`, the
+    /// same slot a `generate` sidecar gives the image prompt: what was asked for.
+    pub prompt: String,
+    /// The authoring model's id, `backend/model` as the arm resolved it.
+    pub model: String,
+    /// The cast whose team is running.
+    pub cast: String,
+    /// The reasoning slot the author filled — `synth` today, since only the consult
+    /// driver loop can save.
+    pub slot: &'static str,
+    /// The consult session, when the call carried one.
+    pub session: Option<String>,
+}
+
+/// One artifact this call saved, as the caller's footer renders it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SavedArtifact {
+    /// The address: 64 lowercase hex, the content's own SHA-256.
+    pub digest: String,
+    /// The mime the `kaibo://cas/<digest>` resource will stamp on these bytes.
+    pub mime: &'static str,
+    /// Size of the content, in bytes.
+    pub bytes: usize,
+    /// The model's own one-line description.
+    pub label: String,
+}
+
+/// A refusal, always loud, always naming the way out. Every variant carries the cap it
+/// hit *and* the actual value, because a model that only learns "too big" has to guess
+/// the next size and pay for the whole payload again to find out.
+#[derive(Debug)]
+pub enum SaveError {
+    /// One artifact's `content` is past [`Caps::per_artifact_bytes`].
+    TooLarge { cap: usize, actual: usize },
+    /// This call has already saved [`Caps::artifacts_per_call`] artifacts.
+    TooMany { cap: usize },
+    /// This artifact would push the call past [`Caps::total_bytes_per_call`].
+    TotalExceeded {
+        cap: usize,
+        used: usize,
+        actual: usize,
+    },
+    /// `format` names something outside [`FORMATS`].
+    UnknownFormat { asked: String },
+    /// `label` came in blank. The label is what the caller reads beside the URI, so an
+    /// artifact with no description is one the caller cannot act on.
+    MissingLabel,
+    /// The store itself refused (capacity, I/O, a corrupt object at this address).
+    Store(String),
+}
+
+impl std::fmt::Display for SaveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SaveError::TooLarge { cap, actual } => write!(
+                f,
+                "This artifact is {actual} bytes and the limit is {cap} bytes per \
+                 artifact. Nothing was saved. Split the content into several smaller \
+                 artifacts and save each one."
+            ),
+            SaveError::TooMany { cap } => write!(
+                f,
+                "This call has already saved {cap} artifacts, which is the limit for one \
+                 call. Nothing was saved. Report what you have saved so far in your \
+                 answer, and leave the rest for a follow-up call."
+            ),
+            SaveError::TotalExceeded { cap, used, actual } => write!(
+                f,
+                "This call has saved {used} bytes and this artifact adds {actual} more, \
+                 which is past the limit of {cap} bytes for one call. Nothing was saved. \
+                 Save a smaller selection, and report the rest in your answer."
+            ),
+            SaveError::UnknownFormat { asked } => write!(
+                f,
+                "`format` was {asked:?}. The formats available are {}. Nothing was saved. \
+                 Choose one of those and save again.",
+                format_names().join(" and ")
+            ),
+            SaveError::MissingLabel => write!(
+                f,
+                "`label` was empty. Nothing was saved. The caller reads the label beside \
+                 the artifact's URI, so give one short line saying what this artifact \
+                 holds, and save again."
+            ),
+            SaveError::Store(e) => write!(
+                f,
+                "kaibo's artifact store refused this write: {e}. Nothing was saved. Report \
+                 what you found in your answer instead."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SaveError {}
+
+/// The per-MCP-call ledger and the one place bytes reach the store.
+///
+/// Built by the server when all three keys hold (the operator enabled artifacts, the
+/// caller asked for them on this call, and the media CAS is live), handed to the consult
+/// driver's toolset, and read back after the loop to render the caller's footer. Its
+/// lifetime **is** the call, which is what makes the per-call caps mean the call.
+#[derive(Debug)]
+pub struct ArtifactSink {
+    store: Arc<MediaStore>,
+    author: ArtifactAuthor,
+    caps: Caps,
+    ledger: Mutex<Ledger>,
+}
+
+#[derive(Debug, Default)]
+struct Ledger {
+    total_bytes: usize,
+    saved: Vec<SavedArtifact>,
+}
+
+impl ArtifactSink {
+    pub fn new(store: Arc<MediaStore>, author: ArtifactAuthor) -> Self {
+        Self::with_caps(store, author, Caps::default())
+    }
+
+    /// A sink with non-shipping limits — the seam a boundary test drives without
+    /// allocating megabytes, and the reason every refusal renders its cap from the sink
+    /// rather than from a constant. Production builds one through
+    /// [`new`](Self::new).
+    pub fn with_caps(store: Arc<MediaStore>, author: ArtifactAuthor, caps: Caps) -> Self {
+        Self {
+            store,
+            author,
+            caps,
+            ledger: Mutex::new(Ledger::default()),
+        }
+    }
+
+    /// This sink's limits — what the tool description states, so the numbers a model
+    /// reads are the numbers the admission check enforces.
+    pub fn caps(&self) -> Caps {
+        self.caps
+    }
+
+    /// Everything this call saved, oldest first — the footer's input.
+    pub fn saved(&self) -> Vec<SavedArtifact> {
+        self.ledger
+            .lock()
+            .expect("artifact ledger poisoned")
+            .saved
+            .clone()
+    }
+
+    /// The caller-facing footer for what this call saved. Empty when nothing was saved.
+    pub fn footer(&self) -> String {
+        artifact_footer(&self.saved(), &self.store)
+    }
+
+    /// Validate, admit against this call's budget, store, and record.
+    ///
+    /// Order is the contract: every check runs *before* [`crate::cas::Cas::put`], so a
+    /// refusal stores nothing. The ledger lock spans the admission and the write so two
+    /// concurrent tool calls in one turn cannot both admit against the same remaining
+    /// budget; nothing here awaits, so the lock is never held across a suspension point.
+    ///
+    /// The return value is the digest and nothing more. Whether these bytes were already
+    /// in the store is deliberately unobservable — see the module doc.
+    pub fn save(
+        &self,
+        label: &str,
+        content: &str,
+        format: Option<&str>,
+    ) -> Result<Digest, SaveError> {
+        let label = label.trim();
+        if label.is_empty() {
+            return Err(SaveError::MissingLabel);
+        }
+        let asked = format
+            .map(str::trim)
+            .filter(|f| !f.is_empty())
+            .unwrap_or("text");
+        let ext = FORMATS
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(asked))
+            .map(|(_, ext)| *ext)
+            .ok_or_else(|| SaveError::UnknownFormat {
+                asked: asked.to_string(),
+            })?;
+        let bytes = content.as_bytes();
+        if bytes.len() > self.caps.per_artifact_bytes {
+            return Err(SaveError::TooLarge {
+                cap: self.caps.per_artifact_bytes,
+                actual: bytes.len(),
+            });
+        }
+
+        let mut ledger = self.ledger.lock().expect("artifact ledger poisoned");
+        if ledger.saved.len() >= self.caps.artifacts_per_call {
+            return Err(SaveError::TooMany {
+                cap: self.caps.artifacts_per_call,
+            });
+        }
+        if ledger.total_bytes + bytes.len() > self.caps.total_bytes_per_call {
+            return Err(SaveError::TotalExceeded {
+                cap: self.caps.total_bytes_per_call,
+                used: ledger.total_bytes,
+                actual: bytes.len(),
+            });
+        }
+
+        let provenance = Provenance {
+            prompt: self.author.prompt.clone(),
+            model: self.author.model.clone(),
+            cast: self.author.cast.clone(),
+            timestamp: now_epoch_secs(),
+            mime: ext.mime().to_string(),
+            seed: None,
+            tool: Some(SaveArtifact::NAME.to_string()),
+            slot: Some(self.author.slot.to_string()),
+            label: Some(label.to_string()),
+            session: self.author.session.clone(),
+        };
+        let digest = self
+            .store
+            .put(bytes, ext, &provenance)
+            .map_err(|e| SaveError::Store(e.to_string()))?;
+
+        ledger.total_bytes += bytes.len();
+        ledger.saved.push(SavedArtifact {
+            digest: digest.to_hex(),
+            mime: ext.mime(),
+            bytes: bytes.len(),
+            label: label.to_string(),
+        });
+        Ok(digest)
+    }
+}
+
+/// Epoch seconds for a sidecar timestamp. Local to this module so the sink needs nothing
+/// from the server layer; a pre-1970 clock reads as 0 rather than panicking.
+fn now_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// The `save_artifact` tool, as the inner model team sees it.
+pub struct SaveArtifact {
+    sink: Arc<ArtifactSink>,
+}
+
+impl SaveArtifact {
+    pub fn new(sink: Arc<ArtifactSink>) -> Self {
+        Self { sink }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SaveArtifactArgs {
+    /// One short line saying what this artifact holds.
+    pub label: String,
+    /// The bytes themselves.
+    pub content: String,
+    /// `text` or `jsonl`; `text` when omitted.
+    #[serde(default)]
+    pub format: Option<String>,
+}
+
+impl Tool for SaveArtifact {
+    const NAME: &'static str = "save_artifact";
+    type Error = SaveError;
+    type Args = SaveArtifactArgs;
+    type Output = String;
+
+    /// Keep the refusal model-visible: rig's default redacts a tool error to a
+    /// kind-level "the tool failed", and every [`SaveError`] exists to tell the model
+    /// the cap, the actual size, and what to do next. A model that only learns "it
+    /// failed" pays the whole payload again to guess.
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        ToolExecutionError::other(error.to_string()).with_source(error)
+    }
+
+    fn description(&self) -> String {
+        // Rendered from the sink's own caps, never a hand-copied number. A rejected save
+        // has already cost the caller the output tokens for the whole payload, so
+        // discover-by-failing is uniquely expensive here and a stale figure is worse than
+        // none.
+        let Caps {
+            per_artifact_bytes,
+            artifacts_per_call,
+            total_bytes_per_call,
+        } = self.sink.caps();
+        format!(
+            "Save bulk content you have written into kaibo's artifact store. You get back \
+             an address, and the caller receives that address with your answer.\n\n\
+             The saved artifact is the delivery vehicle for bulk content. Your final \
+             answer is the report of the work: name the artifact by its URI so the caller \
+             can retrieve it, describe what it covers and how it is organized, and quote \
+             one or two representative entries where they illustrate the coverage. The \
+             full content reaches the caller through the artifact.\n\n\
+             Use this for material the caller wants to keep or to run: a generated \
+             corpus, a long inventory, a fixture. Reach for it when the content is bulk. \
+             Keep your reasoning and your conclusions in the answer itself.\n\n\
+             Limits for one call: {per_artifact_bytes} bytes per artifact, \
+             {artifacts_per_call} artifacts, {total_bytes_per_call} bytes in total. A \
+             save past a limit is refused and stores nothing, and the refusal says which \
+             limit it hit. Split large content into several artifacts to stay inside them."
+        )
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string",
+                    "description": "one short line saying what this artifact holds; the \
+                                    caller reads it beside the artifact's URI"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "the content to save, written out in full"
+                },
+                "format": {
+                    "type": "string",
+                    "enum": format_names(),
+                    "description": "the shape of the content; `text` when omitted"
+                }
+            },
+            "required": ["label", "content"]
+        })
+    }
+
+    async fn call(
+        &self,
+        _ctx: &mut rig_agent::tool::ToolContext,
+        args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
+        let digest = self
+            .sink
+            .save(&args.label, &args.content, args.format.as_deref())?;
+        // Exactly this line for exactly these bytes, every time. A word about whether the
+        // content was new would answer "is this already in the store?" for arbitrary bytes,
+        // across every project this kaibo serves — see the module doc's existence-oracle note.
+        Ok(format!(
+            "Saved. The caller will receive this artifact with your answer, at \
+             {}{}. Name that URI in your answer and describe what the artifact covers.",
+            crate::cas::CAS_URI_PREFIX,
+            digest.to_hex()
+        ))
+    }
+}
+
+/// The caller-facing footer: what this call saved, appended to the consult answer.
+/// Empty (and appends nothing) when the loop saved nothing, so a consult that never
+/// reached for the tool reads byte-for-byte as it always did.
+///
+/// Mirrors `generate`'s per-artifact lines — same URI, same parenthetical, same
+/// `path:` continuation in disk mode — because they are the same retrieval story and a
+/// caller should not have to learn two renderings.
+/// Append a call's artifact footer to its answer. `None` (no sink, so no
+/// `save_artifact` was ever offered) and an unused sink both return `answer` untouched,
+/// which is what keeps a consult that never saved anything byte-for-byte its old self.
+pub fn with_artifacts(answer: String, sink: Option<&ArtifactSink>) -> String {
+    match sink {
+        Some(sink) => answer + &sink.footer(),
+        None => answer,
+    }
+}
+
+fn artifact_footer(saved: &[SavedArtifact], store: &MediaStore) -> String {
+    if saved.is_empty() {
+        return String::new();
+    }
+    let mut out = format!(
+        "\n\n---\nSaved {} artifact{} (retrieve by reading the resource URI):",
+        saved.len(),
+        if saved.len() == 1 { "" } else { "s" }
+    );
+    for (i, a) in saved.iter().enumerate() {
+        out.push_str(&format!(
+            "\n{}. {}{} ({}, {} bytes)\n   {}",
+            i + 1,
+            crate::cas::CAS_URI_PREFIX,
+            a.digest,
+            a.mime,
+            a.bytes,
+            a.label
+        ));
+        if let Some(path) = Digest::from_hex(&a.digest)
+            .ok()
+            .and_then(|d| store.path_for(&d))
+        {
+            out.push_str(&format!("\n   path: {}", path.display()));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cas::MemoryCas;
+
+    fn sink() -> ArtifactSink {
+        ArtifactSink::new(
+            Arc::new(MediaStore::Memory(MemoryCas::new(None))),
+            ArtifactAuthor {
+                prompt: "generate a fuzz corpus".into(),
+                model: "deepseek/deepseek-v4-pro".into(),
+                cast: "deepseek".into(),
+                slot: "synth",
+                session: Some("s-1".into()),
+            },
+        )
+    }
+
+    /// The description renders LIVE cap values. A hand-copied number drifts the moment a
+    /// constant moves, and a model that reads a stale cap pays the whole payload to find
+    /// out — which is exactly why the caps are stated at all.
+    #[test]
+    fn the_description_states_the_live_caps() {
+        let desc = SaveArtifact::new(Arc::new(sink())).description();
+        for n in [
+            MAX_ARTIFACT_BYTES.to_string(),
+            MAX_ARTIFACTS_PER_CALL.to_string(),
+            MAX_TOTAL_BYTES_PER_CALL.to_string(),
+        ] {
+            assert!(desc.contains(&n), "description must state {n}, got: {desc}");
+        }
+    }
+
+    /// The schema names no filesystem location, source or destination — the property the
+    /// whole design rests on. A future parameter that does must fail here first.
+    #[test]
+    fn the_schema_has_no_path_parameter_of_any_kind() {
+        let params = SaveArtifact::new(Arc::new(sink())).parameters();
+        let props = params["properties"].as_object().expect("an object schema");
+        let mut names: Vec<&String> = props.keys().collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["content", "format", "label"],
+            "save_artifact takes bytes, a label, and a format. Nothing else."
+        );
+    }
+}

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -101,7 +101,11 @@ impl Default for Caps {
 /// This is a *serving* concern, not a safety boundary — a model can put anything inside
 /// a `.txt`, and the byte caps are the real limit. What it buys is a retrieval that says
 /// something true about the bytes: `kaibo://cas/<digest>` stamps a mime from this table.
-pub const FORMATS: &[(&str, Extension)] = &[("text", Extension::Txt), ("jsonl", Extension::Jsonl)];
+pub const FORMATS: &[(&str, Extension)] = &[
+    ("text", Extension::Txt),
+    ("jsonl", Extension::Jsonl),
+    ("markdown", Extension::Md),
+];
 
 /// The format names, for a schema `enum` and for error text.
 fn format_names() -> Vec<&'static str> {

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -386,6 +386,18 @@ impl Extension {
         }
     }
 
+    /// Should retrieval serve this format as a **string** rather than base64? The
+    /// producers mark what they make — `save_artifact` writes these formats from UTF-8
+    /// input, `generate` writes images — and this is where retrieval reads the mark.
+    /// Deliberately not `!is_image()`: a future format (audio, an archive) is neither
+    /// an image nor text, so each new variant must answer both questions on its own.
+    pub fn is_textual(&self) -> bool {
+        match self {
+            Extension::Txt | Extension::Jsonl => true,
+            Extension::Png | Extension::Jpeg | Extension::Webp | Extension::Gif => false,
+        }
+    }
+
     /// Map a wire mime string (a producer's own spelling, case-insensitive per RFC
     /// 7231) onto the closed on-disk set. `None` for anything the CAS cannot name on
     /// disk — the caller decides loudly what that means (see

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -332,19 +332,22 @@ pub enum Extension {
     Txt,
     /// JSON Lines: one JSON value per line, the shape a machine consumer streams.
     Jsonl,
+    /// Markdown: the shape a model naturally writes a report in.
+    Md,
 }
 
 impl Extension {
     /// Every variant, in the order [`Cas::entry_for`] probes them when an object has no
     /// readable provenance sidecar to name its format. The sidecar is the authority;
     /// this order only decides the answer for an object that lost one.
-    pub const ALL: [Extension; 6] = [
+    pub const ALL: [Extension; 7] = [
         Extension::Png,
         Extension::Jpeg,
         Extension::Webp,
         Extension::Gif,
         Extension::Txt,
         Extension::Jsonl,
+        Extension::Md,
     ];
 
     /// The bare filename extension (no leading dot).
@@ -356,6 +359,7 @@ impl Extension {
             Extension::Gif => "gif",
             Extension::Txt => "txt",
             Extension::Jsonl => "jsonl",
+            Extension::Md => "md",
         }
     }
 
@@ -371,6 +375,7 @@ impl Extension {
             Extension::Gif => "image/gif",
             Extension::Txt => "text/plain; charset=utf-8",
             Extension::Jsonl => "application/jsonl",
+            Extension::Md => "text/markdown; charset=utf-8",
         }
     }
 
@@ -382,7 +387,7 @@ impl Extension {
     pub fn is_image(&self) -> bool {
         match self {
             Extension::Png | Extension::Jpeg | Extension::Webp | Extension::Gif => true,
-            Extension::Txt | Extension::Jsonl => false,
+            Extension::Txt | Extension::Jsonl | Extension::Md => false,
         }
     }
 
@@ -393,7 +398,7 @@ impl Extension {
     /// an image nor text, so each new variant must answer both questions on its own.
     pub fn is_textual(&self) -> bool {
         match self {
-            Extension::Txt | Extension::Jsonl => true,
+            Extension::Txt | Extension::Jsonl | Extension::Md => true,
             Extension::Png | Extension::Jpeg | Extension::Webp | Extension::Gif => false,
         }
     }
@@ -416,6 +421,7 @@ impl Extension {
             "image/webp" => Some(Extension::Webp),
             "image/gif" => Some(Extension::Gif),
             "text/plain" => Some(Extension::Txt),
+            "text/markdown" | "text/x-markdown" => Some(Extension::Md),
             "application/jsonl"
             | "application/x-ndjson"
             | "application/jsonlines"

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -109,25 +109,42 @@
 //! file in the store on the *write* path, for every new object, over a store that never
 //! deletes and is sharded two levels deep; that walk is O(objects) and only slows down as
 //! the store fills. An operator who never asked for a ceiling should not pay it, so they
-//! do not. Cleanup is theirs to do (`find -mtime` over the sidecars); a TTL may come later.
+//! do not. Cleanup, if an operator wants any, is theirs to do; kaibo offers no verb for it
+//! yet, and the shape a good one wants is an index kaibo maintains rather than a walk of
+//! the store (see "No GC here" below).
 //!
 //! When a cap *is* set, a [`Cas::put`] that would push the store's total size over it is
 //! refused with [`CasError::CapacityExceeded`] — loudly, before any bytes are written. It never deletes anything to make room: eviction would
 //! quietly make "write-only" a lie (a lie exactly one write-time trust judgment away from
 //! looking corrupt), and disk-full-in-effect is precisely the crash-over-corrupt case
-//! kaibo's read-only posture already treats as correct. A dedup write of content already
-//! on disk is exempt from the check (it adds zero bytes, so it cannot be what pushed the
-//! store over the line) — see [`Cas::put`].
+//! kaibo's read-only posture already treats as correct. The check runs on **every** put,
+//! including one whose content is already here: exempting a dedup is right about disk
+//! usage and wrong about disclosure, because succeeding for held bytes while refusing new
+//! ones lets a caller ask *is this content in the store?* across every project this kaibo
+//! has served. See [`Cas::put`] for the full argument, and [`MemoryCas::put`] for the same
+//! ordering in the other mode.
 //!
-//! # No GC here, on purpose — the sidecar is why that's honest
+//! # No GC here, on purpose
 //!
-//! kaibo does not prune this store. The user backs it up or prunes it by hand (`find
-//! -mtime`, `restic`, …) if they want to. For that to be an honest position rather than a
-//! punt, every object gets a `<hex>.json` provenance sidecar (prompt, model, cast,
-//! timestamp, mime, seed) next to it — the metadata a human (or a script) needs to prune
-//! intelligently instead of guessing at opaque bytes. Because nothing here is ever
-//! rewritten, that sidecar's schema can only ever grow *compatibly* — see
-//! [`Provenance`]'s doc for the rule that keeps a decade-old sidecar readable.
+//! kaibo does not prune this store, and the reason is the store's own shape rather than a
+//! deferred feature: the address is the content hash and nothing is ever unlinked, so an
+//! object at a given digest is the same object forever and no reference anyone holds can
+//! go stale. Deletion would trade that guarantee away.
+//!
+//! Every object also gets a `<hex>.json` provenance sidecar (prompt, model, cast,
+//! timestamp, mime, seed, and how it was produced) beside it, which makes an object
+//! **self-describing to whoever holds its address**: one lookup by digest says what these
+//! bytes are, where they came from, and what format to serve them as. That is its job,
+//! and it is the access pattern the whole store is built for.
+//!
+//! It is not a scan target. Sweeping the tree to survey the store gets slower as the
+//! store fills — 65,536 shards, a `readdir` and a parse per object — and nothing here is
+//! indexed for it. Operator-facing inventory (someday: `kaibo cas ls`/`du`) wants an index
+//! kaibo maintains, not a walk; see `docs/issues.md`.
+//!
+//! Because nothing here is ever rewritten, the sidecar's schema can only ever grow
+//! *compatibly* — see [`Provenance`]'s doc for the rule that keeps a decade-old sidecar
+//! readable.
 //!
 //! # Never mounted into kaish
 //!
@@ -217,6 +234,24 @@ pub enum CasError {
     /// story — see the module doc).
     #[error("media CAS provenance sidecar serialize: {0}")]
     Serialize(String),
+    /// **The object landed; its provenance sidecar did not.** [`Cas::put`] writes the
+    /// object first and the sidecar second, so an I/O failure between them leaves the
+    /// content durably stored and retrievable — the probe fallback in
+    /// [`Cas::entry_for`] finds a sidecar-less object — while the call still has to
+    /// report a failure, because the provenance record the store's whole no-GC stance
+    /// rests on is missing.
+    ///
+    /// Its own variant, rather than a plain [`CasError::Io`], because the two demand
+    /// opposite things of a caller: an `Io` failure means the bytes are not there and
+    /// "nothing was saved" is true, while this means they ARE there and saying nothing
+    /// was saved is a lie about durable data. The digest rides along because it is the
+    /// only way back to bytes that no longer describe themselves.
+    #[error(
+        "media CAS object {digest} was stored, but its provenance sidecar could not be \
+         written ({cause}) — the bytes are durable and retrievable at that digest, and \
+         this store never rewrites, so the record cannot be filled in later"
+    )]
+    ProvenanceNotRecorded { digest: String, cause: String },
 }
 
 pub type Result<T> = std::result::Result<T, CasError>;
@@ -381,9 +416,10 @@ impl Extension {
 /// The provenance sidecar recorded next to every object: `prompt`, `model`, `cast`,
 /// `timestamp` (epoch seconds), `mime`, `seed`, and the authorship fields that say which
 /// tool produced it and, for authored text, who wrote it. This is the whole point of shipping
-/// with no built-in GC — a user (or their own script) can `find`/`jq` over these sidecars
-/// and prune intelligently instead of guessing at opaque hashed bytes. See the module
-/// doc's "No GC here, on purpose" section.
+/// with no built-in GC: an object reached **by its address** describes itself, instead of
+/// being opaque hashed bytes. Read it by digest, the way everything in this store is read
+/// — not by sweeping the tree, which does not scale and is not what this is for. See the
+/// module doc's "No GC here, on purpose" section.
 ///
 /// `mime` is also load-bearing at runtime: it is what [`Cas::entry_for`] reads to name
 /// an object's format in one lookup rather than probing every container format kaibo
@@ -486,8 +522,8 @@ impl Cas {
     /// store fills, which is exactly the cost an operator who never asked for a ceiling
     /// should not pay. Amy's call (2026-07-30): leave the accounting off until someone has
     /// a problem that needs it. Disk-full is the real backstop and the OS reports it
-    /// honestly; pruning is `find -mtime` over the provenance sidecars (see the module
-    /// doc's "No GC here, on purpose").
+    /// honestly, and kaibo ships no pruning verb (see the module doc's "No GC here, on
+    /// purpose").
     ///
     /// Unlike [`crate::store::SessionStore::open`], this does **not** create any
     /// directory — there is nothing to eagerly create. The root (and every shard
@@ -671,14 +707,23 @@ impl Cas {
     /// [`CasError::Corrupt`]). If that check fails, the write returns
     /// `Err(CasError::Corrupt)` rather than silently discarding the caller's good bytes
     /// into a poisoned slot — the caller's data was never at risk, only the report of
-    /// success was. A verified dedup is **not** re-checked against the soft cap — it adds
-    /// zero new bytes, so it cannot be what pushes the store over the line. Otherwise (new
-    /// content) the soft cap is checked *before* any write, and it counts the whole
-    /// footprint this put would add — the artifact **and** its provenance sidecar,
-    /// which is real disk usage written by the same call: if the current total plus
-    /// both would exceed `max_bytes`, the write is refused with
-    /// [`CasError::CapacityExceeded`] and nothing is written — never evicted, see the
-    /// module doc.
+    /// success was.
+    ///
+    /// # The cap admits every put the same way, dedup or not
+    ///
+    /// When a cap is configured it is checked *before* any write, counting the whole
+    /// footprint this put would add — the artifact **and** its provenance sidecar, which
+    /// is real disk usage written by the same call — and a put past it is refused with
+    /// [`CasError::CapacityExceeded`], nothing written and nothing evicted.
+    ///
+    /// That check runs **whether or not the content is already here**, which is a
+    /// deliberate reversal (2026-08-05). Exempting a dedup is correct about disk usage —
+    /// re-putting held content adds no bytes — and wrong about disclosure. Once a *model*
+    /// can drive puts (`save_artifact`), "succeeded" versus "refused" at a full store
+    /// answers *is this content already in the store?* for arbitrary bytes, over a store
+    /// that spans every project this kaibo has served. Making admission independent of
+    /// what the store holds closes that oracle: a full store is uniformly closed. The
+    /// price is a wasted no-op write at exactly-full, which loses nothing.
     ///
     /// The whole body runs under the store's write mutex, so concurrent puts on
     /// clones/`Arc`s of one store serialize: the dedup check, the cap accounting, and
@@ -686,6 +731,14 @@ impl Cas {
     /// loses to something that appeared from outside this process (another kaibo, an
     /// operator's copy), the existing bytes are read back and **verified** before
     /// success is reported — never trusted from the path alone.
+    ///
+    /// # One failure that is not a failure to store
+    ///
+    /// The object is written before the sidecar, so a sidecar write that fails leaves the
+    /// content durable and retrievable. That returns
+    /// [`CasError::ProvenanceNotRecorded`] — carrying the digest — rather than a plain
+    /// [`CasError::Io`], because a caller that renders "nothing was saved" from it would
+    /// be lying about data that is on disk and reachable.
     pub fn put(&self, bytes: &[u8], ext: Extension, provenance: &Provenance) -> Result<Digest> {
         let digest = Digest::of_bytes(bytes);
         let shard = self.shard_dir(&digest);
@@ -698,6 +751,23 @@ impl Cas {
         // part of this put's disk footprint, not an afterthought.
         let sidecar_json = serde_json::to_vec_pretty(provenance)
             .map_err(|e| CasError::Serialize(e.to_string()))?;
+
+        // Cap admission FIRST, and unconditionally when a cap is configured — before the
+        // dedup read below, so nothing about the outcome depends on whether these bytes
+        // are already here. See the "admits every put the same way" section above: a
+        // dedup exemption is an existence oracle over every project's artifacts. This is
+        // still the ONLY call site that walks the store, and it is still reached only
+        // when an operator opted into a ceiling; an uncapped CAS never sizes itself.
+        if let Some(max_bytes) = self.max_bytes {
+            let current = self.total_bytes()?;
+            let incoming = bytes.len() as u64 + sidecar_json.len() as u64;
+            if current.saturating_add(incoming) > max_bytes {
+                return Err(CasError::CapacityExceeded {
+                    max_bytes,
+                    current_bytes: current,
+                });
+            }
+        }
 
         if obj_path.is_file() {
             // Dedup path: the module doc's "AlreadyExists means these exact bytes are
@@ -716,18 +786,6 @@ impl Cas {
                 ))
             })?;
             verify(&digest, existing)?;
-        } else if let Some(max_bytes) = self.max_bytes {
-            // New content, and a cap is configured: measure before growing the store at
-            // all. This is the ONLY call site that walks the store, and it is reached only
-            // when an operator opted into a ceiling — an uncapped CAS never sizes itself.
-            let current = self.total_bytes()?;
-            let incoming = bytes.len() as u64 + sidecar_json.len() as u64;
-            if current.saturating_add(incoming) > max_bytes {
-                return Err(CasError::CapacityExceeded {
-                    max_bytes,
-                    current_bytes: current,
-                });
-            }
         }
 
         std::fs::create_dir_all(&shard) // media-cas-write: blessed by the media CAS invariant amendment (AGENTS.md)
@@ -754,11 +812,15 @@ impl Cas {
             verify(&digest, existing)?;
         }
 
+        // Past this point the object IS stored. A sidecar failure is still a failure —
+        // the provenance record is what makes the no-GC stance honest — but it is not a
+        // failure to store, and reporting it as a bare Io error invites a caller to tell
+        // its user "nothing was saved" about durable, reachable bytes. Carry the digest.
         write_new_file(&sidecar_path, &sidecar_json).map_err(|e| {
-            CasError::Io(format!(
-                "writing cas provenance sidecar {}: {e}",
-                sidecar_path.display()
-            ))
+            CasError::ProvenanceNotRecorded {
+                digest: digest.to_hex(),
+                cause: e.to_string(),
+            }
         })?;
 
         Ok(digest)
@@ -772,6 +834,13 @@ struct MemObject {
     bytes: Vec<u8>,
     ext: Extension,
     provenance: Provenance,
+    /// Size of `provenance` in its serialized form — the same representation the disk
+    /// store writes to a sidecar. Held rather than recomputed so the cap sum stays a
+    /// cheap add, and held at all because memory mode really does keep this data: a cap
+    /// that counted only content bytes would let a capped store hold more than the
+    /// operator asked for, and would make one `max_bytes` mean two different things in
+    /// the two modes.
+    provenance_bytes: u64,
 }
 
 /// The in-memory CAS: the same content-addressed contract as [`Cas`] — the address is
@@ -808,22 +877,37 @@ impl MemoryCas {
     /// Store `bytes` under their own digest. A repeat of identical content is a
     /// no-op returning the same digest (dedup needs no verification here: the map is
     /// keyed by the digest of exactly the bytes it holds, and nothing between put and
-    /// get can corrupt process memory the way a torn disk write can). A new object is
-    /// checked against the cap first, mirroring [`Cas::put`].
+    /// get can corrupt process memory the way a torn disk write can).
+    ///
+    /// The cap is checked **before** the dedup short-circuit and counts the provenance
+    /// alongside the content, both mirroring [`Cas::put`] exactly. The admission order is
+    /// the load-bearing half: short-circuiting on "already held" before the cap would let
+    /// a full store answer *is this content here?* by succeeding for held bytes and
+    /// refusing for new ones — an existence oracle over every project's artifacts. One
+    /// meaning per knob, one outcome per full store, in both modes.
     pub fn put(&self, bytes: &[u8], ext: Extension, provenance: &Provenance) -> Result<Digest> {
         let digest = Digest::of_bytes(bytes);
+        // Serialized the same way the disk sidecar is, so `max_bytes` admits the same
+        // footprint in either mode.
+        let provenance_bytes = serde_json::to_vec_pretty(provenance)
+            .map_err(|e| CasError::Serialize(e.to_string()))?
+            .len() as u64;
         let mut objects = self.lock();
-        if objects.contains_key(&digest) {
-            return Ok(digest);
-        }
         if let Some(max_bytes) = self.max_bytes {
-            let current: u64 = objects.values().map(|o| o.bytes.len() as u64).sum();
-            if current.saturating_add(bytes.len() as u64) > max_bytes {
+            let current: u64 = objects
+                .values()
+                .map(|o| o.bytes.len() as u64 + o.provenance_bytes)
+                .sum();
+            let incoming = bytes.len() as u64 + provenance_bytes;
+            if current.saturating_add(incoming) > max_bytes {
                 return Err(CasError::CapacityExceeded {
                     max_bytes,
                     current_bytes: current,
                 });
             }
+        }
+        if objects.contains_key(&digest) {
+            return Ok(digest);
         }
         objects.insert(
             digest,
@@ -831,6 +915,7 @@ impl MemoryCas {
                 bytes: bytes.to_vec(),
                 ext,
                 provenance: provenance.clone(),
+                provenance_bytes,
             },
         );
         Ok(digest)
@@ -846,6 +931,12 @@ impl MemoryCas {
     /// of reading a disk sidecar.
     pub fn provenance(&self, digest: &Digest) -> Option<Provenance> {
         self.lock().get(digest).map(|o| o.provenance.clone())
+    }
+
+    /// The container format this digest is held under, without copying its bytes — the
+    /// in-memory analogue of [`Cas::entry_for`]'s extension half.
+    pub fn extension_for(&self, digest: &Digest) -> Option<Extension> {
+        self.lock().get(digest).map(|o| o.ext)
     }
 }
 
@@ -867,6 +958,26 @@ impl MediaStore {
         match self {
             MediaStore::Disk(cas) => cas.put(bytes, ext, provenance),
             MediaStore::Memory(mem) => mem.put(bytes, ext, provenance),
+        }
+    }
+
+    /// **The store's own answer for what an object IS**, without reading its bytes: the
+    /// container format, and through it the mime the `kaibo://cas/<digest>` resource will
+    /// stamp and the extension the on-disk path carries.
+    ///
+    /// A producer's *requested* format is not that answer. The address is the content
+    /// hash, so identical bytes saved as `jsonl` after they were already stored as `txt`
+    /// land at the same digest; the second put writes a second container file while the
+    /// sidecar — the authority, see [`Cas::entry_for`] — still says `txt`. A caller that
+    /// rendered its own request would advertise `application/jsonl` beside a `.txt` path
+    /// and a `text/plain` resource read. Ask the store instead, always.
+    ///
+    /// Refusing the second put would be the other way to fix that, and it is worse: the
+    /// refusal itself would reveal that the content was already present.
+    pub fn extension_for(&self, digest: &Digest) -> Option<Extension> {
+        match self {
+            MediaStore::Disk(cas) => cas.entry_for(digest).map(|(_, ext)| ext),
+            MediaStore::Memory(mem) => mem.extension_for(digest),
         }
     }
 

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -265,29 +265,41 @@ impl Digest {
     }
 }
 
-/// A generated image's on-disk container format. Deliberately a closed enum, not a
+/// An artifact's on-disk container format. Deliberately a closed enum, not a
 /// caller-supplied string: this is the *only* caller-influenced component of an
 /// object's path (the digest supplies the rest), so it must be a small, fixed set kaibo
 /// controls — a free string here would reopen the aim-the-write hole the digest closes
-/// for the rest of the path. Extend this list as new providers/formats land; never
+/// for the rest of the path. Extend this list as new producers/formats land; never
 /// widen it to `String`.
+///
+/// The image variants come from `generate` (a provider rendered them); the text
+/// variants come from `save_artifact` (a model on kaibo's own team authored them).
+/// [`Extension::is_image`] tells them apart, which is what keeps `generate`'s "an
+/// images provider returned something that is not an image" refusal exactly as loud as
+/// it was when this enum held images alone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Extension {
     Png,
     Jpeg,
     Webp,
     Gif,
+    /// Plain UTF-8 text: a model-authored report, corpus, or listing.
+    Txt,
+    /// JSON Lines: one JSON value per line, the shape a machine consumer streams.
+    Jsonl,
 }
 
 impl Extension {
-    /// Every variant, in the order [`Cas::path_for`]/[`Cas::get`] probe them — a digest
-    /// alone doesn't say which format it was written under, so a lookup by digest tries
-    /// each in turn until one exists on disk.
-    pub const ALL: [Extension; 4] = [
+    /// Every variant, in the order [`Cas::entry_for`] probes them when an object has no
+    /// readable provenance sidecar to name its format. The sidecar is the authority;
+    /// this order only decides the answer for an object that lost one.
+    pub const ALL: [Extension; 6] = [
         Extension::Png,
         Extension::Jpeg,
         Extension::Webp,
         Extension::Gif,
+        Extension::Txt,
+        Extension::Jsonl,
     ];
 
     /// The bare filename extension (no leading dot).
@@ -297,25 +309,48 @@ impl Extension {
             Extension::Jpeg => "jpeg",
             Extension::Webp => "webp",
             Extension::Gif => "gif",
+            Extension::Txt => "txt",
+            Extension::Jsonl => "jsonl",
         }
     }
 
     /// The canonical mime type this on-disk format serves as — what the
-    /// `kaibo://cas/<digest>` resource stamps on a blob it hands back.
+    /// `kaibo://cas/<digest>` resource stamps on a blob it hands back, and what a
+    /// producer records in the provenance sidecar so [`Cas::entry_for`] can read the
+    /// format straight back out.
     pub fn mime(&self) -> &'static str {
         match self {
             Extension::Png => "image/png",
             Extension::Jpeg => "image/jpeg",
             Extension::Webp => "image/webp",
             Extension::Gif => "image/gif",
+            Extension::Txt => "text/plain; charset=utf-8",
+            Extension::Jsonl => "application/jsonl",
         }
     }
 
-    /// Map a wire mime string (a provider's own spelling, case-insensitive per RFC
+    /// Is this a rendered image (a `generate` output) rather than authored text?
+    /// `generate` prevalidates on this, so an images provider handing back a
+    /// `text/plain` body is still refused loudly instead of stored as an artifact:
+    /// growing this enum for `save_artifact` must not quietly widen what the media
+    /// lane accepts.
+    pub fn is_image(&self) -> bool {
+        match self {
+            Extension::Png | Extension::Jpeg | Extension::Webp | Extension::Gif => true,
+            Extension::Txt | Extension::Jsonl => false,
+        }
+    }
+
+    /// Map a wire mime string (a producer's own spelling, case-insensitive per RFC
     /// 7231) onto the closed on-disk set. `None` for anything the CAS cannot name on
     /// disk — the caller decides loudly what that means (see
     /// `stability::MediaType::to_cas_extension` for the same refusal argued at length);
     /// this helper never invents an extension for unknown bytes.
+    ///
+    /// Parameters are dropped before matching, so our own canonical
+    /// `text/plain; charset=utf-8` and a bare `text/plain` name the same format. The
+    /// JSON Lines aliases are all accepted on parse because that format never got one
+    /// registered spelling; [`Extension::mime`] renders exactly one of them.
     pub fn from_mime(mime: &str) -> Option<Self> {
         let essence = mime.split(';').next().unwrap_or(mime).trim();
         match essence.to_ascii_lowercase().as_str() {
@@ -323,6 +358,11 @@ impl Extension {
             "image/jpeg" => Some(Extension::Jpeg),
             "image/webp" => Some(Extension::Webp),
             "image/gif" => Some(Extension::Gif),
+            "text/plain" => Some(Extension::Txt),
+            "application/jsonl"
+            | "application/x-ndjson"
+            | "application/jsonlines"
+            | "application/x-jsonlines" => Some(Extension::Jsonl),
             _ => None,
         }
     }
@@ -333,6 +373,12 @@ impl Extension {
 /// with no built-in GC — a user (or their own script) can `find`/`jq` over these sidecars
 /// and prune intelligently instead of guessing at opaque hashed bytes. See the module
 /// doc's "No GC here, on purpose" section.
+///
+/// `mime` is also load-bearing at runtime: it is what [`Cas::entry_for`] reads to name
+/// an object's format in one lookup rather than probing every container format kaibo
+/// knows. Record the format the object actually is (`Extension::mime` is the canonical
+/// spelling) — a sidecar that disagrees with the bytes beside it mislabels the artifact
+/// on retrieval.
 ///
 /// # Every new field must be `Option`, or carry `#[serde(default)]`
 ///
@@ -463,18 +509,50 @@ impl Cas {
             .join(format!("{}.json", digest.to_hex()))
     }
 
-    /// The path an object would live at, if it exists — probing every [`Extension`]
-    /// variant in turn, since a bare digest doesn't say which format it was written
-    /// under. `None` if no object with this digest has ever been written (or an ancestor
-    /// directory doesn't exist yet, which reads the same way: nothing is here).
+    /// The path an object would live at, if it exists. `None` if no object with this
+    /// digest has ever been written (or an ancestor directory doesn't exist yet, which
+    /// reads the same way: nothing is here).
     pub fn path_for(&self, digest: &Digest) -> Option<PathBuf> {
         self.entry_for(digest).map(|(path, _)| path)
+    }
+
+    /// Read an object's provenance sidecar, if one is there and parses. `None` covers
+    /// three cases the caller treats alike — no sidecar (an object whose write crashed
+    /// between the two files; see [`write_new_file`]), an unreadable one, and one whose
+    /// JSON doesn't deserialize — because each means the same thing to a lookup: this
+    /// object cannot tell us what it is, so something else has to.
+    pub fn provenance_for(&self, digest: &Digest) -> Option<Provenance> {
+        let bytes = std::fs::read(self.sidecar_path(digest)).ok()?;
+        serde_json::from_slice(&bytes).ok()
     }
 
     /// [`path_for`](Self::path_for) plus which [`Extension`] the object was written
     /// under — the extension carries the mime type a resource read needs to stamp on
     /// the bytes, and re-deriving it from the path string would be a second parser.
+    ///
+    /// **The sidecar is the authority.** Every object written by this store gets a
+    /// `<hex>.json` sidecar whose `mime` describes it, so one read of that file names
+    /// the format directly: one lookup, not a walk of every container format kaibo
+    /// knows. That matters more as the set grows past images — a probe answers with
+    /// whichever variant it happens to try first, which for content stored under two
+    /// names is a *mislabel* the `kaibo://cas/<digest>` resource then stamps onto the
+    /// bytes, and for a large set is N stats per read.
+    ///
+    /// **The probe is the fallback, never the requirement.** An object whose sidecar
+    /// is missing, unreadable, or names a mime this kaibo cannot map still resolves by
+    /// trying [`Extension::ALL`]. This store never rewrites, so an old or orphaned
+    /// object can't be migrated into the new scheme — losing one to a metadata gap
+    /// would be exactly the silent data loss the module refuses.
     pub fn entry_for(&self, digest: &Digest) -> Option<(PathBuf, Extension)> {
+        if let Some(ext) = self
+            .provenance_for(digest)
+            .and_then(|p| Extension::from_mime(&p.mime))
+        {
+            let path = self.object_path(digest, ext);
+            if path.is_file() {
+                return Some((path, ext));
+            }
+        }
         Extension::ALL.into_iter().find_map(|ext| {
             let path = self.object_path(digest, ext);
             path.is_file().then_some((path, ext))

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -150,6 +150,16 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+/// The resource-URI prefix an object is addressed by: `kaibo://cas/<digest>`. Declared
+/// here, beside the store, so the MCP resource route and every producer that *renders* an
+/// address (`generate`'s result lines, `save_artifact`'s footer) spell it one way.
+///
+/// Reading that resource is **operator surface only** (Amy's ruling, 2026-08-03): the MCP
+/// client and the CLI resolve it; the inner model team never can. The CAS is not mounted
+/// into kaish and no cast-facing tool reads it, because kaibo state spans projects and a
+/// browsable CAS would let one project's team enumerate another's artifacts.
+pub const CAS_URI_PREFIX: &str = "kaibo://cas/";
+
 /// The CAS's error surface. A persistence-adjacent module wants a typed error callers
 /// can match on, mirroring [`crate::store::StoreError`]'s posture (thiserror over
 /// kaibo's usual anyhow-everywhere interior).
@@ -369,7 +379,8 @@ impl Extension {
 }
 
 /// The provenance sidecar recorded next to every object: `prompt`, `model`, `cast`,
-/// `timestamp` (epoch seconds), `mime`, and `seed`. This is the whole point of shipping
+/// `timestamp` (epoch seconds), `mime`, `seed`, and the authorship fields that say which
+/// tool produced it and, for authored text, who wrote it. This is the whole point of shipping
 /// with no built-in GC — a user (or their own script) can `find`/`jq` over these sidecars
 /// and prune intelligently instead of guessing at opaque hashed bytes. See the module
 /// doc's "No GC here, on purpose" section.
@@ -409,6 +420,39 @@ pub struct Provenance {
     /// its own), and `String` rather than an integer because it is an opaque provider
     /// token we echo back, never arithmetic we perform.
     pub seed: Option<String>,
+
+    // --- Authorship: who made these bytes, and by which route --------------
+    //
+    // Downstream, someone will *execute* an artifact's contents — the motivating
+    // case for `save_artifact` is a corpus of shell commands. The sidecar is the
+    // record they decide trust from, so it has to distinguish a provider's render
+    // from a model's writing. `model` and `cast` already name the team; these name
+    // the route and the intent.
+    //
+    // Each is written only when it applies, so a sidecar carries no null-filled
+    // fields it has nothing to say about, and a `generate` sidecar's shape is what
+    // it always was apart from the `tool` line that now names its producer.
+    /// The kaibo tool that recorded this artifact: `generate` for a provider render,
+    /// `save_artifact` for bytes a model on kaibo's own team wrote. Absent on any
+    /// sidecar written before this field existed, which means `generate` — the only
+    /// producer kaibo had then.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    /// Which reasoning slot the authoring model filled (`synth` today — only the
+    /// consult driver loop can save). Absent for a provider render, which fills the
+    /// `image` slot and has no author.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<String>,
+    /// The authoring model's own one-line description of what it saved. Written by
+    /// the model, so read it as a claim rather than a fact — it is what makes a
+    /// hand-pruning pass over the store legible, next to a `prompt` that describes
+    /// the question rather than this artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// The consult session this artifact was authored in, when the call carried one.
+    /// Ties an artifact back to the conversation that produced it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
 }
 
 /// A content-addressed store of generated media artifacts, rooted at a fixed,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,8 +233,12 @@ pub struct CommonArgs {
     pub max_attachments: Option<usize>,
 }
 
-/// The per-tool `--no-<tool>` gates — serve-only (they only make sense for the
-/// long-lived server). The shared flags live on [`Cli::common`] as globals.
+/// The per-tool gates — serve-only (they only make sense for the long-lived server).
+/// The shared flags live on [`Cli::common`] as globals.
+///
+/// All but one are `--no-<tool>`, which can only narrow what the server advertises.
+/// `--allow-save-artifact` runs the other way: it is the operator key for a capability
+/// whose built-in default is off. See [`crate::config::ArtifactsConfig`].
 #[derive(Args, Debug, Clone, Default)]
 pub struct ServeGates {
     /// Don't advertise the `consult` tool.
@@ -261,6 +265,14 @@ pub struct ServeGates {
     /// Don't advertise the `generate` tool (media generation).
     #[arg(long)]
     pub no_generate: bool,
+
+    /// Let a consult save bulk output as artifacts in kaibo's media store, when the
+    /// call also asks for it with `save_artifacts` (both keys are required, and the
+    /// media CAS must be on). OFF by default — this is the one capability a model,
+    /// rather than the operator, decides to use. Also KAIBO_ARTIFACTS_ENABLED /
+    /// [artifacts] enabled.
+    #[arg(long = "allow-save-artifact")]
+    pub allow_save_artifact: bool,
 }
 
 impl ServeGates {
@@ -534,6 +546,12 @@ fn load_config(common: &CommonArgs) -> anyhow::Result<Config> {
         common.state_db.clone(),
         common.cas_dir.clone(),
         common.cas_max_bytes,
+        // The CLI front doors have no client key to pair with the operator key —
+        // `save_artifacts` is an MCP `consult` argument — so a CLI consult never gets the
+        // tool, and passing `true` here would be a promise nothing keeps. It stays off
+        // rather than silently inert (`--allow-save-artifact` is a serve-only gate on
+        // `ServeGates` for exactly this reason).
+        false,
         common.max_attachments,
     );
     Ok(config)
@@ -761,6 +779,9 @@ async fn resolve_and_run(
         },
         synth_max_turns: args.synth_max_turns.unwrap_or(default_synth_turns),
         attachments,
+        // No client key on this front door (see `load_config`), so no sink and no
+        // `save_artifact` in the CLI consult's toolset.
+        artifacts: None,
     };
 
     match consult(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1022,6 +1022,33 @@ impl Default for CasConfig {
     }
 }
 
+/// `[artifacts]` — whether the inner model team may save what it writes.
+///
+/// **kaibo's first inverted capability, and deliberately so.** Every other tool switch is
+/// a `--no-<tool>` flag: on unless the operator turns it off. This one is off unless the
+/// operator turns it on, because it is the only surface where a *model* decides that
+/// bytes become durable. The default posture of a kaibo install stays exactly what it was
+/// before this existed.
+///
+/// It is one half of a two-key gate (Amy, 2026-08-05: "a code review consult has no
+/// business minting artifacts; the fuzzing job does"). This key is the operator's
+/// standing permission. The other is per call — `save_artifacts` on the `consult` tool —
+/// so enabling it here does not put the tool in front of every consult, only in front of
+/// the ones that asked. Both keys plus a live media CAS are required, and none of the
+/// three implies the others.
+///
+/// Precedence follows the usual ladder (per-call > CLI > env > file > built-in), with one
+/// difference worth naming: the CLI layer *enables* here where `--no-<tool>` only ever
+/// disables. That asymmetry is the inversion, not a hole — the file, the environment, and
+/// the command line are all the operator speaking, and the built-in default is the
+/// conservative end of the range rather than the permissive one.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ArtifactsConfig {
+    /// `[artifacts] enabled = true` / `KAIBO_ARTIFACTS_ENABLED` / `--allow-save-artifact`.
+    /// Default `false`.
+    pub enabled: bool,
+}
+
 /// Which media store a running server holds — the three-way state `kaibo://config`
 /// reports and `main` builds from. Derived in exactly one place
 /// ([`Config::cas_mode`]) so the store `main` constructs, the mode the resource
@@ -1120,6 +1147,9 @@ pub struct Config {
     pub persistence: PersistenceConfig,
     /// `[cas]` — where generated media artifacts land, and an optional size ceiling.
     pub cas: CasConfig,
+    /// `[artifacts]` — whether the inner model team may save what it writes. Off by
+    /// default; see [`ArtifactsConfig`].
+    pub artifacts: ArtifactsConfig,
     /// House-rules files spliced into each consultation tool's preamble (the
     /// `[context]` table). Defaults to reading `AGENTS.md` when present.
     pub context: ContextConfig,
@@ -1941,6 +1971,11 @@ impl Config {
         let telemetry = merge_telemetry(raw.telemetry.unwrap_or_default())?;
         let persistence = merge_persistence(raw.persistence.unwrap_or_default())?;
         let cas = merge_cas(raw.cas.unwrap_or_default())?;
+        // Inverted: absent means off. `unwrap_or(false)` is the whole merge, so it stays
+        // inline rather than earning a `merge_artifacts` that would only restate it.
+        let artifacts = ArtifactsConfig {
+            enabled: raw.artifacts.unwrap_or_default().enabled.unwrap_or(false),
+        };
         let context = merge_context(raw.context.unwrap_or_default())?;
         let prompts = merge_prompts(raw.prompts.unwrap_or_default())?;
         let orientation = merge_orientation(raw.orientation.unwrap_or_default())?;
@@ -1973,6 +2008,7 @@ impl Config {
             telemetry,
             persistence,
             cas,
+            artifacts,
             context,
             prompts,
             orientation,
@@ -2015,8 +2051,16 @@ impl Config {
         state_db: Option<PathBuf>,
         cas_dir: Option<PathBuf>,
         cas_max_bytes: Option<u64>,
+        allow_save_artifact: bool,
         max_attachments: Option<usize>,
     ) {
+        // The one flag here that ENABLES rather than narrows. `[artifacts] enabled`
+        // defaults off (see `ArtifactsConfig`), so a CLI layer that could only disable
+        // would have nothing to say; the file, the env, and the command line are all the
+        // operator, and the conservative end of this range is the built-in default.
+        if allow_save_artifact {
+            self.artifacts.enabled = true;
+        }
         if let Some(root) = root {
             self.root = Some(root);
         }
@@ -2336,6 +2380,7 @@ struct RawConfig {
     telemetry: Option<RawTelemetry>,
     persistence: Option<RawPersistence>,
     cas: Option<RawCas>,
+    artifacts: Option<RawArtifacts>,
     context: Option<RawContext>,
     prompts: Option<RawPrompts>,
     orientation: Option<RawOrientation>,
@@ -2383,6 +2428,14 @@ struct RawCas {
     /// per-environment rather than landing as a literal token.
     dir: Option<String>,
     max_bytes: Option<u64>,
+}
+
+/// `[artifacts]` as written in the file. `enabled` absent means **off** — the inverted
+/// default (see [`ArtifactsConfig`]). Env: `KAIBO_ARTIFACTS_ENABLED`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawArtifacts {
+    enabled: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -3200,6 +3253,19 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if let Some(v) = get("KAIBO_CAS_MAX_BYTES") {
         cas.max_bytes = Some(parse_env_int("KAIBO_CAS_MAX_BYTES", &v)?);
+    }
+
+    // save_artifact's operator key. Same on/off grammar as the `KAIBO_NO_*` flags, but it
+    // sets the parsed bool either way — like `KAIBO_TELEMETRY_ENABLED`, and unlike them,
+    // because this knob's built-in default is OFF, so an env layer that could only
+    // disable would have nothing to say.
+    let artifacts = raw.artifacts.get_or_insert_with(Default::default);
+    if let Some(v) = get("KAIBO_ARTIFACTS_ENABLED") {
+        let on = {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no"
+        };
+        artifacts.enabled = Some(on);
     }
     Ok(())
 }
@@ -5338,6 +5404,8 @@ mod tests {
         check("RawDefaults", serde_fields::<RawDefaults>());
         check("RawTelemetry", serde_fields::<RawTelemetry>());
         check("RawPersistence", serde_fields::<RawPersistence>());
+        check("RawCas", serde_fields::<RawCas>());
+        check("RawArtifacts", serde_fields::<RawArtifacts>());
         check("RawContext", serde_fields::<RawContext>());
         check("RawPrompts", serde_fields::<RawPrompts>());
         check("RawOrientation", serde_fields::<RawOrientation>());

--- a/src/config.rs
+++ b/src/config.rs
@@ -5421,5 +5421,26 @@ mod tests {
              never mentions: {missing:?} — add each knob to the template (a commented \
              default line is enough)"
         );
+
+        // The field-name check above has a blind spot, and `[artifacts]` found it: a
+        // whole NEW stanza whose only knob reuses a name another stanza already has
+        // (`enabled`, `path`, `dir`) passes while the template says nothing about the
+        // stanza at all. So also require each top-level section to appear as a HEADER —
+        // live or commented — which is what an operator actually scans for.
+        let section_missing: Vec<String> = serde_fields::<RawConfig>()
+            .into_iter()
+            .filter(|s| !undocumented.contains(&s.as_str()))
+            // `[section]` or a sub-table of it (`[kaish.ignore]`, `[backends.<name>]`):
+            // several stanzas only ever appear in their sub-tabled form.
+            .filter(|s| {
+                !template.contains(&format!("[{s}]")) && !template.contains(&format!("[{s}."))
+            })
+            .collect();
+        assert!(
+            section_missing.is_empty(),
+            "docs/config.example.toml never shows these stanzas as a section header: \
+             {section_missing:?} — an operator scans for `[section]`, so a knob \
+             documented only by its bare name is not documented"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3255,19 +3255,38 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
         cas.max_bytes = Some(parse_env_int("KAIBO_CAS_MAX_BYTES", &v)?);
     }
 
-    // save_artifact's operator key. Same on/off grammar as the `KAIBO_NO_*` flags, but it
-    // sets the parsed bool either way — like `KAIBO_TELEMETRY_ENABLED`, and unlike them,
-    // because this knob's built-in default is OFF, so an env layer that could only
-    // disable would have nothing to say.
+    // save_artifact's operator key. It sets the parsed bool either way (unlike the
+    // `KAIBO_NO_*` flags, which can only disable) because its built-in default is OFF, so
+    // a disable-only layer would have nothing to say — and it is parsed STRICTLY, unlike
+    // every other flag here. See `parse_strict_bool`.
     let artifacts = raw.artifacts.get_or_insert_with(Default::default);
     if let Some(v) = get("KAIBO_ARTIFACTS_ENABLED") {
-        let on = {
-            let v = v.trim().to_ascii_lowercase();
-            !v.is_empty() && v != "0" && v != "false" && v != "no"
-        };
-        artifacts.enabled = Some(on);
+        artifacts.enabled = Some(parse_strict_bool("KAIBO_ARTIFACTS_ENABLED", &v)?);
     }
     Ok(())
+}
+
+/// Parse a boolean env value that must not be guessed at: exactly `1`/`true`/`yes` or
+/// `0`/`false`/`no`, case-insensitive and trimmed. Anything else is a loud load error.
+///
+/// The rest of kaibo's env flags use a permissive convention — anything that is not empty,
+/// `0`, `false`, or `no` means on. That is fine for a knob whose enabled state is the safe
+/// one, and exactly wrong for `[artifacts] enabled`: under it, `KAIBO_ARTIFACTS_ENABLED=off`
+/// and `=disabled` both **enable** the one capability that lets a model make bytes
+/// durable, and so does any typo. An operator who wrote `off` meaning off would get the
+/// opposite of their intent, silently, with nothing about the running server saying so.
+/// Crash over that — a startup error naming the accepted spellings costs one restart, and
+/// the alternative costs the posture the flag exists to hold.
+fn parse_strict_bool(name: &str, raw: &str) -> Result<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" => Ok(true),
+        "0" | "false" | "no" => Ok(false),
+        other => bail!(
+            "{name}={other:?} is not a value kaibo will guess at. This flag decides \
+             whether the model team may write durable artifacts, so it accepts only \
+             1 / true / yes to enable, and 0 / false / no to disable."
+        ),
+    }
 }
 
 fn parse_env<T: std::str::FromStr>(name: &str, v: &str) -> Result<T>

--- a/src/consult/config.rs
+++ b/src/consult/config.rs
@@ -120,6 +120,19 @@ pub struct ConsultConfig {
     /// path lands under the consult's root and classifies by content before filling
     /// this. `Default` is empty.
     pub attachments: Vec<ConsultAttachment>,
+    /// Where the driver's `save_artifact` calls land, or `None` (the default) for no
+    /// such tool in the toolset at all.
+    ///
+    /// The server builds one sink per MCP call, and only when all three keys hold: the
+    /// operator enabled `[artifacts]`, this call asked with `save_artifacts`, and the
+    /// media CAS is live. `None` is byte-for-byte the pre-artifact consult.
+    ///
+    /// It rides **this** rung, not [`ExploreConfig`], and that placement is the
+    /// enforcement of "v1 is driver-loop only": a delegated `explore′` sweep is built
+    /// from the explore rung, which has no field to read, so a sweep cannot be handed
+    /// the tool by accident. `deliberate`'s dossier stage shares that rung and is
+    /// likewise out of reach.
+    pub artifacts: Option<Arc<crate::artifact::ArtifactSink>>,
 }
 
 impl Default for ConsultConfig {
@@ -128,6 +141,7 @@ impl Default for ConsultConfig {
             explore: ExploreConfig::default(),
             synth_max_turns: crate::config::Defaults::default().synth_max_turns,
             attachments: Vec::new(),
+            artifacts: None,
         }
     }
 }

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -2183,10 +2183,17 @@ pub(crate) async fn consult_session_turn(
     // the model's words uncorrupted (each front door renders warnings its own way). The
     // in-memory arm never errors, so today's default is byte-for-byte unchanged.
     if let Some((store, id)) = session {
-        if let Err(e) = store
-            .record(id, QaTurn::new(question, out.answer.clone()))
-            .await
-        {
+        // Record the answer WITH this call's artifact footer, not the bare answer. The
+        // digests are the only handle on bytes that outlive the call, and kaibo prunes
+        // nothing, so they need somewhere durable — and the session turn already sits in
+        // the state db beside the conversation that produced them, at no schema cost. A
+        // later turn replaying this thread then sees what it saved, which is the honest
+        // continuity too: the model asked for the artifact, so the thread should remember
+        // its address. This is the *persisted* view; the client's copy is rendered by the
+        // server, where warnings ride between the answer and the footer.
+        let recorded =
+            crate::artifact::with_artifacts(out.answer.clone(), cfg.artifacts.as_deref());
+        if let Err(e) = store.record(id, QaTurn::new(question, recorded)).await {
             tracing::warn!(
                 session = id,
                 error = %e,
@@ -6483,6 +6490,109 @@ mod tests {
         assert!(
             sink.saved().is_empty(),
             "nothing was saved in this run, so nothing is in the ledger"
+        );
+    }
+
+    /// **A consult that saves and then fails keeps the artifact.** The sink lives on the
+    /// call, not the loop, so a provider error on a later turn cannot unwrite bytes that
+    /// are already durable. This pins the half the engine owns; the server renders those
+    /// digests into the failure text (see `consultation_failure_text_with_artifacts`), and
+    /// without both halves a failed consult would silently orphan real content.
+    #[tokio::test]
+    async fn artifacts_saved_before_a_failure_survive_the_failure() {
+        const SYNTH: &str = "capable-synth";
+        const BODY: &str = "half the corpus\n";
+
+        let client = ScriptedClient::builder()
+            .on_model(SYNTH, |req| {
+                if !transcript_text(req).contains("kaibo://cas/") {
+                    Ok(tool_call_response(
+                        "t-save",
+                        "save_artifact",
+                        json!({ "label": "partial corpus", "content": BODY }),
+                    ))
+                } else {
+                    // Saved, then the provider falls over.
+                    Err(provider_error("overloaded_error"))
+                }
+            })
+            .on_model("cheap-explorer", |_r| Ok(text_response("unused")))
+            .build();
+
+        let dir = project_with_marker();
+        let (cfg, sink) = cfg_with_artifact_sink();
+        let err = consult_with(
+            "make a corpus",
+            dir.path(),
+            &arm(&client, "cheap-explorer"),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect_err("the scripted provider fails after the save");
+        assert!(
+            format!("{err:#}").contains("overloaded"),
+            "the failure is the provider's, got: {err:#}"
+        );
+
+        let saved = sink.saved();
+        assert_eq!(saved.len(), 1, "the save happened and stands");
+        assert_eq!(
+            saved[0].digest,
+            crate::cas::Digest::of_bytes(BODY.as_bytes()).to_hex()
+        );
+    }
+
+    /// **The answer recorded into a session carries the artifact footer.**
+    ///
+    /// The digests are the only handle on bytes that outlive the call, and kaibo ships no
+    /// GC, so where they get written down matters. The session turn is the natural place:
+    /// it already sits in the state db beside the conversation that produced them, needs
+    /// no schema, and a later turn replaying this thread sees what it saved. Recording the
+    /// bare answer instead would leave the db holding a conversation about artifacts whose
+    /// addresses it does not contain.
+    #[tokio::test]
+    async fn the_recorded_session_answer_carries_the_artifact_footer() {
+        const SYNTH: &str = "capable-synth";
+        const BODY: &str = "one\ntwo\nthree\n";
+
+        let client = ScriptedClient::builder()
+            .on_model(SYNTH, |req| {
+                if !transcript_text(req).contains("kaibo://cas/") {
+                    Ok(tool_call_response(
+                        "t-save",
+                        "save_artifact",
+                        json!({ "label": "the inventory", "content": BODY }),
+                    ))
+                } else {
+                    Ok(text_response("ANSWER: see the artifact."))
+                }
+            })
+            .on_model("cheap-explorer", |_r| Ok(text_response("unused")))
+            .build();
+
+        let dir = project_with_marker();
+        let (cfg, sink) = cfg_with_artifact_sink();
+        let sessions = store();
+        consult_session_turn(
+            Some((&sessions, "s-1")),
+            "make an inventory",
+            None,
+            dir.path(),
+            &arm(&client, "cheap-explorer"),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect("scripted consult should succeed");
+
+        let digest = sink.saved()[0].digest.clone();
+        let history = sessions.history("s-1").await.expect("session history");
+        assert_eq!(history.len(), 1, "one turn recorded");
+        assert!(
+            history[0].answer.contains(&format!("kaibo://cas/{digest}")),
+            "the persisted answer must carry the digest, got: {:?}",
+            history[0].answer
         );
     }
 

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -26,6 +26,7 @@ use rig_core::OneOrMany;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::artifact::SaveArtifact;
 use crate::attach::Attachment;
 use crate::completion_watch::{watched, CompletionLog, Watched};
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot};
@@ -1952,6 +1953,15 @@ fn consult_tools(
     // the explorer arm's caps, inside `explore`). Shares the driver's kernel.
     if synth.caps.vision {
         tools.push(traced(ViewImage::new(worker, root.to_path_buf())));
+    }
+    // save_artifact, when the server built a sink for this call (all three keys held:
+    // operator config, the caller's `save_artifacts`, a live media CAS). The DRIVER only
+    // — a delegated sweep builds its toolset in `run_explore_phase` from the explore
+    // rung, which carries no sink, so this cannot reach one. Every rebuild of this
+    // toolset (the main loop, the forced final turn) shares the one sink, so the
+    // per-call caps count the call rather than the turn.
+    if let Some(sink) = &cfg.artifacts {
+        tools.push(traced(SaveArtifact::new(Arc::clone(sink))));
     }
     Ok(tools)
 }
@@ -6358,6 +6368,182 @@ mod tests {
         assert!(
             seeing_names.iter().any(|n| n == "view_image"),
             "view_image present with vision, got {seeing_names:?}"
+        );
+    }
+
+    /// A `ConsultConfig` carrying an artifact sink over an in-memory store — the shape
+    /// the server builds when all three keys hold.
+    fn cfg_with_artifact_sink() -> (ConsultConfig, Arc<crate::artifact::ArtifactSink>) {
+        let sink = Arc::new(crate::artifact::ArtifactSink::new(
+            Arc::new(crate::cas::MediaStore::Memory(crate::cas::MemoryCas::new(
+                None,
+            ))),
+            crate::artifact::ArtifactAuthor {
+                prompt: "q".into(),
+                model: "synth-model".into(),
+                cast: "test".into(),
+                slot: "synth",
+                session: None,
+            },
+        ));
+        let cfg = ConsultConfig {
+            artifacts: Some(Arc::clone(&sink)),
+            ..ConsultConfig::default()
+        };
+        (cfg, sink)
+    }
+
+    /// `save_artifact` reaches the driver's toolset exactly when the server built a sink
+    /// for this call, and never otherwise. The `None` arm is the default posture of every
+    /// kaibo install — the tool does not exist, so a driver cannot call it whatever it
+    /// decides to try.
+    #[test]
+    fn save_artifact_is_in_the_driver_toolset_only_with_a_sink() {
+        let dir = tempdir().unwrap();
+        let client = ScriptedClient::builder().build();
+        let explorer = arm(&client, "explorer-model");
+        let synth = arm(&client, "synth-model");
+        let names = |cfg: &ConsultConfig| -> Vec<String> {
+            consult_tools(
+                &explorer,
+                dir.path(),
+                cfg,
+                Arc::new(Mutex::new(Vec::new())),
+                Arc::new(Mutex::new(Usage::new())),
+                &synth,
+            )
+            .expect("toolset builds")
+            .iter()
+            .map(|t| t.name().to_string())
+            .collect()
+        };
+
+        let without = names(&ConsultConfig::default());
+        assert!(
+            !without.iter().any(|n| n == "save_artifact"),
+            "no sink means no tool at all, got {without:?}"
+        );
+
+        let (cfg, _sink) = cfg_with_artifact_sink();
+        let with = names(&cfg);
+        assert!(
+            with.iter().any(|n| n == "save_artifact"),
+            "a sink puts the tool in the driver's toolset, got {with:?}"
+        );
+    }
+
+    /// **A delegated sweep never gets `save_artifact`.** v1 is driver-loop only, and the
+    /// placement enforces it: a sweep's toolset is built from the explore rung, which has
+    /// no sink to read. Driven end to end on a real nested sweep so this pins the
+    /// *running* toolset rather than a construction detail.
+    #[tokio::test]
+    async fn a_delegated_sweep_never_carries_save_artifact() {
+        const SYNTH: &str = "capable-synth";
+        const EXPLORER: &str = "cheap-explorer";
+        let client = ScriptedClient::builder()
+            .on_model(SYNTH, |req| {
+                assert!(
+                    has_tool(req, "save_artifact"),
+                    "the driver has the tool in this run, so the sweep's absence is a \
+                     real contrast: {:?}",
+                    req.tools
+                );
+                if !transcript_text(req).contains("SWEPT") {
+                    Ok(tool_call_response(
+                        "t1",
+                        "explore",
+                        json!({ "question": "what is here?" }),
+                    ))
+                } else {
+                    Ok(text_response("ANSWER"))
+                }
+            })
+            .on_model(EXPLORER, |req| {
+                assert!(
+                    !has_tool(req, "save_artifact"),
+                    "a delegated sweep must never be handed save_artifact: {:?}",
+                    req.tools
+                );
+                Ok(text_response("SWEPT: src/foo.rs:1"))
+            })
+            .build();
+
+        let dir = project_with_marker();
+        let (cfg, sink) = cfg_with_artifact_sink();
+        let out = consult_with(
+            "q",
+            dir.path(),
+            &arm(&client, EXPLORER),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect("scripted consult should succeed");
+        assert_eq!(out.answer, "ANSWER");
+        assert!(
+            sink.saved().is_empty(),
+            "nothing was saved in this run, so nothing is in the ledger"
+        );
+    }
+
+    /// The load-bearing offline e2e: a scripted driver calls `save_artifact` mid-loop,
+    /// the bytes land in the store under their own digest, and the caller's footer names
+    /// that digest by its resource URI. If the tool were wired into the toolset but its
+    /// results never reached the caller, this is what would catch it.
+    #[tokio::test]
+    async fn a_driver_that_saves_an_artifact_reports_it_in_the_callers_footer() {
+        const SYNTH: &str = "capable-synth";
+        const CORPUS: &str = "cat -n /etc/passwd\ngrep -rn foo .\n";
+
+        let client = ScriptedClient::builder()
+            .on_model(SYNTH, |req| {
+                if !transcript_text(req).contains("kaibo://cas/") {
+                    Ok(tool_call_response(
+                        "t-save",
+                        "save_artifact",
+                        json!({
+                            "label": "the fuzz corpus",
+                            "content": CORPUS,
+                            "format": "text",
+                        }),
+                    ))
+                } else {
+                    Ok(text_response("ANSWER: the corpus is in the artifact."))
+                }
+            })
+            .on_model("cheap-explorer", |_req| Ok(text_response("unused")))
+            .build();
+
+        let dir = project_with_marker();
+        let (cfg, sink) = cfg_with_artifact_sink();
+        let out = consult_with(
+            "generate a fuzz corpus",
+            dir.path(),
+            &arm(&client, "cheap-explorer"),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect("scripted consult should succeed");
+
+        let saved = sink.saved();
+        assert_eq!(saved.len(), 1, "one save_artifact call, one artifact");
+        assert_eq!(
+            saved[0].digest,
+            crate::cas::Digest::of_bytes(CORPUS.as_bytes()).to_hex(),
+            "the artifact is addressed by the content the model actually wrote"
+        );
+        assert_eq!(saved[0].label, "the fuzz corpus");
+
+        let delivered = crate::artifact::with_artifacts(out.answer, cfg.artifacts.as_deref());
+        assert!(delivered.starts_with("ANSWER:"), "the answer stays first");
+        assert!(
+            delivered.contains(&format!("kaibo://cas/{}", saved[0].digest)),
+            "the caller's footer must name the artifact's resource URI, got: {delivered}"
+        );
+        assert!(
+            delivered.contains("the fuzz corpus"),
+            "the footer carries the model's own label, got: {delivered}"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! store and the media CAS, refuse to resolve into any allowed tree) — and cannot
 //! shell out to external commands.
 
+pub mod artifact;
 pub mod attach;
 pub mod batch;
 pub mod cas;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
         common.state_db.clone(),
         common.cas_dir.clone(),
         common.cas_max_bytes,
+        gates.allow_save_artifact,
         common.max_attachments,
     );
 

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -95,6 +95,9 @@ pub(crate) fn render_config_resource(
         /// The media CAS: the on/off knob, the runtime mode (disk / memory / off),
         /// and where disk mode writes.
         cas: CasDoc,
+        /// `[artifacts]`: whether this server allows the model team to save artifacts.
+        /// Off by default; a call must also pass `save_artifacts`.
+        artifacts: ArtifactsDoc,
         /// alias → canonical backend name. Aliases are valid slot-ref prefixes
         /// and per-call backend overrides, so callers must be able to discover
         /// them here — built-in and file-declared both.
@@ -232,6 +235,17 @@ pub(crate) fn render_config_resource(
         dir: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         max_bytes: Option<u64>,
+    }
+
+    /// `[artifacts]` as resolved: may the inner model team save what it writes?
+    ///
+    /// Rendered even though it is one bool, because it is the only tool switch whose
+    /// default is OFF and the only one a *call* also has to ask for. Without it here, a
+    /// caller whose `save_artifacts` was refused has no way to see which of the two keys
+    /// this server is missing.
+    #[derive(Serialize)]
+    struct ArtifactsDoc {
+        enabled: bool,
     }
 
     #[derive(Serialize)]
@@ -616,6 +630,9 @@ pub(crate) fn render_config_resource(
             mode: cas_mode.as_str().to_string(),
             dir: config.cas.dir.as_ref().map(|p| p.display().to_string()),
             max_bytes: config.cas.max_bytes,
+        },
+        artifacts: ArtifactsDoc {
+            enabled: config.artifacts.enabled,
         },
         backend_aliases: config.backend_aliases().clone(),
         backends,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -69,7 +69,8 @@ pub(crate) use render::{
 };
 
 use render::{
-    append_warnings, batch_poll_brief, consult_result, consultation_failed, fmt_usage,
+    batch_poll_brief, consult_answer_text, consult_result, consultation_failed,
+    consultation_failed_with_artifacts, consultation_failure_text_with_artifacts, fmt_usage,
     is_batch_handle, parse_batch_handle, render_job, render_jobs_section, render_wait,
     wait_level_floor, wait_level_label,
 };
@@ -1720,7 +1721,16 @@ impl KaiboHandler {
             Ok(out) => out,
             // A provider/model-loop failure is a clean tool-result error the host can
             // proceed past, not a JSON-RPC internal_error. See `consultation_failed`.
-            Err(e) => return Ok(consultation_failed("consult", &cast.name, e)),
+            // Artifacts saved before the failure are named in the failure text too — they
+            // are durable either way, and a result without their digests orphans them.
+            Err(e) => {
+                return Ok(consultation_failed_with_artifacts(
+                    "consult",
+                    &cast.name,
+                    e,
+                    cfg.artifacts.as_deref(),
+                ))
+            }
         };
         progress.emit(PhaseEvent::PhaseFinished { phase: "consult" });
 
@@ -1730,11 +1740,10 @@ impl KaiboHandler {
         // Fold any non-fatal warnings (a failed session record) back into the answer
         // text before the footer — the MCP client has no structured warnings channel, so
         // it sees them inline exactly as #76 shipped (the CLI keeps them off `--json`).
-        let answer = with_provenance(
-            crate::artifact::with_artifacts(
-                append_warnings(out.answer, &out.warnings),
-                cfg.artifacts.as_deref(),
-            ),
+        let answer = consult_answer_text(
+            out.answer,
+            &out.warnings,
+            cfg.artifacts.as_deref(),
             &cast.name,
             &[("explorer", &explorer.model), ("synth", &synth.model)],
             &out.usage,
@@ -1860,11 +1869,10 @@ impl KaiboHandler {
             .await
             {
                 Ok(out) => {
-                    let answer = with_provenance(
-                        crate::artifact::with_artifacts(
-                            append_warnings(out.answer, &out.warnings),
-                            cfg.artifacts.as_deref(),
-                        ),
+                    let answer = consult_answer_text(
+                        out.answer,
+                        &out.warnings,
+                        cfg.artifacts.as_deref(),
                         &cast_name,
                         &[
                             ("explorer", explorer_model.as_str()),
@@ -1878,8 +1886,15 @@ impl KaiboHandler {
                     })
                 }
                 // Render the failure to its final text here (classification + guidance),
-                // so `job_get` wraps a ready string without re-deriving anything.
-                Err(e) => Err(consultation_failure_text("consult", &cast_name, e)),
+                // so `job_get` wraps a ready string without re-deriving anything — with
+                // any artifacts this job saved before failing named in it, since they are
+                // durable whether or not the answer arrived.
+                Err(e) => Err(consultation_failure_text_with_artifacts(
+                    "consult",
+                    &cast_name,
+                    e,
+                    cfg.artifacts.as_deref(),
+                )),
             }
         });
 
@@ -5107,7 +5122,12 @@ mod tests {
         let small = png(b"tiny");
         let big = png(&[7u8; 4096]);
         // A capped in-memory store: #1 fits, #2 breaches. Both mimes prevalidate.
-        let toml = format!("{MEDIA_CAST_TOML}\n[cas]\nmax_bytes = 64\n");
+        // The budget has to clear #1's content PLUS its provenance — memory-mode
+        // admission counts the serialized provenance it stores, the same footprint disk
+        // mode has always counted (a cap that ignored it meant two different things in
+        // the two modes). 2 KiB leaves room for one small artifact and its record, and
+        // none for a 4 KiB second.
+        let toml = format!("{MEDIA_CAST_TOML}\n[cas]\nmax_bytes = 2048\n");
         let h = hermetic_handler_from_toml(&toml).with_media_arms(Arc::new(ScriptedMediaArms(
             Arc::new(SyncArtifacts(vec![small.clone(), big])),
         )));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1264,10 +1264,30 @@ impl KaiboHandler {
             .map_err(|e| McpError::invalid_params(format!("{e} (in {uri})"), None))?;
         match store.get(&digest) {
             Ok(Some((bytes, ext))) => {
-                use base64::Engine as _;
-                let blob = base64::engine::general_purpose::STANDARD.encode(bytes);
+                // Textual formats come back as the string they are — the producer
+                // marked them (save_artifact writes UTF-8 text; the sidecar mime
+                // carries the mark), so a client fetching a corpus gets usable text,
+                // not base64 to decode. Bytes that fail to decode fall back to the
+                // blob form untouched: a lossy decode would serve different bytes
+                // than were stored, and the blob form is itself the honest "treat
+                // this as binary" signal.
+                let contents = if ext.is_textual() {
+                    match String::from_utf8(bytes) {
+                        Ok(text) => ResourceContents::text(text, uri).with_mime_type(ext.mime()),
+                        Err(e) => {
+                            use base64::Engine as _;
+                            let blob =
+                                base64::engine::general_purpose::STANDARD.encode(e.into_bytes());
+                            ResourceContents::blob(blob, uri).with_mime_type(ext.mime())
+                        }
+                    }
+                } else {
+                    use base64::Engine as _;
+                    let blob = base64::engine::general_purpose::STANDARD.encode(bytes);
+                    ResourceContents::blob(blob, uri).with_mime_type(ext.mime())
+                };
                 Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
-                    vec![ResourceContents::blob(blob, uri).with_mime_type(ext.mime())],
+                    vec![contents],
                 )))
             }
             Ok(None) => Err(McpError::resource_not_found(
@@ -5348,6 +5368,92 @@ enabled = false
         assert!(
             canceled.contains(&handle) && !canceled.contains("Consultation"),
             "the cancel ack names the job without calling it a consultation:\n{canceled}"
+        );
+    }
+
+    /// A minimal textual-artifact sidecar for driving the resource read directly.
+    fn textual_provenance() -> crate::cas::Provenance {
+        crate::cas::Provenance {
+            prompt: "q".to_string(),
+            model: "m".to_string(),
+            cast: "c".to_string(),
+            timestamp: 1,
+            mime: "text/plain; charset=utf-8".to_string(),
+            seed: None,
+            tool: Some("save_artifact".to_string()),
+            slot: Some("synth".to_string()),
+            label: Some("a test artifact".to_string()),
+            session: None,
+        }
+    }
+
+    /// A textual artifact reads back as **text**, not base64. The producers mark what
+    /// they make — `save_artifact` writes text formats, `generate` writes images — and
+    /// the sidecar mime carries that mark to retrieval, so a client fetching a corpus
+    /// gets the string it can use, not a blob it must decode first.
+    #[tokio::test]
+    async fn cas_resource_serves_textual_artifacts_as_text() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let store = h.media_store().expect("media CAS is on").clone();
+        let content = "line one\nline two\n";
+        let digest = store
+            .put(
+                content.as_bytes(),
+                crate::cas::Extension::Txt,
+                &textual_provenance(),
+            )
+            .expect("put succeeds");
+        let hex = digest.to_hex();
+        let uri = format!("kaibo://cas/{hex}");
+        let ReadResourceResponse::Complete(result) =
+            h.read_cas_resource(&hex, &uri).expect("stored digest reads")
+        else {
+            panic!("expected a complete read");
+        };
+        let ResourceContents::TextResourceContents {
+            text, mime_type, ..
+        } = &result.contents[0]
+        else {
+            panic!(
+                "a textual artifact reads as text, got {:?}",
+                result.contents[0]
+            );
+        };
+        assert_eq!(text, content);
+        assert_eq!(mime_type.as_deref(), Some("text/plain; charset=utf-8"));
+    }
+
+    /// Bytes under a textual extension that do not decode as UTF-8 fall back to a blob
+    /// — never a lossy decode that would hand back different bytes than were stored.
+    /// The blob form itself is the marking that says "treat this as binary"; the mime
+    /// still reports what the object claims to be.
+    #[tokio::test]
+    async fn cas_resource_falls_back_to_blob_for_undecodable_text() {
+        use base64::Engine as _;
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let store = h.media_store().expect("media CAS is on").clone();
+        let bytes: &[u8] = &[0x66, 0x6f, 0x6f, 0xff, 0xfe, 0x62, 0x61, 0x72];
+        let digest = store
+            .put(bytes, crate::cas::Extension::Txt, &textual_provenance())
+            .expect("put succeeds");
+        let hex = digest.to_hex();
+        let uri = format!("kaibo://cas/{hex}");
+        let ReadResourceResponse::Complete(result) =
+            h.read_cas_resource(&hex, &uri).expect("stored digest reads")
+        else {
+            panic!("expected a complete read");
+        };
+        let ResourceContents::BlobResourceContents { blob, .. } = &result.contents[0] else {
+            panic!(
+                "undecodable bytes read as a blob, got {:?}",
+                result.contents[0]
+            );
+        };
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(blob)
+                .expect("valid base64"),
+            bytes
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3885,15 +3885,23 @@ fn store_generated_artifacts(
         .iter()
         .enumerate()
         .map(|(i, artifact)| {
-            crate::cas::Extension::from_mime(&artifact.mime).ok_or_else(|| {
-                anyhow!(
-                    "artifact {} has mime {:?}, which the media store cannot name on \
-                     disk yet — refusing the whole result rather than storing it under \
-                     an invented extension; nothing was stored",
-                    i + 1,
-                    artifact.mime
-                )
-            })
+            // `is_image` and not merely "the store can name it": the store also names
+            // the text formats `save_artifact` writes, and an images provider handing
+            // back a text body is a provider fault, not an artifact. Keeping the
+            // refusal keyed to the media lane's own shape is what stopped growing
+            // `Extension` from quietly widening what `generate` accepts.
+            crate::cas::Extension::from_mime(&artifact.mime)
+                .filter(crate::cas::Extension::is_image)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "artifact {} has mime {:?}, which is not an image format the \
+                         media store can name on disk — refusing the whole result \
+                         rather than storing it under an invented extension; nothing \
+                         was stored",
+                        i + 1,
+                        artifact.mime
+                    )
+                })
         })
         .collect::<Result<_>>()?;
     let timestamp = now_epoch_secs();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -111,7 +111,7 @@ const TOOLS_URI: &str = "kaibo://tools";
 /// the inner model team never can — the CAS is not mounted into kaish and no
 /// cast-facing tool reads it, because kaibo state spans projects and a browsable CAS
 /// would let one project's team enumerate another's artifacts.
-const CAS_RES_PREFIX: &str = "kaibo://cas/";
+const CAS_RES_PREFIX: &str = crate::cas::CAS_URI_PREFIX;
 /// The RFC 6570 template `list_resource_templates` advertises for the CAS reads.
 const CAS_URI_TEMPLATE: &str = "kaibo://cas/{digest}";
 /// The system preambles kaibo hands each model-driven phase — explorer, consult
@@ -343,6 +343,12 @@ pub struct ConsultInput {
     /// the whole files a change touched. See `kaibo://tools`.
     #[serde(default)]
     pub attach: Vec<String>,
+
+    /// Let this consult save bulk output (a generated corpus, a long inventory) into
+    /// kaibo's artifact store instead of the answer; the answer names each
+    /// `kaibo://cas/<digest>` to read. Off by default, and the server must allow it.
+    #[serde(default)]
+    pub save_artifacts: bool,
 }
 
 /// Arguments to the `explore` tool: a single-phase explorer sweep. Explorer-only —
@@ -1527,6 +1533,64 @@ impl KaiboHandler {
         self.resolver.resolve_root(path)
     }
 
+    /// Build this call's [`ArtifactSink`], or refuse loudly.
+    ///
+    /// The two-key gate, resolved in one place so `consult` and `consult_submit` cannot
+    /// drift: the operator's standing permission (`[artifacts] enabled`), the caller's
+    /// per-call `save_artifacts`, and a live media CAS. All three, or no sink — and with
+    /// no sink there is no `save_artifact` in the driver's toolset at all.
+    ///
+    /// A caller that asked and cannot be served gets an **error**, never a quiet consult
+    /// with no artifacts in it. The request is explicit, so a silently-dropped capability
+    /// would leave the caller reading an answer that swallowed the bulk it asked to have
+    /// stored, with nothing saying why. The message names which key is missing and where
+    /// to turn it on.
+    fn artifact_sink(
+        &self,
+        asked: bool,
+        question: &str,
+        session: Option<&str>,
+        cast: &str,
+        synth_model: &str,
+    ) -> Result<Option<Arc<crate::artifact::ArtifactSink>>, McpError> {
+        if !asked {
+            return Ok(None);
+        }
+        if !self.config.artifacts.enabled {
+            return Err(McpError::invalid_params(
+                "`save_artifacts` was requested, but this kaibo does not allow the model \
+                 team to save artifacts. An operator enables it with `[artifacts] enabled \
+                 = true` in config.toml, `KAIBO_ARTIFACTS_ENABLED=1`, or \
+                 `--allow-save-artifact`, then reconnects. Re-run without \
+                 `save_artifacts` to get the answer inline."
+                    .to_string(),
+                None,
+            ));
+        }
+        let Some(store) = self.media_cas.clone() else {
+            return Err(McpError::invalid_params(
+                "`save_artifacts` was requested, but the media CAS is off ([cas] enabled \
+                 = false), so a saved artifact would have nowhere to land. Re-enable the \
+                 CAS and reconnect, or re-run without `save_artifacts`."
+                    .to_string(),
+                None,
+            ));
+        };
+        Ok(Some(Arc::new(crate::artifact::ArtifactSink::new(
+            store,
+            crate::artifact::ArtifactAuthor {
+                prompt: question.to_string(),
+                model: synth_model.to_string(),
+                cast: cast.to_string(),
+                // Only the consult DRIVER loop carries the tool, and that loop runs on
+                // the synth arm. A sweep's sub-agent cannot reach a sink (see
+                // `ConsultConfig::artifacts`), so there is no other slot to record.
+                slot: "synth",
+                session: session.map(str::to_string),
+            },
+        ))))
+    }
+
     /// Shim over [`Resolver::resolve_attachments`].
     pub async fn resolve_attachments(
         &self,
@@ -1614,6 +1678,13 @@ impl KaiboHandler {
             },
             synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
             attachments,
+            artifacts: self.artifact_sink(
+                input.save_artifacts,
+                &input.question,
+                input.session_id.as_deref(),
+                &cast.name,
+                &synth.model,
+            )?,
         };
 
         // Multi-turn: a session_id binds this turn to a thread (replay prior turns,
@@ -1660,7 +1731,10 @@ impl KaiboHandler {
         // text before the footer — the MCP client has no structured warnings channel, so
         // it sees them inline exactly as #76 shipped (the CLI keeps them off `--json`).
         let answer = with_provenance(
-            append_warnings(out.answer, &out.warnings),
+            crate::artifact::with_artifacts(
+                append_warnings(out.answer, &out.warnings),
+                cfg.artifacts.as_deref(),
+            ),
             &cast.name,
             &[("explorer", &explorer.model), ("synth", &synth.model)],
             &out.usage,
@@ -1745,6 +1819,17 @@ impl KaiboHandler {
             },
             synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
             attachments,
+            // Same two-key gate as the sync lane, and refused here for the same reason —
+            // synchronously, before a job exists, so a caller asking for something this
+            // server cannot do gets a clean error rather than a handle that comes back
+            // missing the artifacts it asked for.
+            artifacts: self.artifact_sink(
+                input.save_artifacts,
+                &input.question,
+                input.session_id.as_deref(),
+                &cast.name,
+                &synth.model,
+            )?,
         };
 
         // Owned captures for the `'static` spawned task. The session store is `Clone`
@@ -1776,7 +1861,10 @@ impl KaiboHandler {
             {
                 Ok(out) => {
                     let answer = with_provenance(
-                        append_warnings(out.answer, &out.warnings),
+                        crate::artifact::with_artifacts(
+                            append_warnings(out.answer, &out.warnings),
+                            cfg.artifacts.as_deref(),
+                        ),
                         &cast_name,
                         &[
                             ("explorer", explorer_model.as_str()),
@@ -3919,6 +4007,13 @@ fn store_generated_artifacts(
             timestamp,
             mime: artifact.mime.clone(),
             seed: artifact.seed.clone(),
+            // A provider rendered these bytes; no model on kaibo's team authored them,
+            // so the authorship fields stay absent and the sidecar keeps the shape it
+            // has always had apart from naming its producer.
+            tool: Some("generate".to_string()),
+            slot: None,
+            label: None,
+            session: None,
         };
         let digest =
             store
@@ -4506,6 +4601,87 @@ mod tests {
             None
         })
         .expect("handler builds")
+    }
+
+    /// **The two-key gate on `save_artifact`, all four combinations.**
+    ///
+    /// A sink exists only when the operator enabled `[artifacts]`, the call passed
+    /// `save_artifacts`, and the media CAS is live. No sink means the tool is not in the
+    /// driver's toolset at all (`ConsultConfig::artifacts` is what `consult_tools` reads),
+    /// so this is the whole gate — there is no second place it could leak through.
+    ///
+    /// A caller that asked and cannot be served gets a refusal naming which key is
+    /// missing, never a quiet consult that swallowed the bulk it was told to store.
+    #[test]
+    fn save_artifact_needs_the_operator_key_the_call_key_and_a_live_cas() {
+        let ask = |save_artifacts: bool| ConsultInput {
+            question: "q".into(),
+            context: None,
+            path: None,
+            cast: None,
+            explorer_model: None,
+            explorer_backend: None,
+            synth_model: None,
+            synth_backend: None,
+            session_id: Some("sess-1".into()),
+            explorer_max_turns: None,
+            synth_max_turns: None,
+            include_report: false,
+            attach: Vec::new(),
+            save_artifacts,
+        };
+        let sink = |h: &KaiboHandler, input: &ConsultInput| {
+            h.artifact_sink(
+                input.save_artifacts,
+                &input.question,
+                input.session_id.as_deref(),
+                "deepseek",
+                "deepseek/deepseek-v4-pro",
+            )
+        };
+
+        // Operator key OFF (the default posture of every kaibo install).
+        let off = handler();
+        assert!(
+            sink(&off, &ask(false))
+                .expect("not asking is never an error")
+                .is_none(),
+            "no key asked, no sink"
+        );
+        let err = sink(&off, &ask(true)).expect_err("asking for a disabled capability must refuse");
+        assert!(
+            err.message.contains("[artifacts] enabled")
+                && err.message.contains("--allow-save-artifact"),
+            "the refusal names how an operator turns it on: {}",
+            err.message
+        );
+
+        // Operator key ON, call key OFF: still no sink, and no error — the caller asked
+        // for nothing.
+        let on = handler_from_toml("[artifacts]\nenabled = true\n");
+        assert!(
+            sink(&on, &ask(false))
+                .expect("not asking is never an error")
+                .is_none(),
+            "the operator's permission is standing, not automatic"
+        );
+
+        // Both keys, CAS live: a sink.
+        assert!(
+            sink(&on, &ask(true))
+                .expect("both keys and a live CAS")
+                .is_some(),
+            "all three conditions hold, so the driver gets the tool"
+        );
+
+        // Both keys, CAS off: refused, naming the CAS rather than the artifacts flag.
+        let no_cas = handler_from_toml("[artifacts]\nenabled = true\n\n[cas]\nenabled = false\n");
+        let err = sink(&no_cas, &ask(true)).expect_err("no store means no artifact");
+        assert!(
+            err.message.contains("[cas] enabled = false"),
+            "the refusal names the missing key precisely: {}",
+            err.message
+        );
     }
 
     /// The media-CAS lifecycle on the handler: `new` seeds the in-memory store when

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -137,6 +137,61 @@ pub(super) fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) ->
     ))])
 }
 
+/// [`consultation_failed`] for a consult that may have saved artifacts before it failed:
+/// the same classified failure text, with this call's artifact footer appended.
+///
+/// A consult can save durably and *then* fail — a provider error on a later turn, an
+/// empty final answer, a wall-clock deadline. The bytes are already in the store, so a
+/// failure result carrying no digests orphans them: the caller has no address to read
+/// and, kaibo shipping no GC, no way back to them short of walking the store by hand.
+/// The artifacts are real whether or not the answer arrived, so they are reported either
+/// way. `None`, or a sink nothing was saved through, leaves the text byte-for-byte
+/// [`consultation_failed`]'s.
+pub(super) fn consultation_failed_with_artifacts(
+    tool: &str,
+    cast: &str,
+    err: anyhow::Error,
+    sink: Option<&crate::artifact::ArtifactSink>,
+) -> CallToolResult {
+    CallToolResult::error(vec![ContentBlock::text(
+        consultation_failure_text_with_artifacts(tool, cast, err, sink),
+    )])
+}
+
+/// [`consultation_failure_text`] plus this call's artifact footer — the text half of
+/// [`consultation_failed_with_artifacts`], split out so the deferred lane
+/// (`consult_submit`, which stores a ready string in a failed job) composes it the same
+/// way rather than by hand.
+pub(crate) fn consultation_failure_text_with_artifacts(
+    tool: &str,
+    cast: &str,
+    err: anyhow::Error,
+    sink: Option<&crate::artifact::ArtifactSink>,
+) -> String {
+    crate::artifact::with_artifacts(consultation_failure_text(tool, cast, err), sink)
+}
+
+/// The final answer text for a completed consult, composed once for both lanes.
+///
+/// Order is the contract, and it is why this is a function rather than two call sites:
+/// the model's answer, then any non-fatal warnings (a failed session record — kept out of
+/// the answer body so a machine consumer gets the model's words uncorrupted), then this
+/// call's artifact footer, then the provenance line naming the cast and models. The sync
+/// `consult` and the deferred `consult_submit` must produce the same shape, and a lane
+/// that quietly dropped the footer would strand durably-written artifacts.
+pub(crate) fn consult_answer_text(
+    answer: String,
+    warnings: &[String],
+    sink: Option<&crate::artifact::ArtifactSink>,
+    cast: &str,
+    models: &[(&str, &str)],
+    usage: &rig_core::completion::Usage,
+) -> String {
+    let with_warnings = append_warnings(answer, warnings);
+    let with_footer = crate::artifact::with_artifacts(with_warnings, sink);
+    with_provenance(with_footer, cast, models, usage)
+}
+
 /// The rendered failure text (detail + classified guidance) for a consultation that
 /// errored — the body of [`consultation_failed`], split out so the async path
 /// ([`consult_submit`]) can store a ready string in a [`JobState::Failed`] and the
@@ -629,6 +684,99 @@ mod tests {
 
     /// The text channel of a result (the answer). Panics if it isn't a single
     /// text block, which is the only shape `consult_result` produces.
+    /// A sink with one artifact already saved — a call that reached the store before
+    /// whatever happened next.
+    fn populated_sink() -> crate::artifact::ArtifactSink {
+        let sink = crate::artifact::ArtifactSink::new(
+            std::sync::Arc::new(crate::cas::MediaStore::Memory(crate::cas::MemoryCas::new(
+                None,
+            ))),
+            crate::artifact::ArtifactAuthor {
+                prompt: "q".into(),
+                model: "m".into(),
+                cast: "c".into(),
+                slot: "synth",
+                session: None,
+            },
+        );
+        sink.save("the corpus", "one\ntwo\n", None)
+            .expect("the save lands");
+        sink
+    }
+
+    /// **A failed consult still names what it saved.** A consult can write durably and
+    /// then fail — a provider error on a later turn, an empty answer, a deadline. The
+    /// bytes are in the store either way, and kaibo prunes nothing, so a failure result
+    /// carrying no digests leaves the caller with content it cannot address and no way
+    /// back to it. Both lanes compose their failure text through this one function.
+    #[test]
+    fn a_failure_text_carries_the_artifacts_the_call_saved() {
+        let sink = populated_sink();
+        let digest = sink.saved()[0].digest.clone();
+        let text = consultation_failure_text_with_artifacts(
+            "consult",
+            "deepseek",
+            anyhow::anyhow!("model loop failed: ProviderError: overloaded_error"),
+            Some(&sink),
+        );
+        assert!(
+            text.contains("overloaded_error"),
+            "the failure detail survives: {text}"
+        );
+        assert!(
+            text.contains(&format!("kaibo://cas/{digest}")),
+            "and so does the address of what was already written: {text}"
+        );
+        assert!(text.contains("the corpus"), "with its label: {text}");
+
+        // Nothing saved (or no sink at all) leaves the text exactly as it was.
+        let plain = consultation_failure_text(
+            "consult",
+            "deepseek",
+            anyhow::anyhow!("model loop failed: ProviderError: overloaded_error"),
+        );
+        assert_eq!(
+            consultation_failure_text_with_artifacts(
+                "consult",
+                "deepseek",
+                anyhow::anyhow!("model loop failed: ProviderError: overloaded_error"),
+                None,
+            ),
+            plain
+        );
+    }
+
+    /// **Both consult lanes compose the same answer.** The sync tool and the deferred job
+    /// used to build their final text separately, which is exactly how one of them ends up
+    /// dropping the artifact footer and stranding durably-written content. One function,
+    /// one order: answer, then warnings, then artifacts, then provenance.
+    #[test]
+    fn the_shared_answer_render_orders_answer_warnings_artifacts_then_provenance() {
+        let sink = populated_sink();
+        let digest = sink.saved()[0].digest.clone();
+        let text = consult_answer_text(
+            "ANSWER BODY".into(),
+            &["a warning".to_string()],
+            Some(&sink),
+            "deepseek",
+            &[("synth", "deepseek-v4-pro")],
+            &rig_core::completion::Usage::new(),
+        );
+        let at = |needle: &str| {
+            text.find(needle)
+                .unwrap_or_else(|| panic!("{needle:?} must appear in: {text}"))
+        };
+        assert!(at("ANSWER BODY") < at("a warning"), "answer first: {text}");
+        assert!(
+            at("a warning") < at(&format!("kaibo://cas/{digest}")),
+            "warnings before the artifact footer: {text}"
+        );
+        assert!(
+            at(&format!("kaibo://cas/{digest}")) < at("deepseek-v4-pro"),
+            "and the provenance line last: {text}"
+        );
+    }
+
     fn answer_text(result: &CallToolResult) -> String {
         assert_eq!(
             result.content.len(),

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -511,22 +511,53 @@ fn soft_cap_refuses_a_write_that_would_exceed_it() {
     assert_eq!(cas.get(&rejected_digest).unwrap(), None);
 }
 
-/// A dedup write of content already on disk must not be penalized by the cap check just
-/// because a naive "current + incoming" sum would look like it exceeds — it adds no bytes.
+/// **A full store refuses a dedup exactly as it refuses a new write, and that inversion
+/// is deliberate.**
+///
+/// This test used to pin the opposite — a dedup write was *exempt* from the cap, on the
+/// reasoning that re-putting held content adds no bytes so a naive `current + incoming`
+/// sum shouldn't penalize it. That reasoning is sound about disk usage and wrong about
+/// disclosure, and `save_artifact` is what made it matter: once a *model* can drive puts,
+/// "succeeded" versus "CapacityExceeded" at a full store answers **is this content
+/// already in the store?** for arbitrary bytes. The CAS spans every project this kaibo
+/// has ever served, so that is an existence oracle over other projects' artifacts,
+/// readable by a model whose prompt an untrusted repository can influence.
+///
+/// The cure is to make the admission decision independent of what the store already
+/// holds: when a cap is configured, every put computes the same admission, so a full
+/// store is uniformly closed. The cost is the exempted case — re-putting held content at
+/// exactly-full — which is a wasted no-op write, not lost data (the object is still
+/// there, still readable). Trading that for a closed oracle is the right way round.
 #[test]
-fn soft_cap_does_not_block_a_dedup_write_of_existing_content() {
+fn soft_cap_refuses_a_dedup_write_indistinguishably_from_a_new_one() {
     // Budget for exactly one footprint (object + sidecar): zero slack afterwards.
-    let bytes = vec![7u8; 10];
+    let held = vec![7u8; 10];
     let (probe, probe_dir) = open_uncapped();
-    probe.put(&bytes, Extension::Gif, &prov()).unwrap();
+    probe.put(&held, Extension::Gif, &prov()).unwrap();
     let budget = dir_size(&probe_dir.path().join("cas"));
 
     let (cas, _d) = open(budget);
-    let d1 = cas.put(&bytes, Extension::Gif, &prov()).unwrap();
-    // Re-putting the identical bytes must still succeed even though the cap has no slack
-    // left for "new" bytes — it isn't new, it's the same object.
-    let d2 = cas.put(&bytes, Extension::Gif, &prov()).unwrap();
-    assert_eq!(d1, d2);
+    let d1 = cas.put(&held, Extension::Gif, &prov()).unwrap();
+
+    // The oracle probe: at a full store, ask for content the store HAS and content it
+    // does NOT. Both must come back the same kind of refusal — an attacker learns
+    // nothing about which was which.
+    let absent = vec![9u8; 10];
+    let held_again = cas.put(&held, Extension::Gif, &prov());
+    let fresh = cas.put(&absent, Extension::Gif, &prov());
+    for (what, result) in [("already-held", held_again), ("absent", fresh)] {
+        match result {
+            Err(CasError::CapacityExceeded { .. }) => {}
+            other => panic!(
+                "a full store must refuse {what} content the same way, got {other:?} — \
+                 a difference here is an existence oracle"
+            ),
+        }
+    }
+
+    // And nothing was evicted or lost to the refusal: the held object is still readable.
+    assert_eq!(cas.get(&d1).unwrap(), Some(held));
+    assert_eq!(cas.get(&Digest::of_bytes(&absent)).unwrap(), None);
 }
 
 // --- MemoryCas: same contract, no filesystem ---------------------------------
@@ -562,20 +593,67 @@ fn memory_cas_dedup_returns_the_same_digest() {
     assert_eq!(d1, d2);
 }
 
-/// The soft cap keeps its meaning in memory: refuse loudly, never evict — and a
-/// dedup write of held content is exempt, exactly as on disk.
+/// The soft cap keeps its meaning in memory: refuse loudly, never evict. The *meaning* of
+/// the knob must not change with the mode, and neither must its disclosure behavior — see
+/// the disk twin, `soft_cap_refuses_a_dedup_write_indistinguishably_from_a_new_one`, for
+/// why a dedup at a full store is no longer exempt.
 #[test]
 fn memory_cas_cap_refuses_loudly_and_never_evicts() {
-    let mem = MemoryCas::new(Some(10));
+    // Room for one small object plus its serialized provenance, and no more.
     let first = vec![1u8; 8];
+    let budget = 8 + serde_json::to_vec_pretty(&prov()).unwrap().len() as u64;
+    let mem = MemoryCas::new(Some(budget));
     let d1 = mem.put(&first, Extension::Png, &prov()).unwrap();
     match mem.put(&[2u8; 100], Extension::Png, &prov()) {
-        Err(CasError::CapacityExceeded { max_bytes: 10, .. }) => {}
+        Err(CasError::CapacityExceeded { .. }) => {}
         other => panic!("a write past the cap must be refused, got {other:?}"),
     }
-    // Never evicts, and the dedup write of the held object still succeeds with no slack.
+    // Never evicts: the held object survives the refusal.
     assert_eq!(mem.get(&d1).map(|(b, _)| b), Some(first.clone()));
-    assert_eq!(mem.put(&first, Extension::Png, &prov()).unwrap(), d1);
+
+    // And the oracle stays closed in memory mode too: held and absent content at a full
+    // store are refused the same way.
+    let absent = vec![3u8; 8];
+    for (what, result) in [
+        ("already-held", mem.put(&first, Extension::Png, &prov())),
+        ("absent", mem.put(&absent, Extension::Png, &prov())),
+    ] {
+        match result {
+            Err(CasError::CapacityExceeded { .. }) => {}
+            other => panic!(
+                "a full memory store must refuse {what} content the same way, got \
+                 {other:?} — a difference here is an existence oracle"
+            ),
+        }
+    }
+}
+
+/// **Memory admission counts the provenance it stores.** `MemoryCas` holds a `Provenance`
+/// clone beside every object, so counting only content bytes understates the store's real
+/// footprint and lets a capped memory store hold more than the operator asked for. Disk
+/// admission has always counted the serialized sidecar; memory now counts the same
+/// representation, so one `max_bytes` means the same thing in both modes.
+#[test]
+fn memory_cap_admission_counts_the_provenance_sidecar() {
+    let body = vec![5u8; 16];
+    let sidecar = serde_json::to_vec_pretty(&prov()).unwrap().len() as u64;
+
+    // Exactly enough for content + sidecar: admitted.
+    let exact = MemoryCas::new(Some(16 + sidecar));
+    exact
+        .put(&body, Extension::Png, &prov())
+        .expect("content plus its provenance fits exactly");
+
+    // One byte short of that: refused. Under the old accounting this fit, because the
+    // provenance it stores was invisible to the check.
+    let short = MemoryCas::new(Some(16 + sidecar - 1));
+    match short.put(&body, Extension::Png, &prov()) {
+        Err(CasError::CapacityExceeded { .. }) => {}
+        other => panic!(
+            "the provenance is part of what memory mode stores, so it must be part of \
+             what the cap admits, got {other:?}"
+        ),
+    }
 }
 
 // --- MediaStore: one seam over both modes ------------------------------------
@@ -627,6 +705,64 @@ fn extension_maps_mimes_both_ways_and_refuses_unknown() {
     );
     assert_eq!(Extension::from_mime("audio/mpeg"), None);
     assert_eq!(Extension::from_mime("model/gltf-binary"), None);
+}
+
+/// **An object that landed while its sidecar failed must say so, and must name the
+/// digest.** `put` writes the object first and the provenance second, so an I/O failure
+/// between them leaves bytes durably stored and retrievable (the probe fallback finds a
+/// sidecar-less object) while the call returns `Err`. A caller told only "it failed" then
+/// reports "nothing was saved" about content that is, in fact, saved — and the digest is
+/// the one thing that makes it reachable again, so the error has to carry it.
+///
+/// Driven by making the shard directory read-only with the object already in place: the
+/// object write is a no-op dedup, and the sidecar's `create_new` gets EACCES.
+#[test]
+#[cfg(unix)]
+fn an_object_that_landed_without_its_sidecar_reports_the_digest() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (cas, _d) = open_uncapped();
+    let bytes = b"the object lands, the sidecar does not".to_vec();
+    let digest = Digest::of_bytes(&bytes);
+
+    // Place the object by hand, then close the shard to new files.
+    let shard = object_path(cas.root(), &digest, "txt");
+    let shard_dir = shard.parent().unwrap().to_path_buf();
+    std::fs::create_dir_all(&shard_dir).unwrap();
+    std::fs::write(&shard, &bytes).unwrap();
+    std::fs::set_permissions(&shard_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    // Root (or CAP_DAC_OVERRIDE) ignores the mode bits, so the premise wouldn't hold —
+    // detect it the way `get_surfaces_io_error_for_unreadable_existing_object` does,
+    // before drawing any conclusion from the result.
+    let can_write_anyway = std::fs::write(shard_dir.join("probe"), b"x").is_ok();
+
+    let result = cas.put(&bytes, Extension::Txt, &prov_mime(Extension::Txt.mime()));
+    let _ = std::fs::set_permissions(&shard_dir, std::fs::Permissions::from_mode(0o755));
+
+    if can_write_anyway {
+        eprintln!(
+            "skipping: this process can write into a 0o500 directory (likely running as \
+             root) — cannot exercise a sidecar-write failure here"
+        );
+        return;
+    }
+
+    match result {
+        Err(CasError::ProvenanceNotRecorded { digest: hex, .. }) => {
+            assert_eq!(
+                hex,
+                digest.to_hex(),
+                "the error must name the address the bytes are actually reachable at"
+            );
+        }
+        other => panic!(
+            "an object that landed without its sidecar must be its own error kind \
+             carrying the digest, got {other:?}"
+        ),
+    }
+    // And the claim is true: the bytes really are retrievable at that digest.
+    assert_eq!(cas.get(&digest).unwrap(), Some(bytes));
 }
 
 // --- Lookup: the sidecar's mime is the authority ------------------------------

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -624,6 +624,131 @@ fn extension_maps_mimes_both_ways_and_refuses_unknown() {
     assert_eq!(Extension::from_mime("model/gltf-binary"), None);
 }
 
+// --- Lookup: the sidecar's mime is the authority ------------------------------
+
+/// A provenance sidecar recording `mime`, everything else fixed — the shape
+/// `store_generated_artifacts` writes (the sidecar's mime always describes the object
+/// stored beside it).
+fn prov_mime(mime: &str) -> Provenance {
+    Provenance {
+        mime: mime.into(),
+        ..prov()
+    }
+}
+
+/// The shard path a digest's object would live at, computed the way `Cas` does — so a
+/// test can build (or inspect) a store layout by hand.
+fn object_path(root: &Path, digest: &Digest, ext: &str) -> PathBuf {
+    let hex = digest.to_hex();
+    root.join(&hex[0..2])
+        .join(&hex[2..4])
+        .join(format!("{hex}.{ext}"))
+}
+
+/// **The lookup reads the sidecar, not a probe order.** One content can legitimately be
+/// stored under two container formats (the address is the *content* hash, so the second
+/// put lands at the same digest), and the sidecar written with the first put is the
+/// record of what this object actually is. A probe that walks `Extension::ALL` in
+/// declaration order answers with whichever variant it happens to try first, which is a
+/// mislabel the `kaibo://cas/<digest>` resource then stamps onto the bytes.
+///
+/// Stored webp-first, png-second: probe order says PNG, the recorded provenance says
+/// WEBP. The recorded provenance wins.
+#[test]
+fn lookup_reports_the_extension_the_sidecar_recorded_not_the_probe_order() {
+    let (cas, _dir) = open_uncapped();
+    let bytes = b"one content, two container names".to_vec();
+
+    cas.put(&bytes, Extension::Webp, &prov_mime("image/webp"))
+        .expect("first put records the sidecar");
+    let digest = cas
+        .put(&bytes, Extension::Png, &prov_mime("image/png"))
+        .expect("second put is a verified dedup at the same address");
+
+    let (path, ext) = cas.entry_for(&digest).expect("the object is findable");
+    assert_eq!(
+        ext,
+        Extension::Webp,
+        "the sidecar recorded image/webp, so that is what this object IS — got {ext:?}"
+    );
+    assert!(
+        path.extension().is_some_and(|e| e == "webp"),
+        "the located path must be the object the sidecar describes, got {}",
+        path.display()
+    );
+}
+
+/// The fallback that keeps a decade-old store readable: an object with **no sidecar**
+/// beside it (the crash window between the object write and the sidecar write is real —
+/// see `write_new_file`'s fsync note) still resolves by probing the container formats.
+/// Making the sidecar the authority must not make it a *requirement*.
+#[test]
+fn an_object_with_no_sidecar_still_resolves_by_probe() {
+    let (cas, _dir) = open_uncapped();
+    let bytes = b"orphaned object, sidecar never landed".to_vec();
+    let digest = Digest::of_bytes(&bytes);
+    let path = object_path(cas.root(), &digest, "jpeg");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, &bytes).unwrap();
+
+    let (found, ext) = cas
+        .entry_for(&digest)
+        .expect("a sidecar-less object must still be findable");
+    assert_eq!(found, path);
+    assert_eq!(ext, Extension::Jpeg);
+    assert_eq!(cas.get(&digest).unwrap(), Some(bytes));
+}
+
+/// A sidecar whose `mime` the store cannot name on disk (an older kaibo, a
+/// hand-edited file) falls back to the probe rather than reporting the object missing.
+/// Losing a paid-for artifact to an unrecognized metadata string would be the exact
+/// silent-data-loss shape this store refuses.
+#[test]
+fn an_unmappable_sidecar_mime_falls_back_to_the_probe() {
+    let (cas, _dir) = open_uncapped();
+    let bytes = b"stored under a mime this kaibo does not know".to_vec();
+    let digest = Digest::of_bytes(&bytes);
+    let shard = object_path(cas.root(), &digest, "png");
+    std::fs::create_dir_all(shard.parent().unwrap()).unwrap();
+    std::fs::write(&shard, &bytes).unwrap();
+    std::fs::write(
+        shard.with_extension("json"),
+        serde_json::to_vec(&prov_mime("application/octet-stream")).unwrap(),
+    )
+    .unwrap();
+
+    let (_, ext) = cas
+        .entry_for(&digest)
+        .expect("an unmappable sidecar mime must not hide the object");
+    assert_eq!(ext, Extension::Png);
+}
+
+/// The text formats round-trip through the same address-is-the-content contract the
+/// images do: put bytes under a text container, read them back by digest, and get the
+/// format the sidecar recorded. This is what the sidecar-as-authority change bought —
+/// a lookup that answers correctly for a format declared after the image set.
+#[test]
+fn text_and_jsonl_artifacts_round_trip_by_digest() {
+    let (cas, _dir) = open_uncapped();
+    for (ext, body) in [
+        (
+            Extension::Txt,
+            "a model-authored report\n".as_bytes().to_vec(),
+        ),
+        (
+            Extension::Jsonl,
+            "{\"a\":1}\n{\"a\":2}\n".as_bytes().to_vec(),
+        ),
+    ] {
+        let digest = cas.put(&body, ext, &prov_mime(ext.mime())).expect("put");
+        assert_eq!(cas.get(&digest).unwrap(), Some(body.clone()));
+        let (path, found) = cas.entry_for(&digest).expect("findable by digest");
+        assert_eq!(found, ext);
+        assert!(path.extension().is_some_and(|e| e == ext.as_str()));
+        assert!(!ext.is_image(), "authored text is not a rendered image");
+    }
+}
+
 // --- or-gpt review follow-ups (2026-08-03) ------------------------------------
 
 /// Sum of every file under `dir`, recursively — the store's true on-disk footprint.

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -20,6 +20,11 @@ fn prov() -> Provenance {
         timestamp: 1_753_000_000,
         mime: "image/png".into(),
         seed: Some("9259671".into()),
+        // A provider render: the tool that produced it, and no author.
+        tool: Some("generate".into()),
+        slot: None,
+        label: None,
+        session: None,
     }
 }
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -940,6 +940,7 @@ fn cli_cast_wins_over_env_and_file() {
         None,   // no --state-db
         None,   // --cas-dir
         None,   // --cas-max-bytes
+        false,  // no --allow-save-artifact
         None,   // no --max-attachments
     );
     assert_eq!(c.default_cast, "deepseek", "--cast beats env and file");
@@ -973,9 +974,10 @@ fn empty_cli_allow_paths_preserves_lower_layers() {
         vec![],
         false,
         None,
-        None, // --cas-dir
-        None, // --cas-max-bytes
-        None, // --max-attachments
+        None,  // --cas-dir
+        None,  // --cas-max-bytes
+        false, // --allow-save-artifact
+        None,  // --max-attachments
     );
     // The env/file-layer value must survive.
     assert!(
@@ -2293,6 +2295,7 @@ fn cas_cli_wins_and_absent_flags_do_not_clobber() {
         None,
         Some(std::path::PathBuf::from("/from/cli")), // --cas-dir
         None,                                        // --cas-max-bytes NOT passed
+        false,                                       // --allow-save-artifact
         None,                                        // --max-attachments NOT passed
     );
     assert_eq!(
@@ -2304,6 +2307,107 @@ fn cas_cli_wins_and_absent_flags_do_not_clobber() {
         c.cas.max_bytes,
         Some(111),
         "an absent --cas-max-bytes must leave the file's value alone, not reset it"
+    );
+}
+
+// --- [artifacts]: kaibo's one inverted capability ----------------------------
+
+/// **The default is OFF**, and that is the whole point of this stanza. Every other tool
+/// switch is on unless an operator turns it off; this one is the reverse, because it is
+/// the only surface where a *model* decides that bytes become durable. A regression here
+/// would silently change the posture of every kaibo install.
+#[test]
+fn artifacts_are_disabled_by_default() {
+    assert!(
+        !Config::builtin().artifacts.enabled,
+        "the built-in default must be off"
+    );
+    assert!(
+        !Config::from_toml_str("").unwrap().artifacts.enabled,
+        "an empty config file must not enable it either"
+    );
+    assert!(
+        !Config::from_toml_str("[artifacts]\n")
+            .unwrap()
+            .artifacts
+            .enabled,
+        "an empty [artifacts] stanza is not a request to turn it on"
+    );
+}
+
+#[test]
+fn artifacts_enabled_in_the_file_turns_it_on() {
+    assert!(
+        Config::from_toml_str("[artifacts]\nenabled = true\n")
+            .unwrap()
+            .artifacts
+            .enabled
+    );
+}
+
+/// `deny_unknown_fields`, like every other section: a typo'd knob is a loud load error,
+/// never a silently-ignored request to enable something.
+#[test]
+fn artifacts_unknown_key_is_refused() {
+    assert!(Config::from_toml_str("[artifacts]\nenable = true\n").is_err());
+}
+
+/// Env can set the knob EITHER way (unlike the `KAIBO_NO_*` flags, which can only
+/// disable) — because this knob's built-in default is off, so a layer that could only
+/// disable would have nothing to say.
+#[test]
+fn artifacts_env_sets_the_knob_both_ways() {
+    let with = |val: &str| {
+        let env: HashMap<&str, &str> = [("KAIBO_ARTIFACTS_ENABLED", val)].into_iter().collect();
+        Config::load_with(None, None, |k| env.get(k).map(|s| s.to_string()))
+            .unwrap()
+            .artifacts
+            .enabled
+    };
+    assert!(with("1"));
+    assert!(with("true"));
+    assert!(!with("0"));
+    assert!(!with("false"));
+    assert!(!with("no"));
+}
+
+/// The CLI is the top layer here too, and it runs the OTHER way from `--no-<tool>`: the
+/// flag enables. An absent flag never clobbers a lower layer that already turned it on.
+#[test]
+fn artifacts_cli_flag_enables_and_absence_does_not_clobber() {
+    let apply = |mut c: Config, flag: bool| {
+        c.apply_cli(
+            None,
+            None,
+            ToolDisables::default(),
+            vec![],
+            false,
+            false,
+            vec![],
+            vec![],
+            false,
+            None,
+            None,
+            None,
+            flag, // --allow-save-artifact
+            None, // --max-attachments
+        );
+        c.artifacts.enabled
+    };
+    assert!(
+        apply(Config::from_toml_str("").unwrap(), true),
+        "--allow-save-artifact turns it on over the off default"
+    );
+    assert!(
+        apply(
+            Config::from_toml_str("[artifacts]\nenabled = true\n").unwrap(),
+            false
+        ),
+        "an absent flag must leave a file-enabled knob alone"
+    );
+    assert!(
+        !apply(Config::from_toml_str("").unwrap(), false),
+        "no flag and no file means off"
     );
 }
 
@@ -2326,6 +2430,7 @@ fn persistence_cli_wins_over_lower_layers() {
         Some(std::path::PathBuf::from("/from/cli.db")), // --state-db
         None,                                           // --cas-dir
         None,                                           // --cas-max-bytes
+        false,                                          // no --allow-save-artifact
         None,                                           // no --max-attachments
     );
     assert!(!c.persistence.enabled, "--no-persistence wins");

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2364,11 +2364,35 @@ fn artifacts_env_sets_the_knob_both_ways() {
             .artifacts
             .enabled
     };
-    assert!(with("1"));
-    assert!(with("true"));
-    assert!(!with("0"));
-    assert!(!with("false"));
-    assert!(!with("no"));
+    for on in ["1", "true", "yes", "TRUE", " Yes "] {
+        assert!(with(on), "{on:?} must enable");
+    }
+    for off in ["0", "false", "no", "FALSE", " No "] {
+        assert!(!with(off), "{off:?} must disable");
+    }
+}
+
+/// **This one env flag refuses to guess.** kaibo's other env flags are permissive —
+/// anything not empty/`0`/`false`/`no` means on — which for THIS flag would turn `off`,
+/// `disabled`, and every typo into "let the model write durable bytes", the opposite of
+/// what the operator wrote, silently. So it accepts only the listed spellings and fails
+/// startup on anything else, naming them.
+#[test]
+fn artifacts_env_refuses_a_value_it_would_have_to_guess_at() {
+    for bad in ["off", "disabled", "ture", "on", "", "2"] {
+        let env: HashMap<&str, &str> = [("KAIBO_ARTIFACTS_ENABLED", bad)].into_iter().collect();
+        let err = Config::load_with(None, None, |k| env.get(k).map(|s| s.to_string()))
+            .expect_err(&format!("{bad:?} must be a loud load error, never a guess"));
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("KAIBO_ARTIFACTS_ENABLED"),
+            "the error names the variable: {msg}"
+        );
+        assert!(
+            msg.contains("true") && msg.contains("false"),
+            "and the spellings it accepts: {msg}"
+        );
+    }
 }
 
 /// The CLI is the top layer here too, and it runs the OTHER way from `--no-<tool>`: the

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -615,9 +615,10 @@ fn allow_paths_cli_replaces_env_and_file() {
         vec![],
         false,
         None,
-        None, // --cas-dir
-        None, // --cas-max-bytes
-        None, // --max-attachments
+        None,  // --cas-dir
+        None,  // --cas-max-bytes
+        false, // --allow-save-artifact
+        None,  // --max-attachments
     );
     assert_eq!(c.allow_paths.len(), 2);
     assert!(c

--- a/tests/save_artifact.rs
+++ b/tests/save_artifact.rs
@@ -406,3 +406,361 @@ fn the_footer_names_every_artifact_by_its_resource_uri() {
         "disk mode names the real path, as `generate` does, got: {out}"
     );
 }
+
+// --- Sanitized refusals: the model learns the rule, not the store -------------
+
+/// **A store refusal must not leak the store.** `CasError`'s own `Display` carries the
+/// CAS filesystem path and, for a capacity refusal, `current_bytes` — the total size of a
+/// store shared across every project this kaibo has ever served. That text used to reach
+/// the model verbatim through `map_error`. Two leaks in one: the path tells a model where
+/// kaibo's data dir lives, and the usage number tells it how much other projects' work is
+/// sitting there (and, watched across calls, how it moves).
+///
+/// The operator still gets the whole typed error, on the tracing log. The model gets a
+/// sentence about what to do next.
+#[test]
+fn a_capacity_refusal_leaks_neither_the_store_path_nor_its_usage() {
+    // A store with room for nothing: the very first save is refused on capacity.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("cas");
+    let cas = Cas::open(&root, &[], Some(1)).expect("open a one-byte store");
+    let s = ArtifactSink::new(Arc::new(MediaStore::Disk(cas)), author());
+
+    let msg = match s.save("a corpus", "some content here", Some("text")) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("a one-byte store must refuse"),
+    };
+
+    assert!(
+        !msg.contains('/') && !msg.contains('\\'),
+        "no path separator may appear in what the model reads, got: {msg}"
+    );
+    assert!(
+        !msg.chars().any(|c| c.is_ascii_digit()),
+        "no store measurement may appear in what the model reads, got: {msg}"
+    );
+    assert!(
+        !msg.to_lowercase().contains("cas") || !msg.contains(&root.display().to_string()),
+        "the CAS root must not appear, got: {msg}"
+    );
+    // It still has to be actionable.
+    assert!(
+        msg.to_lowercase().contains("no room") && msg.to_lowercase().contains("nothing was saved"),
+        "the refusal must say what happened and that nothing landed, got: {msg}"
+    );
+}
+
+// --- First-writer-wins provenance ---------------------------------------------
+
+/// **The sidecar beside a content is the record its FIRST write left.** It is created
+/// with `create_new` and never rewritten, so saving content another call already stored
+/// keeps that call's record. This is not a bug to route around — a content-addressed
+/// store that never rewrites structurally cannot hold one record per save — but it is a
+/// claim the docs have to make honestly, so it gets pinned here.
+///
+/// This call's ledger and footer still carry THIS call's label; only the metadata beside
+/// the object is the older one.
+#[test]
+fn a_second_save_of_held_content_keeps_the_first_writers_record() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("cas");
+    let store = Arc::new(MediaStore::Disk(
+        Cas::open(&root, &[], None).expect("open cas"),
+    ));
+
+    let first = ArtifactSink::new(Arc::clone(&store), author());
+    let second = ArtifactSink::new(
+        Arc::clone(&store),
+        ArtifactAuthor {
+            prompt: "a different question".into(),
+            model: "gemini/gemini-3.5-flash".into(),
+            cast: "gemini".into(),
+            slot: "synth",
+            session: Some("sess-99".into()),
+        },
+    );
+
+    let body = "the very same bytes\n";
+    let d1 = first
+        .save("first author's label", body, Some("text"))
+        .unwrap();
+    let d2 = second
+        .save("second author's label", body, Some("text"))
+        .unwrap();
+    assert_eq!(d1, d2, "the address is the content");
+
+    let cas = Cas::open(&root, &[], None).unwrap();
+    let p = cas.provenance_for(&d1).expect("a sidecar is there");
+    assert_eq!(p.cast, "deepseek", "the FIRST writer's cast is the record");
+    assert_eq!(p.label.as_deref(), Some("first author's label"));
+    assert_eq!(p.session.as_deref(), Some("sess-42"));
+
+    // But the second call's own footer describes the second call's save.
+    assert_eq!(second.saved()[0].label, "second author's label");
+    assert!(kaibo::artifact::with_artifacts("A".into(), Some(&second))
+        .contains("second author's label"));
+}
+
+/// The same rule across producers: content a provider render put in the store first keeps
+/// the `generate` record, so a later `save_artifact` of identical bytes does not rewrite
+/// the sidecar to claim a model authored them.
+#[test]
+fn a_save_of_content_generate_stored_first_keeps_the_generate_record() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("cas");
+    let cas = Cas::open(&root, &[], None).expect("open cas");
+    let body = b"bytes a provider produced first".to_vec();
+    cas.put(
+        &body,
+        Extension::Txt,
+        &kaibo::cas::Provenance {
+            prompt: "an image prompt".into(),
+            model: "stability/core".into(),
+            cast: "artist".into(),
+            timestamp: 1,
+            mime: Extension::Txt.mime().into(),
+            seed: Some("42".into()),
+            tool: Some("generate".into()),
+            slot: None,
+            label: None,
+            session: None,
+        },
+    )
+    .expect("the render lands first");
+
+    let s = ArtifactSink::new(Arc::new(MediaStore::Disk(cas)), author());
+    let digest = s
+        .save("a model's label", std::str::from_utf8(&body).unwrap(), None)
+        .expect("saving held content still succeeds");
+
+    let p = Cas::open(&root, &[], None)
+        .unwrap()
+        .provenance_for(&digest)
+        .expect("sidecar");
+    assert_eq!(
+        p.tool.as_deref(),
+        Some("generate"),
+        "the first writer's record stands; a later save does not rewrite it"
+    );
+    assert_eq!(p.seed.as_deref(), Some("42"));
+    assert_eq!(p.label, None);
+}
+
+/// Memory mode holds the same rule: `MemoryCas::put` short-circuits on a held digest, so
+/// the provenance stays the first writer's.
+#[test]
+fn memory_mode_also_keeps_the_first_writers_record() {
+    let store = Arc::new(MediaStore::Memory(MemoryCas::new(None)));
+    let first = ArtifactSink::new(Arc::clone(&store), author());
+    let second = ArtifactSink::new(
+        Arc::clone(&store),
+        ArtifactAuthor {
+            cast: "gemini".into(),
+            ..author()
+        },
+    );
+    let body = "identical\n";
+    first.save("first", body, None).unwrap();
+    second.save("second", body, None).unwrap();
+
+    let MediaStore::Memory(mem) = &*store else {
+        unreachable!("built as memory")
+    };
+    let p = mem.provenance(&Digest::of_bytes(body.as_bytes())).unwrap();
+    assert_eq!(p.cast, "deepseek");
+    assert_eq!(p.label.as_deref(), Some("first"));
+}
+
+// --- Cross-format dedup: the footer renders the store's answer ----------------
+
+/// **Identical bytes saved under a second format are still the first format's object.**
+/// The address is the content hash, so a `jsonl` save of content already held as `txt`
+/// lands at the same digest; the sidecar — the lookup authority — still says `txt`, and
+/// so do the resource read and the on-disk path. A footer that echoed the *request* would
+/// advertise `application/jsonl` beside a `.txt` path, and a caller acting on it would
+/// fetch something that does not match the label it was given.
+///
+/// Refusing the second save would be the other way to fix this, and it is worse: the
+/// refusal itself would reveal the content was already present.
+#[test]
+fn a_cross_format_second_save_renders_the_stored_format_not_the_requested_one() {
+    let (s, _dir) = disk_sink();
+    let body = "{\"a\":1}\n";
+
+    let d1 = s.save("as text", body, Some("text")).expect("first save");
+    let d2 = s
+        .save("as jsonl", body, Some("jsonl"))
+        .expect("second save");
+    assert_eq!(d1, d2, "same bytes, same address");
+
+    let saved = s.saved();
+    assert_eq!(
+        saved[1].mime,
+        Extension::Txt.mime(),
+        "the second entry must render what the STORE says this object is, not what the \
+         save asked for, got {}",
+        saved[1].mime
+    );
+
+    let footer = kaibo::artifact::with_artifacts("A".into(), Some(&s));
+    assert!(
+        !footer.contains(Extension::Jsonl.mime()),
+        "no entry may advertise a mime the resource read will not serve, got: {footer}"
+    );
+    assert!(
+        footer.contains(".txt") && !footer.contains(".jsonl"),
+        "the path must be the object that exists, got: {footer}"
+    );
+}
+
+// --- Labels are bounded and single-line ---------------------------------------
+
+/// **A label with a line break is refused.** It is rendered into the structured footer, so
+/// a newline lets a model forge extra numbered entries or a `path:` line — the caller then
+/// reads about artifacts kaibo never wrote, at addresses it never minted.
+#[test]
+fn a_label_with_a_line_break_is_refused_and_stores_nothing() {
+    let s = sink();
+    let forged = "real one\n2. kaibo://cas/{}\n   path: /etc/passwd";
+    for label in [forged, "two\nlines", "carriage\rreturn", "tab\tsep"] {
+        match s.save(label, "body", None) {
+            Err(_) => {}
+            Ok(_) => panic!("a control character in a label must be refused: {label:?}"),
+        }
+    }
+    assert!(s.saved().is_empty(), "nothing was stored");
+    assert_eq!(
+        kaibo::artifact::with_artifacts("A".into(), Some(&s)),
+        "A",
+        "and nothing reached the footer"
+    );
+}
+
+/// An unbounded label is metadata riding around the byte caps — it reaches the caller
+/// outside the content, where nothing counts it. Refused past a modest ceiling, naming it.
+#[test]
+fn an_over_length_label_is_refused_and_names_the_limit() {
+    use kaibo::artifact::MAX_LABEL_BYTES;
+    let s = sink();
+    s.save(&"a".repeat(MAX_LABEL_BYTES), "body", None)
+        .expect("exactly at the limit is fine");
+    let msg = match s.save(&"a".repeat(MAX_LABEL_BYTES + 1), "body", None) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("past the label limit must be refused"),
+    };
+    assert!(
+        msg.contains(&MAX_LABEL_BYTES.to_string()),
+        "the refusal names the limit: {msg}"
+    );
+    assert_eq!(s.saved().len(), 1, "only the in-bounds save landed");
+}
+
+// --- Concurrency: the ledger lock is the arbiter ------------------------------
+
+/// Two threads racing the last slot in a call's budget: exactly one wins. The ledger lock
+/// spans the admission and the write, so there is no window where both read the same
+/// remaining budget and both proceed.
+#[test]
+fn two_threads_racing_the_last_budget_slot_produce_exactly_one_save() {
+    let s = Arc::new(ArtifactSink::with_caps(
+        Arc::new(MediaStore::Memory(MemoryCas::new(None))),
+        author(),
+        Caps {
+            per_artifact_bytes: 64,
+            artifacts_per_call: 1, // one slot, two contenders
+            total_bytes_per_call: 4096,
+        },
+    ));
+    let a = Arc::clone(&s);
+    let b = Arc::clone(&s);
+    let ta = std::thread::spawn(move || a.save("a", "aaaa", None).is_ok());
+    let tb = std::thread::spawn(move || b.save("b", "bbbb", None).is_ok());
+    let wins = [ta.join().unwrap(), tb.join().unwrap()]
+        .iter()
+        .filter(|ok| **ok)
+        .count();
+    assert_eq!(wins, 1, "exactly one thread may take the last slot");
+    assert_eq!(s.saved().len(), 1, "and the ledger holds exactly one entry");
+}
+
+// --- Memory mode has no path to show ------------------------------------------
+
+/// In memory mode the `kaibo://cas/<digest>` resource is the ONLY retrieval channel —
+/// there is no file. A footer claiming a path would send the caller after something that
+/// does not exist.
+#[test]
+fn the_memory_mode_footer_names_no_path() {
+    let s = sink();
+    s.save("held in memory", "content\n", None).unwrap();
+    let footer = kaibo::artifact::with_artifacts("A".into(), Some(&s));
+    assert!(
+        footer.contains("kaibo://cas/"),
+        "the URI is still there: {footer}"
+    );
+    assert!(
+        !footer.contains("path: "),
+        "memory mode has no file to point at, got: {footer}"
+    );
+}
+
+// --- Object landed, provenance did not ----------------------------------------
+
+/// The sink's half of the disk store's `ProvenanceNotRecorded` contract: the model is told
+/// the artifact WAS saved and given its address, the ledger carries it so the caller's
+/// footer names it, and the footer says the metadata is missing rather than pretending it
+/// is there. The one thing that must never happen here is "nothing was saved" — the bytes
+/// are on disk and reachable.
+#[test]
+#[cfg(unix)]
+fn an_artifact_stored_without_provenance_is_still_reported_to_the_caller() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("cas");
+    let cas = Cas::open(&root, &[], None).expect("open cas");
+    let body = "the object lands, the sidecar does not\n";
+    let digest = Digest::of_bytes(body.as_bytes());
+
+    let hex = digest.to_hex();
+    let shard = root.join(&hex[0..2]).join(&hex[2..4]);
+    std::fs::create_dir_all(&shard).unwrap();
+    std::fs::write(shard.join(format!("{hex}.txt")), body).unwrap();
+    std::fs::set_permissions(&shard, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let can_write_anyway = std::fs::write(shard.join("probe"), b"x").is_ok();
+
+    let s = ArtifactSink::new(Arc::new(MediaStore::Disk(cas)), author());
+    let result = s.save("a corpus", body, Some("text"));
+    let _ = std::fs::set_permissions(&shard, std::fs::Permissions::from_mode(0o755));
+
+    if can_write_anyway {
+        eprintln!("skipping: this process ignores directory permissions (likely root)");
+        return;
+    }
+
+    let msg = match result {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("a missing provenance record is still a reported failure"),
+    };
+    assert!(
+        msg.contains(&hex),
+        "the model must be told the address its bytes are reachable at: {msg}"
+    );
+    assert!(
+        !msg.to_lowercase().contains("nothing was saved"),
+        "the bytes ARE saved — claiming otherwise orphans them: {msg}"
+    );
+    assert_eq!(
+        s.saved().len(),
+        1,
+        "the artifact is real, so it belongs in the ledger"
+    );
+    let footer = kaibo::artifact::with_artifacts("A".into(), Some(&s));
+    assert!(
+        footer.contains(&hex),
+        "and in the caller's footer: {footer}"
+    );
+    assert!(
+        footer.contains("could not write"),
+        "which says the metadata is missing rather than implying it is there: {footer}"
+    );
+}

--- a/tests/save_artifact.rs
+++ b/tests/save_artifact.rs
@@ -1,0 +1,408 @@
+//! Behavioral tests for `save_artifact`'s ledger — the caps, the refusals, the
+//! authorship record, and the one property that is a security boundary rather than a
+//! budget: **dedup opacity**.
+//!
+//! The loop wiring (which toolsets carry the tool, which never do) is tested where the
+//! toolsets are built — `src/consult/engine.rs` — and the two-key gate is tested at the
+//! server seam that resolves it. This file is about what happens once bytes arrive.
+
+use std::sync::Arc;
+
+use kaibo::artifact::{
+    ArtifactAuthor, ArtifactSink, Caps, MAX_ARTIFACTS_PER_CALL, MAX_ARTIFACT_BYTES,
+    MAX_TOTAL_BYTES_PER_CALL,
+};
+use kaibo::cas::{Cas, Digest, Extension, MediaStore, MemoryCas};
+use tempfile::TempDir;
+
+fn author() -> ArtifactAuthor {
+    ArtifactAuthor {
+        prompt: "generate 100 kaish commands that try to break the parser".into(),
+        model: "deepseek/deepseek-v4-pro".into(),
+        cast: "deepseek".into(),
+        slot: "synth",
+        session: Some("sess-42".into()),
+    }
+}
+
+/// A sink over an in-memory store — enough for every ledger property, and it touches no
+/// filesystem.
+fn sink() -> ArtifactSink {
+    ArtifactSink::new(Arc::new(MediaStore::Memory(MemoryCas::new(None))), author())
+}
+
+/// A sink over a real disk CAS, plus the temp dir keeping it alive — for the tests that
+/// read a sidecar back off disk.
+fn disk_sink() -> (ArtifactSink, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let cas = Cas::open(&dir.path().join("cas"), &[], None).expect("open cas");
+    (
+        ArtifactSink::new(Arc::new(MediaStore::Disk(cas)), author()),
+        dir,
+    )
+}
+
+// --- Caps: refuse, never truncate, and store nothing on refusal ---------------
+
+/// Past the per-artifact cap the write is REFUSED, not truncated — and the refusal
+/// carries the cap, the actual size, and the way out. A model that only learns "too
+/// big" has to guess the next size and pay for the whole payload again to find out.
+#[test]
+fn an_oversize_artifact_is_refused_with_the_cap_the_size_and_the_recovery() {
+    let s = sink();
+    let big = "x".repeat(MAX_ARTIFACT_BYTES + 1);
+    let err = s
+        .save("a corpus", &big, Some("text"))
+        .expect_err("past the per-artifact cap must refuse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&MAX_ARTIFACT_BYTES.to_string()),
+        "the refusal must name the cap, got: {msg}"
+    );
+    assert!(
+        msg.contains(&(MAX_ARTIFACT_BYTES + 1).to_string()),
+        "the refusal must name the actual size, got: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("split"),
+        "the refusal must name the recovery, got: {msg}"
+    );
+    assert!(
+        s.saved().is_empty(),
+        "a refused save must store nothing and record nothing"
+    );
+}
+
+/// Truncation is the failure this refusal exists to prevent: a digest handed back for
+/// content that is not what the model wrote is silent corruption. Nothing at the cap
+/// boundary gets shortened — one byte under is stored whole, one byte over stores
+/// nothing at all.
+#[test]
+fn the_cap_boundary_stores_whole_content_or_nothing() {
+    let s = sink();
+    let ok = "y".repeat(MAX_ARTIFACT_BYTES);
+    let digest = s
+        .save("at the limit", &ok, Some("text"))
+        .expect("at the cap");
+    assert_eq!(
+        digest,
+        Digest::of_bytes(ok.as_bytes()),
+        "the digest must address the WHOLE content, never a truncation of it"
+    );
+    assert_eq!(s.saved()[0].bytes, MAX_ARTIFACT_BYTES);
+}
+
+/// The artifact count is per MCP CALL, so a driver cannot spread a flood across turns:
+/// one sink lives for one call, and the ninth save is refused however it arrived.
+#[test]
+fn past_the_per_call_artifact_count_the_save_is_refused() {
+    let s = sink();
+    for i in 0..MAX_ARTIFACTS_PER_CALL {
+        s.save(&format!("part {i}"), &format!("body {i}"), None)
+            .unwrap_or_else(|e| panic!("save {i} within the count must succeed: {e}"));
+    }
+    let err = s
+        .save("one too many", "body", None)
+        .expect_err("past the count must refuse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&MAX_ARTIFACTS_PER_CALL.to_string()),
+        "the refusal must name the cap, got: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("follow-up call"),
+        "the refusal must name the recovery, got: {msg}"
+    );
+    assert_eq!(
+        s.saved().len(),
+        MAX_ARTIFACTS_PER_CALL,
+        "the refused save must not enter the ledger"
+    );
+}
+
+/// The per-call byte total is its own ceiling, independent of the count and of the
+/// per-artifact cap: several artifacts each under the single-artifact limit can still be
+/// too much in aggregate. Driven on a small-caps sink, which is the only way to reach
+/// this branch without allocating megabytes — and, with the shipped numbers, the only
+/// way to reach it at all (see the relationship test below).
+#[test]
+fn past_the_per_call_byte_total_the_save_is_refused() {
+    let s = ArtifactSink::with_caps(
+        Arc::new(MediaStore::Memory(MemoryCas::new(None))),
+        author(),
+        Caps {
+            per_artifact_bytes: 100,
+            artifacts_per_call: 8,
+            total_bytes_per_call: 150,
+        },
+    );
+    s.save("part 1", &"a".repeat(100), None)
+        .expect("first fits");
+    let msg = match s.save("part 2", &"b".repeat(100), None) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("100 + 100 is past a 150-byte call total and must refuse"),
+    };
+    assert!(msg.contains("150"), "the refusal must name the cap: {msg}");
+    assert!(
+        msg.contains("100"),
+        "the refusal must name what was spent and what was asked: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("smaller selection"),
+        "the refusal must name the recovery, got: {msg}"
+    );
+    assert_eq!(
+        s.saved().len(),
+        1,
+        "the refused save must add nothing to the ledger"
+    );
+}
+
+/// **The shipped total cap can never fire, and that is worth stating out loud.**
+///
+/// `8 artifacts × 1 MiB each` is exactly the 8 MiB call total, and the check refuses only
+/// when the total is *exceeded* — so with today's numbers the count and per-artifact caps
+/// bind first, always. The total is a backstop that goes live the moment either of the
+/// other two rises. Pinned here so a later change to any of the three has to look at the
+/// relationship deliberately rather than discovering it as a surprise.
+#[test]
+fn the_shipped_caps_leave_the_call_total_as_a_backstop() {
+    assert_eq!(
+        MAX_ARTIFACTS_PER_CALL * MAX_ARTIFACT_BYTES,
+        MAX_TOTAL_BYTES_PER_CALL,
+        "if this stops holding, the call total starts refusing real saves — re-read \
+         `past_the_per_call_byte_total_the_save_is_refused` and decide whether that is \
+         what you meant"
+    );
+}
+
+// --- The format allowlist -----------------------------------------------------
+
+#[test]
+fn text_and_jsonl_are_stored_under_their_own_container_and_mime() {
+    let (s, _dir) = disk_sink();
+    let text = s.save("a report", "hello\n", Some("text")).unwrap();
+    let jsonl = s.save("rows", "{\"a\":1}\n", Some("jsonl")).unwrap();
+    let saved = s.saved();
+    assert_eq!(saved[0].mime, Extension::Txt.mime());
+    assert_eq!(saved[1].mime, Extension::Jsonl.mime());
+    assert_eq!(saved[0].digest, text.to_hex());
+    assert_eq!(saved[1].digest, jsonl.to_hex());
+}
+
+/// Omitting `format` means text — the common case, and a default the model does not
+/// have to think about.
+#[test]
+fn an_omitted_format_stores_text() {
+    let s = sink();
+    s.save("a report", "hello\n", None).unwrap();
+    assert_eq!(s.saved()[0].mime, Extension::Txt.mime());
+}
+
+/// A format outside the allowlist is refused loudly, naming what IS available, and
+/// stores nothing. The allowlist is a serving concern rather than a safety boundary
+/// (a model can put anything inside a `.txt`), but a silently-coerced format would
+/// mislabel the bytes the caller retrieves.
+#[test]
+fn a_format_outside_the_allowlist_is_refused_and_stores_nothing() {
+    let s = sink();
+    for asked in ["png", "sh", "application/json", "exe"] {
+        let msg = match s.save("payload", "body", Some(asked)) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("format {asked:?} must be refused"),
+        };
+        assert!(msg.contains(asked), "the refusal must echo the ask: {msg}");
+        assert!(
+            msg.contains("text") && msg.contains("jsonl"),
+            "the refusal must name what IS available, got: {msg}"
+        );
+    }
+    assert!(s.saved().is_empty(), "nothing was stored");
+}
+
+/// A blank label is refused: the caller reads the label beside the URI, so an artifact
+/// with no description is one the caller cannot act on.
+#[test]
+fn a_blank_label_is_refused() {
+    let s = sink();
+    assert!(s.save("   ", "body", None).is_err());
+    assert!(s.saved().is_empty());
+}
+
+// --- Dedup opacity: the one property here that is a boundary ------------------
+
+/// **Storing the same content twice must be indistinguishable from storing it once.**
+///
+/// The CAS spans every project this kaibo has ever served. A tool result that said
+/// "already present" would answer "is this content in the store?" for arbitrary bytes —
+/// an existence oracle over other projects' artifacts, handed to a model whose prompt an
+/// untrusted repository can influence. So the observable output is a pure function of
+/// the content: same bytes in, byte-identical result out.
+#[test]
+fn saving_identical_content_twice_yields_byte_identical_results() {
+    let (s, _dir) = disk_sink();
+    let body = "the same corpus, twice\n";
+    let first = s.save("corpus", body, Some("text")).expect("first save");
+    let second = s.save("corpus", body, Some("text")).expect("second save");
+    assert_eq!(
+        first.to_hex(),
+        second.to_hex(),
+        "the address is the content, so both saves address the same object"
+    );
+
+    // And the ledger entries — what the caller's footer is rendered from — agree
+    // field for field. A "new" vs "deduplicated" marker anywhere in this record would
+    // leak straight into the footer.
+    let saved = s.saved();
+    assert_eq!(saved[0], saved[1]);
+}
+
+/// The same, one level up: the *tool result text* a model reads is identical for
+/// identical content. This is where a leak would actually reach the model, so it gets
+/// its own assertion rather than riding on the ledger's.
+#[tokio::test]
+async fn the_tool_result_text_is_identical_for_identical_content() {
+    use kaibo::artifact::{SaveArtifact, SaveArtifactArgs};
+    use rig_agent::tool::{Tool, ToolContext};
+
+    let (s, _dir) = disk_sink();
+    let tool = SaveArtifact::new(Arc::new(s));
+    let args = || SaveArtifactArgs {
+        label: "corpus".into(),
+        content: "the same corpus, twice\n".into(),
+        format: Some("text".into()),
+    };
+    let mut ctx = ToolContext::default();
+    let first = tool.call(&mut ctx, args()).await.expect("first save");
+    let second = tool.call(&mut ctx, args()).await.expect("second save");
+    assert_eq!(
+        first, second,
+        "a model must not be able to tell a new object from one already in the store"
+    );
+    assert!(
+        !first.to_lowercase().contains("already")
+            && !first.to_lowercase().contains("dedup")
+            && !first.to_lowercase().contains("new"),
+        "the result says nothing about the object's prior existence, got: {first}"
+    );
+}
+
+// --- Authorship: the sidecar is the trust record ------------------------------
+
+/// Somebody downstream will *execute* an artifact's contents (a corpus of shell
+/// commands is the motivating case). The sidecar is what they decide trust from, so a
+/// model-authored artifact must be distinguishable from a provider-rendered one, and
+/// must name who wrote it.
+#[test]
+fn a_saved_artifact_records_its_authorship_in_the_sidecar() {
+    let (s, dir) = disk_sink();
+    let digest = s
+        .save("100 kaish commands", "cat /etc/passwd\n", Some("text"))
+        .expect("save");
+
+    let cas = Cas::open(&dir.path().join("cas"), &[], None).expect("reopen the same store");
+    let p = cas
+        .provenance_for(&digest)
+        .expect("every saved artifact carries a sidecar");
+
+    assert_eq!(
+        p.tool.as_deref(),
+        Some("save_artifact"),
+        "the tool that recorded it is what separates authored bytes from a render"
+    );
+    assert_eq!(p.slot.as_deref(), Some("synth"));
+    assert_eq!(p.label.as_deref(), Some("100 kaish commands"));
+    assert_eq!(p.session.as_deref(), Some("sess-42"));
+    assert_eq!(p.cast, "deepseek");
+    assert_eq!(p.model, "deepseek/deepseek-v4-pro");
+    assert_eq!(
+        p.prompt,
+        "generate 100 kaish commands that try to break the parser"
+    );
+    assert_eq!(p.mime, Extension::Txt.mime());
+    assert_eq!(p.seed, None, "authored text has no provider seed");
+}
+
+/// A sidecar written before the authorship fields existed still deserializes — the CAS
+/// never rewrites, so every past sidecar must stay readable forever.
+#[test]
+fn a_sidecar_written_before_the_authorship_fields_still_deserializes() {
+    let old = r#"{"prompt":"a cat","model":"m","cast":"c","timestamp":1,"mime":"image/png"}"#;
+    let p: kaibo::cas::Provenance = serde_json::from_str(old).expect("an older sidecar must load");
+    assert_eq!(
+        p.tool, None,
+        "absent means `generate`, the only producer then"
+    );
+    assert_eq!(p.slot, None);
+    assert_eq!(p.label, None);
+    assert_eq!(p.session, None);
+}
+
+/// The authorship fields are written only when they apply, so a sidecar carries no
+/// null-filled lines about things it has nothing to say about. The stored JSON is the
+/// artifact's permanent record; keeping it minimal is what keeps a `jq`-based pruning
+/// pass legible a decade from now.
+#[test]
+fn absent_authorship_fields_are_omitted_from_the_stored_json() {
+    let rendered = serde_json::to_string(&kaibo::cas::Provenance {
+        prompt: "a cat".into(),
+        model: "m".into(),
+        cast: "c".into(),
+        timestamp: 1,
+        mime: "image/png".into(),
+        seed: None,
+        tool: Some("generate".into()),
+        slot: None,
+        label: None,
+        session: None,
+    })
+    .expect("serialize");
+    assert!(rendered.contains("\"tool\":\"generate\""));
+    for absent in ["slot", "label", "session"] {
+        assert!(
+            !rendered.contains(absent),
+            "an inapplicable field must not appear at all, found {absent} in {rendered}"
+        );
+    }
+}
+
+// --- The caller's footer -------------------------------------------------------
+
+/// A consult that saved nothing appends nothing — the pre-artifact answer, byte for
+/// byte.
+#[test]
+fn an_unused_sink_appends_no_footer() {
+    let s = sink();
+    assert_eq!(
+        kaibo::artifact::with_artifacts("ANSWER".into(), Some(&s)),
+        "ANSWER"
+    );
+    assert_eq!(
+        kaibo::artifact::with_artifacts("ANSWER".into(), None),
+        "ANSWER"
+    );
+}
+
+/// The footer names each artifact by the URI the caller reads it at, with the mime, the
+/// size, and the model's own label — everything needed to decide whether to retrieve it.
+#[test]
+fn the_footer_names_every_artifact_by_its_resource_uri() {
+    let (s, _dir) = disk_sink();
+    let a = s.save("the corpus", "one\ntwo\n", Some("text")).unwrap();
+    let b = s.save("the rows", "{\"a\":1}\n", Some("jsonl")).unwrap();
+
+    let out = kaibo::artifact::with_artifacts("ANSWER".into(), Some(&s));
+    assert!(out.starts_with("ANSWER"), "the answer stays first");
+    for digest in [a, b] {
+        assert!(
+            out.contains(&format!("kaibo://cas/{}", digest.to_hex())),
+            "the footer must name {digest:?} by its resource URI, got: {out}"
+        );
+    }
+    assert!(out.contains("the corpus") && out.contains("the rows"));
+    assert!(out.contains(Extension::Txt.mime()) && out.contains(Extension::Jsonl.mime()));
+    assert!(
+        out.contains("path: "),
+        "disk mode names the real path, as `generate` does, got: {out}"
+    );
+}

--- a/tests/save_artifact.rs
+++ b/tests/save_artifact.rs
@@ -190,6 +190,23 @@ fn text_and_jsonl_are_stored_under_their_own_container_and_mime() {
     assert_eq!(saved[1].digest, jsonl.to_hex());
 }
 
+/// Markdown is a first-class format: the shape a model naturally writes a report in,
+/// stored under its own container with a mime that says so, and textual on retrieval
+/// (`is_textual`), so a client reads the report as a string.
+#[test]
+fn markdown_is_stored_under_its_own_container_and_reads_as_text() {
+    let (s, _dir) = disk_sink();
+    let md = s
+        .save("a report", "# Findings\n\n- one\n", Some("markdown"))
+        .unwrap();
+    let saved = s.saved();
+    assert_eq!(saved[0].mime, "text/markdown; charset=utf-8");
+    assert_eq!(saved[0].digest, md.to_hex());
+    assert!(Extension::Md.is_textual() && !Extension::Md.is_image());
+    assert_eq!(Extension::from_mime("text/markdown"), Some(Extension::Md));
+    assert_eq!(Extension::from_mime("text/x-markdown"), Some(Extension::Md));
+}
+
 /// Omitting `format` means text — the common case, and a default the model does not
 /// have to think about.
 #[test]

--- a/tests/save_artifact.rs
+++ b/tests/save_artifact.rs
@@ -216,25 +216,52 @@ fn an_omitted_format_stores_text() {
     assert_eq!(s.saved()[0].mime, Extension::Txt.mime());
 }
 
-/// A format outside the allowlist is refused loudly, naming what IS available, and
-/// stores nothing. The allowlist is a serving concern rather than a safety boundary
-/// (a model can put anything inside a `.txt`), but a silently-coerced format would
-/// mislabel the bytes the caller retrieves.
+/// **Assume text.** A format name kaibo does not know stores as text — never a
+/// refusal. This deliberately inverts the original allowlist refusal (Amy,
+/// 2026-08-05: "assume text unless something is obviously binary"): the content
+/// arrived as a JSON string, so it IS UTF-8 text whatever the model called it, and
+/// `text/plain` is a true label where a refusal would burn the model's whole payload
+/// to enforce a mime vocabulary — the discover-by-failing cost this design treats as
+/// uniquely expensive. `format` is a hint, not a gate; the binary paths belong to
+/// `generate`.
 #[test]
-fn a_format_outside_the_allowlist_is_refused_and_stores_nothing() {
+fn an_unknown_format_stores_as_text() {
     let s = sink();
-    for asked in ["png", "sh", "application/json", "exe"] {
-        let msg = match s.save("payload", "body", Some(asked)) {
-            Err(e) => e.to_string(),
-            Ok(_) => panic!("format {asked:?} must be refused"),
-        };
-        assert!(msg.contains(asked), "the refusal must echo the ask: {msg}");
-        assert!(
-            msg.contains("text") && msg.contains("jsonl"),
-            "the refusal must name what IS available, got: {msg}"
-        );
+    for asked in ["rust", "sh", "application/json", "markdwon"] {
+        s.save("source", "fn main() {}\n", Some(asked))
+            .unwrap_or_else(|e| panic!("format {asked:?} must store as text, got: {e}"));
     }
-    assert!(s.saved().is_empty(), "nothing was stored");
+    let saved = s.saved();
+    assert_eq!(saved.len(), 4);
+    for a in &saved {
+        assert_eq!(a.mime, Extension::Txt.mime(), "coerced to text: {a:?}");
+    }
+}
+
+/// The coercion is stated, not silent: the tool's own result line tells the model an
+/// unknown name stored as text and names the formats that exist, so the next save can
+/// ask for `markdown` and get it.
+#[tokio::test]
+async fn the_tool_result_states_an_unknown_format_stored_as_text() {
+    use kaibo::artifact::SaveArtifact;
+    use rig_agent::tool::{Tool, ToolContext};
+    let tool = SaveArtifact::new(Arc::new(sink()));
+    let out = tool
+        .call(
+            &mut ToolContext::default(),
+            serde_json::from_value(serde_json::json!({
+                "label": "a source file",
+                "content": "fn main() {}\n",
+                "format": "rust"
+            }))
+            .unwrap(),
+        )
+        .await
+        .expect("an unknown format stores as text");
+    assert!(
+        out.contains("text/plain") && out.contains("markdown"),
+        "the result states the coercion and names the real formats, got: {out}"
+    );
 }
 
 /// A blank label is refused: the caller reads the label beside the URI, so an artifact


### PR DESCRIPTION
An opt-in tool in the consult driver's inner toolset: the model hands kaibo bytes, gets back a CAS digest, and the caller's answer footer names each `kaibo://cas/<digest>` to read — or ignore. One way by construction: the model can write into the store and can never read, list, or probe it.

## Decisions (from the design sessions, 2026-08-04/05)

- **One input path: inline `content`. There is no `from`/path parameter, permanently.** A real-filesystem `from:` was designed and dropped after the hard shake: it could only reach existing project files (a retention risk with no value the client doesn't already have), not the model-authored bulk the tool exists for. The schema is pinned to exactly `{content, format, label}` by a test.
- **Two-key opt-in + CAS liveness.** Operator: `[artifacts] enabled = false` default (kaibo's first inverted capability — the only surface where a *model* decides bytes become durable), `KAIBO_ARTIFACTS_ENABLED`, `--allow-save-artifact`. Client: `save_artifacts: true` per call on `consult`/`consult_submit`. A caller that asks and can't be served gets a loud `invalid_params` naming the missing key — never a quiet consult that swallowed the bulk it asked to have stored.
- **Driver loop only** — delegated explorer sweeps never carry the tool (pinned end-to-end on a real nested sweep).
- **Caps refuse, never truncate** (1 MiB/artifact, 8 artifacts, 8 MiB/call); each refusal names the cap, the actual size, and the recovery, and stores nothing. Caps render into the tool description from live values.
- **Dedup is unobservable.** Same content in, same response out — new-vs-already-present is an existence oracle over every project this kaibo has served, so it is never revealed.
- **Authorship provenance.** Sidecars now distinguish model-authored (`tool: save_artifact`, cast, model, slot, session, the model's label) from provider renders (`generate` sidecars now carry `tool: generate`, additively, old sidecars still deserialize). Someone downstream may *execute* an artifact's contents; the sidecar is the trust record.
- **The delivery framing is probe-validated**: on DeepSeek, 2/2 runs with the framing kept bulk out of the answer (URI + summary + representative entries); 2/2 controls re-dumped the entire corpus. The validated paragraph ships in the tool description. Local-model leg pending (zorak down).

## Prerequisite (first commit)

`cas.rs`: the `<hex>.json` sidecar's `mime` is now the authority for locating and typing an object (one stat), with the extension probe surviving only as a fallback for objects missing a sidecar. This also fixed a live mislabel bug: content stored under two container names resolved by probe order. `Extension` grew `Txt`/`Jsonl`; `generate` now prevalidates on `Extension::is_image`, so widening the enum did not widen what the media lane accepts.

## Security verification

- `tests/no_write_path.rs` pinned blessed-write count unchanged at **4** — artifacts reach disk only through the existing `Cas::put`.
- `src/sandbox.rs`: zero-byte diff. No `cas`/`artifact` reference reachable from kaish.
- Guards proven by mutation (each mutation → named test fails → restored → green): operator-key bypass, sweep-toolset injection, truncate-instead-of-refuse, dedup-oracle leak, missing sidecar authorship.
- 928 → 959 tests, 0 failed; clippy `--all-targets` silent; `cargo tree -i` empty for `aws-lc-rs`, `mimalloc`, `openssl-sys`.

## Known non-blocking notes

- The per-call total cap (8 MiB) cannot fire with the shipped values (8 × 1 MiB = exactly 8 MiB, refusal on exceed only) — pinned by a test whose failure message explains; it's a backstop against future cap changes, not live enforcement today.
- CAS retention changes character with cheap minting; tracked in `docs/issues.md` (operator ls/du verbs, a GC story someday).

## Attribution

First-pass implementation by a Claude Opus subagent; design hard-shake, bulk-suppression probe, and verification by Claude Fable 5 working with Amy. Cross-family reviews (DeepSeek + GPT) to follow as PR comments before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)