### PR TITLE
feat(cas): read_cas — deliberate, metadata-first artifact retrieval (replaces the kaibo://cas resource)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,17 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
-- **`read_cas` — a tool for reading artifacts back, replacing the
-  `kaibo://cas/<digest>` resource.** Pass a digest and metadata comes first: mime,
-  total size, binary or not, the artifact's label, the range served, and the real
-  file path when the store is on disk (open that directly for anything large).
-  Reads are bounded — `length: 0` is a cheap look at what an object is, omitting
-  `length` returns the first 64 KiB and tells you the total, and `offset` pages the
-  rest. Text arrives as text; a small image arrives as an image you can see, and a
-  large one as metadata and a path instead of a wall of base64. Advertised whenever
-  the media CAS is on.
+- **`read_cas` — read a stored artifact back by digest.** Metadata comes first on
+  every response: mime, total size, binary or not, the artifact's label when its
+  record carries one, the range served, and the real file path when the store is on
+  disk (open that directly for anything large). Reads are bounded, and the default
+  fits the object: text gives up to 64 KiB from `offset` and tells you the total so
+  you can page; an image up to 5 MiB arrives whole and viewable, a larger one as
+  metadata alone; any other binary gives metadata until you ask for a range. `length`
+  is capped at 1 MiB and a larger ask is refused rather than trimmed, and paging always
+  advances — a window landing inside a multi-byte character returns those exact bytes
+  as base64 with a note, so a caller resuming at the range it was handed never stalls.
+  Advertised whenever the media CAS is on.
 
 - **A consult can hand you bulk output as an artifact instead of spending your
   context on it.** Ask with `save_artifacts: true` and the investigating model can
@@ -75,11 +77,10 @@ record. Each later release appends a new section at the top.
   gains a `[cas]` section reporting the knob and the live mode
   (`disk` / `memory` / `off`).
 
-- **Artifact retrieval is operator-surface only.** The new `kaibo://cas/{digest}` MCP
-  resource serves an artifact's bytes (base64, correct mime) to the calling client —
-  the inner model team never sees the CAS: it is not mounted into kaish and no
-  cast-facing tool reads it, so one project's team can never enumerate another
-  project's artifacts.
+- **Artifact retrieval is operator-surface only.** The `read_cas` tool serves an
+  artifact's content to the calling client — the inner model team never sees the CAS:
+  it is not mounted into kaish and no cast-facing tool reads it, so one project's team
+  can never enumerate another project's artifacts.
 
 - **Model listings show each model's output ceiling.** `kaibo models` and `list_models`
   render the provider's advertised max completion tokens beside the context window
@@ -129,14 +130,9 @@ record. Each later release appends a new section at the top.
 
 ### Removed
 
-- **The `kaibo://cas/<digest>` MCP resource, replaced by the `read_cas` tool above.**
-  Resources are ambient — hosts prefetch them, attach them to a turn, treat them as
-  context — which is a reasonable posture for a config file kaibo publishes and the
-  wrong one for bytes a model just wrote; a tool call is deliberate, with explicit
-  arguments and a permission prompt in most hosts. And `resources/read` had no way to
-  ask for less than everything: a 3.8 MB artifact came back as roughly 5 MB of base64
-  in a single read. The `kaibo://cas/<digest>` **string** is unchanged and still names
-  every artifact in footers and results — `read_cas` takes the digest out of it.
+- **The `kaibo://cas/<digest>` MCP resource** — briefly on `main`, never in a release,
+  replaced before shipping by the `read_cas` tool above. A stale request for that URI
+  answers with the migration rather than a bare unknown-resource error.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **`read_cas` — a tool for reading artifacts back, replacing the
+  `kaibo://cas/<digest>` resource.** Pass a digest and metadata comes first: mime,
+  total size, binary or not, the artifact's label, the range served, and the real
+  file path when the store is on disk (open that directly for anything large).
+  Reads are bounded — `length: 0` is a cheap look at what an object is, omitting
+  `length` returns the first 64 KiB and tells you the total, and `offset` pages the
+  rest. Text arrives as text; a small image arrives as an image you can see, and a
+  large one as metadata and a path instead of a wall of base64. Advertised whenever
+  the media CAS is on.
+
 - **A consult can hand you bulk output as an artifact instead of spending your
   context on it.** Ask with `save_artifacts: true` and the investigating model can
   write a generated corpus, a long inventory, or a fixture into kaibo's media store;
@@ -45,7 +55,7 @@ record. Each later release appends a new section at the top.
   `[casts.artist] image = "sd/core"`. The tool never inlines bytes: every artifact
   lands in kaibo's content-addressed media store under its own SHA-256 digest with a
   provenance sidecar (prompt, model, cast, timestamp, mime, seed), and the result
-  lists per-artifact `kaibo://cas/<digest>` resource URIs — plus the real file path
+  lists per-artifact `kaibo://cas/<digest>` addresses — plus the real file path
   when the store is on disk. Provider-native options (`aspect_ratio`,
   `output_format`, `seed`, `negative_prompt`, ...) pass through a `fields` object
   verbatim. Operations the provider declares deferred return a `job-N` handle on the
@@ -116,6 +126,17 @@ record. Each later release appends a new section at the top.
   the template you copy, `kaibo://config` is the resolved live state, and
   `kaibo://config/guide` explains what any of it means. The `configure` prompt points at
   all three.
+
+### Removed
+
+- **The `kaibo://cas/<digest>` MCP resource, replaced by the `read_cas` tool above.**
+  Resources are ambient — hosts prefetch them, attach them to a turn, treat them as
+  context — which is a reasonable posture for a config file kaibo publishes and the
+  wrong one for bytes a model just wrote; a tool call is deliberate, with explicit
+  arguments and a permission prompt in most hosts. And `resources/read` had no way to
+  ask for less than everything: a 3.8 MB artifact came back as roughly 5 MB of base64
+  in a single read. The `kaibo://cas/<digest>` **string** is unchanged and still names
+  every artifact in footers and results — `read_cas` takes the digest out of it.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -457,8 +457,9 @@ OpenAI-compatible image endpoints (hosted gpt-image, or a local stable-diffusion
 `sd-server` speaking the same `/v1/images/generations` shape). The bytes never inline into
 your context: each artifact lands in kaibo's content-addressed media store with a
 provenance sidecar (prompt, model, cast, seed), and the result lists per-artifact
-digests as `kaibo://cas/<digest>` resource URIs — plus the real file path when the
-store is on disk. Advertised only when a configured cast carries an `image` slot and
+digests as `kaibo://cas/<digest>` addresses — plus the real file path when the store is
+on disk. Fetch one with the `read_cas` tool: metadata first, bounded ranges on request,
+and a small image comes back viewable rather than as a wall of base64. Advertised only when a configured cast carries an `image` slot and
 the `[cas]` store is on; the project stays untouched — the store lives at a fixed XDG
 data path the model can't steer. See "Media CAS" in [`docs/config.md`](docs/config.md).
 

--- a/README.md
+++ b/README.md
@@ -458,8 +458,9 @@ OpenAI-compatible image endpoints (hosted gpt-image, or a local stable-diffusion
 your context: each artifact lands in kaibo's content-addressed media store with a
 provenance sidecar (prompt, model, cast, seed), and the result lists per-artifact
 digests as `kaibo://cas/<digest>` addresses — plus the real file path when the store is
-on disk. Fetch one with the `read_cas` tool: metadata first, bounded ranges on request,
-and a small image comes back viewable rather than as a wall of base64. Advertised only when a configured cast carries an `image` slot and
+on disk. Fetch one with the `read_cas` tool: metadata first, bounded reads (text pages by
+`offset`, an image up to 5 MiB comes back viewable), and never a wall of base64 you didn't
+ask for. Advertised only when a configured cast carries an `image` slot and
 the `[cas]` store is on; the project stays untouched — the store lives at a fixed XDG
 data path the model can't steer. See "Media CAS" in [`docs/config.md`](docs/config.md).
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -323,8 +323,8 @@ scratch_limit_bytes = 67108864
 #
 # What it buys: a consult producing bulk output (a generated corpus, a long inventory, a
 # fixture) writes it into the CAS and names the digest in its answer, instead of
-# spending your context window on material you may only want to keep. You read it at
-# kaibo://cas/<digest>, or you do not.
+# spending your context window on material you may only want to keep. You read it back
+# with the `read_cas` tool (metadata first, bounded ranges), or you do not.
 #
 # Limits are fixed, not configurable: 1 MiB per artifact, 8 artifacts and 8 MiB per call,
 # and a one-line label of at most 200 bytes. A save past a limit is refused and stores

--- a/docs/config.md
+++ b/docs/config.md
@@ -865,23 +865,34 @@ save emits and the session the answer was recorded into.
 
 **Retrieval is the `read_cas` tool, and it is operator-surface only.** Every producer
 names its artifacts by a `kaibo://cas/<digest>` address; `read_cas` takes the digest out
-of one and hands the content back. The MCP client and CLI call it; the inner model team
-never can — the CAS is not mounted into kaish and no cast-facing tool reads it, because
-kaibo state spans projects and a browsable CAS would let one project's team enumerate
-another's artifacts.
+of one and hands the content back. The MCP client calls it; the inner model team never can
+— the CAS is not mounted into kaish and no cast-facing tool reads it, because kaibo state
+spans projects and a browsable CAS would let one project's team enumerate another's
+artifacts. There is no `kaibo cas` CLI command; on disk, the path a read reports is how an
+operator reaches an object with their own tools.
 
-Reads are **metadata-first and bounded**:
+Reads are **metadata-first and bounded**, and the default depends on what the object is:
 
-| ask | you get |
-|---|---|
-| `length: 0` | metadata only — mime, total bytes, binary or not, the label, and the file path in disk mode |
-| no `length` | metadata plus the first 64 KiB from `offset`, never the whole object |
-| `offset` + `length` | metadata plus exactly that range (`length` up to 1 MiB) |
+| ask | text object | image | any other binary |
+|---|---|---|---|
+| `length: 0` | metadata only | metadata only | metadata only |
+| no `length` | metadata + up to 64 KiB from `offset` | the whole image, viewable, when it is ≤ 5 MiB; otherwise metadata only | metadata only |
+| `offset` + `length` | metadata + that range as text | metadata + that range as base64 | metadata + that range as base64 |
 
-Text comes back as text. A small image (up to 5 MiB) with no range asked for comes back as
-a viewable image; a larger one comes back as metadata and a path, because base64 in a
-context window helps nobody — open the file, or ask for a range explicitly. A binary
-object is never dumped as base64 unless you asked for a range.
+Metadata is always the first content block: digest, URI, mime, total bytes, binary or not,
+the label when the object's record carries one, a `provenance:` line when it has no record
+at all, the range served, and the real file path **in disk mode only** — memory mode has
+no file, so there is nothing to point at. `length` is capped at 1 MiB; a larger ask is
+refused rather than trimmed, so a caller's next `offset` is never wrong.
+
+**A binary object is never dumped as base64 unless you ask for a range.** An image past
+5 MiB comes back as metadata (plus the path, on disk) rather than ~7 MiB of base64 in your
+context — open the file, or page it deliberately.
+
+**Paging always advances.** A window that begins or ends inside a multi-byte character
+comes back as base64 of exactly the bytes you asked for, with a note saying why, so the
+served range still moves. Resuming at the range you were handed always terminates and
+always reassembles the object byte for byte.
 
 `kaibo://cas/<digest>` **was** an MCP resource until 2026-08-05 and no longer is. Two
 reasons. Hosts treat resources as ambient context — some prefetch, some auto-attach —

--- a/docs/config.md
+++ b/docs/config.md
@@ -878,7 +878,7 @@ Reads are **metadata-first and bounded**:
 | no `length` | metadata plus the first 64 KiB from `offset`, never the whole object |
 | `offset` + `length` | metadata plus exactly that range (`length` up to 1 MiB) |
 
-Text comes back as text. A small image (up to 2 MiB) with no range asked for comes back as
+Text comes back as text. A small image (up to 5 MiB) with no range asked for comes back as
 a viewable image; a larger one comes back as metadata and a path, because base64 in a
 context window helps nobody — open the file, or ask for a range explicitly. A binary
 object is never dumped as base64 unless you asked for a range.

--- a/docs/config.md
+++ b/docs/config.md
@@ -863,11 +863,32 @@ an operator, not an audit trail, and a content-addressed store that never rewrit
 be one. For a durable per-call record, kaibo's answers are the tool-call telemetry each
 save emits and the session the answer was recorded into.
 
-**Retrieval is operator-surface only.** A generation result returns each artifact's
-digest, a `kaibo://cas/<digest>` resource URI, and (in disk mode) the real filesystem
-path. The MCP client and CLI read those; the inner model team never sees the CAS — it is
-not mounted into kaish and no cast-facing tool reads it, because kaibo state spans
-projects and a browsable CAS would let one project's team enumerate another's artifacts.
+**Retrieval is the `read_cas` tool, and it is operator-surface only.** Every producer
+names its artifacts by a `kaibo://cas/<digest>` address; `read_cas` takes the digest out
+of one and hands the content back. The MCP client and CLI call it; the inner model team
+never can — the CAS is not mounted into kaish and no cast-facing tool reads it, because
+kaibo state spans projects and a browsable CAS would let one project's team enumerate
+another's artifacts.
+
+Reads are **metadata-first and bounded**:
+
+| ask | you get |
+|---|---|
+| `length: 0` | metadata only — mime, total bytes, binary or not, the label, and the file path in disk mode |
+| no `length` | metadata plus the first 64 KiB from `offset`, never the whole object |
+| `offset` + `length` | metadata plus exactly that range (`length` up to 1 MiB) |
+
+Text comes back as text. A small image (up to 2 MiB) with no range asked for comes back as
+a viewable image; a larger one comes back as metadata and a path, because base64 in a
+context window helps nobody — open the file, or ask for a range explicitly. A binary
+object is never dumped as base64 unless you asked for a range.
+
+`kaibo://cas/<digest>` **was** an MCP resource until 2026-08-05 and no longer is. Two
+reasons. Hosts treat resources as ambient context — some prefetch, some auto-attach —
+which is the wrong posture for bytes a model just wrote; a tool call is deliberate, with
+explicit arguments and a permission prompt. And `resources/read` is whole-blob with no
+negotiation: a measured 3.8 MB PNG produced roughly 5 MB of base64 in one read. The URI
+string survives as the artifact's name; only the resource route is gone.
 
 **`max_bytes` refuses, never evicts.** A write that would pass the cap fails loudly and
 nothing is deleted to make room. The cap is opt-in because enforcing it costs an
@@ -942,7 +963,7 @@ single line because it is rendered into the answer's footer, where a line break 
 forge entries the caller would read as real artifacts.
 
 **What the model cannot do.** It can write and it can never read. There is no list verb,
-no read verb, and no `kaibo://cas` access from inside the loop. The result of a save is a
+no read verb, and no `read_cas` in the inner toolset. The result of a save is a
 digest and nothing else: it never reports whether the content was already in the store,
 because that answer would let one project's model team probe another's artifacts. Refusals
 are sanitized for the same reason — the model is told what to do next, never the store's

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -38,8 +38,11 @@ persistence / in-memory without, SEVERE-warned / `enabled = false` off, un-adver
 tools that need it), the `generate` tool (its own `--no-generate` flag, staffed by the
 `image` slot via `CAST_ENUM_RULES`, deferred shapes on the `job-N` verbs — the lane
 only; every Stability operation wired today is synchronous), and the
-operator-only `kaibo://cas/<digest>` retrieval resource. The tool returns digests +
-URIs (+ real path on disk), never inline bytes — as decided.
+operator-only retrieval surface. The tool returns digests + `kaibo://cas/<digest>`
+addresses (+ real path on disk), never inline bytes — as decided. Retrieval shipped as a
+`kaibo://cas/<digest>` *resource* and became the `read_cas` *tool* on 2026-08-05
+(resources are ambient context in most hosts, and `resources/read` is whole-blob with no
+range); the address string is unchanged.
 
 **Open work that remains:**
 

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -170,7 +170,7 @@ pub struct ArtifactAuthor {
 pub struct SavedArtifact {
     /// The address: 64 lowercase hex, the content's own SHA-256.
     pub digest: String,
-    /// The mime the `kaibo://cas/<digest>` resource will stamp on these bytes — read
+    /// The mime `read_cas` will report for these bytes — read
     /// back from the **store** after the write, never the format this save asked for.
     /// The two can differ: identical bytes saved as `jsonl` when they are already held
     /// as `txt` land at the same address, and the store's answer is `txt`. Rendering the
@@ -646,7 +646,7 @@ fn artifact_footer(saved: &[SavedArtifact], store: &MediaStore) -> String {
         return String::new();
     }
     let mut out = format!(
-        "\n\n---\nSaved {} artifact{} (retrieve by reading the resource URI):",
+        "\n\n---\nSaved {} artifact{} (read one with `read_cas`, passing the digest):",
         saved.len(),
         if saved.len() == 1 { "" } else { "s" }
     );

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -174,7 +174,7 @@ pub struct SavedArtifact {
     /// back from the **store** after the write, never the format this save asked for.
     /// The two can differ: identical bytes saved as `jsonl` when they are already held
     /// as `txt` land at the same address, and the store's answer is `txt`. Rendering the
-    /// request instead would advertise a mime the resource will not serve and a path
+    /// request instead would advertise a mime `read_cas` will not report and a path
     /// that does not exist. See [`MediaStore::extension_for`].
     pub mime: &'static str,
     /// Size of the content, in bytes.
@@ -461,7 +461,7 @@ impl ArtifactSink {
 
         // What the artifact IS, per the store — not what this save asked for. They differ
         // whenever identical content is already held under another container format, and
-        // the footer must agree with the resource read and the on-disk path. A `None`
+        // the footer must agree with what `read_cas` reports and the on-disk path. A `None`
         // here is not reachable through a successful put; treat it as loud-but-recoverable
         // rather than panicking on the caller's paid-for save.
         let stored_ext = self.store.extension_for(&digest).unwrap_or_else(|| {

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -174,7 +174,8 @@ use serde::{Deserialize, Serialize};
 /// A **name, not a route.** It was an MCP resource until 2026-08-05; retrieval is now the
 /// `read_cas` tool, which takes the digest out of this string. Reading is **operator
 /// surface only** (Amy's ruling, 2026-08-03), and that survived the move: the MCP client
-/// and the CLI retrieve; the inner model team never can. The CAS is not mounted
+/// retrieves; the inner model team never can. There is no CLI artifact command — on disk,
+/// an operator reaches an object by the path a read reports. The CAS is not mounted
 /// into kaish and no cast-facing tool reads it, because kaibo state spans projects and a
 /// browsable CAS would let one project's team enumerate another's artifacts.
 pub const CAS_URI_PREFIX: &str = "kaibo://cas/";
@@ -627,8 +628,8 @@ impl Cas {
     }
 
     /// [`path_for`](Self::path_for) plus which [`Extension`] the object was written
-    /// under — the extension carries the mime type a resource read needs to stamp on
-    /// the bytes, and re-deriving it from the path string would be a second parser.
+    /// under — the extension carries the mime type a read needs to report for the
+    /// bytes, and re-deriving it from the path string would be a second parser.
     ///
     /// **The sidecar is the authority.** Every object written by this store gets a
     /// `<hex>.json` sidecar whose `mime` describes it, so one read of that file names
@@ -990,7 +991,7 @@ impl MediaStore {
     /// land at the same digest; the second put writes a second container file while the
     /// sidecar — the authority, see [`Cas::entry_for`] — still says `txt`. A caller that
     /// rendered its own request would advertise `application/jsonl` beside a `.txt` path
-    /// and a `text/plain` resource read. Ask the store instead, always.
+    /// and a `text/plain` read. Ask the store instead, always.
     ///
     /// Refusing the second put would be the other way to fix that, and it is worse: the
     /// refusal itself would reveal that the content was already present.

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -167,12 +167,14 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-/// The resource-URI prefix an object is addressed by: `kaibo://cas/<digest>`. Declared
-/// here, beside the store, so the MCP resource route and every producer that *renders* an
-/// address (`generate`'s result lines, `save_artifact`'s footer) spell it one way.
+/// The URI prefix an object is addressed by: `kaibo://cas/<digest>`. Declared here,
+/// beside the store, so every producer that *renders* an address (`generate`'s result
+/// lines, `save_artifact`'s footer) spells it one way.
 ///
-/// Reading that resource is **operator surface only** (Amy's ruling, 2026-08-03): the MCP
-/// client and the CLI resolve it; the inner model team never can. The CAS is not mounted
+/// A **name, not a route.** It was an MCP resource until 2026-08-05; retrieval is now the
+/// `read_cas` tool, which takes the digest out of this string. Reading is **operator
+/// surface only** (Amy's ruling, 2026-08-03), and that survived the move: the MCP client
+/// and the CLI retrieve; the inner model team never can. The CAS is not mounted
 /// into kaish and no cast-facing tool reads it, because kaibo state spans projects and a
 /// browsable CAS would let one project's team enumerate another's artifacts.
 pub const CAS_URI_PREFIX: &str = "kaibo://cas/";
@@ -364,7 +366,7 @@ impl Extension {
     }
 
     /// The canonical mime type this on-disk format serves as — what the
-    /// `kaibo://cas/<digest>` resource stamps on a blob it hands back, and what a
+    /// `read_cas` reports for an object it hands back, and what a
     /// producer records in the provenance sidecar so [`Cas::entry_for`] can read the
     /// format straight back out.
     pub fn mime(&self) -> &'static str {
@@ -633,7 +635,7 @@ impl Cas {
     /// the format directly: one lookup, not a walk of every container format kaibo
     /// knows. That matters more as the set grows past images — a probe answers with
     /// whichever variant it happens to try first, which for content stored under two
-    /// names is a *mislabel* the `kaibo://cas/<digest>` resource then stamps onto the
+    /// names is a *mislabel* `read_cas` then reports for the
     /// bytes, and for a large set is N stats per read.
     ///
     /// **The probe is the fallback, never the requirement.** An object whose sidecar
@@ -960,7 +962,7 @@ impl MemoryCas {
 
 /// The media store a running kaibo actually holds: the disk [`Cas`] when persistence
 /// is active, the [`MemoryCas`] when it is not. One seam so every consumer (the
-/// generate lane, the `kaibo://cas/<digest>` resource, the `kaibo://config` render)
+/// generate lane, the `read_cas` tool, the `kaibo://config` render)
 /// dispatches over the mode instead of each carrying its own two-armed match — and so
 /// the *contract* (content-addressed, write-only, no destination parameter) is the
 /// same sentence in both modes.
@@ -980,7 +982,7 @@ impl MediaStore {
     }
 
     /// **The store's own answer for what an object IS**, without reading its bytes: the
-    /// container format, and through it the mime the `kaibo://cas/<digest>` resource will
+    /// container format, and through it the mime `read_cas` will
     /// stamp and the extension the on-disk path carries.
     ///
     /// A producer's *requested* format is not that answer. The address is the content
@@ -996,6 +998,21 @@ impl MediaStore {
         match self {
             MediaStore::Disk(cas) => cas.entry_for(digest).map(|(_, ext)| ext),
             MediaStore::Memory(mem) => mem.extension_for(digest),
+        }
+    }
+
+    /// The housekeeping record beside an object, in whichever mode holds it — the disk
+    /// sidecar, or the memory store's clone of it. `None` when the object is unknown, or
+    /// (on disk) when its sidecar is missing or unreadable, which
+    /// [`Cas::provenance_for`] treats alike because a lookup can do nothing with any of
+    /// the three.
+    ///
+    /// Read by address, like everything else here: this is what makes an object
+    /// self-describing to whoever holds its digest — `read_cas` takes the label from it.
+    pub fn provenance(&self, digest: &Digest) -> Option<Provenance> {
+        match self {
+            MediaStore::Disk(cas) => cas.provenance_for(digest),
+            MediaStore::Memory(mem) => mem.provenance(digest),
         }
     }
 
@@ -1016,8 +1033,8 @@ impl MediaStore {
 
     /// The real filesystem path of an object — `Some` only in disk mode, where an
     /// operator (or the calling agent, acting as the operator's proxy) can reach the
-    /// file directly. Memory mode has no path; the `kaibo://cas/<digest>` resource is
-    /// the only retrieval channel there.
+    /// file directly. Memory mode has no path; `read_cas` is the only retrieval channel
+    /// there.
     pub fn path_for(&self, digest: &Digest) -> Option<PathBuf> {
         match self {
             MediaStore::Disk(cas) => cas.path_for(digest),

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -6439,6 +6439,68 @@ mod tests {
         );
     }
 
+    /// Verbs that belong to the MCP **client** and never to the inner model team.
+    ///
+    /// `read_cas` is retrieval for the operator's agent: the CAS spans every project this
+    /// kaibo has served, so a model that could read it by digest — or worse, enumerate it
+    /// — would cross the operator/model-team line from the retrieval side, exactly as a
+    /// mounted CAS would. It replaced a resource that was operator-surface-only for that
+    /// reason, and the boundary moves with it.
+    ///
+    /// `save_artifact` is the interesting contrast: it IS an inner tool, but only on the
+    /// driver loop and only with a sink, which is why the sweep assertions below name
+    /// both and the driver assertions name only `read_cas`.
+    const CLIENT_ONLY_VERBS: [&str; 5] = [
+        "read_cas",
+        "generate",
+        "job_get",
+        "job_list",
+        "consult_submit",
+    ];
+
+    /// **No client-surface verb ever reaches the consult driver's toolset**, whether or
+    /// not artifacts are enabled and whether or not the synth can see. The inner team
+    /// investigates and may write into the store; reading the store back is the
+    /// operator's, and this pins the line at the place the toolset is actually built.
+    #[test]
+    fn the_driver_toolset_never_carries_a_client_surface_verb() {
+        let dir = tempdir().unwrap();
+        let client = ScriptedClient::builder().build();
+        let explorer = arm(&client, "explorer-model");
+        let names = |cfg: &ConsultConfig, synth: &Arm| -> Vec<String> {
+            consult_tools(
+                &explorer,
+                dir.path(),
+                cfg,
+                Arc::new(Mutex::new(Vec::new())),
+                Arc::new(Mutex::new(Usage::new())),
+                synth,
+            )
+            .expect("toolset builds")
+            .iter()
+            .map(|t| t.name().to_string())
+            .collect()
+        };
+        let (with_sink, _sink) = cfg_with_artifact_sink();
+        for (what, cfg, synth) in [
+            ("default", ConsultConfig::default(), arm(&client, "s")),
+            ("with a sink", with_sink, arm(&client, "s")),
+            (
+                "vision synth",
+                ConsultConfig::default(),
+                vision_arm(&client, "s"),
+            ),
+        ] {
+            let live = names(&cfg, &synth);
+            for verb in CLIENT_ONLY_VERBS {
+                assert!(
+                    !live.contains(&verb.to_string()),
+                    "{what}: the driver must never carry {verb}, got {live:?}"
+                );
+            }
+        }
+    }
+
     /// **A delegated sweep never gets `save_artifact`.** v1 is driver-loop only, and the
     /// placement enforces it: a sweep's toolset is built from the explore rung, which has
     /// no sink to read. Driven end to end on a real nested sweep so this pins the
@@ -6466,11 +6528,13 @@ mod tests {
                 }
             })
             .on_model(EXPLORER, |req| {
-                assert!(
-                    !has_tool(req, "save_artifact"),
-                    "a delegated sweep must never be handed save_artifact: {:?}",
-                    req.tools
-                );
+                for verb in CLIENT_ONLY_VERBS {
+                    assert!(
+                        !has_tool(req, verb),
+                        "a delegated sweep must never be handed {verb}: {:?}",
+                        req.tools
+                    );
+                }
                 Ok(text_response("SWEPT: src/foo.rs:1"))
             })
             .build();

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,8 +198,13 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
     // exactly as useless as the state we already refuse, so refuse it the same way and for
     // the same reason: crashing beats running silently useless. The per-tool warnings above
     // have already named what each tool wanted; this says the surface came out empty.
+    //
+    // "Empty" means empty of tools that DO something — see `FOLLOWER_TOOL_NAMES`. A
+    // surface of nothing but `read_cas` and the job verbs can fetch what earlier runs
+    // produced and nothing else, and `read_cas` rides the media CAS, which is on by
+    // default: counting it would leave this guard unable to fire on any stock install.
     anyhow::ensure!(
-        !handler.advertised_tools().is_empty(),
+        handler.has_substantive_tools(),
         "no tools left to advertise — every tool is either disabled by a --no-<tool> flag \
          or has no configured cast that can staff it (the warnings above name what each one \
          needs). Fix by configuring a cast with a working provider key, or by re-enabling a \

--- a/src/server/cas_read.rs
+++ b/src/server/cas_read.rs
@@ -71,12 +71,14 @@ pub const MAX_READ_BYTES: usize = 1 << 20;
 
 /// The largest image `read_cas` will hand back as a rendered image content block.
 ///
-/// Sized to the artifacts kaibo itself mints: a 1024×1024 PNG from Stability or
-/// gpt-image lands around 1–2 MB, so the common case of "look at what I just generated"
-/// takes one hop. Above it the caller gets metadata and (in disk mode) a path, because
-/// base64 inflates by about a third on the way into a context window and the useful move
-/// for a large image is to open the file, not to inline it.
-pub const INLINE_IMAGE_MAX_BYTES: usize = 1 << 21;
+/// Sized loose on purpose (Amy, 2026-08-05: "5MB and we'll see who complains"): a
+/// 1024×1024 PNG from Stability or gpt-image lands around 1–2 MB, so the common case of
+/// "look at what I just generated" takes one hop with room over it. Above the line the
+/// caller gets metadata and (in disk mode) a path, because base64 inflates by about a
+/// third on the way into a context window and the useful move for a very large image is
+/// to open the file, not to inline it. If hosts complain (Anthropic's per-image API cap
+/// is ~5 MB and base64 of 5 MiB lands past it), tighten here — one constant.
+pub const INLINE_IMAGE_MAX_BYTES: usize = 5 << 20;
 
 /// One stored object, resolved and verified, as [`plan`] sees it.
 pub struct CasObject<'a> {

--- a/src/server/cas_read.rs
+++ b/src/server/cas_read.rs
@@ -1,0 +1,537 @@
+//! `read_cas` — the client's retrieval half of the artifact contract.
+//!
+//! kaibo's producers (`generate`, `save_artifact`) hand back a digest and never inline
+//! bytes. This is where those bytes come back, and it is a **tool** rather than the
+//! `kaibo://cas/<digest>` MCP *resource* it replaces. Both halves of that swap were
+//! deliberate.
+//!
+//! # Why a tool and not a resource
+//!
+//! **Resources are ambient; a tool call is deliberate.** MCP hosts treat resources as
+//! attachable context — some prefetch them, some auto-attach them to a turn — which is a
+//! reasonable posture for a config file kaibo publishes and the wrong one for
+//! model-authored content that a producer just minted. A tool call is explicit: named
+//! arguments the caller chose, a permission prompt in most hosts, and a traced call.
+//! Retrieval of bytes a model wrote should be something the operator's agent *does*, not
+//! something that happens to its context.
+//!
+//! **`resources/read` has no negotiation.** It is whole-blob by construction: no range,
+//! no size hint, no way to ask what an object is before pulling it. Measured on a real
+//! 3.8 MB PNG, one read produced roughly 5 MB of base64. Claude Code spilled it to a side
+//! file — host mercy, not protocol — and a host without that reflex would have inlined
+//! the lot. A tool can answer "what is this?" for a few dozen tokens, hand back a bounded
+//! window by default, and let the caller page deliberately.
+//!
+//! The URI **string** survives: `kaibo://cas/<digest>` is still how an artifact is named
+//! in a footer, an answer, or a `generate` result. It is an identifier, and `read_cas`
+//! takes the digest out of it. Only the `resources/read` serving of it is gone.
+//!
+//! # The contract
+//!
+//! - **Metadata always leads**, on every response: digest, mime, total bytes, whether the
+//!   object is binary, the label its sidecar carries, the range actually served, and — in
+//!   disk mode — the real filesystem path, so a caller holding a shell can go direct
+//!   instead of paging bytes through a model's context.
+//! - **Bounded by default.** No `length` gives a [`DEFAULT_READ_BYTES`] window from
+//!   `offset`, never the whole object; the metadata names the total so the caller decides
+//!   whether to page. An explicit `length` may ask for more, up to [`MAX_READ_BYTES`].
+//! - **Never a default base64 dump.** A body is served without being asked for only when
+//!   the object is textual. Binary content reaches a caller two ways and no others: the
+//!   one-hop image path below, or an explicit `length`.
+//! - **Images get one hop to the eye.** A small enough image with no range asked for
+//!   comes back as an MCP image content block, which hosts render straight to a vision
+//!   model — the same mechanism kaibo's inner `view_image` rides. A base64 slice of a PNG
+//!   helps nobody, so it is never the default.
+//!
+//! # Verification is not negotiable, so a read is whole-object
+//!
+//! Ranges are computed *after* [`crate::cas::Cas::get`] has read and verified the whole
+//! object. That is deliberate: the store's guarantee is that content is checked against
+//! its digest before a single byte reaches a caller (see `cas.rs`'s module doc on why a
+//! streaming read could not inherit it), and serving a range straight off disk would
+//! quietly trade that away for local I/O that costs nothing in the only budget that
+//! matters here — the caller's context. "Cheap" in this module means cheap in tokens.
+//! A metadata-only read verifies too, so a corrupt object is loud on every path.
+
+use std::path::Path;
+
+use crate::cas::Extension;
+
+/// The window a read returns when the caller names no `length`: enough to see what an
+/// object holds, far short of the whole thing. The metadata reports the total, so paging
+/// is a deliberate second call rather than something that happens to a context window.
+pub const DEFAULT_READ_BYTES: usize = 1 << 16;
+
+/// The ceiling on an explicit `length`. Deliberately the same figure as
+/// `artifact::MAX_ARTIFACT_BYTES`: the largest thing a model may write in one artifact is
+/// the largest thing a client may pull in one read, which makes the two halves of the
+/// contract one number to remember. A megabyte of text is already ~260K tokens, so this
+/// is a real ceiling rather than a formality — past it the caller pages.
+pub const MAX_READ_BYTES: usize = 1 << 20;
+
+/// The largest image `read_cas` will hand back as a rendered image content block.
+///
+/// Sized to the artifacts kaibo itself mints: a 1024×1024 PNG from Stability or
+/// gpt-image lands around 1–2 MB, so the common case of "look at what I just generated"
+/// takes one hop. Above it the caller gets metadata and (in disk mode) a path, because
+/// base64 inflates by about a third on the way into a context window and the useful move
+/// for a large image is to open the file, not to inline it.
+pub const INLINE_IMAGE_MAX_BYTES: usize = 1 << 21;
+
+/// One stored object, resolved and verified, as [`plan`] sees it.
+pub struct CasObject<'a> {
+    pub digest: &'a str,
+    pub ext: Extension,
+    pub bytes: &'a [u8],
+    /// The model's own one-line description, when the sidecar carries one.
+    pub label: Option<&'a str>,
+    /// The real filesystem path — disk mode only. Memory mode has no file.
+    pub path: Option<&'a Path>,
+}
+
+/// What a read hands back beside its metadata.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Body {
+    /// Metadata only: an explicit `length: 0`, an offset past the end, or a binary
+    /// object nobody asked for a range of.
+    None,
+    /// A textual slice, decoded.
+    Text(String),
+    /// A binary slice, base64 of exactly the bytes named in the metadata.
+    Base64(String),
+    /// The whole image, as a content block a host renders.
+    Image { data: String, mime: &'static str },
+}
+
+/// A planned response: the metadata block that always leads, and the body.
+#[derive(Debug, PartialEq, Eq)]
+pub struct CasView {
+    pub meta: String,
+    pub body: Body,
+}
+
+/// Plan one read. Pure over an already-verified object, so every rule here is testable
+/// without a store, a handler, or a network.
+///
+/// `Err` is the one refusal that belongs to this layer: a `length` past
+/// [`MAX_READ_BYTES`]. Refused rather than clamped, because a caller that asked for 4 MiB
+/// and silently got 1 MiB would page from the wrong place next time; the message names
+/// the ceiling and the recovery.
+pub fn plan(obj: &CasObject, offset: usize, length: Option<usize>) -> Result<CasView, String> {
+    if let Some(asked) = length {
+        if asked > MAX_READ_BYTES {
+            return Err(format!(
+                "`length` {asked} is past the {MAX_READ_BYTES}-byte ceiling on a single \
+                 read. Ask for at most {MAX_READ_BYTES} bytes and walk the object with \
+                 `offset` — every response's metadata names the total size, so you can \
+                 page without guessing."
+            ));
+        }
+    }
+    let total = obj.bytes.len();
+    let start = offset.min(total);
+
+    // The one-hop visual path, and the only case that serves a whole object: an image,
+    // small enough to be worth a context window, that nobody asked for a slice of.
+    if obj.ext.is_image()
+        && offset == 0
+        && length.is_none()
+        && total > 0
+        && total <= INLINE_IMAGE_MAX_BYTES
+    {
+        return Ok(CasView {
+            meta: render_meta(
+                obj,
+                total,
+                &format!("the whole object, {total} bytes, as a rendered image"),
+            ),
+            body: Body::Image {
+                data: encode(obj.bytes),
+                mime: obj.ext.mime(),
+            },
+        });
+    }
+
+    // How much to serve when the caller named no length. Textual content gets a window
+    // because a window of text is *readable*; binary gets nothing, because 64 KiB of
+    // base64 PNG is not a preview of anything. Binary reaches a caller only through an
+    // explicit `length` or the image path above.
+    let want = match length {
+        Some(asked) => asked,
+        None if obj.ext.is_textual() => DEFAULT_READ_BYTES,
+        None => 0,
+    };
+    let end = start.saturating_add(want).min(total);
+
+    if end <= start {
+        let why = if start >= total && offset > 0 {
+            format!("nothing: offset {offset} is at or past the end of {total} bytes")
+        } else if length.is_some() {
+            "nothing: metadata only".to_string()
+        } else {
+            "nothing: this object is binary, so pass a `length` for a base64 range (or \
+             open the file at the path above, when there is one)"
+                .to_string()
+        };
+        return Ok(CasView {
+            meta: render_meta(obj, total, &why),
+            body: Body::None,
+        });
+    }
+
+    // Textual content comes back as the string it is. A window can land mid-character, so
+    // serve the largest whole-character range inside it and report THAT range — the
+    // caller's next offset has to be a byte position it can actually resume from.
+    if obj.ext.is_textual() {
+        if let Some((from, to, text)) = utf8_window(obj.bytes, start, end) {
+            return Ok(CasView {
+                meta: render_meta(obj, total, &format!("bytes {from}..{to} of {total}")),
+                body: Body::Text(text.to_string()),
+            });
+        }
+        // Not UTF-8 at all. Hand back the exact bytes asked for, base64 — a lossy decode
+        // would serve different content than was stored, and the base64 form is itself
+        // the honest "treat this as binary" signal.
+    }
+
+    Ok(CasView {
+        meta: render_meta(obj, total, &format!("bytes {start}..{end} of {total}")),
+        body: Body::Base64(encode(&obj.bytes[start..end])),
+    })
+}
+
+fn encode(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// The metadata block that leads every response. One `key: value` per line — cheap to
+/// read, cheap to parse — with the optional lines simply absent rather than empty.
+fn render_meta(obj: &CasObject, total: usize, served: &str) -> String {
+    let mut out = format!(
+        "digest: {digest}\nuri: {prefix}{digest}\nmime: {mime}\nbytes: {total}\nbinary: {binary}",
+        digest = obj.digest,
+        prefix = crate::cas::CAS_URI_PREFIX,
+        mime = obj.ext.mime(),
+        binary = !obj.ext.is_textual(),
+    );
+    if let Some(label) = obj.label {
+        out.push_str(&format!("\nlabel: {label}"));
+    }
+    if let Some(path) = obj.path {
+        out.push_str(&format!("\npath: {}", path.display()));
+    }
+    out.push_str(&format!("\nserved: {served}"));
+    out
+}
+
+/// The largest whole-character UTF-8 range inside `[start, end)`, with the range it
+/// actually covers. `None` when the bytes are not UTF-8 at all, which is the caller's
+/// signal to fall back to base64 rather than decode lossily.
+///
+/// Two adjustments, for the two ways a byte window can split a character: the start may
+/// land on a continuation byte (no decoder can begin there), and the end may cut the last
+/// character short. Both are ordinary when paging text by byte offset, so neither is
+/// treated as a failure.
+fn utf8_window(bytes: &[u8], start: usize, end: usize) -> Option<(usize, usize, &str)> {
+    let mut from = start;
+    while from < end && (bytes[from] & 0xC0) == 0x80 {
+        from += 1;
+    }
+    match std::str::from_utf8(&bytes[from..end]) {
+        Ok(text) => Some((from, end, text)),
+        // `error_len: None` means the input ended mid-character — the window's tail, not
+        // corruption. Serve up to the last whole character and leave the rest for the
+        // next page.
+        Err(e) if e.error_len().is_none() => {
+            let to = from + e.valid_up_to();
+            std::str::from_utf8(&bytes[from..to])
+                .ok()
+                .map(|text| (from, to, text))
+        }
+        Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    const TEXT_DIGEST: &str = "abababababababababababababababababababababababababababababababab";
+    const PNG_DIGEST: &str = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
+
+    fn text_obj<'a>(bytes: &'a [u8], label: Option<&'a str>) -> CasObject<'a> {
+        CasObject {
+            digest: TEXT_DIGEST,
+            ext: Extension::Txt,
+            bytes,
+            label,
+            path: None,
+        }
+    }
+
+    fn png_obj(bytes: &[u8]) -> CasObject<'_> {
+        CasObject {
+            digest: PNG_DIGEST,
+            ext: Extension::Png,
+            bytes,
+            label: None,
+            path: None,
+        }
+    }
+
+    /// **Metadata leads on every response, including the one that carries nothing else.**
+    /// `length: 0` is the cheap HEAD: what is this, how big, what is it called, where does
+    /// it live — for a few dozen tokens instead of the object.
+    #[test]
+    fn length_zero_is_metadata_only() {
+        let body = "x".repeat(5000);
+        let obj = text_obj(body.as_bytes(), Some("the inventory"));
+        let view = plan(&obj, 0, Some(0)).expect("a HEAD is always legal");
+        assert_eq!(view.body, Body::None, "no content at length 0");
+        assert!(view.meta.contains("5000"), "the total leads: {}", view.meta);
+        assert!(
+            view.meta.contains("text/plain"),
+            "the mime leads: {}",
+            view.meta
+        );
+        assert!(
+            view.meta.contains("the inventory"),
+            "the label leads when there is one: {}",
+            view.meta
+        );
+        assert!(
+            view.meta.contains("binary: false"),
+            "and whether it is binary: {}",
+            view.meta
+        );
+    }
+
+    /// A sidecar with no label simply omits the line — never an empty or invented one.
+    #[test]
+    fn a_missing_label_is_omitted_not_faked() {
+        let obj = text_obj(b"hi", None);
+        let view = plan(&obj, 0, Some(0)).unwrap();
+        assert!(
+            !view.meta.contains("label:"),
+            "no label line without a label: {}",
+            view.meta
+        );
+    }
+
+    /// **The default read is a window, not the object.** An omitted `length` serves
+    /// `DEFAULT_READ_BYTES` from the offset and says so, with the total beside it, so the
+    /// caller decides whether to page rather than discovering the size by paying for it.
+    #[test]
+    fn an_omitted_length_serves_the_default_window_and_names_the_total() {
+        let total = DEFAULT_READ_BYTES * 3;
+        let body = "y".repeat(total);
+        let obj = text_obj(body.as_bytes(), None);
+        let view = plan(&obj, 0, None).expect("a default read is legal");
+        match &view.body {
+            Body::Text(t) => assert_eq!(
+                t.len(),
+                DEFAULT_READ_BYTES,
+                "exactly the default window, not the whole object"
+            ),
+            other => panic!("a textual object serves text, got {other:?}"),
+        }
+        assert!(
+            view.meta.contains(&total.to_string()),
+            "the total is in the metadata so paging is informed: {}",
+            view.meta
+        );
+    }
+
+    /// Paging: a second call with an offset picks up where the first stopped, and the
+    /// served range says so.
+    #[test]
+    fn offset_pages_through_a_large_object() {
+        let total = DEFAULT_READ_BYTES + 100;
+        let body: String = (0..total)
+            .map(|i| ((i % 26) as u8 + b'a') as char)
+            .collect();
+        let obj = text_obj(body.as_bytes(), None);
+
+        let first = plan(&obj, 0, None).unwrap();
+        let second = plan(&obj, DEFAULT_READ_BYTES, None).unwrap();
+        let (Body::Text(a), Body::Text(b)) = (&first.body, &second.body) else {
+            panic!("both pages are text");
+        };
+        assert_eq!(a.len(), DEFAULT_READ_BYTES);
+        assert_eq!(
+            b.len(),
+            100,
+            "the tail is what is left, not a padded window"
+        );
+        assert_eq!(
+            format!("{a}{b}"),
+            body,
+            "the two pages reassemble the object exactly"
+        );
+    }
+
+    /// An offset past the end is an empty range, not an error: a caller paging a loop
+    /// discovers the end by reading past it, and a hard failure there would make that
+    /// normal move look like a fault.
+    #[test]
+    fn an_offset_past_the_end_is_an_empty_range_not_an_error() {
+        let obj = text_obj(b"short", None);
+        let view = plan(&obj, 9_999, None).expect("past the end is legal");
+        assert_eq!(view.body, Body::None, "nothing left to serve");
+        assert!(
+            view.meta.contains('5'),
+            "the total still leads, so the caller learns where the end was: {}",
+            view.meta
+        );
+    }
+
+    /// A `length` past the ceiling is refused, naming the ceiling and the way forward.
+    /// Clamping instead would hand back less than was asked for while the caller's next
+    /// offset assumed otherwise.
+    #[test]
+    fn a_length_past_the_ceiling_is_refused_with_the_ceiling_and_the_recovery() {
+        let obj = text_obj(b"small", None);
+        let err = plan(&obj, 0, Some(MAX_READ_BYTES + 1)).expect_err("past the ceiling");
+        assert!(
+            err.contains(&MAX_READ_BYTES.to_string()),
+            "the refusal names the ceiling: {err}"
+        );
+        assert!(
+            err.to_lowercase().contains("offset"),
+            "and the recovery is paging: {err}"
+        );
+        plan(&obj, 0, Some(MAX_READ_BYTES)).expect("exactly at the ceiling is fine");
+    }
+
+    /// Textual content arrives as text a caller can use, never base64 it must decode.
+    #[test]
+    fn textual_content_arrives_as_text() {
+        let obj = text_obj(b"line one\nline two\n", None);
+        let view = plan(&obj, 0, None).unwrap();
+        assert_eq!(view.body, Body::Text("line one\nline two\n".to_string()));
+    }
+
+    /// A binary range is base64 of **exactly** the bytes the metadata names — no padding,
+    /// no re-encoding of a neighbouring window.
+    #[test]
+    fn a_binary_range_is_base64_of_exactly_those_bytes() {
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let obj = png_obj(&bytes);
+        let view = plan(&obj, 10, Some(20)).unwrap();
+        assert_eq!(view.body, Body::Base64(b64(&bytes[10..30])));
+    }
+
+    /// **A base64 dump is never a default.** A binary object with no range asked for
+    /// serves metadata alone — the caller either asks for a range or, in disk mode, reads
+    /// the path. Sixty-four kilobytes of base64 PNG helps neither a person nor a model.
+    #[test]
+    fn a_binary_object_serves_no_body_unless_a_range_is_asked_for() {
+        let big = vec![7u8; INLINE_IMAGE_MAX_BYTES + 1];
+        let view = plan(&png_obj(&big), 0, None).unwrap();
+        assert_eq!(
+            view.body,
+            Body::None,
+            "an oversize image is metadata only, not a base64 wall"
+        );
+        assert!(
+            view.meta.contains("binary: true"),
+            "and the metadata says why: {}",
+            view.meta
+        );
+    }
+
+    /// **Small images take one hop to the eye.** No range asked for, size under the
+    /// threshold: the whole image comes back as a content block hosts render straight to
+    /// a vision model.
+    #[test]
+    fn a_small_image_with_no_range_comes_back_as_an_image_block() {
+        let bytes = vec![9u8; 1024];
+        let view = plan(&png_obj(&bytes), 0, None).unwrap();
+        assert_eq!(
+            view.body,
+            Body::Image {
+                data: b64(&bytes),
+                mime: "image/png",
+            }
+        );
+        assert!(
+            view.meta.contains("1024"),
+            "the metadata still leads: {}",
+            view.meta
+        );
+    }
+
+    /// An explicit range beats the image path even for a small image: the caller asked
+    /// for bytes, so it gets bytes.
+    #[test]
+    fn an_explicit_range_on_a_small_image_returns_base64_not_an_image_block() {
+        let bytes = vec![9u8; 1024];
+        let view = plan(&png_obj(&bytes), 0, Some(16)).unwrap();
+        assert_eq!(view.body, Body::Base64(b64(&bytes[..16])));
+    }
+
+    /// Disk mode puts the real path in the metadata, so a caller holding a shell can go
+    /// direct instead of paging megabytes through a context window. Memory mode has no
+    /// file and says nothing.
+    #[test]
+    fn the_path_is_in_the_metadata_only_when_there_is_a_file() {
+        let bytes = b"content";
+        let on_disk = CasObject {
+            path: Some(Path::new("/var/lib/kaibo/cas/ab/cd/abcd.txt")),
+            ..text_obj(bytes, None)
+        };
+        assert!(
+            plan(&on_disk, 0, Some(0))
+                .unwrap()
+                .meta
+                .contains("/var/lib/kaibo/cas/ab/cd/abcd.txt"),
+            "disk mode names the file"
+        );
+        assert!(
+            !plan(&text_obj(bytes, None), 0, Some(0))
+                .unwrap()
+                .meta
+                .contains("path:"),
+            "memory mode has no file to name"
+        );
+    }
+
+    /// A window that lands mid-character serves the largest whole-character range inside
+    /// it and reports what it served. Paging UTF-8 by byte offset splits multi-byte
+    /// characters constantly, and neither a lossy decode (different bytes than stored) nor
+    /// a base64 fallback for the whole window (unreadable) is an acceptable answer.
+    #[test]
+    fn a_window_splitting_a_multibyte_character_trims_to_a_boundary() {
+        // Each `é` is two bytes, so a 3-byte window from 0 splits the second one.
+        let body = "ééé";
+        let obj = text_obj(body.as_bytes(), None);
+        let view = plan(&obj, 0, Some(3)).unwrap();
+        assert_eq!(
+            view.body,
+            Body::Text("é".to_string()),
+            "the split character is left for the next page"
+        );
+        assert!(
+            view.meta.contains("0..2") || view.meta.contains("0-2"),
+            "and the served range is the trimmed one, so the next offset is right: {}",
+            view.meta
+        );
+    }
+
+    /// Bytes stored under a textual extension that are not UTF-8 at all fall back to
+    /// base64 of the exact requested range — never a lossy decode, which would hand back
+    /// different bytes than were stored.
+    #[test]
+    fn undecodable_textual_bytes_fall_back_to_base64() {
+        let bytes: &[u8] = &[0x66, 0x6f, 0x6f, 0xff, 0xfe, 0x62, 0x61, 0x72];
+        let obj = text_obj(bytes, None);
+        let view = plan(&obj, 0, None).unwrap();
+        assert_eq!(view.body, Body::Base64(b64(bytes)));
+    }
+}

--- a/src/server/cas_read.rs
+++ b/src/server/cas_read.rs
@@ -86,7 +86,24 @@ pub struct CasObject<'a> {
     pub ext: Extension,
     pub bytes: &'a [u8],
     /// The model's own one-line description, when the sidecar carries one.
+    ///
+    /// `None` covers two different situations, which is why it does not stand alone: a
+    /// record that carries no label, and no record at all. See `provenance_present`.
     pub label: Option<&'a str>,
+    /// Whether this object has a provenance record beside it.
+    ///
+    /// Separate from `label` because "the record says nothing about this" and "there is
+    /// no record" are different facts, and only the second is worth a line. An object can
+    /// legitimately lack one: `CasError::ProvenanceNotRecorded` mints exactly this state
+    /// (the object landed, the sidecar write failed), and the extension-probe fallback in
+    /// `Cas::entry_for` serves objects whose sidecar is missing or unreadable. This store
+    /// never rewrites, so such an object stays recordless forever — worth saying once,
+    /// rather than leaving a caller to read "no label" as "nothing was written down".
+    ///
+    /// The sidecar is best-effort housekeeping, not a promised record (Amy's ruling), so
+    /// a *present* record with no label renders nothing at all: a `label: (none)` line on
+    /// every generated image would be noise on the common case.
+    pub provenance_present: bool,
     /// The real filesystem path — disk mode only. Memory mode has no file.
     pub path: Option<&'a Path>,
 }
@@ -146,6 +163,7 @@ pub fn plan(obj: &CasObject, offset: usize, length: Option<usize>) -> Result<Cas
                 obj,
                 total,
                 &format!("the whole object, {total} bytes, as a rendered image"),
+                None,
             ),
             body: Body::Image {
                 data: encode(obj.bytes),
@@ -166,17 +184,21 @@ pub fn plan(obj: &CasObject, offset: usize, length: Option<usize>) -> Result<Cas
     let end = start.saturating_add(want).min(total);
 
     if end <= start {
-        let why = if start >= total && offset > 0 {
+        let why = if total == 0 {
+            "nothing: this object is empty".to_string()
+        } else if start >= total {
             format!("nothing: offset {offset} is at or past the end of {total} bytes")
         } else if length.is_some() {
             "nothing: metadata only".to_string()
-        } else {
-            "nothing: this object is binary, so pass a `length` for a base64 range (or \
-             open the file at the path above, when there is one)"
+        } else if obj.path.is_some() {
+            "nothing: this object is binary, so pass a `length` for a base64 range, or \
+             open the file at the path above"
                 .to_string()
+        } else {
+            "nothing: this object is binary, so pass a `length` for a base64 range".to_string()
         };
         return Ok(CasView {
-            meta: render_meta(obj, total, &why),
+            meta: render_meta(obj, total, &why, None),
             body: Body::None,
         });
     }
@@ -185,19 +207,51 @@ pub fn plan(obj: &CasObject, offset: usize, length: Option<usize>) -> Result<Cas
     // serve the largest whole-character range inside it and report THAT range — the
     // caller's next offset has to be a byte position it can actually resume from.
     if obj.ext.is_textual() {
-        if let Some((from, to, text)) = utf8_window(obj.bytes, start, end) {
-            return Ok(CasView {
-                meta: render_meta(obj, total, &format!("bytes {from}..{to} of {total}")),
-                body: Body::Text(text.to_string()),
-            });
+        match text_window(obj.bytes, start, end) {
+            TextWindow::Whole { to, text } => {
+                return Ok(CasView {
+                    meta: render_meta(obj, total, &format!("bytes {start}..{to} of {total}"), None),
+                    body: Body::Text(text.to_string()),
+                })
+            }
+            // **The cursor must always move.** A window too narrow to hold one whole
+            // character used to trim to nothing and report `bytes N..N`; a caller
+            // resuming at the endpoint it was handed read the same byte forever, with no
+            // way to detect it. Serving the exact bytes as base64 is imperfect and
+            // *escapable*: the range advances over them, the note says why they are not
+            // text, and the caller widens `length` or realigns `offset`.
+            //
+            // Refusing was the other option and is worse. A mechanical pager cannot act
+            // on a refusal; always-advances is a property it can build on.
+            TextWindow::SplitCharacter => {
+                return Ok(CasView {
+                    meta: render_meta(
+                        obj,
+                        total,
+                        &format!("bytes {start}..{end} of {total}"),
+                        Some(
+                            "these bytes begin or end inside a multi-byte character, so \
+                             they are base64 rather than text — widen `length` or move \
+                             `offset` to a character boundary to read this span as text",
+                        ),
+                    ),
+                    body: Body::Base64(encode(&obj.bytes[start..end])),
+                })
+            }
+            // Not UTF-8 at all. Hand back the exact bytes asked for, base64 — a lossy
+            // decode would serve different content than was stored, and the base64 form
+            // is itself the honest "treat this as binary" signal.
+            TextWindow::NotText => {}
         }
-        // Not UTF-8 at all. Hand back the exact bytes asked for, base64 — a lossy decode
-        // would serve different content than was stored, and the base64 form is itself
-        // the honest "treat this as binary" signal.
     }
 
     Ok(CasView {
-        meta: render_meta(obj, total, &format!("bytes {start}..{end} of {total}")),
+        meta: render_meta(
+            obj,
+            total,
+            &format!("bytes {start}..{end} of {total}"),
+            None,
+        ),
         body: Body::Base64(encode(&obj.bytes[start..end])),
     })
 }
@@ -209,7 +263,7 @@ fn encode(bytes: &[u8]) -> String {
 
 /// The metadata block that leads every response. One `key: value` per line — cheap to
 /// read, cheap to parse — with the optional lines simply absent rather than empty.
-fn render_meta(obj: &CasObject, total: usize, served: &str) -> String {
+fn render_meta(obj: &CasObject, total: usize, served: &str, note: Option<&str>) -> String {
     let mut out = format!(
         "digest: {digest}\nuri: {prefix}{digest}\nmime: {mime}\nbytes: {total}\nbinary: {binary}",
         digest = obj.digest,
@@ -220,38 +274,61 @@ fn render_meta(obj: &CasObject, total: usize, served: &str) -> String {
     if let Some(label) = obj.label {
         out.push_str(&format!("\nlabel: {label}"));
     }
+    if !obj.provenance_present {
+        out.push_str("\nprovenance: absent (this object was stored without its sidecar)");
+    }
     if let Some(path) = obj.path {
         out.push_str(&format!("\npath: {}", path.display()));
     }
     out.push_str(&format!("\nserved: {served}"));
+    if let Some(note) = note {
+        out.push_str(&format!("\nnote: {note}"));
+    }
     out
 }
 
-/// The largest whole-character UTF-8 range inside `[start, end)`, with the range it
-/// actually covers. `None` when the bytes are not UTF-8 at all, which is the caller's
-/// signal to fall back to base64 rather than decode lossily.
+/// What a byte window over textual content turned out to hold.
+enum TextWindow<'a> {
+    /// At least one whole character, starting exactly where the caller asked and ending
+    /// at `to` — which may be earlier than the window's end, because the tail can cut a
+    /// character short.
+    Whole { to: usize, text: &'a str },
+    /// The window cannot produce text starting where the caller asked: it begins inside a
+    /// multi-byte character, or it starts one it has no room to finish. **Never an empty
+    /// [`TextWindow::Whole`]** — see [`plan`] for why that difference is the whole bug.
+    SplitCharacter,
+    /// Not UTF-8 at all, whatever the extension claims.
+    NotText,
+}
+
+/// The whole-character UTF-8 text at `[start, end)`, always **beginning at `start`**.
 ///
-/// Two adjustments, for the two ways a byte window can split a character: the start may
-/// land on a continuation byte (no decoder can begin there), and the end may cut the last
-/// character short. Both are ordinary when paging text by byte offset, so neither is
-/// treated as a failure.
-fn utf8_window(bytes: &[u8], start: usize, end: usize) -> Option<(usize, usize, &str)> {
-    let mut from = start;
-    while from < end && (bytes[from] & 0xC0) == 0x80 {
-        from += 1;
+/// Only the tail is ever trimmed. An earlier version also stepped `start` forward off a
+/// leading continuation byte, which looks like the symmetric courtesy and is silent data
+/// loss: the skipped bytes appear in no response, so a caller paging by the ranges it is
+/// handed reassembles an object with holes in it. A window that cannot begin where it was
+/// asked to begin is [`TextWindow::SplitCharacter`] instead, and `plan` serves those exact
+/// bytes as base64 — imperfect, but complete and escapable.
+fn text_window(bytes: &[u8], start: usize, end: usize) -> TextWindow<'_> {
+    // A continuation byte is a place no decoder can start reading from.
+    if (bytes[start] & 0xC0) == 0x80 {
+        return TextWindow::SplitCharacter;
     }
-    match std::str::from_utf8(&bytes[from..end]) {
-        Ok(text) => Some((from, end, text)),
+    let to = match std::str::from_utf8(&bytes[start..end]) {
+        Ok(_) => end,
         // `error_len: None` means the input ended mid-character — the window's tail, not
         // corruption. Serve up to the last whole character and leave the rest for the
         // next page.
-        Err(e) if e.error_len().is_none() => {
-            let to = from + e.valid_up_to();
-            std::str::from_utf8(&bytes[from..to])
-                .ok()
-                .map(|text| (from, to, text))
-        }
-        Err(_) => None,
+        Err(e) if e.error_len().is_none() => start + e.valid_up_to(),
+        Err(_) => return TextWindow::NotText,
+    };
+    // The window starts a character it has no room to finish.
+    if to <= start {
+        return TextWindow::SplitCharacter;
+    }
+    match std::str::from_utf8(&bytes[start..to]) {
+        Ok(text) => TextWindow::Whole { to, text },
+        Err(_) => TextWindow::NotText,
     }
 }
 
@@ -273,6 +350,7 @@ mod tests {
             ext: Extension::Txt,
             bytes,
             label,
+            provenance_present: true,
             path: None,
         }
     }
@@ -283,6 +361,7 @@ mod tests {
             ext: Extension::Png,
             bytes,
             label: None,
+            provenance_present: true,
             path: None,
         }
     }
@@ -501,6 +580,206 @@ mod tests {
                 .meta
                 .contains("path:"),
             "memory mode has no file to name"
+        );
+    }
+
+    /// The byte range a response says it served, parsed out of the metadata — what a
+    /// mechanical pager reads to pick its next `offset`.
+    fn served_range(meta: &str) -> Option<(usize, usize)> {
+        let line = meta.lines().find(|l| l.starts_with("served: bytes "))?;
+        let span = line
+            .trim_start_matches("served: bytes ")
+            .split(" of ")
+            .next()?;
+        let (a, b) = span.split_once("..")?;
+        Some((a.parse().ok()?, b.parse().ok()?))
+    }
+
+    /// **A missing sidecar is its own state, and the metadata says so.**
+    ///
+    /// Three things a caller can be looking at, and they are not the same: an object whose
+    /// record carries a label, one whose record carries none, and one with no record at
+    /// all. The last is real — it is exactly what `CasError::ProvenanceNotRecorded` mints
+    /// and what the extension-probe fallback serves — and silence about it would let a
+    /// caller read "no label" as "nothing was written down here", which is a different
+    /// and much weaker claim.
+    ///
+    /// A `label:` line when there is a label, a `provenance:` line when there is no
+    /// record, and neither when the record simply has no label to give.
+    #[test]
+    fn the_metadata_distinguishes_no_label_from_no_provenance_at_all() {
+        let bytes = b"content";
+
+        let labeled = text_obj(bytes, Some("the inventory"));
+        let m = plan(&labeled, 0, Some(0)).unwrap().meta;
+        assert!(m.contains("label: the inventory"), "{m}");
+        assert!(
+            !m.contains("provenance:"),
+            "a present record says nothing: {m}"
+        );
+
+        let unlabeled = CasObject {
+            label: None,
+            ..text_obj(bytes, None)
+        };
+        let m = plan(&unlabeled, 0, Some(0)).unwrap().meta;
+        assert!(!m.contains("label:"), "no label, no line: {m}");
+        assert!(
+            !m.contains("provenance:"),
+            "a record that simply has no label is not a missing record: {m}"
+        );
+
+        let orphaned = CasObject {
+            provenance_present: false,
+            ..text_obj(bytes, None)
+        };
+        let m = plan(&orphaned, 0, Some(0)).unwrap().meta;
+        assert!(
+            m.contains("provenance: absent"),
+            "a missing record is stated: {m}"
+        );
+        assert!(!m.contains("label:"), "and still invents no label: {m}");
+    }
+
+    /// **A window that holds no complete character must still advance.**
+    ///
+    /// `é` is two bytes. Asking for one of them used to trim the window to nothing and
+    /// report `served: bytes 0..0` — a caller resuming at the endpoint it was handed reads
+    /// the same byte forever. Serving zero bytes while claiming a range is worse than
+    /// serving something imperfect: a pager cannot detect it and cannot escape it.
+    ///
+    /// So the exact bytes asked for come back as base64, the served range covers them, and
+    /// a note says why they are not text. The cursor moves; the caller can widen or
+    /// realign; nothing loops.
+    #[test]
+    fn a_window_holding_no_whole_character_advances_over_the_bytes_it_was_given() {
+        let obj = text_obj("é".as_bytes(), None);
+        let view = plan(&obj, 0, Some(1)).expect("a legal range");
+        assert_eq!(
+            view.body,
+            Body::Base64(b64(&[0xC3])),
+            "the exact byte asked for, not an empty string"
+        );
+        assert_eq!(
+            served_range(&view.meta),
+            Some((0, 1)),
+            "and the range advances past it: {}",
+            view.meta
+        );
+        assert!(
+            view.meta.contains("note: "),
+            "with a note saying why it is not text: {}",
+            view.meta
+        );
+    }
+
+    /// The same, trimmed at *both* edges: a window entirely inside one 4-byte character is
+    /// all continuation bytes, so neither edge can be salvaged.
+    #[test]
+    fn a_window_inside_one_character_advances_over_the_bytes_it_was_given() {
+        let obj = text_obj("😀".as_bytes(), None); // F0 9F 98 80
+        let view = plan(&obj, 1, Some(2)).expect("a legal range");
+        assert_eq!(view.body, Body::Base64(b64(&[0x9F, 0x98])));
+        assert_eq!(
+            served_range(&view.meta),
+            Some((1, 3)),
+            "the cursor advances over exactly what was asked for: {}",
+            view.meta
+        );
+    }
+
+    /// **The property a pager actually relies on: the cursor always moves.** Walk a
+    /// multi-byte corpus at every small window size; each response's served range must
+    /// start where the last one ended and end strictly later, until the object runs out.
+    /// The old trim-to-empty behavior hangs this test rather than failing an assertion,
+    /// so it carries its own iteration bound.
+    #[test]
+    fn paging_a_multibyte_corpus_always_advances_to_eof() {
+        let corpus = "aé漢😀b\nzこんにちは😀é";
+        let obj = text_obj(corpus.as_bytes(), None);
+        let total = corpus.len();
+
+        for window in 1..=6 {
+            let mut cursor = 0usize;
+            let mut steps = 0;
+            while cursor < total {
+                steps += 1;
+                assert!(
+                    steps <= total + 2,
+                    "window {window}: paging did not terminate — stuck at {cursor}"
+                );
+                let view = plan(&obj, cursor, Some(window)).expect("a legal range");
+                let (from, to) = served_range(&view.meta)
+                    .unwrap_or_else(|| panic!("window {window} at {cursor}: {}", view.meta));
+                assert_eq!(
+                    from, cursor,
+                    "window {window}: the range starts where asked"
+                );
+                assert!(
+                    to > cursor,
+                    "window {window} at {cursor}: served {from}..{to} does not advance"
+                );
+                assert!(to <= total, "window {window}: {to} is past the object");
+                cursor = to;
+            }
+            assert_eq!(
+                cursor, total,
+                "window {window}: paging lands exactly on the end"
+            );
+        }
+    }
+
+    /// Reassembly is the other half of the contract: whatever form each page came back in,
+    /// the bytes a caller collects are the object.
+    #[test]
+    fn pages_of_a_multibyte_corpus_reassemble_the_original_bytes() {
+        use base64::Engine as _;
+        let corpus = "aé漢😀b";
+        let obj = text_obj(corpus.as_bytes(), None);
+        let mut out: Vec<u8> = Vec::new();
+        let mut cursor = 0;
+        // Bounded like its sibling: a non-advancing cursor is the failure under test, and
+        // a test that hangs on the bug reports nothing.
+        for _ in 0..corpus.len() + 2 {
+            if cursor >= corpus.len() {
+                break;
+            }
+            let view = plan(&obj, cursor, Some(3)).unwrap();
+            let (_, to) = served_range(&view.meta).unwrap();
+            match &view.body {
+                Body::Text(t) => out.extend_from_slice(t.as_bytes()),
+                Body::Base64(d) => out.extend_from_slice(
+                    &base64::engine::general_purpose::STANDARD
+                        .decode(d)
+                        .expect("valid base64"),
+                ),
+                other => panic!("unexpected body {other:?}"),
+            }
+            cursor = to;
+        }
+        assert_eq!(
+            cursor,
+            corpus.len(),
+            "paging terminated at the end, not by the bound"
+        );
+        assert_eq!(out, corpus.as_bytes(), "the pages reassemble the object");
+    }
+
+    /// A zero-byte textual object says it is empty — it used to fall through to the
+    /// "this object is binary" wording, which is simply not true of an empty `.txt`.
+    #[test]
+    fn an_empty_object_says_it_is_empty() {
+        let view = plan(&text_obj(b"", None), 0, None).unwrap();
+        assert_eq!(view.body, Body::None);
+        assert!(
+            view.meta.contains("empty"),
+            "an empty textual object says so: {}",
+            view.meta
+        );
+        assert!(
+            !view.meta.contains("binary, so pass"),
+            "and does not claim to be binary: {}",
+            view.meta
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -116,9 +116,11 @@ const TOOLS_URI: &str = "kaibo://tools";
 /// footers, answers, and `generate` results all need a stable name for an artifact.
 ///
 /// OPERATOR SURFACE ONLY (Amy's ruling, 2026-08-03), and that survived the move: the MCP
-/// client and CLI retrieve; the inner model team never can — the CAS is not mounted into
-/// kaish and no cast-facing tool reads it, because kaibo state spans projects and a
-/// browsable CAS would let one project's team enumerate another's artifacts.
+/// client retrieves, through `read_cas`; the inner model team never can — the CAS is not
+/// mounted into kaish and no cast-facing tool reads it, because kaibo state spans projects
+/// and a browsable CAS would let one project's team enumerate another's artifacts. (kaibo's
+/// CLI has no artifact command at all today; on disk, the metadata's path is what an
+/// operator's own tools use.)
 const CAS_RES_PREFIX: &str = crate::cas::CAS_URI_PREFIX;
 /// The system preambles kaibo hands each model-driven phase — explorer, consult
 /// driver, oneshot, and the offline batch/deliberate synth — rendered through the exact
@@ -627,9 +629,10 @@ pub struct ReadCasInput {
     #[serde(default)]
     pub offset: Option<usize>,
 
-    /// How many bytes to read. Omit for a bounded default window (65536 bytes) from
-    /// `offset`; `0` for metadata only. Reads a base64 range of a binary object, which is
-    /// otherwise never served unasked.
+    /// How many bytes to read, capped at 1048576 — a larger ask is refused, not trimmed.
+    /// `0` is metadata only. Omit it for the per-kind default: up to 65536 bytes of TEXT
+    /// from `offset`, a whole image when one qualifies, and metadata alone for any other
+    /// binary (a base64 range is served only when you ask for one).
     #[serde(default)]
     pub length: Option<usize>,
 }
@@ -1309,9 +1312,9 @@ impl KaiboHandler {
     }
 
     /// Swap in a media-arm factory — the seam that lets tests drive the `generate`
-    /// lane (sync store-and-answer, the deferred job, the CAS resource) with a
-    /// scripted [`crate::media::MediaModel`] instead of a real provider client. A
-    /// builder, like [`with_batch_providers`](Self::with_batch_providers).
+    /// lane (sync store-and-answer, the deferred job, and `read_cas` over what it
+    /// stored) with a scripted [`crate::media::MediaModel`] instead of a real provider
+    /// client. A builder, like [`with_batch_providers`](Self::with_batch_providers).
     #[cfg(test)]
     pub fn with_media_arms(mut self, arms: Arc<dyn crate::media::MediaArmFactory>) -> Self {
         self.media_arms = arms;
@@ -2625,11 +2628,14 @@ impl KaiboHandler {
             always comes first: mime, total size, whether it is binary, the artifact's \
             label, the range served, and the real file path when the store is on disk \
             (open that directly with your own tools for anything large). Reads are \
-            BOUNDED: `length` 0 is metadata only, omitting `length` returns the first \
-            65536 bytes, and `offset` pages through the rest — the metadata's total \
-            tells you how far. Text comes back as text. A small image comes back as a \
-            viewable image; a large one comes back as metadata and a path, never a wall \
-            of base64. Ask for `length` explicitly to get a base64 range of any binary."
+            BOUNDED, and what you get depends on the object. TEXT: omitting `length` \
+            returns up to 65536 bytes from `offset`, and `offset` pages the rest — the \
+            metadata's total tells you how far. IMAGE: a whole image up to 5 MiB comes \
+            back viewable; a larger one comes back as metadata alone (plus the file path \
+            in disk mode). ANY BINARY: omitting `length` returns metadata only, never a \
+            wall of base64 — pass `length` to get a base64 range. `length` 0 is metadata \
+            only for anything. `length` is capped at 1048576 bytes and a larger ask is \
+            refused, not trimmed."
     )]
     pub async fn read_cas(
         &self,
@@ -2672,7 +2678,12 @@ impl KaiboHandler {
             // corruption read as an ordinary absence.
             Err(e) => return Err(McpError::internal_error(format!("{e}"), None)),
         };
-        let label = store.provenance(&digest).and_then(|p| p.label);
+        // The record and the label are two facts, not one: an object can have a record
+        // that carries no label, or no record at all (a sidecar write that failed, or one
+        // that went missing — `Cas::entry_for`'s probe fallback still serves the object).
+        // The metadata says which.
+        let provenance = store.provenance(&digest);
+        let label = provenance.as_ref().and_then(|p| p.label.clone());
         let path = store.path_for(&digest);
         let view = cas_read::plan(
             &cas_read::CasObject {
@@ -2680,6 +2691,7 @@ impl KaiboHandler {
                 ext,
                 bytes: &bytes,
                 label: label.as_deref(),
+                provenance_present: provenance.is_some(),
                 path: path.as_deref(),
             },
             input.offset.unwrap_or(0),
@@ -3869,12 +3881,21 @@ sidecar (prompt, model, cast, timestamp, mime, seed) beside it in the store.
 
 `read_cas` is the retrieval half — for you, the client, never for kaibo's own models.
 Pass the digest from a `kaibo://cas/<digest>` address and you get **metadata first**:
-mime, total bytes, whether it is binary, the artifact's label, the range served, and the
-real file path when the store is on disk. Reads are bounded on purpose. `length: 0` is a
-cheap look at what an object is; omitting `length` returns the first 65536 bytes and tells
-you the total, and `offset` pages the rest. Text arrives as text. A small image arrives as
-an image you can actually see; a large one arrives as metadata and a path, because a
-megabyte of base64 helps nobody — open the file, or ask for a range explicitly.
+mime, total bytes, whether it is binary, the artifact's label when its record carries one,
+the range served, and the real file path when the store is on disk.
+
+Reads are bounded, and the default depends on what the object is. Text: omitting `length`
+gives up to 65536 bytes from `offset`, and `offset` pages the rest — the metadata's total
+says how far. An image up to 5 MiB with no range asked for arrives whole and viewable; a
+larger one arrives as metadata alone, plus the file path when the store is on disk. Any
+other binary gives metadata only until you ask: pass `length` for a base64 range, capped
+at 1048576 bytes (a larger ask is refused rather than trimmed). `length: 0` is the cheap
+look at any object.
+
+Paging always advances. A window that lands inside a multi-byte character comes back as
+base64 of exactly the bytes you asked for, with a note saying so — so the served range
+still moves and you can widen `length` or realign `offset`, rather than reading the same
+byte forever.
 
 ## Driving the read-only shell (`run_kaish`)
 
@@ -4234,6 +4255,21 @@ fn read_kaibo_resource_with_config(
         return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
             vec![ResourceContents::text(CONFIG_EXAMPLE_TOML, uri)],
         )));
+    }
+    // A host that cached the old resource template still asks for this. The route is
+    // gone and stays gone — but a bare "unknown resource" tells a caller nothing about
+    // where its artifacts went, and the digest it already holds is the whole argument it
+    // needs. Recognized, never served: the answer is a pointer to `read_cas`.
+    if let Some(hex) = uri.strip_prefix(crate::cas::CAS_URI_PREFIX) {
+        return Err(McpError::resource_not_found(
+            format!(
+                "the {}<digest> resource was removed — artifact retrieval is now the \
+                 `read_cas` tool. Call read_cas with digest {hex} (it takes an optional \
+                 `offset`/`length`, and answers metadata first).",
+                crate::cas::CAS_URI_PREFIX
+            ),
+            None,
+        ));
     }
     let body = render_resource(uri, schemas)
         .ok_or_else(|| McpError::resource_not_found(format!("unknown resource: {uri}"), None))?;
@@ -5718,6 +5754,49 @@ enabled = false
         );
     }
 
+    /// **An object whose sidecar is gone still reads, and says its record is gone.**
+    ///
+    /// This is a real state, not a hypothetical: `Cas::put` writes the object first and
+    /// the sidecar second, so a failure between them leaves exactly this, and
+    /// `Cas::entry_for`'s probe fallback is what keeps such an object reachable. The store
+    /// never rewrites, so it stays recordless — a caller deciding whether to trust the
+    /// bytes deserves to know that, rather than reading "no label" as "nothing to say".
+    #[tokio::test]
+    async fn read_cas_reports_an_object_whose_provenance_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let toml = format!(
+            "{MEDIA_CAST_TOML}\n[cas]\ndir = \"{}\"\n",
+            dir.path().join("cas").display()
+        );
+        let h = hermetic_handler_from_toml(&toml)
+            .finalize_media_store(true)
+            .expect("disk-backed store");
+        let hex = with_text_artifact(&h, b"the object outlives its record");
+        let digest = crate::cas::Digest::from_hex(&hex).unwrap();
+
+        // With the sidecar in place: the label rides, and nothing claims a missing record.
+        let meta = meta_of(&read(&h, &hex, None, Some(0)).await);
+        assert!(meta.contains("label: a test artifact"), "{meta}");
+        assert!(!meta.contains("provenance:"), "{meta}");
+
+        // Now take the record away, leaving the object.
+        let object = h.media_store().unwrap().path_for(&digest).unwrap();
+        std::fs::remove_file(object.with_extension("json")).expect("remove the sidecar");
+
+        let r = read(&h, &hex, None, None).await;
+        let meta = meta_of(&r);
+        assert!(
+            meta.contains("provenance: absent"),
+            "the missing record is stated: {meta}"
+        );
+        assert!(!meta.contains("label:"), "and no label is invented: {meta}");
+        assert_eq!(
+            r.content[1].as_text().expect("text body").text,
+            "the object outlives its record",
+            "and the bytes still come back — a lost record is not a lost object"
+        );
+    }
+
     /// The digest is validated before it can touch a lookup, an unknown one is a clean
     /// not-found, and neither folds into the other. Ported from the resource this tool
     /// replaced — the guarantees survive the change of surface.
@@ -5785,6 +5864,48 @@ enabled = false
         );
     }
 
+    /// **A server whose whole surface is `read_cas` does nothing, and says so.**
+    ///
+    /// `has_substantive_tools` is what `main`'s empty-surface guard actually asks, and
+    /// until this test it was only exercised through configurations the *flag* guard
+    /// rejects first — so the follower rule itself was never pinned. Build the real
+    /// degenerate server: every flag off, no staffable cast, media CAS on. It advertises
+    /// exactly one tool, that tool is a follower, and the answer is no.
+    ///
+    /// This matters because `read_cas` rides a store that is ON by default. Counted as
+    /// substantive, it would keep the guard from ever firing on a stock install — a check
+    /// that cannot fire protects nothing.
+    #[test]
+    fn a_surface_of_only_read_cas_is_not_substantive() {
+        let h = hermetic_handler_from_toml(
+            "[server.tools]\nconsult = false\nexplore = false\ndeliberate = false\n\
+             oneshot = false\nrun_kaish = false\nbatch = false\nlist_models = false\n\
+             generate = false\n",
+        );
+        assert_eq!(
+            h.advertised_tools(),
+            vec!["read_cas".to_string()],
+            "the degenerate surface is exactly the follower"
+        );
+        assert!(
+            !h.has_substantive_tools(),
+            "a server that can only hand back what earlier runs produced is the useless \
+             server the startup guard exists to refuse"
+        );
+
+        // And the same handler with one castless tool back on IS substantive — the rule
+        // is about followers, not about being small.
+        let with_shell = hermetic_handler_from_toml(
+            "[server.tools]\nconsult = false\nexplore = false\ndeliberate = false\n\
+             oneshot = false\nbatch = false\nlist_models = false\ngenerate = false\n",
+        );
+        assert!(
+            with_shell.has_substantive_tools(),
+            "run_kaish alone is a narrow server, not an empty one: {:?}",
+            with_shell.advertised_tools()
+        );
+    }
+
     /// `read_cas` is advertised exactly when the media CAS is live — the same liveness the
     /// resource it replaces keyed on. It takes no cast, so nothing else gates it.
     #[test]
@@ -5825,9 +5946,16 @@ enabled = false
             crate::config::CasMode::Memory,
         )
         .expect_err("the CAS resource route no longer exists");
+        // Recognized, not served: a host with a cached template gets told where the
+        // bytes went, with the digest it already has as the argument to use.
         assert!(
-            err.message.to_lowercase().contains("unknown"),
-            "an artifact URI is now just an unknown resource: {}",
+            err.message.contains("read_cas") && err.message.contains(&hex),
+            "the removal must hand a stale caller its migration: {}",
+            err.message
+        );
+        assert!(
+            !err.message.to_lowercase().contains("unknown resource"),
+            "and not the bare unknown-resource message: {}",
             err.message
         );
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -52,6 +52,7 @@ use crate::sandbox::{builtin_schemas, KaishWorker};
 use crate::session::{SessionStore, Sessions};
 use crate::sweep_attach::{SweepAttachSink, SweepConsumer, SweepConsumerKind};
 
+mod cas_read;
 mod config_resource;
 mod containment;
 mod render;
@@ -107,14 +108,18 @@ const CONFIG_GUIDE_URI: &str = "kaibo://config/guide";
 /// on demand, not in every agent's startup context (the AGENTS.md prompt-writing split:
 /// terse where it's always loaded, generous where it's pulled).
 const TOOLS_URI: &str = "kaibo://tools";
-/// Generated-artifact retrieval by content digest: `kaibo://cas/<sha256-hex>`.
-/// OPERATOR SURFACE ONLY (Amy's ruling, 2026-08-03): the MCP client and CLI read it;
-/// the inner model team never can — the CAS is not mounted into kaish and no
-/// cast-facing tool reads it, because kaibo state spans projects and a browsable CAS
-/// would let one project's team enumerate another's artifacts.
+/// How an artifact is NAMED wherever kaibo prints one: `kaibo://cas/<sha256-hex>`.
+///
+/// It is an identifier, not a route. It was an MCP resource until 2026-08-05; retrieval
+/// is now the `read_cas` tool, which takes the digest out of this string (see
+/// [`cas_read`]'s module doc for why a tool and not a resource). The string stays because
+/// footers, answers, and `generate` results all need a stable name for an artifact.
+///
+/// OPERATOR SURFACE ONLY (Amy's ruling, 2026-08-03), and that survived the move: the MCP
+/// client and CLI retrieve; the inner model team never can — the CAS is not mounted into
+/// kaish and no cast-facing tool reads it, because kaibo state spans projects and a
+/// browsable CAS would let one project's team enumerate another's artifacts.
 const CAS_RES_PREFIX: &str = crate::cas::CAS_URI_PREFIX;
-/// The RFC 6570 template `list_resource_templates` advertises for the CAS reads.
-const CAS_URI_TEMPLATE: &str = "kaibo://cas/{digest}";
 /// The system preambles kaibo hands each model-driven phase — explorer, consult
 /// driver, oneshot, and the offline batch/deliberate synth — rendered through the exact
 /// same [`resolve_phase_preamble`](crate::consult::resolve_phase_preamble) seam the live
@@ -605,6 +610,30 @@ pub struct ListModelsInput {
     pub backend: Option<String>,
 }
 
+/// Arguments for [`KaiboHandler::read_cas`] — a digest and an optional byte range.
+///
+/// No path of any kind, in either direction: the address is the content hash, so there is
+/// nothing to aim. The range exists because `resources/read`, which this replaces, had no
+/// way to ask for less than everything.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReadCasInput {
+    /// The artifact's content digest: 64 lowercase hex, exactly as a `generate` result or
+    /// a consult's artifact footer prints it (the `kaibo://cas/<digest>` tail).
+    pub digest: String,
+
+    /// Byte offset to read from. Default 0. Past the end is an empty range with the
+    /// metadata, not an error — that is how a paging loop learns where the object ended.
+    #[serde(default)]
+    pub offset: Option<usize>,
+
+    /// How many bytes to read. Omit for a bounded default window (65536 bytes) from
+    /// `offset`; `0` for metadata only. Reads a base64 range of a binary object, which is
+    /// otherwise never served unasked.
+    #[serde(default)]
+    pub length: Option<usize>,
+}
+
 /// Arguments to `generate`: media generation through the cast's `image` slot. No
 /// `path` — generation reads no project (the prompt is the whole input), so there is
 /// nothing to scope to an allowed tree.
@@ -837,7 +866,7 @@ pub(crate) fn cast_requirement_for(name: &str) -> Option<&'static str> {
 /// Every `#[tool]` route name kaibo can advertise — the fixed universe [`live_tools`]
 /// filters. `KaiboHandler::new` asserts each really exists on the router, so a renamed
 /// tool method fails the build rather than leaving a gate quietly inert.
-pub(crate) const ALL_TOOL_NAMES: [&str; 13] = [
+pub(crate) const ALL_TOOL_NAMES: [&str; 14] = [
     "consult",
     "consult_submit",
     "explore",
@@ -846,12 +875,25 @@ pub(crate) const ALL_TOOL_NAMES: [&str; 13] = [
     "run_kaish",
     "batch_submit",
     "generate",
+    "read_cas",
     "job_get",
     "job_cancel",
     "job_list",
     "job_wait",
     "list_models",
 ];
+
+/// Tools that only *collect* or *retrieve* what other tools produce. They are a real
+/// surface, but they are not on their own a reason for a server to exist: a kaibo whose
+/// entire offering is "fetch a handle" or "read a digest" cannot investigate, answer, or
+/// generate anything, which is the useless-server state startup already refuses.
+///
+/// The `job_*` verbs enforce this through their own liveness (they need a producer).
+/// `read_cas` cannot: it keys on the media CAS, which is ON by default, so counting it
+/// would make the empty-surface guard in `main` unreachable for every stock install — a
+/// check that can no longer fire is a check that no longer protects anything.
+pub(crate) const FOLLOWER_TOOL_NAMES: &[&str] =
+    &["read_cas", "job_get", "job_cancel", "job_list", "job_wait"];
 
 /// Which tools this config actually advertises: the operator's `--no-<tool>` flags AND
 /// a cast that can staff each one.
@@ -882,6 +924,12 @@ pub(crate) fn live_tools(config: &Config, usable: &[String]) -> Vec<&'static str
     // ([cas] enabled = false is the operator's explicit choice; the startup log and
     // kaibo://config's [cas] section name it, distinct from the unstaffable warning).
     let generate_live = gating.generate && can_staff("generate") && config.cas.enabled;
+    // `read_cas` is the retrieval half of the artifact contract, keyed on the SAME
+    // liveness the resource it replaces was keyed on: a live media CAS, nothing else. It
+    // takes no cast (there is no model in a byte range) and it is deliberately NOT tied to
+    // `[artifacts] enabled` — that flag gates whether the model team may *write*, while
+    // `generate`'s artifacts need retrieving whether or not a consult may save.
+    let read_cas_live = config.cas.enabled;
     let jobs_live = consult_live || batch_live || deliberate_live || generate_live;
 
     [
@@ -902,6 +950,9 @@ pub(crate) fn live_tools(config: &Config, usable: &[String]) -> Vec<&'static str
         // Media generation through the cast's image slot; a deferred operation mints a
         // `job-N`, so it is a job producer like the three above.
         (generate_live, "generate"),
+        // Client-side retrieval by digest. Operator surface, like the resource it
+        // replaces: the inner model team never carries it.
+        (read_cas_live, "read_cas"),
         // The collect verbs follow their producers — see the fn doc. "Live" folds the
         // flag AND staffing together, so a producer nothing can staff keeps them no more
         // than a producer the operator switched off does: neither mints a handle.
@@ -1244,63 +1295,6 @@ impl KaiboHandler {
         self.media_cas.as_ref()
     }
 
-    /// Serve one `kaibo://cas/<digest>` read: the artifact's bytes as a base64 blob
-    /// stamped with its mime. The retrieval half of the `generate` contract — the tool
-    /// returns digests, this resource returns the bytes, and only to the operator
-    /// surface (the MCP client / CLI caller); the inner model team has no path here.
-    /// The digest is validated before it goes anywhere near a lookup
-    /// ([`crate::cas::Digest::from_hex`] — 64 lowercase hex or refused), a missing
-    /// object is a clean not-found, and a corrupt or unreadable object is a loud error,
-    /// never folded into "not found".
-    fn read_cas_resource(&self, hex: &str, uri: &str) -> Result<ReadResourceResponse, McpError> {
-        let Some(store) = &self.media_cas else {
-            return Err(McpError::resource_not_found(
-                "the media CAS is disabled ([cas] enabled = false); no artifacts are held"
-                    .to_string(),
-                None,
-            ));
-        };
-        let digest = crate::cas::Digest::from_hex(hex)
-            .map_err(|e| McpError::invalid_params(format!("{e} (in {uri})"), None))?;
-        match store.get(&digest) {
-            Ok(Some((bytes, ext))) => {
-                // Textual formats come back as the string they are — the producer
-                // marked them (save_artifact writes UTF-8 text; the sidecar mime
-                // carries the mark), so a client fetching a corpus gets usable text,
-                // not base64 to decode. Bytes that fail to decode fall back to the
-                // blob form untouched: a lossy decode would serve different bytes
-                // than were stored, and the blob form is itself the honest "treat
-                // this as binary" signal.
-                let contents = if ext.is_textual() {
-                    match String::from_utf8(bytes) {
-                        Ok(text) => ResourceContents::text(text, uri).with_mime_type(ext.mime()),
-                        Err(e) => {
-                            use base64::Engine as _;
-                            let blob =
-                                base64::engine::general_purpose::STANDARD.encode(e.into_bytes());
-                            ResourceContents::blob(blob, uri).with_mime_type(ext.mime())
-                        }
-                    }
-                } else {
-                    use base64::Engine as _;
-                    let blob = base64::engine::general_purpose::STANDARD.encode(bytes);
-                    ResourceContents::blob(blob, uri).with_mime_type(ext.mime())
-                };
-                Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
-                    vec![contents],
-                )))
-            }
-            Ok(None) => Err(McpError::resource_not_found(
-                format!(
-                    "no artifact with digest {hex} — it was never generated on this \
-                     store, or (in memory mode) it did not survive a restart"
-                ),
-                None,
-            )),
-            Err(e) => Err(McpError::internal_error(format!("{e}"), None)),
-        }
-    }
-
     /// Swap in a batch-provider factory — the seam that lets tests drive the batch
     /// handlers (`batch_submit`, `deliberate`'s batch lane, the `job_*` batch arms) with a
     /// scripted double instead of real network clients. A builder, like
@@ -1335,6 +1329,16 @@ impl KaiboHandler {
     pub fn apply_log_level(&self, level: LoggingLevel) {
         self.mcp_log_level
             .store(mcp_log::rank(level), Ordering::Relaxed);
+    }
+
+    /// Does this server offer anything beyond collecting and retrieving? See
+    /// [`FOLLOWER_TOOL_NAMES`] — `main`'s empty-surface guard asks this rather than
+    /// "is the list empty", because a surface of nothing but followers is the same
+    /// useless server by a different route.
+    pub fn has_substantive_tools(&self) -> bool {
+        self.advertised_tools()
+            .iter()
+            .any(|name| !FOLLOWER_TOOL_NAMES.contains(&name.as_str()))
     }
 
     /// Tool names this handler advertises, after gating. For tests/diagnostics.
@@ -2616,13 +2620,96 @@ impl KaiboHandler {
     }
 
     #[tool(
+        description = "Read one stored artifact by its digest — what `generate` and a \
+            consult's `save_artifact` hand back as kaibo://cas/<digest>. Metadata \
+            always comes first: mime, total size, whether it is binary, the artifact's \
+            label, the range served, and the real file path when the store is on disk \
+            (open that directly with your own tools for anything large). Reads are \
+            BOUNDED: `length` 0 is metadata only, omitting `length` returns the first \
+            65536 bytes, and `offset` pages through the rest — the metadata's total \
+            tells you how far. Text comes back as text. A small image comes back as a \
+            viewable image; a large one comes back as metadata and a path, never a wall \
+            of base64. Ask for `length` explicitly to get a base64 range of any binary."
+    )]
+    pub async fn read_cas(
+        &self,
+        Parameters(input): Parameters<ReadCasInput>,
+    ) -> Result<CallToolResult, McpError> {
+        // The route is dropped when the CAS is off, so this is a belt for a direct caller
+        // that bypasses the advertised list.
+        let Some(store) = &self.media_cas else {
+            return Err(McpError::invalid_params(
+                "the media CAS is disabled ([cas] enabled = false); no artifacts are \
+                 held, so there is nothing to read."
+                    .to_string(),
+                None,
+            ));
+        };
+        // Validated before it can become part of a path — the same structural guard the
+        // resource this tool replaces applied, and the reason a traversal-shaped
+        // "digest" never reaches a lookup.
+        let digest = crate::cas::Digest::from_hex(&input.digest)
+            .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+        // Whole-object read, verified against the digest, THEN sliced. See
+        // `cas_read`'s module doc: the store's verify-before-return guarantee is worth
+        // more than the local I/O a ranged read would save, and the budget this tool
+        // exists to protect is the caller's context, not the disk.
+        let (bytes, ext) = match store.get(&digest) {
+            Ok(Some(found)) => found,
+            Ok(None) => {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "no artifact with digest {} — it was never produced on this \
+                         store, or (in memory mode) it did not survive a restart",
+                        input.digest
+                    ),
+                    None,
+                ))
+            }
+            // Corrupt or unreadable stays loud and distinct: an object whose bytes do not
+            // hash to their address is not "missing", and folding the two would let real
+            // corruption read as an ordinary absence.
+            Err(e) => return Err(McpError::internal_error(format!("{e}"), None)),
+        };
+        let label = store.provenance(&digest).and_then(|p| p.label);
+        let path = store.path_for(&digest);
+        let view = cas_read::plan(
+            &cas_read::CasObject {
+                digest: &input.digest,
+                ext,
+                bytes: &bytes,
+                label: label.as_deref(),
+                path: path.as_deref(),
+            },
+            input.offset.unwrap_or(0),
+            input.length,
+        )
+        .map_err(|e| McpError::invalid_params(e, None))?;
+
+        // Metadata leads every response — a caller that reads only the first block still
+        // learns what this object is, how big it is, and where the rest of it lives.
+        let mut blocks = vec![ContentBlock::text(view.meta)];
+        match view.body {
+            cas_read::Body::None => {}
+            cas_read::Body::Text(text) => blocks.push(ContentBlock::text(text)),
+            cas_read::Body::Base64(data) => blocks.push(ContentBlock::text(data)),
+            // The one hop to the eye: hosts render an image content block straight to a
+            // vision model, the same mechanism the inner `view_image` tool rides.
+            cas_read::Body::Image { data, mime } => blocks.push(ContentBlock::image(data, mime)),
+        }
+        Ok(CallToolResult::success(blocks))
+    }
+
+    #[tool(
         description = "Generate images from a text prompt with the cast's `image` \
             model (a media backend: Stability, or an OpenAI-compatible images \
             endpoint — hosted gpt-image or a local stable-diffusion.cpp sd-server). \
             Bytes are never inlined: each artifact lands in kaibo's content-addressed \
             media store and the result lists per-artifact digests — a \
-            kaibo://cas/<digest> resource URI, the mime, the provider's seed when \
-            reported, and the real file path when the store is on disk. \
+            kaibo://cas/<digest> address, the mime, the provider's seed when reported, \
+            and the real file path when the store is on disk. Fetch one with `read_cas` \
+            (metadata first, ranges on request; a small image comes back viewable). \
             Provider-native options (aspect_ratio, size, n, output_format, seed, \
             negative_prompt, style_preset, ...) pass through `fields` verbatim, each \
             value's JSON type (string | number | boolean) preserved to the wire. An \
@@ -3256,7 +3343,7 @@ impl rmcp::ServerHandler for KaiboHandler {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
         Ok(ListResourceTemplatesResult {
-            resource_templates: kaibo_resource_templates(self.media_cas.is_some()),
+            resource_templates: kaibo_resource_templates(),
             ..Default::default()
         })
     }
@@ -3266,12 +3353,6 @@ impl rmcp::ServerHandler for KaiboHandler {
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
-        // Generated-artifact reads by digest — handled here, not in the pure dispatch,
-        // because they need the handler's live media store. Operator surface only: MCP
-        // resources reach the client, never the inner model team.
-        if let Some(hex) = request.uri.strip_prefix(CAS_RES_PREFIX) {
-            return self.read_cas_resource(hex, &request.uri);
-        }
         // Compute the runtime-derived worktree set here (it needs the handler's
         // allowed_set and reflects worktrees that exist *now*); the renderer is a
         // pure function of its inputs, so it can't reach back for this itself.
@@ -3580,7 +3661,7 @@ pub(crate) fn configure_prompt_text_cli(goal: Option<&str>) -> String {
 
 /// The URI templates kaibo advertises: per-builtin help and per-cast prompts, each
 /// addressed by name.
-fn kaibo_resource_templates(cas_on: bool) -> Vec<rmcp::model::ResourceTemplate> {
+fn kaibo_resource_templates() -> Vec<rmcp::model::ResourceTemplate> {
     let builtin = ResourceTemplate::new(BUILTIN_URI_TEMPLATE, "kaish builtin help")
         .with_description(
             "Help for a single kaish builtin — parameters and examples. \
@@ -3593,20 +3674,12 @@ fn kaibo_resource_templates(cas_on: bool) -> Vec<rmcp::model::ResourceTemplate> 
              `preamble`s folded in as a live call resolves them. e.g. kaibo://prompts/deepseek",
         )
         .with_mime_type("text/markdown");
-    let mut templates = vec![builtin, prompts];
-    // Advertised only while a media store exists — a template whose every read would
-    // error is the resource-shaped version of the unstaffable-tool lie the staffing
-    // gate exists to prevent.
-    if cas_on {
-        templates.push(
-            ResourceTemplate::new(CAS_URI_TEMPLATE, "kaibo: generated artifact by digest")
-                .with_description(
-                    "One generated artifact's bytes, addressed by the content digest a \
-                     `generate` result returned (64 lowercase hex).",
-                ),
-        );
-    }
-    templates
+    // Artifact retrieval is deliberately NOT here. It was a `kaibo://cas/{digest}`
+    // template until 2026-08-05, and it is now the `read_cas` tool: hosts treat resources
+    // as ambient context to prefetch or attach, which is the wrong posture for
+    // model-authored bytes, and `resources/read` is whole-blob with no way to ask what an
+    // object is before pulling all of it. See `cas_read`'s module doc.
+    vec![builtin, prompts]
 }
 
 /// Render the markdown body for a kaibo resource URI, or `None` if the URI isn't
@@ -3781,9 +3854,9 @@ backend: Stability's v2beta family, or an OpenAI-compatible images endpoint (hos
 gpt-image, or a local stable-diffusion.cpp sd-server; one call may return several
 images via `n`). It is advertised only when a configured cast carries that slot and
 the media CAS is on. The result is never inline bytes: each artifact lands in kaibo's
-content-addressed store and you get its digest as a `kaibo://cas/<digest>` resource
-URI (read it as an MCP resource for the bytes), the mime, the provider's seed when
-reported, and — when the store is on disk — the real file path. Provider-native
+content-addressed store and you get its digest as a `kaibo://cas/<digest>` address, the
+mime, the provider's seed when reported, and — when the store is on disk — the real file
+path. Provider-native
 options ride the `fields` object verbatim, each value's JSON type preserved
 (Stability: `aspect_ratio` \"16:9\", `output_format` png|jpeg|webp, `seed`,
 `negative_prompt`, `style_preset`; OpenAI-compatible: `size` \"1024x1024\", `n`,
@@ -3791,6 +3864,17 @@ options ride the `fields` object verbatim, each value's JSON type preserved
 deferred hands back a `job-N` on the same collect verbs above — the lane is wired,
 though every route wired today answers in-call. Every artifact gets a provenance
 sidecar (prompt, model, cast, timestamp, mime, seed) beside it in the store.
+
+## Reading artifacts back: `read_cas`
+
+`read_cas` is the retrieval half — for you, the client, never for kaibo's own models.
+Pass the digest from a `kaibo://cas/<digest>` address and you get **metadata first**:
+mime, total bytes, whether it is binary, the artifact's label, the range served, and the
+real file path when the store is on disk. Reads are bounded on purpose. `length: 0` is a
+cheap look at what an object is; omitting `length` returns the first 65536 bytes and tells
+you the total, and `offset` pages the rest. Text arrives as text. A small image arrives as
+an image you can actually see; a large one arrives as metadata and a path, because a
+megabyte of base64 helps nobody — open the file, or ask for a range explicitly.
 
 ## Driving the read-only shell (`run_kaish`)
 
@@ -4029,7 +4113,7 @@ fn store_generated_artifacts(
         .collect::<Result<_>>()?;
     let timestamp = now_epoch_secs();
     let mut lines = vec![format!(
-        "Generated {} artifact{}:",
+        "Generated {} artifact{} (read one with `read_cas`, passing the digest):",
         artifacts.len(),
         if artifacts.len() == 1 { "" } else { "s" }
     )];
@@ -5387,83 +5471,170 @@ enabled = false
         }
     }
 
-    /// A textual artifact reads back as **text**, not base64. The producers mark what
-    /// they make — `save_artifact` writes text formats, `generate` writes images — and
-    /// the sidecar mime carries that mark to retrieval, so a client fetching a corpus
-    /// gets the string it can use, not a blob it must decode first.
-    #[tokio::test]
-    async fn cas_resource_serves_textual_artifacts_as_text() {
-        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
-        let store = h.media_store().expect("media CAS is on").clone();
-        let content = "line one\nline two\n";
-        let digest = store
-            .put(
-                content.as_bytes(),
-                crate::cas::Extension::Txt,
-                &textual_provenance(),
-            )
-            .expect("put succeeds");
-        let hex = digest.to_hex();
-        let uri = format!("kaibo://cas/{hex}");
-        let ReadResourceResponse::Complete(result) =
-            h.read_cas_resource(&hex, &uri).expect("stored digest reads")
-        else {
-            panic!("expected a complete read");
-        };
-        let ResourceContents::TextResourceContents {
-            text, mime_type, ..
-        } = &result.contents[0]
-        else {
-            panic!(
-                "a textual artifact reads as text, got {:?}",
-                result.contents[0]
-            );
-        };
-        assert_eq!(text, content);
-        assert_eq!(mime_type.as_deref(), Some("text/plain; charset=utf-8"));
+    /// Call `read_cas` and unwrap the success, for the many shapes below.
+    async fn read(
+        h: &KaiboHandler,
+        digest: &str,
+        offset: Option<usize>,
+        length: Option<usize>,
+    ) -> CallToolResult {
+        h.read_cas(Parameters(ReadCasInput {
+            digest: digest.to_string(),
+            offset,
+            length,
+        }))
+        .await
+        .expect("a stored digest reads")
     }
 
-    /// Bytes under a textual extension that do not decode as UTF-8 fall back to a blob
-    /// — never a lossy decode that would hand back different bytes than were stored.
-    /// The blob form itself is the marking that says "treat this as binary"; the mime
-    /// still reports what the object claims to be.
+    /// The metadata block — always the FIRST content block, on every response.
+    fn meta_of(r: &CallToolResult) -> String {
+        r.content
+            .first()
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
+            .expect("every response leads with metadata")
+    }
+
+    /// A handler with the media CAS on and one textual artifact stored; returns the hex.
+    fn with_text_artifact(h: &KaiboHandler, content: &[u8]) -> String {
+        h.media_store()
+            .expect("media CAS is on")
+            .put(content, crate::cas::Extension::Txt, &textual_provenance())
+            .expect("put succeeds")
+            .to_hex()
+    }
+
+    /// **Metadata leads, and `length: 0` is the cheap HEAD.** The whole point of
+    /// replacing `resources/read`: ask what an object is for a few dozen tokens instead
+    /// of pulling it to find out. The label the sidecar carries rides along, so a caller
+    /// can tell one digest from another without reading either.
     #[tokio::test]
-    async fn cas_resource_falls_back_to_blob_for_undecodable_text() {
+    async fn read_cas_length_zero_returns_metadata_only() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let hex = with_text_artifact(&h, &b"z".repeat(9000));
+        let r = read(&h, &hex, None, Some(0)).await;
+        assert_eq!(r.content.len(), 1, "metadata only, no body block");
+        let meta = meta_of(&r);
+        for needle in [
+            hex.as_str(),
+            "mime: text/plain",
+            "bytes: 9000",
+            "binary: false",
+            "label: a test artifact",
+        ] {
+            assert!(
+                meta.contains(needle),
+                "metadata must carry {needle}: {meta}"
+            );
+        }
+    }
+
+    /// **The default read is bounded.** An omitted `length` returns the first window and
+    /// says how much more there is — the behavior `resources/read` structurally could not
+    /// offer, and the reason a 3.8 MB artifact no longer lands whole in a context window.
+    /// Paging with `offset` reassembles the object exactly.
+    #[tokio::test]
+    async fn read_cas_defaults_to_a_bounded_window_and_pages_with_offset() {
+        use super::cas_read::DEFAULT_READ_BYTES;
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let total = DEFAULT_READ_BYTES + 250;
+        let content: Vec<u8> = (0..total).map(|i| b'a' + (i % 26) as u8).collect();
+        let hex = with_text_artifact(&h, &content);
+
+        let first = read(&h, &hex, None, None).await;
+        let head = first.content[1].as_text().expect("text body").text.clone();
+        assert_eq!(
+            head.len(),
+            DEFAULT_READ_BYTES,
+            "the default window, not the whole object"
+        );
+        assert!(
+            meta_of(&first).contains(&total.to_string()),
+            "and the total, so paging is informed: {}",
+            meta_of(&first)
+        );
+
+        let second = read(&h, &hex, Some(DEFAULT_READ_BYTES), None).await;
+        let tail = second.content[1].as_text().expect("text body").text.clone();
+        assert_eq!(
+            format!("{head}{tail}").as_bytes(),
+            content.as_slice(),
+            "the pages reassemble the artifact byte for byte"
+        );
+    }
+
+    /// An offset past the end is a clean empty response, not a failure — a paging loop
+    /// finds the end by reading past it.
+    #[tokio::test]
+    async fn read_cas_offset_past_the_end_is_empty_not_an_error() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let hex = with_text_artifact(&h, b"tiny");
+        let r = read(&h, &hex, Some(4096), None).await;
+        assert_eq!(r.content.len(), 1, "metadata only");
+        assert!(meta_of(&r).contains("bytes: 4"), "{}", meta_of(&r));
+    }
+
+    /// A `length` past the ceiling is refused, naming the ceiling — never silently
+    /// clamped, which would leave the caller's next offset wrong.
+    #[tokio::test]
+    async fn read_cas_refuses_a_length_past_the_ceiling() {
+        use super::cas_read::MAX_READ_BYTES;
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let hex = with_text_artifact(&h, b"tiny");
+        let err = h
+            .read_cas(Parameters(ReadCasInput {
+                digest: hex,
+                offset: None,
+                length: Some(MAX_READ_BYTES + 1),
+            }))
+            .await
+            .expect_err("past the ceiling is refused");
+        assert!(
+            err.message.contains(&MAX_READ_BYTES.to_string()),
+            "the refusal names the ceiling: {}",
+            err.message
+        );
+    }
+
+    /// A textual artifact arrives as **text**, not base64 to decode. The producers mark
+    /// what they make (`save_artifact` writes text formats, `generate` writes images) and
+    /// the sidecar mime carries that mark to retrieval.
+    #[tokio::test]
+    async fn read_cas_serves_textual_artifacts_as_text() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let hex = with_text_artifact(&h, b"line one\nline two\n");
+        let r = read(&h, &hex, None, None).await;
+        assert_eq!(
+            r.content[1].as_text().expect("text body").text,
+            "line one\nline two\n"
+        );
+    }
+
+    /// Bytes stored under a textual extension that are not UTF-8 fall back to base64 of
+    /// exactly those bytes — never a lossy decode, which would hand back content the
+    /// store does not hold.
+    #[tokio::test]
+    async fn read_cas_falls_back_to_base64_for_undecodable_text() {
         use base64::Engine as _;
         let h = media_handler(Arc::new(SyncArtifacts(vec![])));
-        let store = h.media_store().expect("media CAS is on").clone();
         let bytes: &[u8] = &[0x66, 0x6f, 0x6f, 0xff, 0xfe, 0x62, 0x61, 0x72];
-        let digest = store
-            .put(bytes, crate::cas::Extension::Txt, &textual_provenance())
-            .expect("put succeeds");
-        let hex = digest.to_hex();
-        let uri = format!("kaibo://cas/{hex}");
-        let ReadResourceResponse::Complete(result) =
-            h.read_cas_resource(&hex, &uri).expect("stored digest reads")
-        else {
-            panic!("expected a complete read");
-        };
-        let ResourceContents::BlobResourceContents { blob, .. } = &result.contents[0] else {
-            panic!(
-                "undecodable bytes read as a blob, got {:?}",
-                result.contents[0]
-            );
-        };
+        let hex = with_text_artifact(&h, bytes);
+        let r = read(&h, &hex, None, None).await;
+        let body = r.content[1].as_text().expect("base64 body").text.clone();
         assert_eq!(
             base64::engine::general_purpose::STANDARD
-                .decode(blob)
+                .decode(&body)
                 .expect("valid base64"),
             bytes
         );
     }
 
-    /// The `kaibo://cas/<digest>` read: bytes come back base64 with the right mime, an
-    /// unknown digest is a clean not-found, and a malformed digest is refused before it
-    /// goes near a lookup. Operator surface — served straight off the handler's store.
+    /// **A small image takes one hop to the eye**: an image content block, which hosts
+    /// render straight to a vision model. This is the retrieval shape `generate`'s output
+    /// actually wants, and the one a resource read could never produce.
     #[tokio::test]
-    async fn cas_resource_serves_stored_bytes_and_validates_the_digest() {
-        use base64::Engine as _;
-        let h = media_handler(Arc::new(SyncArtifacts(vec![png(b"resource-bytes")])));
+    async fn read_cas_returns_a_small_image_as_an_image_block() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![png(b"pretend-png-bytes")])));
         h.generate(Parameters(GenerateInput {
             prompt: "p".to_string(),
             cast: Some("artist".to_string()),
@@ -5471,44 +5642,210 @@ enabled = false
         }))
         .await
         .expect("generate succeeds");
+        let hex = crate::cas::Digest::of_bytes(b"pretend-png-bytes").to_hex();
 
-        let digest = crate::cas::Digest::of_bytes(b"resource-bytes");
-        let hex = digest.to_hex();
-        let uri = format!("kaibo://cas/{hex}");
-        let ReadResourceResponse::Complete(result) = h
-            .read_cas_resource(&hex, &uri)
-            .expect("stored digest reads")
-        else {
-            panic!("expected a complete read");
-        };
-        let ResourceContents::BlobResourceContents {
-            blob, mime_type, ..
-        } = &result.contents[0]
-        else {
-            panic!("an artifact read is a blob, got {:?}", result.contents[0]);
-        };
-        assert_eq!(mime_type.as_deref(), Some("image/png"));
+        let r = read(&h, &hex, None, None).await;
+        assert!(
+            meta_of(&r).contains("binary: true"),
+            "metadata still leads: {}",
+            meta_of(&r)
+        );
+        let image = r.content[1].as_image().expect("an image content block");
+        assert_eq!(image.mime_type, "image/png");
+        use base64::Engine as _;
         assert_eq!(
             base64::engine::general_purpose::STANDARD
-                .decode(blob)
+                .decode(&image.data)
                 .expect("valid base64"),
-            b"resource-bytes"
+            b"pretend-png-bytes"
         );
+    }
 
-        let missing = crate::cas::Digest::of_bytes(b"never-generated").to_hex();
+    /// **An image past the inline threshold is metadata only** — no image block, and no
+    /// base64 wall either. The measured failure this whole tool exists to prevent: a
+    /// 3.8 MB PNG became ~5 MB of base64 through the resource route. Over the threshold
+    /// the useful move is the path, not the bytes.
+    #[tokio::test]
+    async fn read_cas_refuses_to_inline_an_image_past_the_threshold() {
+        use super::cas_read::INLINE_IMAGE_MAX_BYTES;
+        let big = vec![3u8; INLINE_IMAGE_MAX_BYTES + 1];
+        let h = media_handler(Arc::new(SyncArtifacts(vec![png(&big)])));
+        h.generate(Parameters(GenerateInput {
+            prompt: "p".to_string(),
+            cast: Some("artist".to_string()),
+            fields: None,
+        }))
+        .await
+        .expect("generate succeeds");
+        let hex = crate::cas::Digest::of_bytes(&big).to_hex();
+
+        let r = read(&h, &hex, None, None).await;
+        assert_eq!(
+            r.content.len(),
+            1,
+            "metadata only — neither an image block nor a base64 dump"
+        );
+        assert!(meta_of(&r).contains("binary: true"));
+
+        // But an explicit range still works: the caller asked, so it gets bytes.
+        let ranged = read(&h, &hex, Some(0), Some(8)).await;
+        assert_eq!(ranged.content.len(), 2, "an explicit range is served");
+    }
+
+    /// Disk mode names the real file, so a caller holding a shell can go direct instead
+    /// of paging megabytes through a model. Memory mode has no file and says nothing.
+    #[tokio::test]
+    async fn read_cas_metadata_carries_the_path_only_in_disk_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let toml = format!(
+            "{MEDIA_CAST_TOML}\n[cas]\ndir = \"{}\"\n",
+            dir.path().join("cas").display()
+        );
+        let h = hermetic_handler_from_toml(&toml)
+            .finalize_media_store(true)
+            .expect("disk-backed store");
+        let hex = with_text_artifact(&h, b"on disk");
+        let meta = meta_of(&read(&h, &hex, None, Some(0)).await);
+        assert!(meta.contains("path: "), "disk mode names the file: {meta}");
+        assert!(meta.contains(".txt"), "with its real extension: {meta}");
+
+        let mem = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let mem_hex = with_text_artifact(&mem, b"in memory");
+        let mem_meta = meta_of(&read(&mem, &mem_hex, None, Some(0)).await);
+        assert!(
+            !mem_meta.contains("path: "),
+            "memory mode has no file to name: {mem_meta}"
+        );
+    }
+
+    /// The digest is validated before it can touch a lookup, an unknown one is a clean
+    /// not-found, and neither folds into the other. Ported from the resource this tool
+    /// replaced — the guarantees survive the change of surface.
+    #[tokio::test]
+    async fn read_cas_validates_the_digest_and_reports_a_miss_cleanly() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+
+        let missing = crate::cas::Digest::of_bytes(b"never-produced").to_hex();
         let err = h
-            .read_cas_resource(&missing, &format!("kaibo://cas/{missing}"))
+            .read_cas(Parameters(ReadCasInput {
+                digest: missing,
+                offset: None,
+                length: None,
+            }))
+            .await
             .expect_err("unknown digest is not found");
         assert!(err.message.contains("no artifact"), "got: {}", err.message);
 
+        for bad in ["../../etc/passwd", "ABCD", "", &"f".repeat(63)] {
+            let err = h
+                .read_cas(Parameters(ReadCasInput {
+                    digest: bad.to_string(),
+                    offset: None,
+                    length: None,
+                }))
+                .await
+                .expect_err("a malformed digest never reaches a lookup");
+            assert!(
+                err.message.contains("64 lowercase hex"),
+                "the refusal names the rule, got: {}",
+                err.message
+            );
+        }
+    }
+
+    /// A corrupt object stays a LOUD, distinct failure — never folded into "not found",
+    /// which would let real corruption read as an ordinary absence.
+    #[tokio::test]
+    async fn read_cas_surfaces_a_corrupt_object_loudly() {
+        let dir = tempfile::tempdir().unwrap();
+        let toml = format!(
+            "{MEDIA_CAST_TOML}\n[cas]\ndir = \"{}\"\n",
+            dir.path().join("cas").display()
+        );
+        let h = hermetic_handler_from_toml(&toml)
+            .finalize_media_store(true)
+            .expect("disk-backed store");
+        let hex = with_text_artifact(&h, b"honest content");
+        let digest = crate::cas::Digest::from_hex(&hex).unwrap();
+        let path = h.media_store().unwrap().path_for(&digest).unwrap();
+        std::fs::write(&path, b"tampered content").unwrap();
+
         let err = h
-            .read_cas_resource("../../etc/passwd", "kaibo://cas/../../etc/passwd")
-            .expect_err("a traversal-shaped digest is refused");
+            .read_cas(Parameters(ReadCasInput {
+                digest: hex,
+                offset: None,
+                length: None,
+            }))
+            .await
+            .expect_err("a corrupt object is an error");
         assert!(
-            err.message.contains("64 lowercase hex"),
-            "the refusal names the rule, got: {}",
+            err.message.contains("corrupt"),
+            "and it says so rather than reporting a miss: {}",
             err.message
         );
+    }
+
+    /// `read_cas` is advertised exactly when the media CAS is live — the same liveness the
+    /// resource it replaces keyed on. It takes no cast, so nothing else gates it.
+    #[test]
+    fn read_cas_is_advertised_only_while_the_media_cas_is_on() {
+        let on = handler();
+        assert!(
+            on.advertised_tools().contains(&"read_cas".to_string()),
+            "a live CAS advertises retrieval, got {:?}",
+            on.advertised_tools()
+        );
+        let off = handler_from_toml("[cas]\nenabled = false\n");
+        assert!(
+            !off.advertised_tools().contains(&"read_cas".to_string()),
+            "no store, no retrieval verb, got {:?}",
+            off.advertised_tools()
+        );
+    }
+
+    /// **The `kaibo://cas/<digest>` RESOURCE is gone.** Retrieval is a tool now, and the
+    /// route it replaced must not linger: a resource read of that URI is refused like any
+    /// other unknown URI, and the templates no longer advertise it. The URI string itself
+    /// survives as the artifact's name — this pins that only the *serving* went away.
+    #[tokio::test]
+    async fn the_cas_resource_route_is_gone() {
+        let h = media_handler(Arc::new(SyncArtifacts(vec![])));
+        let hex = with_text_artifact(&h, b"still reachable by tool");
+        let uri = format!("kaibo://cas/{hex}");
+
+        let err = read_kaibo_resource_with_config(
+            &uri,
+            &[],
+            &Config::builtin(),
+            &[],
+            None,
+            false,
+            Vec::new(),
+            false,
+            crate::config::CasMode::Memory,
+        )
+        .expect_err("the CAS resource route no longer exists");
+        assert!(
+            err.message.to_lowercase().contains("unknown"),
+            "an artifact URI is now just an unknown resource: {}",
+            err.message
+        );
+
+        assert!(
+            // The prefix, not a bare "cas" — `kaibo://prompts/{cast}` contains that
+            // substring and is a template we still very much serve.
+            !kaibo_resource_templates()
+                .iter()
+                .any(|t| t.uri_template.starts_with(crate::cas::CAS_URI_PREFIX)),
+            "and no template advertises it, got {:?}",
+            kaibo_resource_templates()
+                .iter()
+                .map(|t| t.uri_template.clone())
+                .collect::<Vec<_>>()
+        );
+
+        // The bytes are still reachable — through the tool.
+        read(&h, &hex, None, None).await;
     }
 
     /// The joined text of a successful `CallToolResult` — for asserting on a handler's
@@ -6816,7 +7153,7 @@ enabled = false
 
     #[test]
     fn advertises_the_per_builtin_template() {
-        let templates = kaibo_resource_templates(true);
+        let templates = kaibo_resource_templates();
         assert!(
             templates
                 .iter()
@@ -7250,7 +7587,7 @@ enabled = false
     /// message names the known casts (so a caller recovers to a real cast name).
     #[test]
     fn per_cast_prompts_template_advertised_and_unknown_cast_is_not_found() {
-        let templates: Vec<String> = kaibo_resource_templates(true)
+        let templates: Vec<String> = kaibo_resource_templates()
             .into_iter()
             .map(|t| t.uri_template)
             .collect();

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -659,8 +659,8 @@ fn memory_cap_admission_counts_the_provenance_sidecar() {
 // --- MediaStore: one seam over both modes ------------------------------------
 
 /// Disk mode exposes the real filesystem path beside the digest; memory mode has no
-/// path at all (the kaibo://cas resource is its only retrieval channel). Both modes
-/// serve the same bytes+extension read.
+/// path at all (`read_cas` is its only retrieval channel). Both modes serve the same
+/// bytes+extension read.
 #[test]
 fn media_store_paths_exist_on_disk_and_not_in_memory() {
     let (cas, _dir) = open_uncapped();
@@ -791,7 +791,7 @@ fn object_path(root: &Path, digest: &Digest, ext: &str) -> PathBuf {
 /// put lands at the same digest), and the sidecar written with the first put is the
 /// record of what this object actually is. A probe that walks `Extension::ALL` in
 /// declaration order answers with whichever variant it happens to try first, which is a
-/// mislabel the `kaibo://cas/<digest>` resource then stamps onto the bytes.
+/// mislabel `read_cas` then reports for the bytes.
 ///
 /// Stored webp-first, png-second: probe order says PNG, the recorded provenance says
 /// WEBP. The recorded provenance wins.

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -13,8 +13,11 @@ use kaibo::server::{KaiboHandler, ToolGating};
 /// `job_cancel`/`job_list`/`job_wait` are *shared* — they manage both kinds of handle
 /// and stay advertised as long as either capability is on, so they belong to neither
 /// flag. `list_models` is its own gate — a read-only operator/config tool, no model in
-/// the loop, independent of everything else here.
-const ALL_TOOLS: [&str; 13] = [
+/// the loop, independent of everything else here. `read_cas` has no flag at all: it is
+/// the client's artifact-retrieval verb, live exactly while the media CAS is (see
+/// `read_cas_is_advertised_only_while_the_media_cas_is_on`), so every `--no-<tool>` case
+/// below keeps it.
+const ALL_TOOLS: [&str; 14] = [
     "batch_submit",
     "consult",
     "consult_submit",
@@ -27,6 +30,7 @@ const ALL_TOOLS: [&str; 13] = [
     "job_wait",
     "list_models",
     "oneshot",
+    "read_cas",
     "run_kaish",
 ];
 

--- a/tests/save_artifact.rs
+++ b/tests/save_artifact.rs
@@ -729,9 +729,8 @@ fn two_threads_racing_the_last_budget_slot_produce_exactly_one_save() {
 
 // --- Memory mode has no path to show ------------------------------------------
 
-/// In memory mode the `kaibo://cas/<digest>` resource is the ONLY retrieval channel —
-/// there is no file. A footer claiming a path would send the caller after something that
-/// does not exist.
+/// In memory mode `read_cas` is the ONLY retrieval channel — there is no file. A footer
+/// claiming a path would send the caller after something that does not exist.
 #[test]
 fn the_memory_mode_footer_names_no_path() {
     let s = sink();


### PR DESCRIPTION
The retrieval half of the artifact contract becomes a tool, and the `kaibo://cas/<digest>` MCP resource is deleted. Follow-up to #125, on Amy's direction.

## Why replace the resource

- **Resources are ambient; a tool call is deliberate.** Hosts treat resources as attachable context (some prefetch/auto-attach) — the wrong posture for model-authored bytes. A tool call is explicit arguments + a permission prompt + a traced span: retrieval becomes something the operator's agent *does*, not something that happens to its context.
- **`resources/read` has no negotiation** — whole-blob by construction. Measured on a real 3.8 MB PNG: ~5 MB of base64, kept out of context only by Claude Code spilling it to a side file. Host mercy, not protocol.
- One audited surface instead of two. The URI **string** survives as the artifact's stable name; only the serving route is gone.

## The tool

`read_cas(digest, offset?, length?)` — client-facing, gated on CAS liveness alone (not `[artifacts] enabled` — `generate` artifacts need retrieval too), never in the inner model toolsets (pinned).

- **Metadata leads every response**: digest, mime, total bytes, `binary:`, label (when the sidecar has one), range served, and — disk mode — the real filesystem path, so a client holding a shell goes direct (Amy's call).
- `length: 0` → metadata only. Omitted `length` → a bounded 64 KiB window, never the whole object; the metadata names the total so paging is deliberate.
- Text arrives as text, with UTF-8-aware window trimming so a byte offset never splits a character and every reported range is resumable. Binary arrives as base64 **only when explicitly asked** — a base64 dump is never something that happens to you.
- **Images ≤ 2 MiB with no range** return an MCP image content block — one hop to a vision model's eye, the same mechanism as the inner `view_image`. Larger: metadata + path.
- An over-ceiling `length` (> 1 MiB, deliberately the same figure as `MAX_ARTIFACT_BYTES`) is refused with the recovery, never clamped — a silent clamp would corrupt the caller's next offset.
- Ranges are computed after the store's whole-object digest verification — corruption stays loud on every path, including metadata-only reads. "Cheap" here means cheap in tokens.

## Notable judgment calls (agent's, verified)

- **`FOLLOWER_TOOL_NAMES` + `has_substantive_tools()`**: `read_cas` rides a store that is on by default, so counting it toward the empty-surface guard would leave that startup refusal unable to fire on any stock install. Retrieval and the `job_*` collect verbs are now "followers"; a server offering only followers still refuses to start. A deliberate startup-behavior change, test-pinned.
- New `MediaStore::provenance` read-only accessor so the label reaches the metadata.
- Sweep: footer + `generate` result lines + tool description + `kaibo://tools` + guide + template + README now point at `read_cas`; instruction-budget tests unaffected.

## Verification

1005 tests / 0 failed (main was 980), 13/14 planner tests proven red-first against a stubbed planner; clippy `--all-targets` silent; `aws-lc-rs`/`mimalloc` trees empty; `no_write_path` pinned at exactly 4 — this PR adds no write site. Implementation by a Claude Opus subagent; verification by Claude Fable 5 with Amy. Cross-family reviews to follow as comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)