### PR TITLE
feat(cas): warn severely when disk-mode CAS sits on an ephemeral filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **kaibo warns when the media CAS is on a disk that will not survive the
+  container.** A container with no volume mounted looks exactly like durable disk
+  mode: persistence comes up, the store opens, artifacts write and read back — and
+  the whole filesystem evaporates on exit, after you have paid provider credits for
+  what was in it. On Linux, startup now checks the CAS directory's backing
+  filesystem and warns severely on overlayfs, tmpfs, or ramfs, naming the filesystem
+  and the directory. It **proceeds** — a throwaway store is a legitimate thing to
+  run on purpose — and `kaibo://config` reports the finding under `[cas] backing`
+  (as does `kaibo config`), so it is checkable before you spend anything instead of
+  only in startup log. A durable filesystem, or a check that cannot answer, says
+  nothing at all.
+
 - **`read_cas` — read a stored artifact back by digest.** Metadata comes first on
   every response: mime, total size, binary or not, the artifact's label when its
   record carries one, the range served, and the real file path when the store is on

--- a/docs/config.md
+++ b/docs/config.md
@@ -908,6 +908,21 @@ the same way, including one whose content the store already holds: exempting tho
 let a full store answer "is this content already here?" by succeeding for held bytes and
 refusing for new ones, across every project this kaibo has served.
 
+**Disk mode warns when the disk is not really a disk.** On Linux, startup checks what
+filesystem the CAS directory sits on. If it is overlayfs, tmpfs, or ramfs — the shape of a
+container with no volume mounted — kaibo logs a severe warning and **proceeds**. It is not
+a refusal and there is no acknowledgement flag: running on a throwaway filesystem on
+purpose is legitimate, and what is not legitimate is finding out only after a generation
+has been paid for. The warning names the filesystem and the directory; `kaibo://config`
+reports the same finding under `[cas] backing`, and `kaibo config` prints it, so you can
+check before spending anything rather than hunting through startup log after.
+
+The fix is to mount a volume at the CAS directory, or point `[cas] dir` at one. A durable
+filesystem produces no warning and no `backing` line. So does a check that cannot answer
+(a non-Linux host, or a `statfs` that fails) — an unreadable filesystem type is not
+evidence of anything, and a guard that spoke every time it failed to look would be tuned
+out by the time it mattered.
+
 **Failure is loud.** In disk mode, a structurally unusable CAS path fails startup with
 an error naming the escape hatches: a dir that resolves inside an allowed project tree
 (refused the same way the state db is), or a file sitting where the store or one of its

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -46,15 +46,6 @@ range); the address string is unchanged.
 
 **Open work that remains:**
 
-- **A loud guard when the CAS is on ephemeral DISK storage.** The ghcr image is a
-  first-class distribution path, and a disk CAS at `$XDG_DATA_HOME/kaibo/cas` in a
-  container with no volume mounted will accept the prompt, **spend the user's provider
-  credits**, verify and write the artifact, then destroy it on exit. Ranked the top
-  remaining risk by the Gemini design pass. **Decided (Amy, 2026-07-30): detect
-  overlay/tmpfs backing and warn severely, then proceed** — not a refusal gated on an
-  acknowledgement flag. The memory-mode SEVERE warn that shipped covers the
-  no-persistence path; this remaining piece is the disk mode whose backing store is
-  secretly ephemeral (statfs the CAS dir, warn on overlay/tmpfs magic).
 - **Cross-agent CAS sharing is DEFERRED** (Amy, 2026-08-03): no tracking of which agent
   created which object, no allow-listing, until a concrete need shows up. The CAS's job
   in one line, hers: "cas should be a way for the kaibo agents to get stuff to the

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -1109,6 +1109,118 @@ fn verify(digest: &Digest, bytes: Vec<u8>) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
+// --- The backing-filesystem guard -------------------------------------------
+//
+// Disk mode means "artifacts survive a restart", and on a container with no volume
+// mounted that sentence is false while every other signal says it is true: persistence
+// comes up, `Cas::open` succeeds, writes land, reads verify. overlayfs behaves exactly
+// like ext4 right up to the moment the container exits and takes the store with it. So
+// the store cannot notice from the inside — the only tell is what the directory is
+// sitting on, and that is a question for startup, once, out of band.
+//
+// Amy's design ruling (2026-07-30): **warn severely, then proceed.** Not a refusal, and
+// not gated on an acknowledgement flag. Running on tmpfs is a legitimate thing to do
+// deliberately (a scratch run, a test rig, a cache you mean to throw away); what is not
+// legitimate is *discovering* it after paying for a generation. The guard's whole job is
+// to make sure the operator heard it.
+
+/// What the filesystem under an object store turns out to be.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backing {
+    /// A filesystem whose contents die with the process's container or host: overlayfs
+    /// with no volume, tmpfs, ramfs. Carries the name so the warning can say which.
+    Ephemeral { fs: &'static str },
+    /// Nothing here says the store is ephemeral.
+    Durable,
+    /// The probe could not answer — an unsupported platform, a stat failure, a path with
+    /// an interior NUL.
+    ///
+    /// **Deliberately not folded into either other arm.** Treating it as ephemeral would
+    /// warn on every non-Linux install and train operators to ignore the one message
+    /// that has to land; treating it as durable would *claim* something the probe never
+    /// established. Not knowing is its own answer, and the only correct response to it
+    /// is silence (at debug, for whoever is actually debugging).
+    Unknown,
+}
+
+impl Backing {
+    /// The ephemeral filesystem's name, or `None` for anything that is not a positive
+    /// ephemerality finding. The predicate every caller wants: only `Ephemeral` speaks.
+    pub fn ephemeral_fs(&self) -> Option<&'static str> {
+        match self {
+            Backing::Ephemeral { fs } => Some(fs),
+            Backing::Durable | Backing::Unknown => None,
+        }
+    }
+}
+
+/// The startup warning for a CAS sitting on an ephemeral filesystem.
+///
+/// Pure, so its content is testable without a subscriber, and separate from the
+/// `tracing` call so the *wording* is a thing with a test rather than a string literal
+/// buried in a match arm. It carries four facts because an operator gets one chance to
+/// read this: which filesystem, which directory, what happens to the artifacts, and the
+/// fix.
+pub fn ephemeral_backing_warning(fs: &str, dir: &Path) -> String {
+    format!(
+        "MEDIA CAS IS ON AN EPHEMERAL FILESYSTEM: {dir} is backed by {fs}. kaibo will \
+         store generated artifacts there and they will read back correctly for this run, \
+         but they will NOT survive this container or host — they are paid for with real \
+         provider credits and may not be reproducible. If you meant this (a scratch run), \
+         carry on; if you did not, mount a volume at that path (or point [cas] dir at one) \
+         and restart. kaibo://config reports this under [cas] backing.",
+        dir = dir.display(),
+    )
+}
+
+/// Ask what filesystem `dir` is sitting on.
+///
+/// Answers for a directory that **does not exist yet** by asking about its nearest
+/// existing ancestor: the CAS root is created lazily on the first write, so a probe that
+/// insisted on the leaf would return [`Backing::Unknown`] on every fresh install — which
+/// is precisely the fresh-container case this guard exists for.
+#[cfg(target_os = "linux")]
+pub fn probe_backing(dir: &Path) -> Backing {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let Some(existing) = first_existing_ancestor(dir) else {
+        return Backing::Unknown;
+    };
+    let Ok(c_path) = CString::new(existing.as_os_str().as_bytes()) else {
+        // An interior NUL means we cannot ask. Not knowing is not evidence.
+        return Backing::Unknown;
+    };
+    // SAFETY: `buf` is a zeroed, owned `statfs`; `c_path` is a valid NUL-terminated path.
+    // `statfs` only writes into `buf` and reads the path, and reports failure via `rc`.
+    let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(c_path.as_ptr(), &mut buf) } != 0 {
+        return Backing::Unknown;
+    }
+    // Keep the low 32 bits so the compare is width-agnostic across arches — the same
+    // treatment `store.rs`'s network-fs guard gives `f_type`.
+    match (buf.f_type as i64) & 0xFFFF_FFFF {
+        0x794C_7630 => Backing::Ephemeral { fs: "overlayfs" },
+        0x0102_1994 => Backing::Ephemeral { fs: "tmpfs" },
+        0x8584_58F6 => Backing::Ephemeral { fs: "ramfs" },
+        _ => Backing::Durable,
+    }
+}
+
+/// Non-Linux: a quiet no-op. The magics are not portable, and the container-without-a-
+/// volume scenario this guard defends is a Linux one. The seam is the point — a platform
+/// that grows its own detection (a macOS `statfs` `f_fstypename` compare, say) replaces
+/// this arm and every caller is already written against [`Backing`].
+#[cfg(not(target_os = "linux"))]
+pub fn probe_backing(_dir: &Path) -> Backing {
+    Backing::Unknown
+}
+
+/// The probe a caller injects. Production passes [`probe_backing`]; tests script the
+/// answer, because the one thing a test cannot arrange portably is what filesystem it is
+/// running on.
+pub type BackingProbe = fn(&Path) -> Backing;
+
 /// The default media CAS directory: `$XDG_DATA_HOME/kaibo/cas`, else
 /// `~/.local/share/kaibo/cas` — the XDG *data* dir, deliberately not the *state* dir
 /// [`crate::store`] uses (see the module doc's "Why `$XDG_DATA_HOME`" section). `None`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1005,6 +1005,14 @@ pub fn run_config(common: CommonArgs) -> i32 {
     // a consult here would activate, so report that. The CAS mode is predicted from
     // the same assumption, through the one shared derivation (`Config::cas_mode`).
     let cas_mode = resolver.config.cas_mode(persistence_enabled);
+    // Probe the backing filesystem here too, on the same prediction. `kaibo config` is
+    // the natural place an operator checks *before* spending anything, and answering
+    // "disk" without saying the disk is a container's overlay would make this the one
+    // surface that still hides it. Read-only and cheap; only meaningful in disk mode.
+    let cas_ephemeral_fs = match (cas_mode, resolver.config.cas.dir.as_deref()) {
+        (crate::config::CasMode::Disk, Some(dir)) => crate::cas::probe_backing(dir).ephemeral_fs(),
+        _ => None,
+    };
     let body = render_config_resource(
         &resolver.config,
         resolver.allowed_trees(),
@@ -1013,6 +1021,7 @@ pub fn run_config(common: CommonArgs) -> i32 {
         resolver.followed_worktrees(),
         persistence_enabled,
         cas_mode,
+        cas_ephemeral_fs,
     );
     println!("{body}");
     EXIT_OK

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -22,6 +22,11 @@ use super::ToolGating;
 /// values. The backend struct stores sources, not secrets; this renderer reads only
 /// those source fields. If Config ever gains a resolved-key cache, do not read it here.
 /// Tests in this file assert the contract holds.
+// The inputs are inherently many — the resolved config plus five pieces of runtime truth
+// the renderer cannot reach for itself (allowed set, default root and how it was chosen,
+// live worktrees, persistence, CAS mode and its backing). Bundling them into a struct
+// would relocate the list, not shorten it.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn render_config_resource(
     config: &Config,
     allowed_set: &[PathBuf],
@@ -30,6 +35,7 @@ pub(crate) fn render_config_resource(
     followed_worktrees: Vec<PathBuf>,
     persistence_active: bool,
     cas_mode: crate::config::CasMode,
+    cas_ephemeral_fs: Option<&'static str>,
 ) -> String {
     use serde::Serialize;
     use std::collections::BTreeMap;
@@ -235,6 +241,15 @@ pub(crate) fn render_config_resource(
         dir: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         max_bytes: Option<u64>,
+        /// The ephemeral filesystem the store is sitting on, when the startup probe
+        /// found one — absent otherwise, so a normal install reads exactly as before.
+        ///
+        /// Present here and not only in the startup log because startup log is the thing
+        /// an operator scrolls past, or never sees at all when a client launched kaibo
+        /// for them. `mode = "disk"` claims durability; this is the line that qualifies
+        /// it, at a place they can query after the fact.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        backing: Option<String>,
     }
 
     /// `[artifacts]` as resolved: may the inner model team save what it writes?
@@ -630,6 +645,12 @@ pub(crate) fn render_config_resource(
             mode: cas_mode.as_str().to_string(),
             dir: config.cas.dir.as_ref().map(|p| p.display().to_string()),
             max_bytes: config.cas.max_bytes,
+            backing: cas_ephemeral_fs.map(|fs| {
+                format!(
+                    "{fs} — EPHEMERAL: artifacts here will not survive this container \
+                         or host. Mount a volume at [cas] dir to keep them."
+                )
+            }),
         },
         artifacts: ArtifactsDoc {
             enabled: config.artifacts.enabled,
@@ -681,6 +702,7 @@ mod tests {
             followed,
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         assert!(
             body.contains("[runtime]") && body.contains("follow_worktrees = true"),
@@ -712,6 +734,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         assert!(
             body.contains(r#"kind = "openai-images""#),
@@ -752,6 +775,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let runtime = section(&body, "[runtime]");
         assert!(
@@ -792,6 +816,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         assert!(
             !section(&body, "[runtime.unstaffable_tools]").contains("deliberate"),
@@ -851,6 +876,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let inert = |cast: &str, role: &str| -> Vec<String> {
@@ -936,6 +962,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let inert = |cast: &str, role: &str| -> Vec<String> {
@@ -1020,6 +1047,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let inert = |cast: &str, role: &str| -> Vec<String> {
@@ -1112,6 +1140,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let render_flags = |cast: &str, role: &str| -> bool {
@@ -1186,6 +1215,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let wire = |name: &str| -> Option<String> {
@@ -1233,6 +1263,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         // Structural presence checks — the resource is TOML or a document, not prose.
         for needle in [
@@ -1330,6 +1361,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         // The header NAME is discoverable…
         assert!(
@@ -1358,6 +1390,7 @@ mod tests {
             vec![],
             true,
             crate::config::CasMode::Disk,
+            None,
         );
         let section = body
             .split_once("[persistence]")
@@ -1380,6 +1413,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let section = body.split_once("[persistence]").expect("table renders").1;
         assert!(
@@ -1397,7 +1431,8 @@ mod tests {
         use crate::config::CasMode;
 
         let config = Config::from_toml_str("[cas]\ndir = \"/srv/art\"\n").unwrap();
-        let body = render_config_resource(&config, &[], None, false, vec![], true, CasMode::Disk);
+        let body =
+            render_config_resource(&config, &[], None, false, vec![], true, CasMode::Disk, None);
         let section = body.split_once("[cas]").expect("a [cas] table renders").1;
         assert!(
             section.contains("enabled = true")
@@ -1406,8 +1441,16 @@ mod tests {
             "disk mode must show on, the mode word, and the dir:\n{body}"
         );
 
-        let body =
-            render_config_resource(&config, &[], None, false, vec![], false, CasMode::Memory);
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            CasMode::Memory,
+            None,
+        );
         let section = body.split_once("[cas]").expect("table renders").1;
         assert!(
             section.contains(r#"mode = "memory""#) && section.contains("/srv/art"),
@@ -1415,7 +1458,8 @@ mod tests {
         );
 
         let off = Config::from_toml_str("[cas]\nenabled = false\n").unwrap();
-        let body = render_config_resource(&off, &[], None, false, vec![], false, CasMode::Off);
+        let body =
+            render_config_resource(&off, &[], None, false, vec![], false, CasMode::Off, None);
         let section = body.split_once("[cas]").expect("table renders").1;
         assert!(
             section.contains("enabled = false") && section.contains(r#"mode = "off""#),
@@ -1449,6 +1493,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         for needle in ["[backend_aliases]", "[cast_aliases]"] {
             assert!(body.contains(needle), "must render {needle}:\n{body}");
@@ -1504,6 +1549,7 @@ mod tests {
                 vec![],
                 false,
                 crate::config::CasMode::Memory,
+                None,
             );
             #[allow(deprecated)]
             unsafe {
@@ -1538,6 +1584,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         // The file path (source pointer) may appear, but not the file contents.
         assert!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -740,6 +740,19 @@ pub struct KaiboHandler {
     /// store once `main` knows whether persistence actually came up. `Arc` so
     /// per-request handler clones share one store.
     media_cas: Option<Arc<crate::cas::MediaStore>>,
+    /// How the CAS directory's backing filesystem is probed at startup. A field rather
+    /// than a direct call so a test can script the answer — what filesystem the test
+    /// process happens to be running on is the one thing it cannot arrange portably.
+    backing_probe: crate::cas::BackingProbe,
+    /// The ephemeral filesystem the CAS turned out to sit on, if any — set by
+    /// [`finalize_media_store`](Self::finalize_media_store) in disk mode, and reported by
+    /// `kaibo://config` under `[cas] backing`.
+    ///
+    /// The startup warning is the loud channel, but startup log is exactly the thing an
+    /// operator scrolls past or never sees (a client launched kaibo for them). Leaving
+    /// the finding somewhere queryable is what turns "we told you" into "you can check" —
+    /// the same reason memory mode reports `mode = "memory"` rather than only warning.
+    cas_ephemeral_fs: Option<&'static str>,
     /// How `generate` builds its media arm — the injection seam mirroring
     /// `batch_providers`: production seeds [`crate::media::LiveMediaArms`]; tests swap
     /// in a factory returning a scripted model via
@@ -1173,6 +1186,8 @@ impl KaiboHandler {
         Ok(Self {
             config,
             media_cas,
+            backing_probe: crate::cas::probe_backing,
+            cas_ephemeral_fs: None,
             tool_router,
             tool_schemas: Arc::new(builtin_schemas()?),
             sessions,
@@ -1272,10 +1287,32 @@ impl KaiboHandler {
                             dir.display()
                         )
                     })?;
-                tracing::info!(
-                    cas_dir = %dir.display(),
-                    "media CAS on disk — generated artifacts are durable across restarts"
-                );
+                // Disk mode's promise is "durable across restarts", and on a container
+                // with no volume mounted that promise is false while everything else
+                // looks fine. Ask what the directory is actually sitting on, and if the
+                // answer is a filesystem that dies with the container, say so LOUDLY —
+                // then proceed (Amy, 2026-07-30). Not a refusal and no ack flag: running
+                // on tmpfs on purpose is legitimate, discovering it after paying for a
+                // generation is not.
+                match (self.backing_probe)(&dir).ephemeral_fs() {
+                    Some(fs) => {
+                        tracing::warn!("{}", crate::cas::ephemeral_backing_warning(fs, &dir));
+                        self.cas_ephemeral_fs = Some(fs);
+                    }
+                    // Durable, or the probe could not answer. Neither is worth a word at
+                    // startup: one is the expected case, and the other established
+                    // nothing. The debug line is for whoever is actually debugging.
+                    None => {
+                        tracing::debug!(
+                            cas_dir = %dir.display(),
+                            "media CAS backing filesystem: nothing indicates it is ephemeral"
+                        );
+                        tracing::info!(
+                            cas_dir = %dir.display(),
+                            "media CAS on disk — generated artifacts are durable across restarts"
+                        );
+                    }
+                }
                 self.media_cas = Some(Arc::new(crate::cas::MediaStore::Disk(cas)));
             }
         }
@@ -1309,6 +1346,23 @@ impl KaiboHandler {
     ) -> Self {
         self.batch_providers = providers;
         self
+    }
+
+    /// Swap in the backing-filesystem probe — the seam that lets a test say what the CAS
+    /// directory is sitting on, since the real answer depends on where the test process
+    /// happens to be running. A builder, like
+    /// [`with_media_arms`](Self::with_media_arms); apply it BEFORE
+    /// [`finalize_media_store`](Self::finalize_media_store), which is what reads it.
+    #[cfg(test)]
+    pub fn with_backing_probe(mut self, probe: crate::cas::BackingProbe) -> Self {
+        self.backing_probe = probe;
+        self
+    }
+
+    /// The ephemeral filesystem the CAS is sitting on, if the startup probe found one.
+    /// `None` covers durable, unknown, and every non-disk mode.
+    pub fn cas_ephemeral_fs(&self) -> Option<&'static str> {
+        self.cas_ephemeral_fs
     }
 
     /// Swap in a media-arm factory — the seam that lets tests drive the `generate`
@@ -3378,6 +3432,7 @@ impl rmcp::ServerHandler for KaiboHandler {
             self.followed_worktrees(),
             self.sessions.store().is_some(),
             self.live_cas_mode(),
+            self.cas_ephemeral_fs,
         )
     }
 
@@ -4213,6 +4268,7 @@ fn read_kaibo_resource_with_config(
     followed_worktrees: Vec<PathBuf>,
     persistence_active: bool,
     cas_mode: crate::config::CasMode,
+    cas_ephemeral_fs: Option<&'static str>,
 ) -> Result<ReadResourceResponse, McpError> {
     if uri == PROMPTS_URI {
         return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
@@ -4245,6 +4301,7 @@ fn read_kaibo_resource_with_config(
             followed_worktrees,
             persistence_active,
             cas_mode,
+            cas_ephemeral_fs,
         );
         return Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
             vec![ResourceContents::text(body, uri)],
@@ -4836,6 +4893,121 @@ mod tests {
             err.message.contains("[cas] enabled = false"),
             "the refusal names the missing key precisely: {}",
             err.message
+        );
+    }
+
+    /// A handler in real DISK mode at a temp dir, with the backing probe scripted — the
+    /// one fact a test cannot arrange portably is what filesystem it is running on.
+    fn disk_handler_with_probe(
+        dir: &std::path::Path,
+        probe: crate::cas::BackingProbe,
+    ) -> KaiboHandler {
+        let toml = format!("[cas]\ndir = \"{}\"\n", dir.join("cas").display());
+        hermetic_handler_from_toml(&toml)
+            .with_backing_probe(probe)
+            .finalize_media_store(true)
+            .expect("disk-backed store opens")
+    }
+
+    fn probe_overlayfs(_: &std::path::Path) -> crate::cas::Backing {
+        crate::cas::Backing::Ephemeral { fs: "overlayfs" }
+    }
+    fn probe_durable(_: &std::path::Path) -> crate::cas::Backing {
+        crate::cas::Backing::Durable
+    }
+    fn probe_unknown(_: &std::path::Path) -> crate::cas::Backing {
+        crate::cas::Backing::Unknown
+    }
+
+    /// The `[cas]` section of a handler's rendered `kaibo://config`.
+    fn cas_section(h: &KaiboHandler) -> String {
+        let body = render_config_resource(
+            &h.config,
+            &[],
+            None,
+            false,
+            vec![],
+            true,
+            h.live_cas_mode(),
+            h.cas_ephemeral_fs(),
+        );
+        let start = body.find("[cas]").expect("a [cas] section");
+        let rest = &body[start..];
+        let end = rest[1..].find("\n[").map(|i| i + 1).unwrap_or(rest.len());
+        rest[..end].to_string()
+    }
+
+    /// **Disk mode on an ephemeral filesystem is recorded, not just logged.**
+    ///
+    /// The scenario: a container with no volume mounted. Persistence comes up, the CAS
+    /// opens, `mode = "disk"` — every signal says durable, and the whole store vanishes
+    /// on exit. The startup warning is the loud channel, but startup log is exactly what
+    /// an operator scrolls past or never sees when a client launched kaibo for them, so
+    /// the finding also has to be somewhere they can query afterwards. That is the same
+    /// reason memory mode reports `mode = "memory"` instead of only warning.
+    #[test]
+    fn an_ephemeral_cas_backing_is_recorded_and_surfaced_in_the_config_resource() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = disk_handler_with_probe(dir.path(), probe_overlayfs);
+
+        assert_eq!(h.live_cas_mode(), crate::config::CasMode::Disk);
+        assert_eq!(
+            h.cas_ephemeral_fs(),
+            Some("overlayfs"),
+            "the finding is kept, not discarded after the log line"
+        );
+
+        let cas = cas_section(&h);
+        assert!(cas.contains("overlayfs"), "names the filesystem: {cas}");
+        assert!(
+            cas.to_uppercase().contains("EPHEMERAL"),
+            "and says what that means: {cas}"
+        );
+        assert!(cas.to_lowercase().contains("volume"), "and the fix: {cas}");
+        assert!(
+            cas.contains("mode = \"disk\""),
+            "beside the mode it is qualifying: {cas}"
+        );
+    }
+
+    /// **A durable filesystem leaves no trace at all**, and neither does a probe that
+    /// could not answer. An operator on ext4 must not gain a line, and an unreadable
+    /// `f_type` establishes nothing — a guard that spoke on every failure to look would
+    /// be ignored by the time it mattered.
+    #[test]
+    fn a_durable_or_unreadable_backing_leaves_the_config_untouched() {
+        for (what, probe) in [
+            ("durable", probe_durable as crate::cas::BackingProbe),
+            ("unknown", probe_unknown as crate::cas::BackingProbe),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let h = disk_handler_with_probe(dir.path(), probe);
+            assert_eq!(h.cas_ephemeral_fs(), None, "{what}: nothing to record");
+            let cas = cas_section(&h);
+            assert!(
+                !cas.contains("backing"),
+                "{what}: no backing line at all, got: {cas}"
+            );
+        }
+    }
+
+    /// The guard is disk-only. Memory mode already warns severely about exactly this
+    /// loss, on its own terms; probing what a store that is not on a filesystem is
+    /// sitting on would be a second warning about a fact the first one already owns.
+    #[test]
+    fn memory_mode_never_reports_a_backing_filesystem() {
+        // Persistence inactive → memory mode, even though a dir resolves.
+        let dir = tempfile::tempdir().unwrap();
+        let toml = format!("[cas]\ndir = \"{}\"\n", dir.path().join("cas").display());
+        let h = hermetic_handler_from_toml(&toml)
+            .with_backing_probe(probe_overlayfs)
+            .finalize_media_store(false)
+            .expect("memory-mode handler");
+        assert_eq!(h.live_cas_mode(), crate::config::CasMode::Memory);
+        assert_eq!(
+            h.cas_ephemeral_fs(),
+            None,
+            "memory mode owns its own durability warning; this guard stays out of it"
         );
     }
 
@@ -5944,6 +6116,7 @@ enabled = false
             Vec::new(),
             false,
             crate::config::CasMode::Memory,
+            None,
         )
         .expect_err("the CAS resource route no longer exists");
         // Recognized, not served: a host with a cached template gets told where the
@@ -7509,6 +7682,7 @@ enabled = false
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         )
         .expect("known uri must read");
         let result = match result {
@@ -7735,6 +7909,7 @@ enabled = false
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         )
         .expect_err("an unknown cast must be a not-found");
         assert!(
@@ -7765,6 +7940,7 @@ enabled = false
                 vec![],
                 false,
                 crate::config::CasMode::Memory,
+                None,
             )
             .is_err(),
             "an unregistered builtin must be a not-found error"
@@ -7786,6 +7962,7 @@ enabled = false
                 vec![],
                 false,
                 crate::config::CasMode::Memory,
+                None,
             )
             .is_err(),
             "an unknown URI must be a not-found error, not an empty success"
@@ -7818,6 +7995,7 @@ enabled = false
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         )
         .expect("example resource must be readable");
         let result = match result {
@@ -7920,6 +8098,7 @@ enabled = false
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         // Sanity: the rendered document has something in it.
         assert!(
@@ -7937,6 +8116,7 @@ enabled = false
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         assert!(
             result.is_ok(),

--- a/tests/cas.rs
+++ b/tests/cas.rs
@@ -9,7 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
-use kaibo::cas::{Cas, CasError, Digest, Extension, Provenance};
+use kaibo::cas::{Backing, Cas, CasError, Digest, Extension, Provenance};
 use tempfile::TempDir;
 
 fn prov() -> Provenance {
@@ -1057,4 +1057,126 @@ fn open_refuses_a_file_at_the_root_or_in_its_ancestry() {
 
     // A plain directory (or a path whose ancestors are dirs) still opens fine.
     Cas::open(&dir.path().join("fresh").join("cas"), &[], None).expect("clean path opens");
+}
+
+// --- Backing-filesystem guard: ephemeral disk is still ephemeral --------------
+
+// The scenario this guard defends, stated once: a container with no volume mounted looks
+// exactly like disk mode. Persistence comes up, the CAS opens on what appears to be a
+// filesystem, kaibo accepts a `generate` prompt, spends the operator's provider credits,
+// writes the artifact — and the whole filesystem evaporates when the container exits.
+// Nothing in the store's own contract can notice: overlayfs answers writes and reads
+// exactly like ext4 right up until it doesn't exist.
+
+/// The warning has to carry four things, because an operator reading one line of startup
+/// log is the only chance this has to land: which filesystem was detected, which
+/// directory is on it, what will happen to the artifacts, and the fix (mount a volume).
+#[test]
+fn the_ephemeral_backing_warning_names_the_fs_the_dir_the_loss_and_the_fix() {
+    let msg = kaibo::cas::ephemeral_backing_warning("overlayfs", Path::new("/data/kaibo/cas"));
+    assert!(msg.contains("overlayfs"), "names the filesystem: {msg}");
+    assert!(
+        msg.contains("/data/kaibo/cas"),
+        "names the directory: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("not survive") || msg.to_lowercase().contains("lost"),
+        "says what happens to the artifacts: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("volume"),
+        "names the fix — mount a volume: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("credit") || msg.to_lowercase().contains("paid"),
+        "and why it costs something real: {msg}"
+    );
+}
+
+/// A durable filesystem says nothing at all. This guard is a warning, not a survey — an
+/// operator on ext4 must not learn a new line of startup noise.
+#[test]
+fn a_durable_backing_is_reported_as_durable_and_says_nothing() {
+    assert_eq!(Backing::Durable.ephemeral_fs(), None);
+    assert_eq!(Backing::Unknown.ephemeral_fs(), None);
+    assert_eq!(
+        Backing::Ephemeral { fs: "tmpfs" }.ephemeral_fs(),
+        Some("tmpfs")
+    );
+}
+
+/// **A probe that cannot answer says `Unknown`, never `Ephemeral`.** An unreadable
+/// `f_type` is not evidence of ephemerality, and a guard that warned every time it failed
+/// to look would train operators to ignore it — the one thing a severe warning cannot
+/// afford.
+///
+/// The reachable version of "cannot answer" is a relative path with nothing existing
+/// anywhere up its chain: there is no directory to ask about, and the walk bottoms out
+/// rather than guessing at the current directory. (The other no-answer paths — an
+/// unsupported platform, a `statfs` failure, a path holding an interior NUL — land on the
+/// same arm by construction.)
+#[test]
+fn a_probe_that_cannot_answer_reports_unknown_not_ephemeral() {
+    let nowhere = Path::new("kaibo-no-such-relative-dir-9f2c/deeper/still");
+    assert!(!nowhere.exists(), "the fixture must not exist");
+    assert_eq!(
+        kaibo::cas::probe_backing(nowhere),
+        Backing::Unknown,
+        "nothing to ask about is not proof of anything"
+    );
+}
+
+/// A path that does not exist is NOT a probe failure — it is the fresh-install case, and
+/// answering it from the nearest existing ancestor is the whole reason this guard fires
+/// on a fresh container at all. `/` exists on every machine, so a nonexistent path under
+/// it answers durably rather than shrugging.
+#[test]
+#[cfg(target_os = "linux")]
+fn a_nonexistent_path_answers_from_its_nearest_existing_ancestor() {
+    let missing = Path::new("/nonexistent-kaibo-probe-target/deeper/still");
+    assert_ne!(
+        kaibo::cas::probe_backing(missing),
+        Backing::Unknown,
+        "the ancestor walk means a not-yet-created dir still gets a real answer"
+    );
+}
+
+/// Opportunistic real teeth: `/dev/shm` is tmpfs on essentially every Linux, so when it
+/// is there the probe must actually detect it — the scripted seam elsewhere proves the
+/// wiring, and this proves the syscall. Skipped cleanly where it does not exist, the way
+/// the repo's other environment-dependent tests do.
+#[test]
+#[cfg(target_os = "linux")]
+fn the_real_probe_detects_tmpfs_on_dev_shm() {
+    let shm = Path::new("/dev/shm");
+    if !shm.is_dir() {
+        eprintln!("skipping: /dev/shm is not present, so there is no known tmpfs to probe");
+        return;
+    }
+    match kaibo::cas::probe_backing(shm) {
+        Backing::Ephemeral { fs } => assert_eq!(fs, "tmpfs", "/dev/shm is tmpfs"),
+        other => panic!("/dev/shm must probe as ephemeral tmpfs, got {other:?}"),
+    }
+}
+
+/// The probe answers about a directory that does not exist yet by asking about the
+/// deepest ancestor that does — the CAS root is created lazily on first write, so the
+/// startup check would otherwise be `Unknown` on every fresh install and never fire in
+/// the one scenario it exists for (a fresh container).
+#[test]
+#[cfg(target_os = "linux")]
+fn the_probe_answers_for_a_not_yet_created_cas_dir() {
+    let shm = Path::new("/dev/shm");
+    if !shm.is_dir() {
+        eprintln!("skipping: /dev/shm is not present");
+        return;
+    }
+    let unborn = shm.join("kaibo-probe-not-created").join("cas");
+    assert!(!unborn.exists(), "the fixture path must not exist");
+    match kaibo::cas::probe_backing(&unborn) {
+        Backing::Ephemeral { fs } => assert_eq!(fs, "tmpfs"),
+        other => {
+            panic!("a not-yet-created dir must answer from its nearest ancestor, got {other:?}")
+        }
+    }
 }


### PR DESCRIPTION
The last unbuilt P1 media item (decided 2026-07-30). The scenario: a container with no volume mounted looks like disk mode, accepts a generate/save prompt, **spends the user's provider credits**, writes the artifact, then destroys everything on exit. Now: at startup, disk mode probes the CAS directory's backing filesystem; overlayfs/tmpfs/ramfs draws a SEVERE warning naming the fix (mount a volume) — then proceeds. Deliberately not a refusal and not gated on an ack flag, per the decided design.

Design points:
- **`cas::Backing`** (`Ephemeral { fs }` / `Durable` / `Unknown`) with a statfs probe that walks to the nearest *existing* ancestor — the CAS root is created lazily, so probing the leaf would return Unknown on exactly the fresh-container case the guard exists for (test-pinned).
- **`Unknown` is never folded** into either verdict: warn-on-unknown would cry wolf on every non-Linux install; durable-on-unknown would claim what was never established. Probe failure is debug-level silence.
- **Queryable after the fact**: `[cas] backing` renders in `kaibo://config` when the probe found something, and `kaibo config` (CLI) probes on the same prediction — an operator can ask before spending anything.
- **No new dependency**: `libc` was already declared (Linux-only) for `store.rs`'s network-fs guard; the probe mirrors that code's shape, low-32-bit compare and all. Non-Linux is a quiet `Unknown` with the seam left for platform-specific detection later.
- **Memory mode never probes** — it already owns a severe warning about precisely this loss; double-warning is test-pinned out.
- Read-only work: `no_write_path` stays pinned at exactly 4.

Verification: 1022 tests / 0 failed, clippy silent, `aws-lc-rs`/`mimalloc` trees empty. Real teeth: `/dev/shm` probes as tmpfs (runs where present, skips cleanly elsewhere); mutation-tested recording and rendering. One failing-first test corrected the design premise itself (a nonexistent absolute path resolves through the ancestor walk to a real answer, not Unknown). The tracked issues.md entry is deleted (ship = delete).

Implementation by a Claude Opus subagent; verification by Claude Fable 5 with Amy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)