### PR TITLE
chore: accuracy fixes — inert thinking_style flagged, template clarity, the no-CAS-index ruling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,14 @@ record. Each later release appends a new section at the top.
   blind to `lane = "batch"` — rendering a batch slot's `effort` and `temperature` as
   effective when batch sends no sampling at all and floors the effort.
 
+- **`kaibo://config` now flags `thinking_style` as inert on a non-Anthropic slot.**
+  The override only moves anything on the Anthropic wire (it picks the adaptive vs.
+  budget tier there); every other wire classifies its thinking style from the model
+  id alone and never reads it, so a `thinking_style` forced on a DeepSeek/Gemini/
+  OpenRouter/generic-OpenAI slot — on the slot itself or inherited from
+  `[defaults]` — used to render as if it were shaping the request when it was a
+  pure no-op.
+
 - **The startup warning and `kaibo://config` can no longer disagree about an effort.**
   They answer from one shared rule now, so a value the batch lane lifts is reported by
   both (it used to be flagged in the resource and stay silent at startup), and the

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -358,30 +358,33 @@ scratch_limit_bytes = 67108864
 # base_url at load (rig fixes those endpoints).
 # ---------------------------------------------------------------------------
 
-# --- The five built-ins, shown with their current defaults. You only need to
-#     list a backend here to CHANGE something; these blocks are illustrative.
-#     Their alias names (claude, google, local, lemonade, gemma, gemma4) are
-#     reserved at both levels — naming a new backend or cast after one is a
-#     loud collision error. ---
+# --- The five built-ins, shown COMMENTED OUT with their current defaults. They
+#     ship in code already — kaibo runs with all five even when this whole file is
+#     absent — so uncomment one only to CHANGE something (a gateway base_url, a
+#     different key file, ...); these blocks are illustrative, not required
+#     configuration to copy verbatim. Their alias names (claude, google, local,
+#     lemonade, gemma, gemma4) are reserved at both levels regardless of whether
+#     you uncomment them — naming a new backend or cast after one is a loud
+#     collision error. ---
 
-[backends.anthropic]                         # alias: claude
-kind = "anthropic"
-api_key_env  = "ANTHROPIC_API_KEY"
-api_key_file = "~/.anthropic-key.txt"
+# [backends.anthropic]                         # alias: claude
+# kind = "anthropic"
+# api_key_env  = "ANTHROPIC_API_KEY"
+# api_key_file = "~/.anthropic-key.txt"
 # Uncomment to dial an Anthropic-Messages-API-compatible gateway/proxy (e.g. a
 # corporate LLM gateway) instead of api.anthropic.com directly. Optional —
 # unlike the openai kind, unset still resolves to rig's built-in endpoint.
 # base_url = "https://llm-gateway.example.internal"
 
-[backends.deepseek]
-kind = "deepseek"
-api_key_env  = "DEEPSEEK_API_KEY"
-api_key_file = "~/.deepseek-key"
+# [backends.deepseek]
+# kind = "deepseek"
+# api_key_env  = "DEEPSEEK_API_KEY"
+# api_key_file = "~/.deepseek-key"
 
-[backends.gemini]                            # alias: google
-kind = "gemini"
-api_key_env  = "GEMINI_API_KEY"
-api_key_file = "~/.gemini-api-key"
+# [backends.gemini]                            # alias: google
+# kind = "gemini"
+# api_key_env  = "GEMINI_API_KEY"
+# api_key_file = "~/.gemini-api-key"
 # Uncomment to dial a Gemini-API-compatible gateway/proxy (e.g. a corporate LLM
 # gateway) instead of generativelanguage.googleapis.com directly. Optional —
 # unset still resolves to rig's built-in endpoint. A HOST ROOT, same as the
@@ -402,19 +405,19 @@ api_key_file = "~/.gemini-api-key"
 # leaking quietly. `data_collection = "allow"` is the explicit opt-in: kaibo
 # emits no restriction and your OpenRouter account settings govern. This knob
 # exists only on the openrouter kind — anywhere else it's a load error.
-[backends.openrouter]
-kind = "openrouter"
-api_key_env  = "OPENROUTER_API_KEY"
-api_key_file = "~/.openrouter-key"
+# [backends.openrouter]
+# kind = "openrouter"
+# api_key_env  = "OPENROUTER_API_KEY"
+# api_key_file = "~/.openrouter-key"
 # kaibo always denies unless you uncomment this line:
 # data_collection = "allow"
 
-[backends.openai-local]                            # aliases: local, lemonade, gemma, gemma4
-kind = "openai"
-base_url = "http://localhost:13305/api/v1"   # also overridable via OPENAI_BASE_URL
-api_key_env  = "OPENAI_API_KEY"
-api_key_file = "~/.openai-key"
-key_optional = true                          # keyless local default → placeholder
+# [backends.openai-local]                            # aliases: local, lemonade, gemma, gemma4
+# kind = "openai"
+# base_url = "http://localhost:13305/api/v1"   # also overridable via OPENAI_BASE_URL
+# api_key_env  = "OPENAI_API_KEY"
+# api_key_file = "~/.openai-key"
+# key_optional = true                          # keyless local default → placeholder
 
 # --- New backends: any number of openai-kind endpoints, each its own connection.
 #     A new backend must declare its `kind`; it seeds that kind's default key
@@ -476,6 +479,13 @@ wire = "responses"
 # slash. A slot ref borrows the backend's CONNECTION only — it never follows
 # another cast, so chains and cycles are structurally impossible. An unknown
 # backend in a slot is a load error naming the known backends.
+#
+# Backends and casts are SEPARATE NAMESPACES, so the same name may legally head
+# both — [backends.gpt] below (a connection) and [casts.gpt] further down (a
+# composition) are two different things that happen to share a name, not a
+# collision. A cast's slot still spells out which backend it wants
+# (`{ backend = "gpt", id = "…" }`), so the shared name never needs
+# disambiguating at the point of use.
 # ---------------------------------------------------------------------------
 
 # --- Advanced — a chimera: mix model FAMILIES across roles, a different lineage per

--- a/docs/config.md
+++ b/docs/config.md
@@ -852,9 +852,11 @@ Each object gets a `<hex>.json` provenance sidecar (prompt, model, cast, timesta
 seed, and which tool produced it). It makes an object self-describing **to whoever holds
 its address**: one lookup by digest says what the bytes are and what format to serve them
 as. Read it that way. The store is not built to be swept — a survey means walking 65,536
-shards and parsing a file per object, and it only gets slower as the store fills. Operator
-inventory verbs are tracked in `docs/issues.md` and want an index kaibo maintains, not a
-scan.
+shards and parsing a file per object, and it only gets slower as the store fills, so kaibo
+builds no index and offers no scan verb over it. Access is by address; a saved digest also
+rides the session turn that produced it, so tracking what was created lives with the
+conversation, not the store. An operator's cleanup, if wanted, is plain file mtime on the
+object tree for now — see `docs/issues.md`.
 
 The sidecar is **first-writer-wins**: it records the first write of a given content and is
 never rewritten. Save bytes the store already holds and the record stays the original

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -66,41 +66,26 @@ is resident tool cost and curation. `MediaType::to_cas_extension` already refuse
 and `model/gltf-binary` loudly so that adding one forces a deliberate naming decision rather
 than silently writing bytes nobody can open.
 
-### CAS retention changed character with `save_artifact` — the store wants operator verbs and a GC story
+### CAS retention — no index, by design (Amy, 2026-08-05)
 
-The no-GC stance was honest while `generate` was the only producer: every artifact cost a
-paid provider call, so minting was rare and self-limiting, and `find -mtime` over the
-sidecars was proportionate cleanup. `save_artifact` (shipped 2026-08-05) breaks that
-assumption — a consult can mint eight artifacts a call for the price of tokens it was
-already spending, against an append-only store that never unlinks. XDG data grows without
-bound and the operator's only tools are shell commands over a two-level sharded tree.
+`save_artifact` (2026-08-05) raised the visibility question harder than `generate` ever
+did — a consult can mint several artifacts a call against an append-only, two-level-sharded
+store that never unlinks. Ruled: no `kaibo cas ls`/`du`/`rm`, and no index to back them.
+The store stays opaque, on purpose — reached only by the address a caller already holds.
+Tracking of what was created lives WITH the conversation that made it, not with the store:
+a session turn already records the artifact footer (digest, mime, size), so those digests
+sit beside the conversation in the persistence store. Operator cleanup, if wanted, is plain
+file mtime over the object tree (e.g. `find $XDG_DATA_HOME/kaibo/cas -mtime +30 -type f
+-delete`) — a one-off shell habit, not a kaibo workflow, and not mentioned again beyond
+this line. The one walk the store still does: `[cas] max_bytes` (opt-in) sums the store on
+every write to enforce its cap — accepted cost, since it only runs for an operator who
+chose a ceiling.
 
-What it wants, roughly in order: `kaibo cas ls` / `kaibo cas du`, so an operator can *see*
-what accumulated without learning the shard layout — then a pruning story.
-
-**Neither should be built on a filesystem sweep.** The sidecar is metadata for an object
-you already have the address of; it is not an index. Surveying the store by walking it
-means 65,536 shards and a read-plus-parse per object, and it degrades exactly as the store
-grows — which is the condition that makes anyone want `ls` in the first place. The shape
-these verbs want is an index kaibo maintains as it writes (its own persistence store is
-the obvious home: it is already open, already at a fixed XDG path no model steers, and
-already the place kaibo records what it did). That also makes `du` an O(1) read instead of
-a full walk, and would let the `[cas] max_bytes` admission stop walking the store on every
-capped write.
-
-Pruning is the harder half and a real design question rather than a missing command: the
-store's safety argument is that it never unlinks (`src/cas.rs`'s module doc), so a GC verb
-is a new mutation surface needing its own justification, its own containment check, and
-probably its own blessed line in `tests/no_write_path.rs`. A TTL sweep, an explicit
-`kaibo cas rm <digest>`, and "the operator prunes by hand, with better visibility" are
-three answers with different blast radii.
-
-Related gap worth folding in when this is picked up: **cancelling a `consult_submit` job
-aborts the future, so artifacts it saved before the cancel are never reported** — they are
-durable and readable by digest, but their addresses are lost unless the call carried a
-`session_id` (whose persisted answer keeps the footer). Surfacing them would mean the job
-record carrying the call's artifact sink, which touches every producer's `jobs.rs`
-signature; documented in `docs/config.md` rather than papered over.
+**Still open:** cancelling a `consult_submit` job aborts the future, so artifacts it saved
+before the cancel are never reported in the answer — durable and readable by digest, but
+their addresses are lost unless the call carried a `session_id` (whose persisted answer
+keeps the footer). Fixing this means the job record itself carrying the call's artifact
+sink, which touches every producer's `jobs.rs` signature.
 
 ### Someday: the CAS as kaish's egress gateway (design note, not scheduled)
 Amy's direction 2026-07-25, explicitly *"need to think about it more"* — recorded so the
@@ -818,26 +803,6 @@ endpoint still surfaces as a mid-call error. A startup check (key presence + an
 `openai` `base_url/models` ping) would fail faster and, under casts, report degraded
 teams up front — "cast `chimera` is degraded: backend `sd` unreachable" beats a
 mid-consult error. An MCP resource enumerating models could ride along.
-
-### `config.example.toml` clarity — illustrative stanzas read as required; `gpt` dual-name
-Surfaced by the cross-model review of the cast-roster change (an Anthropic `consult`
-cross-checking the example against `config.rs`, plus a deepseek/gemini/anthropic
-parse-back, 2026-06-29). Both are doc-clarity, not correctness — the example parses and
-all three families read it right otherwise — so they were left out of the roster PR:
-- **The four built-in backend stanzas are shown uncommented.** The
-  `[backends.anthropic/deepseek/gemini/openai-local]` block sits live even though the
-  preceding comment says they're illustrative and you only list a backend to *change*
-  something. An operator scanning the file may copy all four as if required — the
-  getting-started block and `[telemetry]` are commented-out for exactly this reason.
-  Comment them out (or collapse to one representative stanza). Care needed: the example's
-  casts resolve against these backends, so a wrong cut breaks
-  `tests/config.rs::the_shipped_example_config_parses` (which is the guard that makes the
-  pass safe).
-- **`gpt` names both `[backends.gpt]` and `[casts.gpt]`.** The namespaces are separate so
-  this is legal, but the file reserves *alias* names "at both levels" without saying a
-  *primary* name may be shared across the backend/cast namespaces — a reader can't tell the
-  co-naming is intentional vs. a latent collision. One clarifying clause near the
-  `[casts.<name>]` header settles it.
 
 ---
 

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -109,9 +109,8 @@
 //! file in the store on the *write* path, for every new object, over a store that never
 //! deletes and is sharded two levels deep; that walk is O(objects) and only slows down as
 //! the store fills. An operator who never asked for a ceiling should not pay it, so they
-//! do not. Cleanup, if an operator wants any, is theirs to do; kaibo offers no verb for it
-//! yet, and the shape a good one wants is an index kaibo maintains rather than a walk of
-//! the store (see "No GC here" below).
+//! do not. Cleanup, if an operator wants any, is theirs to do — kaibo builds no index and
+//! offers no scan verb for it, on purpose (see "No GC here" below).
 //!
 //! When a cap *is* set, a [`Cas::put`] that would push the store's total size over it is
 //! refused with [`CasError::CapacityExceeded`] — loudly, before any bytes are written. It never deletes anything to make room: eviction would
@@ -137,10 +136,16 @@
 //! bytes are, where they came from, and what format to serve them as. That is its job,
 //! and it is the access pattern the whole store is built for.
 //!
-//! It is not a scan target. Sweeping the tree to survey the store gets slower as the
-//! store fills — 65,536 shards, a `readdir` and a parse per object — and nothing here is
-//! indexed for it. Operator-facing inventory (someday: `kaibo cas ls`/`du`) wants an index
-//! kaibo maintains, not a walk; see `docs/issues.md`.
+//! It is not a scan target, and stays that way on purpose (Amy, 2026-08-05: no index,
+//! ever). Sweeping the tree to survey the store gets slower as the store fills — 65,536
+//! shards, a `readdir` and a parse per object — and kaibo builds nothing here to make that
+//! walk cheap, because it never runs one: the store stays opaque, reached only by the
+//! address a caller already holds. Tracking of what was created lives WITH the
+//! conversation that created it, not in the store — a `consult`/`oneshot` session turn
+//! already records the artifact footer (digest, mime, size), so those digests sit beside
+//! the conversation in the persistence store, not in a CAS-side index. An operator's
+//! cleanup, if wanted, is plain file mtime on the object tree for now; see
+//! `docs/issues.md`.
 //!
 //! Because nothing here is ever rewritten, the sidecar's schema can only ever grow
 //! *compatibly* — see [`Provenance`]'s doc for the rule that keeps a decade-old sidecar

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -609,6 +609,37 @@ mod tests {
         }
     }
 
+    /// `always_b64` is a prefix match, not an exact-name match — boundary cases the
+    /// three-model table above doesn't reach. The bare family name (no `-1`/`-mini`
+    /// suffix) still counts, matching is case- and surrounding-whitespace-insensitive,
+    /// and a model that merely *contains* the string without leading it (or leads
+    /// with something else entirely) does not match — a prefix, not a substring.
+    #[test]
+    fn always_b64_is_a_case_insensitive_trimmed_prefix_match() {
+        for model in [
+            "gpt-image",        // bare family name, no version suffix
+            "GPT-IMAGE",        // case-insensitive
+            "  gpt-image-1  ",  // surrounding whitespace trimmed before matching
+            "Gpt-Image-1-Mini", // mixed case
+        ] {
+            assert!(
+                always_b64(model),
+                "expected {model:?} to match the gpt-image family"
+            );
+        }
+        for model in [
+            "dall-e-3",
+            "sd-gpt-image", // contains the string but does not lead with it
+            "gptimage-1",   // missing the separating hyphen
+            "",
+        ] {
+            assert!(
+                !always_b64(model),
+                "expected {model:?} not to match the gpt-image family"
+            );
+        }
+    }
+
     /// The caller's stated JSON type rides through verbatim — no re-typing in
     /// either direction. `n` passed as a number arrives as the integer `2` (never
     /// `2.0`, never `"2"`); `user = "123"` passed as a STRING stays the string

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -7,7 +7,8 @@
 use std::path::{Path, PathBuf};
 
 use crate::config::{Config, Lane, ModelSlot};
-use crate::consult::ModelShape;
+use crate::consult::{ModelShape, ThinkingStyleOverride};
+use crate::credentials::WireKind;
 
 use super::ToolGating;
 
@@ -461,6 +462,21 @@ pub(crate) fn render_config_resource(
                         }
                         if temperature.is_some() && !sampling_sinks {
                             inert.push("temperature");
+                        }
+                        // The Anthropic thinking-style escape hatch only reaches the
+                        // wire on an Anthropic slot — `ModelShape::resolve` reads `ovr`
+                        // in exactly one match arm. Every other wire classifies its
+                        // thinking style from the model id alone and never consults the
+                        // override, so a style forced on this slot (a per-slot override
+                        // or an inherited `[defaults].thinking_style`, both already
+                        // folded into `t.thinking_style`) is silently dropped there.
+                        // `Auto` stays quiet: it is the no-override default and behaves
+                        // identically to an absent override on every wire, Anthropic
+                        // included.
+                        if t.thinking_style != ThinkingStyleOverride::Auto
+                            && backend.kind.wire() != Some(WireKind::Anthropic)
+                        {
+                            inert.push("thinking_style");
                         }
                         inert
                     } else {
@@ -1038,8 +1054,10 @@ mod tests {
         };
         assert_eq!(
             inert("lab_cast", "synth"),
-            vec!["effort"],
-            "a [defaults] effort on a toggle-less wire is just as inert as a slot one"
+            vec!["effort", "thinking_style"],
+            "a [defaults] effort on a toggle-less wire is just as inert as a slot one, \
+             and the [defaults] thinking_style forced onto a non-Anthropic wire is \
+             equally never consulted"
         );
         assert_eq!(
             inert("forced", "synth"),
@@ -1056,6 +1074,67 @@ mod tests {
             inert("bat_deep", "synth").is_empty(),
             "a batch slot deeper than the floor keeps its effort: {:?}",
             inert("bat_deep", "synth")
+        );
+    }
+
+    /// `thinking_style` reaches the wire only on an Anthropic slot —
+    /// `ModelShape::resolve` reads the override in exactly one match arm (Anthropic's,
+    /// picking adaptive vs budget tier). Every other wire classifies its thinking
+    /// style from the model id alone and never looks at the override, so a style
+    /// forced on a non-Anthropic slot is a pure no-op there — the render must flag it
+    /// the same way it flags an inert `thinking_budget`/`effort`/`temperature`, not
+    /// show it as if it were shaping the request.
+    #[test]
+    fn config_render_flags_thinking_style_inert_on_a_non_anthropic_slot() {
+        let config = Config::from_toml_str(
+            r#"
+            # Forced on a DeepSeek slot: DeepSeek's shape never consults the override.
+            [casts.ds_forced]
+            synth = { backend = "deepseek", id = "deepseek-v4-pro", thinking_style = "adaptive" }
+
+            # The identical override on an Anthropic slot moves the wire's shape (it
+            # picks the adaptive tier over Haiku's default budget tier), so it must
+            # NOT be flagged.
+            [casts.anthropic_forced]
+            synth = { backend = "anthropic", id = "claude-haiku-4-5", thinking_style = "adaptive" }
+            "#,
+        )
+        .unwrap();
+        let body = render_config_resource(
+            &config,
+            &[],
+            None,
+            false,
+            vec![],
+            false,
+            crate::config::CasMode::Memory,
+        );
+        let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
+        let inert = |cast: &str, role: &str| -> Vec<String> {
+            doc.get("casts")
+                .and_then(|c| c.get(cast))
+                .and_then(|c| c.get(role))
+                .and_then(|s| s.get("inert_tunables"))
+                .map(|a| {
+                    a.as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|v| v.as_str().unwrap().to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        assert_eq!(
+            inert("ds_forced", "synth"),
+            vec!["thinking_style"],
+            "a thinking_style override on a DeepSeek slot is never consulted by \
+             ModelShape::resolve and must render as inert"
+        );
+        assert!(
+            inert("anthropic_forced", "synth").is_empty(),
+            "the same override on an Anthropic slot moves the wire's shape and must \
+             stay unflagged: {:?}",
+            inert("anthropic_forced", "synth")
         );
     }
 


### PR DESCRIPTION
Small accuracy/polish slate, plus encoding a design ruling.

- **`kaibo://config` now flags an inert `thinking_style`**: `ModelShape::resolve` reads the override only on the Anthropic wire, but the config render showed it as effective on any slot. It now joins the other tunables in `inert_tunables` when written on a non-Anthropic slot. Failing-first tested; CHANGELOG entry.
- **`config.example.toml`**: the five built-in backend stanzas were live TOML while the surrounding comment called them illustrative — now commented like the other optional examples. Added the clarifying clause that `gpt` legally names both a backend and a cast in separate namespaces. (Closes the tracked "config.example.toml clarity" issue — entry deleted.)
- **openai-images**: boundary test pinning `always_b64` as a case-insensitive trimmed *prefix* match (bare `gpt-image`, case, whitespace, and a contains-but-not-prefix non-match) — the #122 review leftover.
- **The no-CAS-index ruling (Amy, 2026-08-05) encoded where the old plan lived**: kaibo will not build a CAS index. The store stays opaque — access is direct by content address; what was created is tracked *with the conversations* (session turns carry the artifact footer, so digests already sit beside the conversation in the store); operator cleanup is plain file mtime. `docs/issues.md`'s retention essay shrinks to that posture plus the one real remaining gap (artifacts orphaned by a cancelled no-session `consult_submit`); `src/cas.rs`'s module doc and `docs/config.md` no longer point at a future index.

Not done, honestly: the "CAST_ENUM_RULES literal list" item from the old session notes does not exist in #122's review comments (checked all three comments plus the reviews API) — left untouched rather than inventing a finding.

Verification: full suite 0 failed, clippy silent, `aws-lc-rs`/`mimalloc` trees empty, `no_write_path` pinned at 4. Implementation by a Claude Sonnet subagent; verification by Claude Fable 5 with Amy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
