### PR TITLE
fix: reconcile the #127/#128 merge union

### DIFF
--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -1136,6 +1136,7 @@ mod tests {
             vec![],
             false,
             crate::config::CasMode::Memory,
+            None,
         );
         let doc: toml::Value = toml::from_str(&body).expect("render is valid TOML");
         let inert = |cast: &str, role: &str| -> Vec<String> {


### PR DESCRIPTION
Two green branches, textually clean merge, semantically broken union: #127 added an eighth parameter to render_config_resource while #128's new test called the seven-argument form. One line: the test passes None (no backing finding) — also the correct fixture for what it tests. 1024 tests / 0 failed, clippy silent on the reconciled tree. Merged immediately to restore main's build; disclosed to Amy in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)