### PR TITLE
feat(deliberate): keep the dossier, and let a second synth reuse it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **`deliberate` keeps its dossier, and can reuse one.** The explorer sweep a
+  deliberation is built on is the expensive half — it can run hundreds of thousands
+  of tokens — and it used to be consumed invisibly: no way to see what the offline
+  synth actually reasoned over, and no way to ask a second model the same question
+  without paying for the sweep again. kaibo now stores the finished dossier in its
+  media CAS and names it in the reply (and in the answer when the deliberation
+  lands), so you can `read_cas` it. Pass that digest back as `dossier` and no
+  explorer runs at all: the same evidence goes to whichever cast you point at, for
+  the price of one synth — which is also the fair way to compare two synths, since
+  only the model differs. Any stored text artifact can serve as a dossier, not only
+  one `deliberate` wrote. It rides the CAS's own switch (`[cas] enabled`) with no
+  new key to turn on, a store that refuses the write costs you the record and never
+  the deliberation, and the explorer arguments (`attach`, the explorer overrides,
+  `explorer_max_turns`) are refused on a reuse call rather than silently ignored.
+  Batch deliberations now persist their handle too, with the dossier's address on
+  it, so `job_list` still leads back to the evidence after a restart.
+
 - **kaibo warns when the media CAS is on a disk that will not survive the
   container.** A container with no volume mounted looks exactly like durable disk
   mode: persistence comes up, the store opens, artifacts write and read back — and

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -283,6 +283,11 @@ scratch_limit_bytes = 67108864
 # entirely and un-advertises every tool that needs it (the startup log and
 # kaibo://config's [cas] section say which state you are in, and why).
 #
+# Three tools write here: `generate` (rendered images), `save_artifact` (bulk text a
+# model saved — see [artifacts]), and `deliberate`, which keeps every dossier it builds
+# so you can read it back or hand it to a second synth. Dossiers need no extra key and
+# are usually the bulk of the store; see kaibo://config/guide.
+#
 # It lives under the XDG *data* dir, deliberately NOT beside the state db: the session
 # store is reconstructible bookkeeping, while these are artifacts you spent real provider
 # credits on and may never be able to reproduce (the seed is recorded in a sidecar, but

--- a/docs/config.md
+++ b/docs/config.md
@@ -821,9 +821,25 @@ explicit. Every other open failure stays fatal.
 ## Media CAS: `[cas]`
 
 **On by default, and it follows persistence.** The CAS is the content-addressed store an
-artifact-producing tool writes into. Two produce today: `generate` (images a provider
-rendered) and `save_artifact` (bulk text a consult's model wrote, see `[artifacts]`
-below). Its lifecycle has three states, reported as `mode` in `kaibo://config`'s `[cas]`
+artifact-producing tool writes into. Three produce today:
+
+| producer | what it stores | opt-in |
+|---|---|---|
+| `generate` | images a provider rendered | a cast with an `image` slot |
+| `save_artifact` | bulk text a consult's model wrote | `[artifacts] enabled` **and** a per-call `save_artifacts` (see below) |
+| `deliberate` | the explorer dossier each deliberation was built on | none — the CAS being on is the only key |
+
+`deliberate` is the one kaibo writes on its own, because the dossier is kaibo's own
+byproduct of a call you already made rather than something a model chose to save. Each
+deliberation's reply names the dossier's `kaibo://cas/<digest>`; pass that digest back as
+the tool's `dossier` argument to run a second synth over the same evidence with no
+explorer sweep. Sizing note: dossiers are the bulkiest thing most installs put in this
+store, so an install that deliberates often accumulates faster than the two
+opt-in producers suggest. A store that refuses the write (a full `max_bytes`, an I/O
+error) costs you the record and never the deliberation — it is logged and the call
+proceeds.
+
+Its lifecycle has three states, reported as `mode` in `kaibo://config`'s `[cas]`
 section:
 
 | mode | when | what it means |

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,104 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-07 — the dossier stops being invisible
+
+`deliberate` had a hole in the middle of it. An explorer sweep builds a dossier — minutes
+of live reading, and on one measured run a 652k-token sweep over three trees — then hands
+it to an offline synth that reasons for hours. Nothing recorded the middle. When that
+run's answer came back, there was no way to ask the only question that mattered: *what did
+the synth actually receive?* Amy, from the kaish session: "I want to have the dossiers
+tossed into cas so we can peek at them or reuse them sometimes."
+
+Peek and reuse are one feature with two ends, and the second end is the interesting one.
+Peeking is auditing. Reusing is arbitrage: the dossier is the expensive half, so handing
+the same one to a second cast costs a synth and nothing else — and it makes a two-model
+comparison *fair*, because the evidence is byte-identical and only the model differs.
+Without it, "ask DeepSeek and Fable the same question" really means asking two questions
+over two different sweeps, and any difference in the answers is confounded by what each
+explorer happened to look at.
+
+Three decisions did most of the work:
+
+**It rides `[cas] enabled`, not `[artifacts] enabled`.** The two-key gate on
+`save_artifact` exists for one specific reason — that surface is where a *model* decides
+bytes become durable. A dossier is kaibo's own byproduct of a call the operator already
+made. No model chose the content, wrote the label, or asked for the save. Putting it
+behind the artifacts key would teach operators that the key means "kaibo writes things",
+when it means "a model does", and that confusion gets expensive later.
+
+**Keeping never fails the call.** A refused write (a full `max_bytes`, an I/O error) costs
+the record, never the deliberation the caller is paying for — loud on the operator's log,
+invisible to the model team. Same posture as the ephemeral-backing warning: what you have
+already paid for proceeds.
+
+**Refuse the inert arguments, don't strip them.** A reuse call runs no sweep, so `attach`
+and the explorer overrides have nothing to act on. Silently ignoring `attach` is the quiet
+kind of wrong: the caller attached a file, got a real deliberation, and would have no way
+to learn the file never reached it. The synth overrides stay live, because retargeting
+which model reads the evidence is the whole point.
+
+Two things fell out that weren't the plan. The batch lane had never persisted its handle
+at all — `batch_submit` did, `deliberate` didn't — which on the *long* lane is the ordinary
+case rather than the edge one: a restart mid-deliberation lost the way back. It records
+the handle now, with the dossier's address on its label, so `job_list` after a restart
+leads to both the deliberation and the evidence. And the reuse road accepts any *text*
+artifact, not only something `deliberate` wrote — the caller is the operator's proxy
+handing kaibo its own stored evidence, so a report or a parked transcript is as legitimate
+as a dossier. Binary is refused by name.
+
+Reuse also means a synth-only offline cast (`fable`, `anthropic-batch`) can serve a
+`deliberate` call, since no explorer arm has to resolve. Advertisement gating deliberately
+did *not* move: the route still appears only where a cast can staff the full job, because
+advertising a tool whose headline behavior cannot run is worse than the gap. Written down
+in `issues.md` rather than fixed.
+
+## 2026-08-05 — the media arc: the model team gets a way to hand you bulk, and you get a way to read it
+
+Written late, on 2026-08-07, for five PRs that shipped without their story (#125–#129).
+Amy's note on the omission is why this entry exists: "that shoulda gone with the PRs."
+
+The arc solved one problem from both ends. A consult that produces *bulk* — a fuzz corpus,
+a per-file inventory, a generated fixture — had exactly one channel: the answer text,
+which is the caller's context window. A driver that dumps ten kilobytes there has spent
+the caller's budget on material the caller may only want to store.
+
+**`save_artifact` (#125)** gave the model team a second channel: hand kaibo bytes, get a
+digest. One way by construction — the tool can write and can never read, list, or probe,
+because the CAS spans every project this kaibo has served, so "is this content already
+here?" answered for arbitrary bytes is a cross-project existence oracle. Not a theoretical
+worry: the two-family review caught a real one, where a capacity refusal arrived *before*
+the dedup branch and so answered the question through timing. The fix was ordering —
+admission runs before dedup, in both stores. The design also permanently dropped a `from:`
+path parameter (inline `content` is the only input this tool will ever take), and made
+every cap refuse rather than truncate, because a digest for content that is not what the
+model wrote is the silent corruption this codebase refuses.
+
+**`read_cas` (#126)** gave the operator the other end, and in doing so *replaced* the
+`kaibo://cas/<digest>` resource. Two reasons, both measured. Hosts treat resources as
+ambient context — some prefetch, some auto-attach — which is exactly the wrong posture for
+bytes a model just wrote; a tool call is deliberate, with arguments and a permission
+prompt. And `resources/read` is whole-blob: a 3.8 MB PNG produced roughly 5 MB of base64
+in one read, and only host mercy kept it out of a context window. The tool is
+metadata-first and bounded, and its own review fix batch caught a second real bug — a
+paging window could drop bytes on reassembly. Ranges always advance now, which is exactly
+what a caller resuming at the range it was handed depends on.
+
+Two smaller ships closed the arc. **#127** made disk-mode CAS warn severely when it sits
+on overlayfs/tmpfs/ramfs — a container with no volume mounted looks exactly like durable
+disk, right up until it evaporates with what you paid for inside it. It warns and proceeds
+(a throwaway store is legitimate; discovering it afterward is not), and `kaibo://config`
+reports it under `[cas] backing` so it is checkable before spending. **#128** carried
+accuracy fixes, including the ruling that the CAS stays opaque: no index, no scan verbs,
+cleanup by file mtime. What was created is tracked *with the conversation* that made it —
+the session turn records the artifact footer — not with the store.
+
+**#129 is the lesson.** #127 and #128 merged back to back; each was textually clean
+against `main` and against the other, and their union did not compile — one branch added
+an eighth parameter to `render_config_resource`, the other added a test calling it with
+seven. A clean three-way merge says nothing about semantics. Update the second branch
+against `main` before merging it, even when GitHub is green.
+
 ## 2026-08-03 — Output ceilings surfaced, and the feature's first catch was its own premise
 
 Configure-time agents were sizing synth `max_tokens` blind: the ceiling arrived in

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -354,16 +354,31 @@ lowered by #114's role-identity preambles; n=3 can't tell). Open work, in order:
   If that shape shows up in practice it's a different problem (answer-quality, not
   emptiness) and wants its own thinking, not a heuristic bolted onto this gate.
 
-### Dossier checkpointing via the persistence store
-`deliberate`'s dossier (the synchronous explorer sweep) is the expensive artifact — minutes
-of live exploration — yet it lives only in memory until the offline synth consumes it.
-Persist it to the state store (`src/store.rs`) on completion so a **failed synth hand-off
-can resubmit without re-exploring**, and a mid-explore failure can resume from the last
-checkpoint. Natural follow-on to the persistent session/batch store: a lean text artifact
-keyed by a deliberation/job id, and kept like the rest of the store — expensive model
-output we hold onto, not a scratch cache. Dovetails the "deliberate dossier vs. caller timeout" entry above — a
-persisted dossier also survives the caller dropping the connection. Surfaced by the
+### Dossier durability — what's left after keep + reuse (2026-08-07)
+A finished dossier now lands in the media CAS and can be handed back as `deliberate`'s
+`dossier` argument, so a failed synth hand-off is re-runnable by hand and a caller who
+dropped the connection still holds the evidence. Two pieces remain:
+
+- **A mid-sweep failure still loses everything.** The dossier is kept only after a
+  *successful* sweep, so an explorer that dies at turn 90 of 100 leaves nothing behind.
+  Checkpointing a partial sweep is a different mechanism — incremental writes do not fit a
+  store whose address is the hash of the whole content, so that one belongs in the state
+  store, not the CAS.
+- **Nothing resubmits automatically.** A failed hand-off leaves the caller to re-run with
+  the digest. Deliberate for now (they may want a different cast anyway), but worth
+  revisiting if that failure turns out to be common.
+
+Dovetails the "deliberate dossier vs. caller timeout" entry above. Surfaced by the
 DeepSeek CLI-subcommands review (2026-07-17).
+
+### Should a reuse-only install advertise `deliberate`?
+Reusing a stored dossier needs no explorer, so a synth-only offline cast (`fable`,
+`anthropic-batch`) serves that call fine — but the route is advertised only when some cast
+can staff the *full* job (`cast_can_deliberate` wants explorer + offline synth, pinned in
+`tests/gating.rs`). An install holding only synth-only offline casts therefore cannot reuse
+a dossier it already has, though the machinery works. Widening the gate would advertise
+`deliberate` where its headline behavior — sweep, then deliberate — cannot run, which is
+worse than the gap. Left as-is on purpose; revisit if someone hits it.
 
 ## P3 — Infra, perf, polish
 

--- a/src/server/dossier.rs
+++ b/src/server/dossier.rs
@@ -1,0 +1,335 @@
+//! Keeping the dossier a `deliberate` call builds.
+//!
+//! `deliberate` runs an explorer sweep to build a dossier, then hands that dossier to an
+//! offline synth. Until now the dossier was consumed invisibly: the caller paid for a
+//! sweep that could run hundreds of thousands of tokens, waited minutes for it, and never
+//! saw the evidence the synth actually reasoned over. Two things were impossible — to
+//! **peek** (audit what reached the synth when its answer looks thin or wrong) and to
+//! **reuse** (ask a second synth the same question over the same evidence, without paying
+//! for the sweep twice).
+//!
+//! So the dossier lands in the media CAS like any other artifact, and the caller gets its
+//! address. Amy, 2026-08-05: "I want to have the dossiers tossed into cas so we can peek
+//! at them or reuse them sometimes."
+//!
+//! # What this is not
+//!
+//! It is not a new write path, not a new capability, and not a model-steered one:
+//!
+//! - The bytes reach disk through [`crate::cas::MediaStore::put`] — the blessed surface
+//!   `generate` and `save_artifact` already use. `tests/no_write_path.rs` stays pinned.
+//! - **kaibo writes this, not a model.** The dossier is kaibo's own byproduct of a call
+//!   the operator made, so it rides the CAS's own switch (`[cas] enabled`) rather than
+//!   `[artifacts] enabled` — that key exists for the one surface where a *model* decides
+//!   bytes become durable ([`crate::artifact`]), and nothing here is model-decided. There
+//!   is no `dossier` content a model chose, no label it wrote, and no per-call ask.
+//! - **Keeping it never fails the call.** A refused or broken write is housekeeping lost,
+//!   not evidence lost: the dossier is already in hand and the deliberation the caller is
+//!   paying for proceeds. The refusal is loud on the operator's log and silent to the
+//!   model team, exactly as `save_artifact`'s store errors are.
+//!
+//! The dossier is kept *before* stage 2 runs, so a deliberation that fails, times out, or
+//! comes back thin still leaves the evidence behind to look at.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::cas::{Extension, MediaStore, Provenance};
+
+/// The dossier is a cited prose report, so it is stored as markdown — that is what
+/// `read_cas` will report its mime as, and what the sidecar records.
+const DOSSIER_EXT: Extension = Extension::Md;
+
+/// How much of the question rides in the sidecar `label`. The full question is already in
+/// the sidecar's `prompt`; the label is the one line a hand-pruning pass reads, so it is a
+/// short summary rather than a second copy.
+const MAX_LABEL_BYTES: usize = 120;
+
+/// A dossier kaibo kept: what the caller reads it back with.
+///
+/// `path` is `Some` only in disk mode — the same "read it with the tool, or find it on
+/// disk" pair the artifact footer renders, because an operator holding a shell often
+/// wants the file rather than a tool call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct KeptDossier {
+    pub digest: String,
+    pub bytes: usize,
+    pub path: Option<PathBuf>,
+}
+
+/// Put a built dossier in the media CAS and describe where it landed.
+///
+/// `None` means the dossier was not kept — the CAS is off, or the store refused the
+/// write. Both are non-events for the call in flight: see the module doc. Every refusal
+/// is logged with its typed error, since the operator is the only audience who can act on
+/// one.
+pub(crate) fn keep_dossier(
+    store: Option<&Arc<MediaStore>>,
+    question: &str,
+    dossier: &str,
+    cast: &str,
+    explorer_model: &str,
+) -> Option<KeptDossier> {
+    let store = store?;
+    let bytes = dossier.as_bytes();
+    let provenance = Provenance {
+        prompt: question.to_string(),
+        model: explorer_model.to_string(),
+        cast: cast.to_string(),
+        timestamp: crate::server::now_epoch_secs(),
+        mime: DOSSIER_EXT.mime().to_string(),
+        seed: None,
+        // The producing tool and the slot that wrote the bytes — an explorer sweep, not a
+        // synth's `save_artifact` and not a provider render. Whoever holds this digest can
+        // tell the three apart without reading the content.
+        tool: Some("deliberate".to_string()),
+        slot: Some("explorer".to_string()),
+        label: Some(label_for(question)),
+        // `deliberate` carries no `session_id` — it is one question, not a conversation.
+        session: None,
+    };
+    match store.put(bytes, DOSSIER_EXT, &provenance) {
+        Ok(digest) => Some(KeptDossier {
+            path: store.path_for(&digest),
+            digest: digest.to_hex(),
+            bytes: bytes.len(),
+        }),
+        // The bytes are durable; only the sidecar is missing. Still a kept dossier — the
+        // digest names readable content, which is the whole point of handing it back.
+        Err(crate::cas::CasError::ProvenanceNotRecorded { digest, cause }) => {
+            tracing::warn!(
+                digest = %digest,
+                cause = %cause,
+                "dossier stored without its provenance sidecar — the dossier is readable, \
+                 the housekeeping record beside it is not"
+            );
+            let parsed = crate::cas::Digest::from_hex(&digest)
+                .expect("the store renders its own digests in canonical hex");
+            Some(KeptDossier {
+                path: store.path_for(&parsed),
+                digest,
+                bytes: bytes.len(),
+            })
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "could not keep this deliberate call's dossier — the deliberation \
+                 proceeds, but the evidence it reasoned over will not be readable"
+            );
+            None
+        }
+    }
+}
+
+/// One single line of question text for the sidecar label, bounded and control-free.
+fn label_for(question: &str) -> String {
+    let mut flat = String::with_capacity(question.len());
+    let mut spacing = false;
+    for c in question.chars() {
+        if c.is_control() || c == '\u{feff}' {
+            spacing = true;
+            continue;
+        }
+        if c.is_whitespace() {
+            spacing = true;
+            continue;
+        }
+        if spacing && !flat.is_empty() {
+            flat.push(' ');
+        }
+        spacing = false;
+        flat.push(c);
+    }
+    let flat = if flat.len() > MAX_LABEL_BYTES {
+        let mut cut = MAX_LABEL_BYTES;
+        while cut > 0 && !flat.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        format!("{}…", &flat[..cut])
+    } else {
+        flat
+    };
+    if flat.is_empty() {
+        "deliberate dossier".to_string()
+    } else {
+        format!("deliberate dossier — {flat}")
+    }
+}
+
+/// The clause both lane acks carry, naming where the dossier landed. Empty when nothing
+/// was kept, so an ack on a CAS-off server reads exactly as it did before.
+pub(crate) fn dossier_ack(kept: Option<&KeptDossier>) -> String {
+    match kept {
+        Some(k) => format!(
+            " The dossier it built is kept at {}{} ({} bytes) — read it with `read_cas`.",
+            crate::cas::CAS_URI_PREFIX,
+            k.digest,
+            k.bytes
+        ),
+        None => String::new(),
+    }
+}
+
+/// Append the kept dossier's address to a finished deliberation, so the answer carries
+/// its own evidence trail. Mirrors [`crate::artifact::with_artifacts`]: no kept dossier
+/// leaves the answer byte-for-byte its old self.
+pub(crate) fn with_dossier(answer: String, kept: Option<&KeptDossier>) -> String {
+    let Some(k) = kept else {
+        return answer;
+    };
+    let mut out = format!(
+        "{answer}\n\n---\nDossier: {}{} ({}, {} bytes) — the explorer's report this \
+         deliberation reasoned over; read it with `read_cas`.",
+        crate::cas::CAS_URI_PREFIX,
+        k.digest,
+        DOSSIER_EXT.mime(),
+        k.bytes
+    );
+    if let Some(path) = &k.path {
+        out.push_str(&format!("\n   path: {}", path.display()));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cas::{Digest, MemoryCas};
+
+    fn store() -> Arc<MediaStore> {
+        Arc::new(MediaStore::Memory(MemoryCas::new(None)))
+    }
+
+    /// The kept dossier is the dossier — byte-for-byte, at its own content address, with a
+    /// sidecar that says which tool and which slot wrote it. The whole point is to audit
+    /// what the synth received, so content that is not *exactly* what stage 2 gets would
+    /// be worse than keeping nothing.
+    #[test]
+    fn the_dossier_is_kept_verbatim_at_its_content_address() {
+        let store = store();
+        let dossier = "src/consult/engine.rs:2064 the offline synth runs one turn\n";
+        let kept = keep_dossier(
+            Some(&store),
+            "is the deliberate lane right?",
+            dossier,
+            "gemini-deliberate",
+            "gemini/gemini-flash-lite-latest",
+        )
+        .expect("a live store keeps the dossier");
+
+        assert_eq!(
+            kept.digest,
+            Digest::of_bytes(dossier.as_bytes()).to_hex(),
+            "the address must be the dossier's own hash"
+        );
+        assert_eq!(kept.bytes, dossier.len());
+        let digest = Digest::from_hex(&kept.digest).unwrap();
+        let (bytes, ext) = store.get(&digest).expect("readable").expect("present");
+        assert_eq!(
+            String::from_utf8(bytes).unwrap(),
+            dossier,
+            "the stored bytes must be the dossier verbatim"
+        );
+        assert_eq!(ext, Extension::Md, "a dossier is stored as markdown");
+
+        let p = store.provenance(&digest).expect("a sidecar was written");
+        assert_eq!(p.tool.as_deref(), Some("deliberate"));
+        assert_eq!(p.slot.as_deref(), Some("explorer"));
+        assert_eq!(p.cast, "gemini-deliberate");
+        assert_eq!(p.model, "gemini/gemini-flash-lite-latest");
+        assert_eq!(p.prompt, "is the deliberate lane right?");
+        assert_eq!(p.session, None, "deliberate carries no session");
+        assert!(
+            p.label.as_deref().unwrap().contains("deliberate lane"),
+            "the label names the question: {:?}",
+            p.label
+        );
+    }
+
+    /// A server with the CAS off deliberates exactly as it always did. Keeping is an
+    /// addition to the call, never a precondition of it.
+    #[test]
+    fn a_cas_off_server_keeps_nothing_and_says_nothing() {
+        assert_eq!(keep_dossier(None, "q", "dossier", "cast", "model"), None);
+        assert_eq!(dossier_ack(None), "");
+        assert_eq!(with_dossier("answer".into(), None), "answer");
+    }
+
+    /// A store that refuses the write loses the housekeeping, never the deliberation:
+    /// `None` comes back and the caller carries on. This is the failure mode that must
+    /// not turn a paid-for sweep into an error.
+    #[test]
+    fn a_refused_write_is_not_an_error_for_the_call() {
+        // A capped store with no room for even a small dossier.
+        let store = Arc::new(MediaStore::Memory(MemoryCas::new(Some(8))));
+        let kept = keep_dossier(
+            Some(&store),
+            "q",
+            "a dossier far larger than eight bytes",
+            "cast",
+            "model",
+        );
+        assert_eq!(
+            kept, None,
+            "a refused write keeps nothing, and does not panic"
+        );
+    }
+
+    /// The sidecar label is one bounded line: a multi-line question cannot forge extra
+    /// structure into it, and a long one is cut at a character boundary rather than
+    /// panicking on a multi-byte split.
+    #[test]
+    fn the_label_is_one_bounded_line() {
+        let label = label_for("first line\nsecond line\r\n\tthird");
+        assert_eq!(label, "deliberate dossier — first line second line third");
+
+        let long = label_for(&"あ".repeat(200));
+        assert!(
+            long.len() <= MAX_LABEL_BYTES + "deliberate dossier — ".len() + "…".len(),
+            "the label is bounded: {} bytes",
+            long.len()
+        );
+        assert!(long.ends_with('…'), "a cut label says it was cut: {long}");
+
+        assert_eq!(
+            label_for("   \n  "),
+            "deliberate dossier",
+            "a question with nothing quotable still labels the object"
+        );
+    }
+
+    /// Both surfaces name the URI a caller acts on, and the answer footer names the disk
+    /// path when there is one — the same pair the artifact footer renders.
+    #[test]
+    fn both_surfaces_name_the_uri_the_caller_reads() {
+        let kept = KeptDossier {
+            digest: "ab".repeat(32),
+            bytes: 4096,
+            path: Some(PathBuf::from("/data/kaibo/cas/ab/abab.md")),
+        };
+        let ack = dossier_ack(Some(&kept));
+        assert!(
+            ack.contains(&format!("kaibo://cas/{}", kept.digest)),
+            "{ack}"
+        );
+        assert!(
+            ack.contains("read_cas"),
+            "the ack names the way to read it: {ack}"
+        );
+
+        let answer = with_dossier("DELIBERATION".into(), Some(&kept));
+        assert!(
+            answer.starts_with("DELIBERATION"),
+            "the answer leads: {answer}"
+        );
+        assert!(
+            answer.contains(&format!("kaibo://cas/{}", kept.digest)),
+            "{answer}"
+        );
+        assert!(
+            answer.contains("path: /data/kaibo/cas/ab/abab.md"),
+            "disk mode names the file: {answer}"
+        );
+    }
+}

--- a/src/server/dossier.rs
+++ b/src/server/dossier.rs
@@ -45,6 +45,16 @@ const DOSSIER_EXT: Extension = Extension::Md;
 /// short summary rather than a second copy.
 const MAX_LABEL_BYTES: usize = 120;
 
+/// How this call came by its dossier — the one thing the caller-facing lines say
+/// differently, since "kept" and "reused" describe opposite spends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Origin {
+    /// An explorer sweep built it on this call, and kaibo kept it.
+    Built,
+    /// The caller supplied its digest; no sweep ran.
+    Reused,
+}
+
 /// A dossier kaibo kept: what the caller reads it back with.
 ///
 /// `path` is `Some` only in disk mode — the same "read it with the tool, or find it on
@@ -55,6 +65,7 @@ pub(crate) struct KeptDossier {
     pub digest: String,
     pub bytes: usize,
     pub path: Option<PathBuf>,
+    pub origin: Origin,
 }
 
 /// Put a built dossier in the media CAS and describe where it landed.
@@ -93,6 +104,7 @@ pub(crate) fn keep_dossier(
             path: store.path_for(&digest),
             digest: digest.to_hex(),
             bytes: bytes.len(),
+            origin: Origin::Built,
         }),
         // The bytes are durable; only the sidecar is missing. Still a kept dossier — the
         // digest names readable content, which is the whole point of handing it back.
@@ -109,6 +121,7 @@ pub(crate) fn keep_dossier(
                 path: store.path_for(&parsed),
                 digest,
                 bytes: bytes.len(),
+                origin: Origin::Built,
             })
         }
         Err(e) => {
@@ -120,6 +133,123 @@ pub(crate) fn keep_dossier(
             None
         }
     }
+}
+
+/// The refusal a `deliberate` call earns when it supplies a dossier AND explorer
+/// arguments, or `None` when there is nothing wrong.
+///
+/// With a dossier supplied there is no sweep, so `attach`, the explorer overrides, and
+/// `explorer_max_turns` have nothing to act on. Ignoring them would hand back an answer
+/// that looks like it honored them, which is the quiet kind of wrong: the caller attached
+/// a file, saw a deliberation, and has no way to learn the file never reached it.
+///
+/// A call that builds its own dossier can carry every one of them, so only a reuse call
+/// has anything to answer for here. Checked before the handler resolves anything, so a
+/// self-contradictory request costs nothing.
+pub(crate) fn inert_explorer_args(input: &crate::server::DeliberateInput) -> Option<String> {
+    input.dossier.as_ref()?;
+    let inert: Vec<&str> = [
+        (!input.attach.is_empty()).then_some("attach"),
+        input.explorer_model.is_some().then_some("explorer_model"),
+        input
+            .explorer_backend
+            .is_some()
+            .then_some("explorer_backend"),
+        input
+            .explorer_max_turns
+            .is_some()
+            .then_some("explorer_max_turns"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    if inert.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "`dossier` reuses evidence that is already built, so no explorer runs on this call \
+         and {} would do nothing. Drop {} to reuse the stored dossier, or drop `dossier` to \
+         sweep for a fresh one.",
+        inert
+            .iter()
+            .map(|a| format!("`{a}`"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        if inert.len() == 1 { "it" } else { "them" }
+    ))
+}
+
+/// Load a dossier the caller supplied by address, for a second synth to reason over.
+///
+/// This is the reuse half of keeping them: a sweep that cost hundreds of thousands of
+/// tokens is worth asking twice over, and the second ask should cost only the synth. The
+/// text comes back exactly as the store holds it — the same bytes the first synth read.
+///
+/// The caller is the operator's proxy, so any *textual* object in the store is fair
+/// evidence here, not just something `deliberate` wrote: a report, a spec, a pasted
+/// transcript a `save_artifact` call parked. What it will not do is hand an image or any
+/// other binary to a text prompt, or invent a dossier when the address names nothing.
+/// Every refusal says which of those happened.
+///
+/// `Err` is a sentence for the caller — the handler wraps it as invalid params.
+pub(crate) fn load_dossier(
+    store: Option<&Arc<MediaStore>>,
+    reference: &str,
+) -> Result<(String, KeptDossier), String> {
+    let Some(store) = store else {
+        return Err(
+            "`dossier` names a stored dossier, but the media CAS is off ([cas] enabled = \
+             false), so kaibo holds none. Re-enable the CAS and reconnect, or omit \
+             `dossier` to build a fresh one."
+                .to_string(),
+        );
+    };
+    // The ack and the answer footer both render a `kaibo://cas/<digest>` URI, so the
+    // caller most often has the URI in hand rather than the bare digest. Taking either is
+    // not a fallback: the prefix is unambiguous, and refusing the exact string kaibo just
+    // printed would be a puzzle, not a guardrail.
+    let hex = reference
+        .trim()
+        .strip_prefix(crate::cas::CAS_URI_PREFIX)
+        .unwrap_or(reference.trim());
+    let digest = crate::cas::Digest::from_hex(hex).map_err(|e| {
+        format!(
+            "{e} — pass the digest kaibo handed back for a dossier, either bare or as its \
+             full {}<digest> URI.",
+            crate::cas::CAS_URI_PREFIX
+        )
+    })?;
+    let (bytes, ext) = match store.get(&digest) {
+        Ok(Some(found)) => found,
+        Ok(None) => {
+            return Err(format!(
+                "no artifact with digest {hex} — it was never stored here, or (in memory \
+                 mode) it did not survive a restart. Omit `dossier` to build a fresh one."
+            ))
+        }
+        Err(e) => return Err(format!("{e}")),
+    };
+    if !ext.is_textual() {
+        return Err(format!(
+            "the artifact at {hex} is {}, and a dossier is the text an offline synth \
+             reasons over. Pass the digest of a dossier or another text artifact.",
+            ext.mime()
+        ));
+    }
+    // Stored text is UTF-8 by construction on every path that writes it (a dossier is a
+    // Rust `String`; `save_artifact` takes a JSON string). Say so plainly if some other
+    // route ever produced text that is not, rather than deliberating over replacement
+    // characters.
+    let text = String::from_utf8(bytes).map_err(|_| {
+        format!("the artifact at {hex} is not valid UTF-8, so it cannot be read as a dossier.")
+    })?;
+    let kept = KeptDossier {
+        digest: hex.to_string(),
+        bytes: text.len(),
+        path: store.path_for(&digest),
+        origin: Origin::Reused,
+    };
+    Ok((text, kept))
 }
 
 /// One single line of question text for the sidecar label, bounded and control-free.
@@ -160,14 +290,22 @@ fn label_for(question: &str) -> String {
 /// The clause both lane acks carry, naming where the dossier landed. Empty when nothing
 /// was kept, so an ack on a CAS-off server reads exactly as it did before.
 pub(crate) fn dossier_ack(kept: Option<&KeptDossier>) -> String {
-    match kept {
-        Some(k) => format!(
-            " The dossier it built is kept at {}{} ({} bytes) — read it with `read_cas`.",
-            crate::cas::CAS_URI_PREFIX,
-            k.digest,
+    let Some(k) = kept else {
+        return String::new();
+    };
+    let uri = format!("{}{}", crate::cas::CAS_URI_PREFIX, k.digest);
+    match k.origin {
+        Origin::Built => format!(
+            " The dossier it built is kept at {uri} ({} bytes) — read it with `read_cas`, \
+             or pass it back as `dossier` to ask another cast the same question without \
+             re-exploring.",
             k.bytes
         ),
-        None => String::new(),
+        Origin::Reused => format!(
+            " It is reasoning over the dossier you passed, {uri} ({} bytes) — no sweep ran \
+             on this call.",
+            k.bytes
+        ),
     }
 }
 
@@ -178,12 +316,14 @@ pub(crate) fn with_dossier(answer: String, kept: Option<&KeptDossier>) -> String
     let Some(k) = kept else {
         return answer;
     };
+    let how = match k.origin {
+        Origin::Built => "the explorer's report this deliberation reasoned over",
+        Origin::Reused => "the dossier this deliberation reused; no sweep ran on this call",
+    };
     let mut out = format!(
-        "{answer}\n\n---\nDossier: {}{} ({}, {} bytes) — the explorer's report this \
-         deliberation reasoned over; read it with `read_cas`.",
+        "{answer}\n\n---\nDossier: {}{} ({} bytes) — {how}; read it with `read_cas`.",
         crate::cas::CAS_URI_PREFIX,
         k.digest,
-        DOSSIER_EXT.mime(),
         k.bytes
     );
     if let Some(path) = &k.path {
@@ -299,6 +439,149 @@ mod tests {
         );
     }
 
+    /// The round trip that makes reuse worth anything: what `keep_dossier` stored comes
+    /// back byte-for-byte, so a second synth reasons over the same evidence the first one
+    /// did rather than a re-rendering of it.
+    #[test]
+    fn a_kept_dossier_loads_back_verbatim_for_a_second_synth() {
+        let store = store();
+        let dossier = "src/x.rs:1 fn retry\nsrc/x.rs:9 the backoff is unbounded\n";
+        let kept = keep_dossier(Some(&store), "is the retry safe?", dossier, "c", "m").unwrap();
+
+        for reference in [
+            kept.digest.clone(),
+            format!("{}{}", crate::cas::CAS_URI_PREFIX, kept.digest),
+            format!("  {}  ", kept.digest),
+        ] {
+            let (text, reused) = load_dossier(Some(&store), &reference)
+                .unwrap_or_else(|e| panic!("loading {reference:?} must work: {e}"));
+            assert_eq!(text, dossier, "the reused dossier is the stored one");
+            assert_eq!(reused.digest, kept.digest);
+            assert_eq!(
+                reused.origin,
+                Origin::Reused,
+                "a loaded dossier is reused, not built — the two read differently"
+            );
+        }
+    }
+
+    /// Every way a supplied `dossier` can fail says which thing went wrong, and none of
+    /// them invents a dossier or quietly falls back to sweeping.
+    #[test]
+    fn a_dossier_that_cannot_be_reused_says_which_thing_went_wrong() {
+        let store = store();
+        let cas_off = load_dossier(None, &"aa".repeat(32)).expect_err("no store, no reuse");
+        assert!(cas_off.contains("[cas] enabled"), "{cas_off}");
+
+        let bad = load_dossier(Some(&store), "not-a-digest").expect_err("garbage is refused");
+        assert!(
+            bad.contains("kaibo://cas/"),
+            "the refusal shows the shape: {bad}"
+        );
+
+        let missing =
+            load_dossier(Some(&store), &"aa".repeat(32)).expect_err("an absent object is refused");
+        assert!(
+            missing.contains("never stored here"),
+            "an absent dossier is not a corrupt one: {missing}"
+        );
+
+        // A stored PNG is a real address, and emphatically not a dossier.
+        let png = store
+            .put(
+                &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+                Extension::Png,
+                &Provenance {
+                    prompt: "p".into(),
+                    model: "m".into(),
+                    cast: "c".into(),
+                    timestamp: 0,
+                    mime: "image/png".into(),
+                    seed: None,
+                    tool: Some("generate".into()),
+                    slot: None,
+                    label: None,
+                    session: None,
+                },
+            )
+            .unwrap();
+        let binary = load_dossier(Some(&store), &png.to_hex()).expect_err("an image is refused");
+        assert!(
+            binary.contains("image/png"),
+            "the refusal names what it actually is: {binary}"
+        );
+    }
+
+    /// A reuse call that also carries explorer arguments is refused by name, never quietly
+    /// stripped: `attach` is the dangerous one — a caller who attached a file and got an
+    /// answer would have no way to learn the file never reached the synth.
+    #[test]
+    fn explorer_arguments_are_refused_on_a_reuse_call_by_name() {
+        let base = || crate::server::DeliberateInput {
+            question: "q".into(),
+            attach: vec![],
+            path: None,
+            cast: None,
+            explorer_model: None,
+            explorer_backend: None,
+            synth_model: None,
+            synth_backend: None,
+            explorer_max_turns: None,
+            dossier: Some("aa".repeat(32)),
+        };
+        assert_eq!(
+            inert_explorer_args(&base()),
+            None,
+            "a plain reuse call is fine"
+        );
+
+        let with_attach = crate::server::DeliberateInput {
+            attach: vec!["src/x.rs".into()],
+            ..base()
+        };
+        let refusal = inert_explorer_args(&with_attach).expect("attach is inert here");
+        assert!(refusal.contains("`attach`"), "named: {refusal}");
+
+        let many = crate::server::DeliberateInput {
+            explorer_model: Some("m".into()),
+            explorer_max_turns: Some(10),
+            ..base()
+        };
+        let refusal = inert_explorer_args(&many).expect("both are inert");
+        assert!(
+            refusal.contains("`explorer_model`") && refusal.contains("`explorer_max_turns`"),
+            "every inert argument is named, not just the first: {refusal}"
+        );
+
+        // The synth overrides are the ones that still MEAN something on a reuse call —
+        // choosing which model reads the reused evidence is the whole point.
+        let synth_override = crate::server::DeliberateInput {
+            synth_model: Some("other-synth".into()),
+            synth_backend: Some("other-backend".into()),
+            ..base()
+        };
+        assert_eq!(
+            inert_explorer_args(&synth_override),
+            None,
+            "retargeting the synth is exactly what reuse is for"
+        );
+
+        // And a call that builds its own dossier carries every explorer argument happily —
+        // this check must never touch the road it isn't about.
+        let building = crate::server::DeliberateInput {
+            dossier: None,
+            attach: vec!["src/x.rs".into()],
+            explorer_model: Some("m".into()),
+            explorer_max_turns: Some(10),
+            ..base()
+        };
+        assert_eq!(
+            inert_explorer_args(&building),
+            None,
+            "a sweeping call is what the explorer arguments are for"
+        );
+    }
+
     /// Both surfaces name the URI a caller acts on, and the answer footer names the disk
     /// path when there is one — the same pair the artifact footer renders.
     #[test]
@@ -307,6 +590,7 @@ mod tests {
             digest: "ab".repeat(32),
             bytes: 4096,
             path: Some(PathBuf::from("/data/kaibo/cas/ab/abab.md")),
+            origin: Origin::Built,
         };
         let ack = dossier_ack(Some(&kept));
         assert!(
@@ -330,6 +614,24 @@ mod tests {
         assert!(
             answer.contains("path: /data/kaibo/cas/ab/abab.md"),
             "disk mode names the file: {answer}"
+        );
+
+        // A reused dossier reads as reused on both surfaces — the caller must be able to
+        // tell "kaibo swept for this" from "kaibo reasoned over what you handed it",
+        // because only one of those cost an explorer.
+        let reused = KeptDossier {
+            origin: Origin::Reused,
+            ..kept
+        };
+        assert!(
+            dossier_ack(Some(&reused)).contains("no sweep ran"),
+            "{}",
+            dossier_ack(Some(&reused))
+        );
+        assert!(
+            with_dossier("D".into(), Some(&reused)).contains("reused"),
+            "{}",
+            with_dossier("D".into(), Some(&reused))
         );
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -460,6 +460,15 @@ pub struct DeliberateInput {
     /// Max tool-loop turns for the dossier-building explorer sweep (default 100).
     #[serde(default)]
     pub explorer_max_turns: Option<usize>,
+
+    /// Reuse a dossier kaibo already built instead of sweeping for a new one: pass the
+    /// digest (bare, or as its `kaibo://cas/<digest>` URI) that an earlier `deliberate`
+    /// handed back. No explorer runs, so this call costs only the synth — the way to put
+    /// the same evidence in front of a second cast. The explorer arguments (`attach`,
+    /// `explorer_model`, `explorer_backend`, `explorer_max_turns`) have nothing to act on
+    /// here, and are refused rather than ignored.
+    #[serde(default)]
+    pub dossier: Option<String>,
 }
 
 /// The handle addressing one piece of async work — a durable batch or a
@@ -2072,8 +2081,10 @@ impl KaiboHandler {
             provider's batch lane (max thinking, half price) or a big local model taking \
             the time it takes. Returns a durable handle once the dossier is built; keep \
             working, then `job_wait`/`job_get` it. Best for hard questions worth hours — a \
-            design review, a gnarly bug, \"is this abstraction right\". For an answer this \
-            turn, use `consult`."
+            design review, a gnarly bug, \"is this abstraction right\". kaibo keeps the \
+            dossier and hands back its digest: pass it as `dossier` to put the same \
+            evidence in front of a second cast for the price of one synth. For an answer \
+            this turn, use `consult`."
     )]
     async fn deliberate(
         &self,
@@ -2081,6 +2092,11 @@ impl KaiboHandler {
         peer: Peer<RoleServer>,
         meta: RequestMetaObject,
     ) -> Result<CallToolResult, McpError> {
+        // A reuse call that also carries explorer arguments is self-contradictory; say so
+        // before resolving anything, so it costs nothing.
+        if let Some(refusal) = dossier::inert_explorer_args(&input) {
+            return Err(McpError::invalid_params(refusal, None));
+        }
         let root = self.resolve_root(input.path)?;
         let mut cast = self.resolve_cast(input.cast)?;
         // deliberate = explore → OFFLINE synth. Require the synth on an offline lane
@@ -2098,106 +2114,132 @@ impl KaiboHandler {
             input.synth_model.as_deref(),
             input.synth_backend.as_deref(),
         )?;
-        let explorer = self.arm(&cast, ModelRole::Explorer)?;
-        let explorer_model = explorer.model.clone();
+        // Stage 2's preamble, resolved before the branch because both roads reach it:
+        // the offline-synth prompt, overridable via `[prompts].batch` OR the synth slot's
+        // own `preamble` (`resolved_prompts` layers both, same as the dossier phase does).
+        let system =
+            crate::consult::batch_system_prompt(self.resolved_prompts(&cast).batch.as_deref());
 
-        // Stage 1 — build the dossier synchronously, on the live progress sink: the
-        // caller waits through this bounded (minutes) explorer sweep, exactly as `explore`
-        // does, so a thin/failed dossier is a clean error *before* any offline tokens are
-        // spent. Only the deliberation (Stage 2) is handed off async. Attachments reach
-        // the dossier-builder as read-WHOLE directives (the sweep semantics), so their
-        // content flows to the offline synth through the dossier it writes.
-        let progress = progress_sink(peer, &meta);
-        let defaults = &self.config.defaults;
-        let attachments = self
-            .resolve_sweep_attachments(&root, &input.attach, "deliberate")
-            .await?;
-        let cfg = ExploreConfig {
-            phase: PhaseContext {
-                progress: progress.clone(),
-                house_rules: self.house_rules(&root)?,
-                prompts: self.resolved_prompts(&cast),
-                orientation: self.orientation(&root).await?,
-                call_deadline: defaults.call_deadline,
-            },
-            explorer_max_turns: input
-                .explorer_max_turns
-                .unwrap_or(defaults.explorer_max_turns),
-            sandbox: self.config.sandbox.clone(),
-            max_attachments: defaults.max_attachments,
-        };
-        // The offline synth's resolved caps, without building a network client — pure
-        // and key-free, so this can run before the (bounded but real) dossier sweep,
-        // and it's valid for both lanes (batch and direct both require the synth
-        // slot). Lets the dossier sweep's `attach` gate on the synth's real vision
-        // cap instead of assuming blind.
-        let (synth_slot, _synth_backend, synth_caps) = self.batch_synth(&cast)?;
-        let consumer = SweepConsumer {
-            kind: SweepConsumerKind::OfflineSynth,
-            label: Arc::from(format!(
-                "the offline synth (`{}`) on cast `{}`",
-                synth_slot.id, cast.name
-            )),
-            vision: synth_caps.vision,
-        };
-        // Deliberate's dossier sweep does NOT dedupe against the caller's own attach
-        // list (an empty seed): a caller-attached file reaches the offline synth ONLY
-        // through what the explorer writes (it's a read-WHOLE directive here, never
-        // inlined), so deduping would silently strand it — see SweepAttachSink's doc.
-        let sink = (defaults.max_attachments > 0).then(|| {
-            Arc::new(SweepAttachSink::new(
-                defaults.max_attachments,
-                consumer.clone(),
-                std::collections::HashSet::new(),
-            ))
-        });
-
-        let span = tracing::info_span!("deliberate.dossier", cast = %cast.name, explorer_model = %explorer_model);
-        progress.emit(PhaseEvent::PhaseStarted {
-            phase: "deliberate.dossier",
-        });
-        let (mut dossier, dossier_usage) = match explore_with(
-            &input.question,
-            root,
-            &explorer,
-            &cfg,
-            &attachments,
-            sink.as_ref(),
-        )
-        .instrument(span)
-        .await
+        // Stage 1 — build the dossier, or reuse one already built.
+        //
+        // The reuse road exists because a dossier is the expensive half: a sweep can run
+        // hundreds of thousands of tokens, and asking a second cast the same question over
+        // the same evidence should cost only the second synth. It is also the honest way to
+        // compare two synths — same evidence, so the answers differ by the model alone.
+        let (dossier, images, dossier_usage, kept, explorer_model) = if let Some(reference) =
+            input.dossier.as_deref()
         {
-            Ok(out) => out,
-            Err(e) => return Ok(consultation_failed("deliberate", &cast.name, e)),
+            let (text, kept) = dossier::load_dossier(self.media_cas.as_ref(), reference)
+                .map_err(|msg| McpError::invalid_params(msg, None))?;
+            // No sweep, so no routed images and no explorer spend — and no explorer to
+            // name in the provenance footer. The synth is the only model this call ran.
+            (text, Vec::new(), Usage::new(), Some(kept), None)
+        } else {
+            let explorer = self.arm(&cast, ModelRole::Explorer)?;
+            let explorer_model = explorer.model.clone();
+
+            // The dossier is built synchronously, on the live progress sink: the caller
+            // waits through this bounded (minutes) explorer sweep, exactly as `explore`
+            // does, so a thin/failed dossier is a clean error *before* any offline tokens
+            // are spent. Only the deliberation (Stage 2) is handed off async. Attachments
+            // reach the dossier-builder as read-WHOLE directives (the sweep semantics), so
+            // their content flows to the offline synth through the dossier it writes.
+            let progress = progress_sink(peer, &meta);
+            let defaults = &self.config.defaults;
+            let attachments = self
+                .resolve_sweep_attachments(&root, &input.attach, "deliberate")
+                .await?;
+            let cfg = ExploreConfig {
+                phase: PhaseContext {
+                    progress: progress.clone(),
+                    house_rules: self.house_rules(&root)?,
+                    prompts: self.resolved_prompts(&cast),
+                    orientation: self.orientation(&root).await?,
+                    call_deadline: defaults.call_deadline,
+                },
+                explorer_max_turns: input
+                    .explorer_max_turns
+                    .unwrap_or(defaults.explorer_max_turns),
+                sandbox: self.config.sandbox.clone(),
+                max_attachments: defaults.max_attachments,
+            };
+            // The offline synth's resolved caps, without building a network client — pure
+            // and key-free, so this can run before the (bounded but real) dossier sweep,
+            // and it's valid for both lanes (batch and direct both require the synth
+            // slot). Lets the dossier sweep's `attach` gate on the synth's real vision
+            // cap instead of assuming blind.
+            let (synth_slot, _synth_backend, synth_caps) = self.batch_synth(&cast)?;
+            let consumer = SweepConsumer {
+                kind: SweepConsumerKind::OfflineSynth,
+                label: Arc::from(format!(
+                    "the offline synth (`{}`) on cast `{}`",
+                    synth_slot.id, cast.name
+                )),
+                vision: synth_caps.vision,
+            };
+            // Deliberate's dossier sweep does NOT dedupe against the caller's own attach
+            // list (an empty seed): a caller-attached file reaches the offline synth ONLY
+            // through what the explorer writes (it's a read-WHOLE directive here, never
+            // inlined), so deduping would silently strand it — see SweepAttachSink's doc.
+            let sink = (defaults.max_attachments > 0).then(|| {
+                Arc::new(SweepAttachSink::new(
+                    defaults.max_attachments,
+                    consumer.clone(),
+                    std::collections::HashSet::new(),
+                ))
+            });
+
+            let span = tracing::info_span!("deliberate.dossier", cast = %cast.name, explorer_model = %explorer_model);
+            progress.emit(PhaseEvent::PhaseStarted {
+                phase: "deliberate.dossier",
+            });
+            let (mut dossier, dossier_usage) = match explore_with(
+                &input.question,
+                root,
+                &explorer,
+                &cfg,
+                &attachments,
+                sink.as_ref(),
+            )
+            .instrument(span)
+            .await
+            {
+                Ok(out) => out,
+                Err(e) => return Ok(consultation_failed("deliberate", &cast.name, e)),
+            };
+            progress.emit(PhaseEvent::PhaseFinished {
+                phase: "deliberate.dossier",
+            });
+            // Stitch whatever the dossier sweep routed via `attach` into the dossier text
+            // itself (text bodies, notes, demotions); collect any routed images separately
+            // — they ride the synth's single turn as native parts, not as dossier text.
+            let images = stitch_dossier_delivery(&mut dossier, &consumer, sink.as_ref());
+            // Keep the finished dossier before stage 2 spends anything on it, so a
+            // deliberation that fails, times out, or comes back thin still leaves the
+            // evidence it was built from readable. Never fatal — see `server::dossier`.
+            let kept = keep_dossier(
+                self.media_cas.as_ref(),
+                &input.question,
+                &dossier,
+                &cast.name,
+                &explorer_model,
+            );
+            (
+                dossier,
+                images,
+                dossier_usage,
+                kept,
+                Some(explorer_model),
+            )
         };
-        progress.emit(PhaseEvent::PhaseFinished {
-            phase: "deliberate.dossier",
-        });
-        // Stitch whatever the dossier sweep routed via `attach` into the dossier text
-        // itself (text bodies, notes, demotions); collect any routed images separately
-        // — they ride the synth's single turn as native parts, not as dossier text.
-        let images = stitch_dossier_delivery(&mut dossier, &consumer, sink.as_ref());
-        // Keep the finished dossier before stage 2 spends anything on it, so a
-        // deliberation that fails, times out, or comes back thin still leaves the evidence
-        // it was built from readable. Never fatal — see `server::dossier`.
-        let kept = keep_dossier(
-            self.media_cas.as_ref(),
-            &input.question,
-            &dossier,
-            &cast.name,
-            &explorer_model,
-        );
 
         // Stage 2 — hand the dossier to the offline synth. Its lane picks the mechanism
-        // and the handle; both share the offline-synth preamble (`batch_system_prompt`,
-        // overridable via `[prompts].batch` OR the synth slot's own `preamble` — the
-        // resolved `cfg.phase.prompts` already layered both, same as the dossier phase above).
-        let system = crate::consult::batch_system_prompt(cfg.phase.prompts.batch.as_deref());
+        // and the handle.
         match lane {
             Lane::Batch => {
                 self.deliberate_batch(
                     &cast,
-                    &explorer_model,
+                    explorer_model.as_deref(),
                     &input.question,
                     &dossier,
                     &images,
@@ -2209,7 +2251,7 @@ impl KaiboHandler {
             }
             Lane::Direct => self.deliberate_direct_job(
                 &cast,
-                &explorer_model,
+                explorer_model.as_deref(),
                 &input.question,
                 &dossier,
                 &images,
@@ -2234,7 +2276,10 @@ impl KaiboHandler {
     async fn deliberate_batch(
         &self,
         cast: &Cast,
-        explorer_model: &str,
+        // The explorer that built the dossier, or `None` when this call reused a stored
+        // one — there was no explorer then, and naming one would bill a model that never
+        // ran to this call.
+        explorer_model: Option<&str>,
         question: &str,
         dossier: &str,
         // Images the dossier sweep routed via `attach` — the batch builders already
@@ -2295,15 +2340,22 @@ impl KaiboHandler {
             }
         }
         // Fold the dossier build's real cost into the ack — the synth's own tokens land
-        // later on the provider's batch result, but the build spend is knowable now.
-        let dossier_cost = fmt_usage(&dossier_usage)
-            .map(|t| format!(", {t}"))
-            .unwrap_or_default();
+        // later on the provider's batch result, but the build spend is knowable now. A
+        // reused dossier cost this call nothing, and says so.
+        let stage_one = match explorer_model {
+            Some(m) => {
+                let cost = fmt_usage(&dossier_usage)
+                    .map(|t| format!(", {t}"))
+                    .unwrap_or_default();
+                format!("Dossier built (explorer `{m}`{cost})")
+            }
+            None => "Dossier reused (no explorer ran)".to_string(),
+        };
         let msg = format!(
-            "Dossier built (explorer `{explorer_model}`{dossier_cost}) and handed to the batch \
-             lane as `{handle}` — cast `{}`, synth `{model}` at max thinking. It deliberates \
-             offline; collect it with `job_get {handle}` (durable — survives restart), or stop it \
-             with `job_cancel {handle}`. Nothing to wait on now.{}",
+            "{stage_one} and handed to the batch lane as `{handle}` — cast `{}`, synth \
+             `{model}` at max thinking. It deliberates offline; collect it with `job_get \
+             {handle}` (durable — survives restart), or stop it with `job_cancel \
+             {handle}`. Nothing to wait on now.{}",
             cast.name,
             dossier_ack(kept)
         );
@@ -2319,7 +2371,10 @@ impl KaiboHandler {
     fn deliberate_direct_job(
         &self,
         cast: &Cast,
-        explorer_model: &str,
+        // `None` when the dossier was reused rather than swept for — see the batch lane's
+        // note. The provenance footer then names the synth alone, because the synth is the
+        // only model this call ran.
+        explorer_model: Option<&str>,
         question: &str,
         dossier: &str,
         // Images the dossier sweep routed via `attach` — ride the synth's single
@@ -2356,7 +2411,8 @@ impl KaiboHandler {
         // it emits no beats of its own — the log carries the job's own start/finish.
         let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
         let cast_name = cast.name.clone();
-        let explorer_model = explorer_model.to_string();
+        let swept = explorer_model.is_some();
+        let explorer_model = explorer_model.map(str::to_string);
         let question = question.to_string();
         let dossier = dossier.to_string();
         let images = images.to_vec();
@@ -2370,31 +2426,42 @@ impl KaiboHandler {
             )
             .await
             {
-                Ok((answer, synth_usage)) => Ok(JobResult {
-                    answer: with_provenance(
-                        // The dossier line sits between the answer and the provenance
-                        // footer: it is part of what this deliberation is grounded in,
-                        // not part of who ran it.
-                        with_dossier(answer, kept_for_job.as_ref()),
-                        &cast_name,
-                        &[
-                            ("explorer", explorer_model.as_str()),
-                            ("synth", synth_model.as_str()),
-                        ],
-                        &(dossier_usage + synth_usage),
-                    ),
-                    report: None,
-                }),
+                Ok((answer, synth_usage)) => {
+                    // Name only the models this call actually ran: a reused dossier had no
+                    // explorer, and the token line counts the synth alone because that is
+                    // the whole spend.
+                    let mut roles: Vec<(&str, &str)> = Vec::with_capacity(2);
+                    if let Some(m) = explorer_model.as_deref() {
+                        roles.push(("explorer", m));
+                    }
+                    roles.push(("synth", synth_model.as_str()));
+                    Ok(JobResult {
+                        answer: with_provenance(
+                            // The dossier line sits between the answer and the provenance
+                            // footer: it is part of what this deliberation is grounded in,
+                            // not part of who ran it.
+                            with_dossier(answer, kept_for_job.as_ref()),
+                            &cast_name,
+                            &roles,
+                            &(dossier_usage + synth_usage),
+                        ),
+                        report: None,
+                    })
+                }
                 Err(e) => Err(consultation_failure_text("deliberate", &cast_name, e)),
             }
         });
 
         let msg = format!(
-            "Dossier built; the direct (local) synth is now deliberating offline as \
-             `{job_id}` — cast `{}`. This is one long local completion (it can take a \
-             while): `job_wait {job_id}` parks for it, `job_get {job_id}` collects, \
-             `job_cancel {job_id}` stops it. Session-scoped — the job lives for this \
-             server session only.{}",
+            "{}; the direct (local) synth is now deliberating offline as `{job_id}` — cast \
+             `{}`. This is one long local completion (it can take a while): `job_wait \
+             {job_id}` parks for it, `job_get {job_id}` collects, `job_cancel {job_id}` \
+             stops it. Session-scoped — the job lives for this server session only.{}",
+            if swept {
+                "Dossier built"
+            } else {
+                "Dossier reused (no explorer ran)"
+            },
             cast.name,
             dossier_ack(kept)
         );
@@ -7114,7 +7181,7 @@ enabled = false
         let out = h
             .deliberate_batch(
                 &cast,
-                "gem/some-lite",
+                Some("gem/some-lite"),
                 "Is the retry safe?",
                 "DOSSIER: src/x.rs:1 fn retry",
                 &[],
@@ -7124,6 +7191,7 @@ enabled = false
                     digest: "cd".repeat(32),
                     bytes: 29,
                     path: None,
+                    origin: crate::server::dossier::Origin::Built,
                 }),
             )
             .await
@@ -7197,7 +7265,7 @@ enabled = false
 
         h.deliberate_batch(
             &cast,
-            "gem/some-lite",
+            Some("gem/some-lite"),
             "Is the retry safe?",
             "DOSSIER: src/x.rs:1 fn retry",
             &[],
@@ -7207,6 +7275,7 @@ enabled = false
                 digest: digest.clone(),
                 bytes: 29,
                 path: None,
+                origin: crate::server::dossier::Origin::Built,
             }),
         )
         .await

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -55,6 +55,7 @@ use crate::sweep_attach::{SweepAttachSink, SweepConsumer, SweepConsumerKind};
 mod cas_read;
 mod config_resource;
 mod containment;
+mod dossier;
 mod render;
 mod resolver;
 
@@ -69,6 +70,7 @@ pub(crate) use render::{
     BATCH_RECENCY_WINDOW_SECS,
 };
 
+use dossier::{dossier_ack, keep_dossier, with_dossier, KeptDossier};
 use render::{
     batch_poll_brief, consult_answer_text, consult_result, consultation_failed,
     consultation_failed_with_artifacts, consultation_failure_text_with_artifacts, fmt_usage,
@@ -2175,6 +2177,16 @@ impl KaiboHandler {
         // itself (text bodies, notes, demotions); collect any routed images separately
         // — they ride the synth's single turn as native parts, not as dossier text.
         let images = stitch_dossier_delivery(&mut dossier, &consumer, sink.as_ref());
+        // Keep the finished dossier before stage 2 spends anything on it, so a
+        // deliberation that fails, times out, or comes back thin still leaves the evidence
+        // it was built from readable. Never fatal — see `server::dossier`.
+        let kept = keep_dossier(
+            self.media_cas.as_ref(),
+            &input.question,
+            &dossier,
+            &cast.name,
+            &explorer_model,
+        );
 
         // Stage 2 — hand the dossier to the offline synth. Its lane picks the mechanism
         // and the handle; both share the offline-synth preamble (`batch_system_prompt`,
@@ -2191,6 +2203,7 @@ impl KaiboHandler {
                     &images,
                     &system,
                     dossier_usage,
+                    kept.as_ref(),
                 )
                 .await
             }
@@ -2202,6 +2215,7 @@ impl KaiboHandler {
                 &images,
                 &system,
                 dossier_usage,
+                kept.as_ref(),
             ),
         }
     }
@@ -2233,6 +2247,11 @@ impl KaiboHandler {
         // provider's batch result (not rendered here), but the caller should still see
         // what the build cost rather than have it silently dropped on this lane.
         dossier_usage: Usage,
+        // Where the dossier landed in the media CAS, when it was kept. This lane is the
+        // long one — a batch deliberation runs for hours and is collected by a later
+        // `job_get`, possibly after a restart — so the address rides both the ack and the
+        // persisted handle's label, and survives the server session either way.
+        kept: Option<&KeptDossier>,
     ) -> Result<CallToolResult, McpError> {
         let (slot, backend, _caps) = self.batch_synth(cast)?;
         let backend_name = backend.name.clone();
@@ -2252,6 +2271,29 @@ impl KaiboHandler {
             .await
             .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
         let handle = format!("{backend_name}/{provider_id}");
+        // Persist the handle so a restart can re-list and re-address this deliberation,
+        // exactly as `batch_submit` does — this lane runs for hours, so a restart in the
+        // middle is the ordinary case, not the edge one. The label carries the synth model
+        // AND the dossier's address, which is what makes the evidence recoverable from
+        // `job_list` alone after the ack has scrolled out of the caller's context. A store
+        // failure is logged, never fatal: the batch is already live at the provider, so
+        // failing here would strand it.
+        if let Some(store) = self.sessions.store() {
+            let label = match kept {
+                Some(k) => format!(
+                    "deliberate · synth `{model}` · dossier {}{}",
+                    crate::cas::CAS_URI_PREFIX,
+                    k.digest
+                ),
+                None => format!("deliberate · synth `{model}`"),
+            };
+            if let Err(e) = store
+                .put_batch(&backend_name, &provider_id, Some(&label))
+                .await
+            {
+                tracing::warn!(handle = %handle, error = %e, "could not persist batch handle");
+            }
+        }
         // Fold the dossier build's real cost into the ack — the synth's own tokens land
         // later on the provider's batch result, but the build spend is knowable now.
         let dossier_cost = fmt_usage(&dossier_usage)
@@ -2261,8 +2303,9 @@ impl KaiboHandler {
             "Dossier built (explorer `{explorer_model}`{dossier_cost}) and handed to the batch \
              lane as `{handle}` — cast `{}`, synth `{model}` at max thinking. It deliberates \
              offline; collect it with `job_get {handle}` (durable — survives restart), or stop it \
-             with `job_cancel {handle}`. Nothing to wait on now.",
-            cast.name
+             with `job_cancel {handle}`. Nothing to wait on now.{}",
+            cast.name,
+            dossier_ack(kept)
         );
         Ok(CallToolResult::success(vec![ContentBlock::text(msg)]))
     }
@@ -2286,6 +2329,10 @@ impl KaiboHandler {
         // The dossier stage's explorer tokens, summed into the final footer with the
         // synth's — the footer names both roles, so it counts both.
         dossier_usage: Usage,
+        // Where the dossier landed, when it was kept — named in the ack now and in the
+        // finished answer later, so a `job_get` that arrives long after the ack still
+        // carries the evidence trail.
+        kept: Option<&KeptDossier>,
     ) -> Result<CallToolResult, McpError> {
         let synth = self.arm(cast, ModelRole::Synth)?;
         let synth_model = synth.model.clone();
@@ -2314,6 +2361,7 @@ impl KaiboHandler {
         let dossier = dossier.to_string();
         let images = images.to_vec();
         let system = system.to_string();
+        let kept_for_job = kept.cloned();
         let label = format!("cast `{cast_name}` deliberate (direct synth `{synth_model}`)");
 
         let job_id = self.jobs.submit(label, progress_log, async move {
@@ -2324,7 +2372,10 @@ impl KaiboHandler {
             {
                 Ok((answer, synth_usage)) => Ok(JobResult {
                     answer: with_provenance(
-                        answer,
+                        // The dossier line sits between the answer and the provenance
+                        // footer: it is part of what this deliberation is grounded in,
+                        // not part of who ran it.
+                        with_dossier(answer, kept_for_job.as_ref()),
                         &cast_name,
                         &[
                             ("explorer", explorer_model.as_str()),
@@ -2343,8 +2394,9 @@ impl KaiboHandler {
              `{job_id}` — cast `{}`. This is one long local completion (it can take a \
              while): `job_wait {job_id}` parks for it, `job_get {job_id}` collects, \
              `job_cancel {job_id}` stops it. Session-scoped — the job lives for this \
-             server session only.",
-            cast.name
+             server session only.{}",
+            cast.name,
+            dossier_ack(kept)
         );
         Ok(CallToolResult::success(vec![ContentBlock::text(msg)]))
     }
@@ -7068,6 +7120,11 @@ enabled = false
                 &[],
                 "offline-synth-system",
                 dossier_usage,
+                Some(&KeptDossier {
+                    digest: "cd".repeat(32),
+                    bytes: 29,
+                    path: None,
+                }),
             )
             .await
             .expect("scripted deliberate_batch succeeds");
@@ -7076,6 +7133,10 @@ enabled = false
         assert!(
             ack.contains("gem/msgbatch_d"),
             "the reply carries the durable batch handle"
+        );
+        assert!(
+            ack.contains(&format!("kaibo://cas/{}", "cd".repeat(32))),
+            "the ack names the kept dossier's address: {ack}"
         );
         assert!(
             ack.contains("tokens · 200 in · 20 out"),
@@ -7103,6 +7164,80 @@ enabled = false
                 && items[0].prompt.contains("DOSSIER: src/x.rs:1 fn retry"),
             "the one item is the deliberation_prompt — question AND dossier: {}",
             items[0].prompt
+        );
+    }
+
+    /// A batch deliberation runs for hours, so the ack that named its dossier is long gone
+    /// (or the server restarted) by the time anyone collects it. The dossier's address
+    /// must therefore be recoverable from kaibo's own durable record: `deliberate`'s batch
+    /// lane persists its handle — which it did not do at all before dossiers were kept —
+    /// with a label naming the synth AND the dossier, and `job_list` surfaces both after a
+    /// restart. Without this, keeping the dossier would still lose the way back to it on
+    /// the one lane where losing it is likely.
+    #[tokio::test]
+    async fn a_deliberate_batch_handle_recovers_with_its_dossier_address() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("state.db");
+        let cap = std::num::NonZeroUsize::new(8).unwrap();
+        let digest = "ef".repeat(32);
+
+        let store = crate::store::SessionStore::open(&db, cap, &[])
+            .await
+            .unwrap();
+        // Empty provider listing, so the recovered section is the only way back.
+        let scripted = Arc::new(
+            crate::batch::ScriptedBatch::new("msgbatch_dl", vec![]).with_listing(vec![], false),
+        );
+        let h = handler_from_toml(BATCH_CASTS_TOML)
+            .with_batch_providers(Arc::new(crate::batch::ScriptedBatchProviders(
+                scripted.clone(),
+            )))
+            .with_session_store(store.clone());
+        let cast = h.config.resolve_cast("mydeliberate").unwrap().clone();
+
+        h.deliberate_batch(
+            &cast,
+            "gem/some-lite",
+            "Is the retry safe?",
+            "DOSSIER: src/x.rs:1 fn retry",
+            &[],
+            "offline-synth-system",
+            Usage::new(),
+            Some(&KeptDossier {
+                digest: digest.clone(),
+                bytes: 29,
+                path: None,
+            }),
+        )
+        .await
+        .expect("scripted deliberate_batch succeeds");
+
+        // Simulated restart: a new handler and a store reopened on the same db file.
+        let store2 = crate::store::SessionStore::open(&db, cap, &[])
+            .await
+            .unwrap();
+        let empty = Arc::new(
+            crate::batch::ScriptedBatch::new("unused", vec![]).with_listing(vec![], false),
+        );
+        let h2 = handler_from_toml(BATCH_CASTS_TOML)
+            .with_batch_providers(Arc::new(crate::batch::ScriptedBatchProviders(empty)))
+            .with_session_store(store2);
+        let listing = result_text(
+            h2.job_list(Parameters(ListInput {
+                backend: None,
+                all: false,
+            }))
+            .await
+            .expect("job_list succeeds"),
+        );
+
+        assert!(
+            listing.contains("gem/msgbatch_dl"),
+            "a deliberate batch handle must survive a restart:\n{listing}"
+        );
+        assert!(
+            listing.contains(&format!("kaibo://cas/{digest}")),
+            "the recovered handle must name the dossier it was built from:\n{listing}"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -194,6 +194,28 @@ fn stitch_dossier_delivery(
     }
 }
 
+/// Stitch a dossier sweep's delivery, then keep the finished dossier — in that order.
+///
+/// The order is the whole reason this is one function. [`stitch_dossier_delivery`]
+/// *appends* the routed text bodies to the dossier, so keeping it first would store a
+/// dossier missing evidence the synth then reasons over — an audit record that quietly
+/// disagrees with what was actually sent, which is worse than keeping nothing. Composed
+/// here so a test can pin the order (DeepSeek cross-family review, 2026-08-07); the
+/// handler calls this rather than the two steps by hand.
+fn stitch_and_keep(
+    dossier: &mut String,
+    consumer: &SweepConsumer,
+    sink: Option<&std::sync::Arc<SweepAttachSink>>,
+    store: Option<&Arc<crate::cas::MediaStore>>,
+    question: &str,
+    cast: &str,
+    explorer_model: &str,
+) -> (Vec<crate::attach::Attachment>, Option<KeptDossier>) {
+    let images = stitch_dossier_delivery(dossier, consumer, sink);
+    let kept = keep_dossier(store, question, dossier, cast, explorer_model);
+    (images, kept)
+}
+
 /// Which tools to advertise. All on by default; each `--no-<tool>` flips one off.
 ///
 /// Composes to any posture: `{oneshot:false}` ≈ the codebase-only surface; only
@@ -2092,6 +2114,21 @@ impl KaiboHandler {
         peer: Peer<RoleServer>,
         meta: RequestMetaObject,
     ) -> Result<CallToolResult, McpError> {
+        self.deliberate_call(input, progress_sink(peer, &meta)).await
+    }
+
+    /// The `deliberate` handler, with the live peer already reduced to a progress sink.
+    ///
+    /// Split from the tool entry point for one reason: a `Peer` needs a real MCP
+    /// connection, so the whole handler was unreachable from a test. Everything the reuse
+    /// road does — the inert-argument refusal, resolution order, the load, the hand-off to
+    /// a lane — is in here, where a test can drive it with a `NullSink` (DeepSeek
+    /// cross-family review, 2026-08-07).
+    async fn deliberate_call(
+        &self,
+        input: DeliberateInput,
+        progress: Arc<dyn ProgressSink>,
+    ) -> Result<CallToolResult, McpError> {
         // A reuse call that also carries explorer arguments is self-contradictory; say so
         // before resolving anything, so it costs nothing.
         if let Some(refusal) = dossier::inert_explorer_args(&input) {
@@ -2144,7 +2181,6 @@ impl KaiboHandler {
             // are spent. Only the deliberation (Stage 2) is handed off async. Attachments
             // reach the dossier-builder as read-WHOLE directives (the sweep semantics), so
             // their content flows to the offline synth through the dossier it writes.
-            let progress = progress_sink(peer, &meta);
             let defaults = &self.config.defaults;
             let attachments = self
                 .resolve_sweep_attachments(&root, &input.attach, "deliberate")
@@ -2210,17 +2246,17 @@ impl KaiboHandler {
             progress.emit(PhaseEvent::PhaseFinished {
                 phase: "deliberate.dossier",
             });
-            // Stitch whatever the dossier sweep routed via `attach` into the dossier text
-            // itself (text bodies, notes, demotions); collect any routed images separately
-            // — they ride the synth's single turn as native parts, not as dossier text.
-            let images = stitch_dossier_delivery(&mut dossier, &consumer, sink.as_ref());
-            // Keep the finished dossier before stage 2 spends anything on it, so a
-            // deliberation that fails, times out, or comes back thin still leaves the
-            // evidence it was built from readable. Never fatal — see `server::dossier`.
-            let kept = keep_dossier(
+            // Stitch whatever the sweep routed via `attach` into the dossier text itself
+            // (text bodies, notes, demotions), then keep the finished dossier — that
+            // order, so what is stored is what stage 2 receives. Routed images come back
+            // separately: they ride the synth's single turn as native parts, never as
+            // dossier text. Keeping is never fatal — see `server::dossier`.
+            let (images, kept) = stitch_and_keep(
+                &mut dossier,
+                &consumer,
+                sink.as_ref(),
                 self.media_cas.as_ref(),
                 &input.question,
-                &dossier,
                 &cast.name,
                 &explorer_model,
             );
@@ -4615,9 +4651,39 @@ mod tests {
             "the image must route: {receipt}"
         );
 
-        // Drain + stitch — the extracted handler step.
+        // Drain + stitch + keep — the extracted handler step, in the handler's order.
+        // Keeping BEFORE stitching would store a dossier missing the routed evidence the
+        // synth then reasons over: an audit record that disagrees with what was sent.
+        let store: Arc<crate::cas::MediaStore> = Arc::new(crate::cas::MediaStore::Memory(
+            crate::cas::MemoryCas::new(None),
+        ));
         let mut dossier = String::from("src/x.rs:1 DOSSIER");
-        let images = stitch_dossier_delivery(&mut dossier, &consumer, Some(&sink));
+        let (images, kept) = stitch_and_keep(
+            &mut dossier,
+            &consumer,
+            Some(&sink),
+            Some(&store),
+            "does the diagram confirm it?",
+            "scripted",
+            "scripted-explorer",
+        );
+        let kept = kept.expect("a live store keeps the dossier");
+        let stored = String::from_utf8(
+            store
+                .get(&crate::cas::Digest::from_hex(&kept.digest).unwrap())
+                .expect("readable")
+                .expect("present")
+                .0,
+        )
+        .unwrap();
+        assert_eq!(
+            stored, dossier,
+            "what is kept must be the STITCHED dossier — the exact text stage 2 receives"
+        );
+        assert!(
+            stored.contains("notes.md"),
+            "a dossier kept before stitching would be missing the routed evidence: {stored}"
+        );
         assert!(
             dossier.contains("notes.md"),
             "the text body is stitched into the dossier: {dossier}"
@@ -7232,6 +7298,121 @@ enabled = false
                 && items[0].prompt.contains("DOSSIER: src/x.rs:1 fn retry"),
             "the one item is the deliberation_prompt — question AND dossier: {}",
             items[0].prompt
+        );
+    }
+
+    /// The reuse road, driven end to end through the real handler: a stored dossier goes in
+    /// as `dossier`, NO explorer runs, and the offline synth receives exactly the stored
+    /// bytes.
+    ///
+    /// The lane tests drive `deliberate_batch` directly, so they cannot see the handler's
+    /// own wiring — the branch that skips stage 1, what it hands the lane, or whether the
+    /// ack still claims an explorer ran. This is that wiring (gap named by the DeepSeek
+    /// cross-family review, 2026-08-07).
+    #[tokio::test]
+    async fn the_reuse_road_runs_the_synth_over_the_stored_dossier_with_no_explorer() {
+        let scripted = Arc::new(crate::batch::ScriptedBatch::new("msgbatch_reuse", vec![]));
+        let h = handler_from_toml(BATCH_CASTS_TOML).with_batch_providers(Arc::new(
+            crate::batch::ScriptedBatchProviders(scripted.clone()),
+        ));
+
+        // A dossier already in the store, put there the way an earlier call would have.
+        let text = "DOSSIER\nsrc/x.rs:1 fn retry\nsrc/x.rs:9 unbounded backoff\n";
+        let kept = dossier::keep_dossier(
+            h.media_store(),
+            "an earlier question",
+            text,
+            "mydeliberate",
+            "gem/some-lite",
+        )
+        .expect("the test handler has a live memory CAS");
+
+        let out = h
+            .deliberate_call(
+                DeliberateInput {
+                    question: "does the second synth see the same evidence?".into(),
+                    attach: vec![],
+                    path: None,
+                    cast: Some("mydeliberate".into()),
+                    explorer_model: None,
+                    explorer_backend: None,
+                    synth_model: None,
+                    synth_backend: None,
+                    explorer_max_turns: None,
+                    dossier: Some(kept.digest.clone()),
+                },
+                Arc::new(NullSink),
+            )
+            .await
+            .expect("a reuse call succeeds");
+
+        let ack = result_text(out);
+        assert!(
+            ack.contains("Dossier reused") && ack.contains("no explorer ran"),
+            "the ack must not claim a sweep that never happened: {ack}"
+        );
+        assert!(
+            ack.contains(&format!("kaibo://cas/{}", kept.digest)),
+            "the ack names the dossier it reasoned over: {ack}"
+        );
+
+        // The stored bytes are what reached the synth — verbatim, beside the new question.
+        // Anything less and reuse is not reuse.
+        let submits = scripted.submits();
+        assert_eq!(submits.len(), 1, "one deliberation was submitted");
+        let (_system, attach, items) = &submits[0];
+        assert!(
+            attach.is_empty(),
+            "no sweep ran, so nothing routed images into the submit"
+        );
+        assert_eq!(items.len(), 1);
+        assert!(
+            items[0].prompt.contains(text)
+                && items[0]
+                    .prompt
+                    .contains("does the second synth see the same evidence?"),
+            "the reused dossier AND the new question must both reach the synth: {}",
+            items[0].prompt
+        );
+    }
+
+    /// A reuse call carrying explorer arguments is refused by the handler, and a dossier
+    /// kaibo does not hold is an error — never a silent fall back to sweeping, since the
+    /// caller asked to reason over specific evidence.
+    #[tokio::test]
+    async fn the_handler_refuses_a_reuse_call_it_cannot_serve_as_asked() {
+        let h = handler_from_toml(BATCH_CASTS_TOML);
+        let reuse = |attach: Vec<String>, digest: &str| DeliberateInput {
+            question: "q".into(),
+            attach,
+            path: None,
+            cast: Some("mydeliberate".into()),
+            explorer_model: None,
+            explorer_backend: None,
+            synth_model: None,
+            synth_backend: None,
+            explorer_max_turns: None,
+            dossier: Some(digest.to_string()),
+        };
+
+        let err = h
+            .deliberate_call(reuse(vec!["src/x.rs".into()], &"aa".repeat(32)), Arc::new(NullSink))
+            .await
+            .expect_err("`attach` on a reuse call is refused");
+        assert!(
+            err.message.contains("`attach`"),
+            "the refusal names the inert argument: {}",
+            err.message
+        );
+
+        let err = h
+            .deliberate_call(reuse(vec![], &"aa".repeat(32)), Arc::new(NullSink))
+            .await
+            .expect_err("an unknown digest is refused");
+        assert!(
+            err.message.contains("never stored here"),
+            "the refusal says the dossier is not held: {}",
+            err.message
         );
     }
 


### PR DESCRIPTION
`deliberate` builds a dossier — minutes of live explorer sweep, and on one measured run a 652k-token sweep over three trees — then hands it to an offline synth and forgets it. Two things were impossible: **peek** (audit what the synth actually received when its answer looks thin) and **reuse** (ask a second cast the same question over the same evidence without paying for the sweep again).

Amy, from the kaish session: *"I want to have the dossiers tossed into cas so we can peek at them or reuse them sometimes."*

## What lands

- **Keep.** The finished dossier goes into the media CAS before stage 2 spends anything, so a deliberation that fails, times out, or comes back thin still leaves its evidence readable. The address rides the ack, the answer footer, and — on the batch lane — the persisted handle.
- **Reuse.** `deliberate` takes a `dossier` digest (bare or as the `kaibo://cas/<digest>` URI kaibo printed). No explorer runs; the call costs the synth alone. That is also the fair way to compare two synths: byte-identical evidence, so only the model differs.

## Decisions

- **`[cas] enabled`, not `[artifacts] enabled`.** The artifacts key exists for the one surface where a *model* decides bytes become durable. A dossier is kaibo's own byproduct of a call the operator already made — no model chose the content, the label, or the save.
- **Keeping never fails the call.** A refused write costs the record, never the deliberation — loud on the operator's log, silent to the model team.
- **Explorer arguments on a reuse call are refused, not ignored.** `attach` especially: a caller who attached a file, got a deliberation, and was never told the file went nowhere is the silent-wrong we don't ship. Checked before anything resolves. The *synth* overrides stay live — retargeting the model that reads the evidence is the point.
- **Any text artifact may be reused,** not only something `deliberate` wrote. The caller is the operator's proxy handing kaibo its own stored evidence. Binary is refused by name; so is a digest that resolves to nothing.
- **The batch lane now persists its handle at all** — it never did. That lane runs for hours, so a restart before collection is ordinary, and the label carries the dossier's address so `job_list` still leads back to the evidence.

## Invariants

No new write site: the bytes reach disk through `MediaStore::put`, the surface `generate` and `save_artifact` already use. `tests/no_write_path.rs` stays pinned at four blessed lines. The CAS is still never mounted into kaish, and the inner model team still cannot read, list, or probe it — `dossier` is an *operator* argument on an MCP tool.

Advertisement gating is unchanged: `deliberate` still appears only where a cast can staff the full job, even though a synth-only offline cast can now serve a reuse call. Recorded in `docs/issues.md` as a deliberate non-fix.

## Tests

Eight new unit tests in `src/server/dossier.rs` (verbatim keep + sidecar authorship, load round-trip in all three reference spellings, each refusal by name, the bounded single-line label, both render surfaces) plus a handler test that a batch deliberation's handle and its dossier address survive a simulated restart. Both new paths were sabotage-checked — breaking the keep and breaking the label each fail their test. Full suite green (1032 passing), clippy clean.

Docs: CHANGELOG, the config guide's CAS producer table (dossiers are usually the bulk of the store, and an operator sizing `max_bytes` needs to know), and two devlog entries — today's, plus the media arc's (#125–#129), which shipped without its story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)