### PR TITLE
feat(cli): kaibo generate + kaibo cas read (completes CLI parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **`kaibo generate` and `kaibo cas read`.** The CLI can now render an image into kaibo's
+  artifact store and read anything back out of it, which completes the MCP-to-CLI parity
+  sweep. `kaibo cas read <digest> > arch.png` gives you the bytes with no flag to
+  remember: metadata goes to stderr and content to stdout, text as text and binary as raw
+  bytes, because the bounded base64 rules the MCP tool follows exist to protect a model's
+  context window and a pipe has no such budget. `read` is the only verb — the store stays
+  opaque and index-free, so there is still no listing, usage report, or delete. A
+  deferred `generate` polls in the foreground rather than handing back a handle nothing
+  could collect.
+
 - **`kaibo deliberate` on the command line, and `kaibo batch cancel`.** Deliberate was
   MCP-only for no recorded reason on its batch lane, and for a good one on its direct
   lane (that lane's handle lives in the running server's memory, so a one-shot process

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ human at a terminal can drive kaibo directly:
 | `explore` | `kaibo explore "question" [--cast … --json]` |
 | `deliberate` | `kaibo deliberate "question" [--cast … --attach … --dossier … --json]` |
 | `run_kaish` | `kaibo kaish -c 'script'` |
+| `generate` | `kaibo generate "prompt" [--cast … --field k=v --json]` |
+| `read_cas` | `kaibo cas read <digest> [--offset … --length … --json]` |
 | `batch_submit`, `job_get`/`job_list`/`job_cancel` (batch handles) | `kaibo batch submit \| get \| list \| cancel` |
 | `kaibo://config` resource | `kaibo config` |
 | `kaibo://config/example` resource | `kaibo example-config` |
@@ -291,6 +293,19 @@ sweep at all, across front doors:
 ```sh
 kaibo deliberate "second opinion, same evidence" --cast fable --dossier kaibo://cas/<digest>
 ```
+
+`kaibo cas read` follows the CLI's contract rather than the tool's: **metadata to stderr,
+content to stdout** — text as text, binary as raw bytes. So the obvious thing works:
+
+```sh
+kaibo cas read <digest> > arch.png     # bytes, no flag, no base64
+kaibo cas read <digest>                # a text artifact reads on your terminal
+```
+
+The bounded, base64-averse rules `read_cas` follows exist to protect a model's context
+window; a pipe has no such budget. `read` is the only verb — the store is content-addressed
+and opaque, with no listing, usage report, or delete, because none of those can exist
+without an index it deliberately does not keep.
 
 `consult_submit`/`job_wait` remain MCP-only: their value is keeping work running inside
 a long-lived session, which does not map onto a process that exits.

--- a/docs/config.md
+++ b/docs/config.md
@@ -881,13 +881,32 @@ an operator, not an audit trail, and a content-addressed store that never rewrit
 be one. For a durable per-call record, kaibo's answers are the tool-call telemetry each
 save emits and the session the answer was recorded into.
 
-**Retrieval is the `read_cas` tool, and it is operator-surface only.** Every producer
-names its artifacts by a `kaibo://cas/<digest>` address; `read_cas` takes the digest out
-of one and hands the content back. The MCP client calls it; the inner model team never can
-— the CAS is not mounted into kaish and no cast-facing tool reads it, because kaibo state
-spans projects and a browsable CAS would let one project's team enumerate another's
-artifacts. There is no `kaibo cas` CLI command; on disk, the path a read reports is how an
-operator reaches an object with their own tools.
+**Retrieval is operator-surface only.** Every producer names its artifacts by a
+`kaibo://cas/<digest>` address, and two commands take the digest out of one and hand the
+content back: the `read_cas` MCP tool, and `kaibo cas read` on the command line. The MCP
+client or the CLI caller runs them; the inner model team never can — the CAS is not
+mounted into kaish and no cast-facing tool reads it, because kaibo state spans projects
+and a browsable CAS would let one project's team enumerate another's artifacts.
+
+`read` is the only verb either surface offers, and that is the whole of the store's
+interface. There is no listing, no usage report, and no delete, because none of them can
+exist without an index this store deliberately does not keep. Retention stays file mtime
+over the object tree, with your own tools.
+
+The two surfaces differ in exactly one way, because their output goes to different places:
+
+| | `read_cas` (MCP) | `kaibo cas read` (CLI) |
+|---|---|---|
+| metadata | the first content block | **stderr** |
+| text content | a bounded window | **stdout** |
+| binary content | base64 only when a range is asked for; a small image as a rendered block | **raw bytes on stdout** |
+
+The MCP rules exist to protect a context window. A pipe has no such budget, and someone
+asking for an image by its digest expects its bytes — so `kaibo cas read <digest> >
+arch.png` works with no flag, and metadata never contaminates the payload. `--json` puts
+both in one envelope on stdout, base64-encoding a binary body. The CLI command runs in
+disk mode only: an in-memory store is empty in a new process, so it says that plainly
+rather than reporting a digest as "not found".
 
 Reads are **metadata-first and bounded**, and the default depends on what the object is:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -829,15 +829,12 @@ artifact-producing tool writes into. Three produce today:
 | `save_artifact` | bulk text a consult's model wrote | `[artifacts] enabled` **and** a per-call `save_artifacts` (see below) |
 | `deliberate` | the explorer dossier each deliberation was built on | none — the CAS being on is the only key |
 
-`deliberate` is the one kaibo writes on its own, because the dossier is kaibo's own
-byproduct of a call you already made rather than something a model chose to save. Each
-deliberation's reply names the dossier's `kaibo://cas/<digest>`; pass that digest back as
-the tool's `dossier` argument to run a second synth over the same evidence with no
-explorer sweep. Sizing note: dossiers are the bulkiest thing most installs put in this
-store, so an install that deliberates often accumulates faster than the two
-opt-in producers suggest. A store that refuses the write (a full `max_bytes`, an I/O
-error) costs you the record and never the deliberation — it is logged and the call
-proceeds.
+`deliberate` needs no key of its own — kaibo writes the dossier, not a model. Each
+deliberation names its dossier's `kaibo://cas/<digest>`; pass that digest back as the
+`dossier` argument to run a second synth over the same evidence with no explorer sweep.
+Size the store for dossiers: they are the bulkiest objects most installs hold, and they
+accumulate on every deliberation. A refused write (a full `max_bytes`, an I/O error) is
+logged and the deliberation proceeds — you lose the record, never the answer.
 
 Its lifecycle has three states, reported as `mode` in `kaibo://config`'s `[cas]`
 section:
@@ -888,25 +885,23 @@ client or the CLI caller runs them; the inner model team never can — the CAS i
 mounted into kaish and no cast-facing tool reads it, because kaibo state spans projects
 and a browsable CAS would let one project's team enumerate another's artifacts.
 
-`read` is the only verb either surface offers, and that is the whole of the store's
-interface. There is no listing, no usage report, and no delete, because none of them can
-exist without an index this store deliberately does not keep. Retention stays file mtime
-over the object tree, with your own tools.
+`read` is the only verb on either surface. There is no listing, no usage report, and no
+delete — each needs an index this store does not keep. Prune by file mtime over the object
+tree with your own tools.
 
-The two surfaces differ in exactly one way, because their output goes to different places:
+The two surfaces serve the same object differently, because they write to different
+places:
 
 | | `read_cas` (MCP) | `kaibo cas read` (CLI) |
 |---|---|---|
-| metadata | the first content block | **stderr** |
-| text content | a bounded window | **stdout** |
-| binary content | base64 only when a range is asked for; a small image as a rendered block | **raw bytes on stdout** |
+| metadata | leads as the first content block | goes to stderr, so stdout stays the payload |
+| text content | returns a bounded window | goes to stdout as text |
+| binary content | returns base64 only for an explicit range; returns a small image as a rendered block | goes to stdout as raw bytes — `kaibo cas read <digest> > arch.png` needs no flag |
+| `--json` | not applicable | puts metadata and body in one stdout envelope, base64 for binary |
 
-The MCP rules exist to protect a context window. A pipe has no such budget, and someone
-asking for an image by its digest expects its bytes — so `kaibo cas read <digest> >
-arch.png` works with no flag, and metadata never contaminates the payload. `--json` puts
-both in one envelope on stdout, base64-encoding a binary body. The CLI command runs in
-disk mode only: an in-memory store is empty in a new process, so it says that plainly
-rather than reporting a digest as "not found".
+`kaibo cas read` runs in disk mode only. It refuses in memory mode and names the mode — a
+memory store is empty in a new process, so every digest would otherwise read as "not
+found".
 
 Reads are **metadata-first and bounded**, and the default depends on what the object is:
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,61 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-07 — finishing the CLI, and what a front door is allowed to be
+
+Amy, looking at the morning's work: *"hm did we ever say why deliberate isn't on the cli?
+I think we built deliberate around the same time as cli mode and it just wasn't ready. so
+maybe the easier fix is to finish exposing kaibo features on cli."*
+
+The history turned out to be nearly the opposite of the memory, and worth writing down so
+it isn't re-derived a third time. `deliberate` shipped 2026-07-02; the CLI front door
+shipped 2026-07-17, two weeks *later*, starting as `consult` + `config` and growing
+outward. Deliberate was finished and stable when the CLI arrived. It just never got its
+turn.
+
+Issue #82 (2026-07-18) *did* record a reason — but only for the **direct** lane, and it is
+a good one: that lane's handle is a `job-N` held in a running server's memory, so a
+one-shot CLI process would submit, exit, and take the job with it. The batch lane had no
+reason at all; its handle is durable *at the provider*, which is precisely the property
+that gave `batch submit` a CLI story on day one. Two gaps, one explained and one not, and
+the explained one had been quietly generalized into "deliberate is MCP-only".
+
+**Amy's call dissolved the hard half in one sentence: on the direct lane, the process
+*is* the job.** It blocks, prints the answer, exits — the CLI's ordinary contract — and
+needs no daemon, no durable job store, and none of the "candidate directions" #82 was
+holding open. The same answer then served `generate`'s deferred lane, which had the
+identical shape. What made this look hard for three weeks was assuming a CLI had to
+imitate the server's async surface rather than being allowed its own.
+
+The rest of the sweep — `batch cancel` (the CLI could submit and list but never stop),
+`generate`, `kaibo cas read` — was ordinary work. Two things in it are worth keeping.
+
+**A front door may differ from the tool where the reason for the rule doesn't apply.**
+`read_cas` is metadata-first, bounded, and refuses to dump base64 nobody asked for. Those
+rules exist to protect a *context window*. A pipe has no context window. Amy: *"we do know
+when we might output binary and the caller likely knows they're gonna get binary."* So
+`kaibo cas read` follows the CLI's own standing contract instead — metadata to stderr,
+content to stdout, text as text and binary as raw bytes — and `kaibo cas read <digest> >
+arch.png` works with no flag to remember. A `--raw` flag was designed, built, and deleted
+once it was clear it was a worse spelling of the default. Both surfaces still share one
+planner, which grew a `Delivery` mode so its metadata stops claiming "as a rendered image"
+where nothing renders.
+
+**The write-path guard got stricter in the change that added to it.** Serving those bytes
+means a `write_all` to stdout, which the guard cannot distinguish from writing a file, so
+it became the fifth blessed line — a real decision, taken visibly, with the pinned count
+moving 4 → 5. Writing to stdout creates nothing: it is a descriptor the operator's shell
+already opened and aimed, so the store still has no destination parameter anywhere. The
+useful part came from the teeth test written for the new marker, which failed: blessings
+were pinned per-(file, marker) but not per-*needle*, so pasting the new marker onto an
+`fs::write(out_path, …)` would have laundered a caller-named destination straight through
+— and the CLI is exactly where a `--out FILE` flag gets proposed. Needle pinning is back.
+A guard that grows a carve-out is the right moment to ask what else it was not checking.
+
+Left MCP-only on purpose: `consult_submit` and `job_wait`. Their value is work continuing
+inside a session that outlives the call, and a process that exits has nothing to offer
+there. That is a real difference between the front doors, not a gap in one of them.
+
 ## 2026-08-07 — the dossier stops being invisible
 
 `deliberate` had a hole in the middle of it. An explorer sweep builds a dossier — minutes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1996,7 +1996,7 @@ async fn generate_inner(
                                 ),
                             ));
                         }
-                        tokio::time::sleep(GENERATE_POLL_INTERVAL).await;
+                        tokio::time::sleep(crate::server::GENERATE_POLL_INTERVAL).await;
                     }
                     Err(e) => return Ok(fail_consultation(args.json, "generate", &cast.name, e)),
                 }
@@ -2027,10 +2027,6 @@ async fn generate_inner(
     }
     Ok(EXIT_OK)
 }
-
-/// How often a foreground `kaibo generate` asks a deferred provider job whether it is
-/// done — the CLI twin of the server's poll cadence.
-const GENERATE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Run `kaibo cas read` — read one artifact by the address you already hold.
 pub async fn run_cas(common: CommonArgs, args: CasArgs) -> i32 {
@@ -3362,10 +3358,81 @@ mod tests {
         );
     }
 
-    /// `kaibo cas read` takes either spelling kaibo prints, and refuses anything that is
-    /// not a digest — a traversal-shaped string never gets near a path.
+    /// A real read, end to end: a disk-mode store, an object put in it, and the digest
+    /// read back through the command — the path that reaches `plan` and then writes to
+    /// stdout. Everything else here stops at a refusal, so without this the byte-serving
+    /// half of the command has no test at all (DeepSeek cross-family review, 2026-08-07).
     #[tokio::test]
-    async fn cas_read_refuses_a_string_that_is_not_a_digest() {
+    async fn cas_read_serves_a_stored_object_by_its_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::builtin();
+        config.root = Some(dir.path().join("proj"));
+        std::fs::create_dir_all(dir.path().join("proj")).unwrap();
+        // Disk mode needs persistence active AND a resolvable cas dir, both outside the
+        // allowed tree — the same containment rule the store enforces in production.
+        config.persistence.enabled = true;
+        config.persistence.path = Some(dir.path().join("state.db"));
+        config.cas.dir = Some(dir.path().join("cas"));
+        let resolver = Resolver::from_config(Arc::new(config)).unwrap();
+
+        // Put an object the way a producer would, through the store's own write path.
+        let cas = crate::cas::Cas::open(&dir.path().join("cas"), &[], None).expect("cas opens");
+        let digest = cas
+            .put(
+                b"the artifact body",
+                crate::cas::Extension::Txt,
+                &crate::cas::Provenance {
+                    prompt: "p".into(),
+                    model: "m".into(),
+                    cast: "c".into(),
+                    timestamp: 0,
+                    mime: "text/plain".into(),
+                    seed: None,
+                    tool: Some("generate".into()),
+                    slot: None,
+                    label: Some("a stored artifact".into()),
+                    session: None,
+                },
+            )
+            .expect("the object stores");
+
+        // Both spellings kaibo prints resolve to the same object.
+        for reference in [
+            digest.to_hex(),
+            format!("{}{}", crate::cas::CAS_URI_PREFIX, digest.to_hex()),
+        ] {
+            let cli = Cli::parse_from(["kaibo", "cas", "read", &reference]);
+            let args = match cli.command {
+                Some(Command::Cas(c)) => match c.cmd {
+                    CasCmd::Read(r) => r,
+                },
+                other => panic!("expected cas read, got {other:?}"),
+            };
+            let code = cas_read_inner(&args, &resolver)
+                .await
+                .unwrap_or_else(|e| panic!("reading {reference} must succeed: {}", e.message));
+            assert_eq!(code, EXIT_OK);
+        }
+
+        // A digest this store never held is a usage error naming the digest, not a crash.
+        let cli = Cli::parse_from(["kaibo", "cas", "read", &"bb".repeat(32)]);
+        let args = match cli.command {
+            Some(Command::Cas(c)) => match c.cmd {
+                CasCmd::Read(r) => r,
+            },
+            other => panic!("expected cas read, got {other:?}"),
+        };
+        let err = cas_read_inner(&args, &resolver)
+            .await
+            .expect_err("an absent digest is refused");
+        assert_eq!(err.code, EXIT_USAGE);
+    }
+
+    /// A memory-mode store is empty in a new process, so `kaibo cas read` refuses and
+    /// names the mode. Reporting "not found" would send a caller hunting for a typo in an
+    /// address that was never the problem.
+    #[tokio::test]
+    async fn cas_read_in_memory_mode_says_so_instead_of_reporting_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let mut config = Config::builtin();
         config.root = Some(dir.path().to_path_buf());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2131,12 +2131,16 @@ async fn cas_read_inner(args: &CasReadArgs, resolver: &Resolver) -> Result<i32, 
         provenance_present: provenance.is_some(),
         path: path.as_deref(),
     };
-    let view = crate::server::plan_cas_read(&obj, args.offset, args.length, crate::server::Delivery::Bytes).map_err(|message| {
-        SetupError {
-            kind: "usage",
-            message,
-            code: EXIT_USAGE,
-        }
+    let view = crate::server::plan_cas_read(
+        &obj,
+        args.offset,
+        args.length,
+        crate::server::Delivery::Bytes,
+    )
+    .map_err(|message| SetupError {
+        kind: "usage",
+        message,
+        code: EXIT_USAGE,
     })?;
 
     // `--json` keeps the MCP shape: one object on stdout, a binary body base64-encoded
@@ -3290,6 +3294,130 @@ mod tests {
             .expect_err("an interactive cast on batch submit must be refused");
         assert_eq!(err.code, EXIT_USAGE);
         assert_eq!(err.kind, "usage");
+    }
+
+    /// `--field` carries a TYPE, because a provider's wire distinguishes `2` from `"2"`
+    /// and a shell has only strings. The value's own JSON syntax is what decides, so
+    /// nothing extra has to be learned — and a value that is not JSON at all is exactly
+    /// what it looks like.
+    #[test]
+    fn a_generate_field_takes_its_type_from_the_value() {
+        use crate::media::FieldValue;
+
+        let (k, v) = parse_generate_field("n=2").expect("a number");
+        assert_eq!(k, "n");
+        assert!(
+            matches!(&v, FieldValue::Num(n) if n.to_string() == "2"),
+            "an integer must stay integral, got {v:?}"
+        );
+        assert!(matches!(
+            parse_generate_field("transparent=true").unwrap().1,
+            FieldValue::Bool(true)
+        ));
+        // Not JSON, and not a mistake: the common case for an image knob.
+        assert!(matches!(
+            parse_generate_field("size=1024x1024").unwrap().1,
+            FieldValue::Str(s) if s == "1024x1024"
+        ));
+        // A quoted JSON string keeps its content, not its quotes.
+        assert!(matches!(
+            parse_generate_field("style=\"3d-model\"").unwrap().1,
+            FieldValue::Str(s) if s == "\"3d-model\""
+        ));
+        // The value may itself contain `=` — only the FIRST one splits.
+        let (k, v) = parse_generate_field("prompt_suffix=a=b").expect("split on the first =");
+        assert_eq!(k, "prompt_suffix");
+        assert!(matches!(v, FieldValue::Str(s) if s == "a=b"));
+
+        for bad in ["noequals", "=value"] {
+            let err = parse_generate_field(bad).expect_err("must be refused");
+            assert_eq!(err.code, EXIT_USAGE);
+        }
+    }
+
+    /// A cast with no `image` slot cannot generate, and the refusal says what a cast needs
+    /// rather than failing later in a provider call. Exit 2, before any network.
+    #[tokio::test]
+    async fn generate_on_a_cast_without_an_image_slot_is_a_usage_error_exit_2() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::builtin();
+        config.root = Some(dir.path().to_path_buf());
+        let resolver = Resolver::from_config(Arc::new(config)).unwrap();
+
+        let cli = Cli::parse_from(["kaibo", "generate", "a cat", "--cast", "deepseek"]);
+        let common = cli.common.clone();
+        let args = match cli.command {
+            Some(Command::Generate(g)) => g,
+            other => panic!("expected generate, got {other:?}"),
+        };
+        let err = generate_inner(&common, &args, &resolver)
+            .await
+            .expect_err("a cast with no image slot must be refused");
+        assert_eq!(err.code, EXIT_USAGE);
+        assert_eq!(err.kind, "usage");
+        assert!(
+            err.message.contains("`image` slot"),
+            "the refusal names what the cast is missing: {}",
+            err.message
+        );
+    }
+
+    /// `kaibo cas read` takes either spelling kaibo prints, and refuses anything that is
+    /// not a digest — a traversal-shaped string never gets near a path.
+    #[tokio::test]
+    async fn cas_read_refuses_a_string_that_is_not_a_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::builtin();
+        config.root = Some(dir.path().to_path_buf());
+        // Persistence off ⇒ the store is in-memory ⇒ nothing is readable. That refusal
+        // comes first and says so plainly, which is the honest answer: hunting for a typo
+        // in a digest that was never the problem is the failure mode to avoid.
+        config.persistence.enabled = false;
+        let resolver = Resolver::from_config(Arc::new(config)).unwrap();
+
+        let cli = Cli::parse_from(["kaibo", "cas", "read", "../../etc/passwd"]);
+        let args = match cli.command {
+            Some(Command::Cas(c)) => match c.cmd {
+                CasCmd::Read(r) => r,
+            },
+            other => panic!("expected cas read, got {other:?}"),
+        };
+        let err = cas_read_inner(&args, &resolver)
+            .await
+            .expect_err("an in-memory store holds nothing to read");
+        assert!(
+            err.message.contains("in-memory"),
+            "a memory-mode read says why nothing can be found: {}",
+            err.message
+        );
+        assert_eq!(err.code, EXIT_SETUP);
+    }
+
+    /// The `cas` group carries exactly one verb, and it parses its window flags.
+    #[test]
+    fn cas_read_parses_its_window() {
+        let cli = Cli::parse_from([
+            "kaibo",
+            "cas",
+            "read",
+            "kaibo://cas/abc",
+            "--offset",
+            "64",
+            "--length",
+            "128",
+            "--json",
+        ]);
+        match cli.command {
+            Some(Command::Cas(c)) => match c.cmd {
+                CasCmd::Read(r) => {
+                    assert_eq!(r.digest, "kaibo://cas/abc");
+                    assert_eq!(r.offset, 64);
+                    assert_eq!(r.length, Some(128));
+                    assert!(r.json);
+                }
+            },
+            other => panic!("expected cas read, got {other:?}"),
+        }
     }
 
     /// `kaibo deliberate` takes the same arguments as the MCP tool under the CLI's

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,6 +131,10 @@ pub enum Command {
     Kaish(KaishArgs),
     /// Provider batch lanes — submit a fan-out, get results, list live/recovered handles.
     Batch(BatchArgs),
+    /// Generate an image into kaibo's artifact store; prints the digest to read it back.
+    Generate(GenerateCliArgs),
+    /// Read an artifact kaibo stored, by its digest.
+    Cas(CasArgs),
     /// List available models a backend's provider actually serves — read-only model
     /// discovery via the backend's real /models endpoint, no cast/model in the loop.
     Models(ModelsArgs),
@@ -496,6 +500,73 @@ pub struct KaishArgs {
 
     /// Emit a JSON object `{stdout, stderr, exit_code}` instead of raw streams (the
     /// process still exits with kaish's exit code).
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// `kaibo generate` — render an image through the cast's `image` slot into kaibo's own
+/// artifact store, and print the digest that reads it back.
+///
+/// Never writes into your project: the address is the content's hash and the store is
+/// kaibo's, which is the same contract the MCP tool holds. `kaibo cas read <digest>`
+/// fetches it, and in disk mode the printed path reaches it with any tool you like.
+#[derive(Args, Debug)]
+pub struct GenerateCliArgs {
+    /// What to generate, described in prose.
+    pub prompt: String,
+
+    /// A provider-native option, `key=value`, passed through verbatim. Repeatable. The
+    /// value is read as JSON when it parses as one, so `--field n=2` sends a number and
+    /// `--field transparent=true` a boolean; anything else rides as a string
+    /// (`--field size=1024x1024`). The provider validates its own knobs. `prompt` and
+    /// `model` are reserved — use the argument and the cast's image slot.
+    #[arg(long = "field", value_name = "KEY=VALUE", action = clap::ArgAction::Append)]
+    pub fields: Vec<String>,
+
+    /// Emit a JSON envelope on stdout (the artifacts and their digests) instead of prose.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// `kaibo cas` — read what kaibo stored, by address.
+///
+/// **`read` is the only verb, on purpose.** The store is content-addressed and opaque:
+/// you reach an object with a digest you already hold, and there is deliberately no
+/// listing, no usage report, and no delete — none of those can exist without an index the
+/// store does not keep (`docs/config.md`). Retention is file mtime over the object tree,
+/// with your own tools.
+#[derive(Args, Debug)]
+pub struct CasArgs {
+    #[command(subcommand)]
+    pub cmd: CasCmd,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CasCmd {
+    /// Read one artifact by digest — metadata first, then a bounded window of content.
+    Read(CasReadArgs),
+}
+
+/// `kaibo cas read` — metadata-first, bounded retrieval, the same rules the `read_cas`
+/// MCP tool applies, because they are one planner.
+#[derive(Args, Debug)]
+pub struct CasReadArgs {
+    /// The artifact's digest, bare or as its full `kaibo://cas/<digest>` URI — whichever
+    /// kaibo printed.
+    pub digest: String,
+
+    /// Start reading at this byte offset (default 0). Every read's metadata names the
+    /// total size, so you can page without guessing.
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub offset: usize,
+
+    /// How many bytes to serve. Omitted, a text object gives a bounded window and a
+    /// binary one gives metadata alone; `0` is metadata only for anything. Refused past
+    /// the per-read ceiling rather than trimmed, so your next `offset` is never wrong.
+    #[arg(long, value_name = "N")]
+    pub length: Option<usize>,
+
+    /// Emit a JSON envelope on stdout (metadata + the served body) instead of prose.
     #[arg(long)]
     pub json: bool,
 }
@@ -1766,6 +1837,367 @@ async fn deliberate_direct_cli(
         }
         Err(e) => Ok(fail_consultation(args.json, "deliberate", &cast.name, e)),
     }
+}
+
+// ---------------------------------------------------------------------------
+// generate / cas
+// ---------------------------------------------------------------------------
+
+/// Run `kaibo generate` — render through the cast's `image` slot into kaibo's store.
+pub async fn run_generate(common: CommonArgs, args: GenerateCliArgs) -> i32 {
+    init_cli_logging();
+    let config = match load_config(&common) {
+        Ok(c) => c,
+        Err(e) => {
+            return fail_preflight(
+                args.json,
+                "config",
+                format!("config error: {e:#}"),
+                EXIT_USAGE,
+            )
+        }
+    };
+    let resolver = match Resolver::from_config(Arc::new(config)) {
+        Ok(r) => r,
+        Err(e) => return fail_preflight(args.json, "setup", format!("{e:#}"), EXIT_SETUP),
+    };
+    match generate_inner(&common, &args, &resolver).await {
+        Ok(code) => code,
+        Err(SetupError {
+            kind,
+            message,
+            code,
+        }) => fail_preflight(args.json, kind, message, code),
+    }
+}
+
+/// Split one `--field key=value`, reading the value as JSON when it parses as one.
+///
+/// A provider's wire cares about the difference between `2` and `"2"`, and a shell has
+/// only strings — so the value's own JSON syntax carries the type, and anything that is
+/// not valid JSON is exactly what it looks like: a string. That keeps `--field n=2` a
+/// number and `--field size=1024x1024` a string with no extra flag to learn.
+fn parse_generate_field(raw: &str) -> Result<(String, crate::media::FieldValue), SetupError> {
+    let (key, value) = raw.split_once('=').ok_or_else(|| SetupError {
+        kind: "usage",
+        message: format!(
+            "`--field {raw}` must be KEY=VALUE, e.g. `--field aspect_ratio=16:9` or \
+             `--field n=2`"
+        ),
+        code: EXIT_USAGE,
+    })?;
+    if key.is_empty() {
+        return Err(SetupError {
+            kind: "usage",
+            message: format!("`--field {raw}` has an empty key"),
+            code: EXIT_USAGE,
+        });
+    }
+    let typed = match serde_json::from_str::<serde_json::Value>(value) {
+        Ok(serde_json::Value::Bool(b)) => crate::media::FieldValue::Bool(b),
+        Ok(serde_json::Value::Number(n)) => crate::media::FieldValue::Num(n),
+        // A JSON string, or anything that isn't JSON at all, is a string either way.
+        _ => crate::media::FieldValue::Str(value.to_string()),
+    };
+    Ok((key.to_string(), typed))
+}
+
+async fn generate_inner(
+    common: &CommonArgs,
+    args: &GenerateCliArgs,
+    resolver: &Resolver,
+) -> Result<i32, SetupError> {
+    let cast = resolver
+        .resolve_cast(common.cast.clone())
+        .map_err(SetupError::usage)?;
+    let slot = cast.slot(ModelRole::Image).ok_or_else(|| SetupError {
+        kind: "usage",
+        message: format!(
+            "cast `{}` has no `image` slot — `generate` needs a cast whose `image` slot \
+             points at a media backend (kind {}). `kaibo config` lists the configured \
+             casts and their slots.",
+            cast.name,
+            crate::credentials::media_kinds_list(),
+        ),
+        code: EXIT_USAGE,
+    })?;
+    let backend = resolver
+        .config
+        .resolve_backend(&slot.backend)
+        .map_err(|e| SetupError {
+            kind: "setup",
+            message: format!("{e:#}"),
+            code: EXIT_SETUP,
+        })?;
+    // Building the arm resolves the provider key — a missing one is the operator's setup
+    // gap, named with the cast and slot.
+    let arm = crate::media::MediaArmFactory::build(&crate::media::LiveMediaArms, backend, slot)
+        .map_err(|e| SetupError {
+            kind: "setup",
+            message: format!("cast `{}` image slot: {e:#}", cast.name),
+            code: EXIT_SETUP,
+        })?;
+    let mut fields = Vec::with_capacity(args.fields.len());
+    for raw in &args.fields {
+        fields.push(parse_generate_field(raw)?);
+    }
+    // The store settles the same way it does on the MCP road, and an artifact with
+    // nowhere to land is refused before a provider is paid.
+    let persistence = open_batch_store(resolver).await;
+    let store = open_media_cas(resolver, persistence.is_some())?.ok_or_else(|| SetupError {
+        kind: "usage",
+        message: "the media CAS is disabled ([cas] enabled = false), so `generate` has \
+                  nowhere to store what it renders. Re-enable it and run again."
+            .to_string(),
+        code: EXIT_USAGE,
+    })?;
+
+    let request = crate::media::MediaRequest {
+        prompt: args.prompt.clone(),
+        fields,
+        // Text-to-image only from the CLI today: the edit/upscale operations that take an
+        // input image would need a file to read, and the CLI has no such argument yet.
+        input_image: None,
+    };
+    let outcome = match arm.generate(&request).await {
+        Ok(o) => o,
+        Err(e) => return Ok(fail_consultation(args.json, "generate", &cast.name, e)),
+    };
+    // A deferred generation has no `job-N` to hand back here — this process is the job,
+    // exactly as `deliberate`'s direct lane is. It polls on the provider's cadence until
+    // the call deadline, then says plainly that kaibo stopped watching while the provider
+    // may not have stopped working.
+    let artifacts = match outcome {
+        crate::media::MediaOutcome::Complete(artifacts) => artifacts,
+        crate::media::MediaOutcome::Deferred(job) => {
+            eprintln!(
+                "kaibo: the provider is rendering in the background — this process waits \
+                 for it (cast `{}`, image `{}`).",
+                cast.name,
+                arm.slot_ref()
+            );
+            let deadline = resolver.config.defaults.call_deadline;
+            let started = tokio::time::Instant::now();
+            loop {
+                match arm.poll(&job).await {
+                    Ok(crate::media::MediaPollOutcome::Complete(a)) => break a,
+                    Ok(crate::media::MediaPollOutcome::Pending) => {
+                        if started.elapsed() > deadline {
+                            return Ok(fail_consultation(
+                                args.json,
+                                "generate",
+                                &cast.name,
+                                anyhow::anyhow!(
+                                    "still pending after {}s (the call_deadline budget) — \
+                                     provider job id `{}` may still finish on the \
+                                     provider's side, but kaibo has stopped polling it",
+                                    deadline.as_secs(),
+                                    job.0
+                                ),
+                            ));
+                        }
+                        tokio::time::sleep(GENERATE_POLL_INTERVAL).await;
+                    }
+                    Err(e) => return Ok(fail_consultation(args.json, "generate", &cast.name, e)),
+                }
+            }
+        }
+    };
+    let text = match crate::server::store_generated_artifacts(
+        &store,
+        &artifacts,
+        &args.prompt,
+        arm.slot_ref(),
+        &cast.name,
+    ) {
+        Ok(t) => t,
+        Err(e) => return Ok(fail_consultation(args.json, "generate", &cast.name, e)),
+    };
+    if args.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "result": text,
+                "cast": cast.name,
+                "image": arm.slot_ref(),
+            })
+        );
+    } else {
+        println!("{text}");
+    }
+    Ok(EXIT_OK)
+}
+
+/// How often a foreground `kaibo generate` asks a deferred provider job whether it is
+/// done — the CLI twin of the server's poll cadence.
+const GENERATE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Run `kaibo cas read` — read one artifact by the address you already hold.
+pub async fn run_cas(common: CommonArgs, args: CasArgs) -> i32 {
+    init_cli_logging();
+    let CasCmd::Read(args) = args.cmd;
+    let config = match load_config(&common) {
+        Ok(c) => c,
+        Err(e) => {
+            return fail_preflight(
+                args.json,
+                "config",
+                format!("config error: {e:#}"),
+                EXIT_USAGE,
+            )
+        }
+    };
+    let resolver = match Resolver::from_config(Arc::new(config)) {
+        Ok(r) => r,
+        Err(e) => return fail_preflight(args.json, "setup", format!("{e:#}"), EXIT_SETUP),
+    };
+    match cas_read_inner(&args, &resolver).await {
+        Ok(code) => code,
+        Err(SetupError {
+            kind,
+            message,
+            code,
+        }) => fail_preflight(args.json, kind, message, code),
+    }
+}
+
+async fn cas_read_inner(args: &CasReadArgs, resolver: &Resolver) -> Result<i32, SetupError> {
+    let persistence = open_batch_store(resolver).await;
+    let mode = resolver.config.cas_mode(persistence.is_some());
+    let store = open_media_cas(resolver, persistence.is_some())?.ok_or_else(|| SetupError {
+        kind: "usage",
+        message: "the media CAS is disabled ([cas] enabled = false), so kaibo holds no \
+                  artifacts to read."
+            .to_string(),
+        code: EXIT_USAGE,
+    })?;
+    // Memory mode is worth saying out loud on THIS command: a fresh process gets a fresh
+    // empty store, so no digest can ever resolve. Reporting "not found" alone would send
+    // someone hunting for a typo in an address that was never the problem.
+    if mode == crate::config::CasMode::Memory {
+        return Err(SetupError {
+            kind: "setup",
+            message: "kaibo's artifact store is in-memory this run (persistence is off or \
+                      no data directory resolves), and an in-memory store is empty in a \
+                      new process — nothing is readable by digest. Enable persistence \
+                      (and a resolvable $XDG_DATA_HOME or $HOME) to keep artifacts on \
+                      disk; `kaibo config` shows the store's mode."
+                .to_string(),
+            code: EXIT_SETUP,
+        });
+    }
+    // Either spelling kaibo prints is accepted — refusing the exact string we handed back
+    // would be a puzzle, not a guardrail.
+    let hex = args
+        .digest
+        .trim()
+        .strip_prefix(crate::cas::CAS_URI_PREFIX)
+        .unwrap_or(args.digest.trim());
+    let digest = crate::cas::Digest::from_hex(hex).map_err(|e| SetupError {
+        kind: "usage",
+        message: format!(
+            "{e} — pass the digest kaibo printed, either bare or as its full {}<digest> URI.",
+            crate::cas::CAS_URI_PREFIX
+        ),
+        code: EXIT_USAGE,
+    })?;
+    // The store verifies content against its address before a byte comes back, so a
+    // corrupt object is loud here rather than silently served.
+    let (bytes, ext) = match store.get(&digest) {
+        Ok(Some(found)) => found,
+        Ok(None) => {
+            return Err(SetupError {
+                kind: "usage",
+                message: format!("no artifact with digest {hex} — this store never held it."),
+                code: EXIT_USAGE,
+            })
+        }
+        Err(e) => {
+            return Err(SetupError {
+                kind: "setup",
+                message: format!("{e:#}"),
+                code: EXIT_SETUP,
+            })
+        }
+    };
+
+    let provenance = store.provenance(&digest);
+    let path = store.path_for(&digest);
+    let obj = crate::server::CasObject {
+        digest: hex,
+        ext,
+        bytes: &bytes,
+        label: provenance.as_ref().and_then(|p| p.label.as_deref()),
+        provenance_present: provenance.is_some(),
+        path: path.as_deref(),
+    };
+    let view = crate::server::plan_cas_read(&obj, args.offset, args.length, crate::server::Delivery::Bytes).map_err(|message| {
+        SetupError {
+            kind: "usage",
+            message,
+            code: EXIT_USAGE,
+        }
+    })?;
+
+    // `--json` keeps the MCP shape: one object on stdout, a binary body base64-encoded
+    // because JSON has no other way to carry bytes.
+    if args.json {
+        let body = match &view.body {
+            crate::server::CasBody::None => None,
+            crate::server::CasBody::Text(t) => Some(t.clone()),
+            crate::server::CasBody::Base64(b) => Some(b.clone()),
+            crate::server::CasBody::Image { data, .. } => Some(data.clone()),
+        };
+        println!(
+            "{}",
+            serde_json::json!({
+                "metadata": view.meta,
+                "body": body,
+                "binary": !ext.is_textual(),
+            })
+        );
+        return Ok(EXIT_OK);
+    }
+
+    // Prose form follows the CLI's standing contract — **stdout is the payload, stderr is
+    // everything else** — which is what makes `kaibo cas read <digest> > arch.png` work
+    // with no flag to remember. The metadata a `read_cas` caller needs in-band goes to
+    // stderr here, because a terminal caller reads it with their eyes and a script must
+    // not have to strip it.
+    //
+    // The rules that bound an MCP read exist to protect a CONTEXT WINDOW. A pipe has no
+    // such budget, and someone who asked for a PNG by its digest knows what is coming — so
+    // a binary object's content goes out as bytes, never as base64 nobody wants. That is
+    // the one place this front door legitimately differs from the tool.
+    eprintln!("{}", view.meta);
+    match view.body {
+        crate::server::CasBody::None => {}
+        crate::server::CasBody::Text(t) => println!("{t}"),
+        // Binary: the exact bytes the metadata just described, straight to stdout. This is
+        // the single blessed write site outside the two stores — see the marker, and
+        // `tests/no_write_path.rs`, whose pinned count makes it impossible to add another
+        // one quietly. Nothing is created on any filesystem here: stdout is a descriptor
+        // the operator's shell already opened and aimed, so kaibo still has no
+        // destination parameter anywhere in this store's surface.
+        crate::server::CasBody::Base64(_) | crate::server::CasBody::Image { .. } => {
+            let start = args.offset.min(bytes.len());
+            let end = match args.length {
+                Some(n) => start.saturating_add(n).min(bytes.len()),
+                None => bytes.len(),
+            };
+            use std::io::Write as _;
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
+            out.write_all(&bytes[start..end]) // cas-stdout-bytes: blessed by the media CAS invariant amendment (AGENTS.md)
+                .and_then(|()| out.flush())
+                .map_err(|e| SetupError {
+                    kind: "setup",
+                    message: format!("writing artifact bytes to stdout: {e}"),
+                    code: EXIT_SETUP,
+                })?;
+        }
+    }
+    Ok(EXIT_OK)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ async fn main() -> Result<()> {
         Some(Command::Batch(args)) => {
             std::process::exit(kaibo::cli::run_batch(cli.common, args).await)
         }
+        Some(Command::Generate(args)) => {
+            std::process::exit(kaibo::cli::run_generate(cli.common, args).await)
+        }
+        Some(Command::Cas(args)) => std::process::exit(kaibo::cli::run_cas(cli.common, args).await),
         Some(Command::Models(args)) => {
             std::process::exit(kaibo::cli::run_models(cli.common, args).await)
         }

--- a/src/server/cas_read.rs
+++ b/src/server/cas_read.rs
@@ -391,6 +391,40 @@ mod tests {
         }
     }
 
+    /// `Delivery` changes the CLAIM, never the body: the same small image is planned
+    /// identically either way, and only the sentence describing how it is served differs.
+    /// A terminal renders nothing, so saying "as a rendered image" there would describe
+    /// something that did not happen.
+    #[test]
+    fn delivery_changes_only_what_the_metadata_claims() {
+        let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        let obj = png_obj(&png);
+        let rendered = plan(&obj, 0, None, Delivery::Rendered).expect("a legal read");
+        let bytes = plan(&obj, 0, None, Delivery::Bytes).expect("a legal read");
+
+        assert_eq!(
+            rendered.body, bytes.body,
+            "the body a delivery mode gets is the same body"
+        );
+        assert!(
+            rendered.meta.contains("as a rendered image"),
+            "an MCP host renders the block: {}",
+            rendered.meta
+        );
+        assert!(
+            !bytes.meta.contains("rendered"),
+            "a stream renders nothing, so the metadata must not claim it: {}",
+            bytes.meta
+        );
+        assert!(
+            bytes
+                .meta
+                .contains(&format!("the whole object, {} bytes", png.len())),
+            "both modes still name exactly what was served: {}",
+            bytes.meta
+        );
+    }
+
     /// **Metadata leads on every response, including the one that carries nothing else.**
     /// `length: 0` is the cheap HEAD: what is this, how big, what is it called, where does
     /// it live — for a few dozen tokens instead of the object.
@@ -503,7 +537,8 @@ mod tests {
     #[test]
     fn a_length_past_the_ceiling_is_refused_with_the_ceiling_and_the_recovery() {
         let obj = text_obj(b"small", None);
-        let err = plan(&obj, 0, Some(MAX_READ_BYTES + 1), Delivery::Rendered).expect_err("past the ceiling");
+        let err = plan(&obj, 0, Some(MAX_READ_BYTES + 1), Delivery::Rendered)
+            .expect_err("past the ceiling");
         assert!(
             err.contains(&MAX_READ_BYTES.to_string()),
             "the refusal names the ceiling: {err}"
@@ -512,7 +547,8 @@ mod tests {
             err.to_lowercase().contains("offset"),
             "and the recovery is paging: {err}"
         );
-        plan(&obj, 0, Some(MAX_READ_BYTES), Delivery::Rendered).expect("exactly at the ceiling is fine");
+        plan(&obj, 0, Some(MAX_READ_BYTES), Delivery::Rendered)
+            .expect("exactly at the ceiling is fine");
     }
 
     /// Textual content arrives as text a caller can use, never base64 it must decode.
@@ -647,7 +683,9 @@ mod tests {
             label: None,
             ..text_obj(bytes, None)
         };
-        let m = plan(&unlabeled, 0, Some(0), Delivery::Rendered).unwrap().meta;
+        let m = plan(&unlabeled, 0, Some(0), Delivery::Rendered)
+            .unwrap()
+            .meta;
         assert!(!m.contains("label:"), "no label, no line: {m}");
         assert!(
             !m.contains("provenance:"),
@@ -658,7 +696,9 @@ mod tests {
             provenance_present: false,
             ..text_obj(bytes, None)
         };
-        let m = plan(&orphaned, 0, Some(0), Delivery::Rendered).unwrap().meta;
+        let m = plan(&orphaned, 0, Some(0), Delivery::Rendered)
+            .unwrap()
+            .meta;
         assert!(
             m.contains("provenance: absent"),
             "a missing record is stated: {m}"
@@ -733,7 +773,8 @@ mod tests {
                     steps <= total + 2,
                     "window {window}: paging did not terminate — stuck at {cursor}"
                 );
-                let view = plan(&obj, cursor, Some(window), Delivery::Rendered).expect("a legal range");
+                let view =
+                    plan(&obj, cursor, Some(window), Delivery::Rendered).expect("a legal range");
                 let (from, to) = served_range(&view.meta)
                     .unwrap_or_else(|| panic!("window {window} at {cursor}: {}", view.meta));
                 assert_eq!(

--- a/src/server/cas_read.rs
+++ b/src/server/cas_read.rs
@@ -136,7 +136,27 @@ pub struct CasView {
 /// [`MAX_READ_BYTES`]. Refused rather than clamped, because a caller that asked for 4 MiB
 /// and silently got 1 MiB would page from the wrong place next time; the message names
 /// the ceiling and the recovery.
-pub fn plan(obj: &CasObject, offset: usize, length: Option<usize>) -> Result<CasView, String> {
+/// How the caller's side will deliver a body, which changes exactly one sentence: what a
+/// whole small image is *served as*.
+///
+/// The rules of a read belong to one planner, but the claim "as a rendered image" is only
+/// true where a host turns an image block into pixels. A terminal gets bytes on a
+/// descriptor, and saying otherwise would be kaibo describing something that did not
+/// happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delivery {
+    /// An MCP host renders the image content block.
+    Rendered,
+    /// The bytes go to a stream the caller already aimed (the CLI).
+    Bytes,
+}
+
+pub fn plan(
+    obj: &CasObject,
+    offset: usize,
+    length: Option<usize>,
+    delivery: Delivery,
+) -> Result<CasView, String> {
     if let Some(asked) = length {
         if asked > MAX_READ_BYTES {
             return Err(format!(
@@ -162,7 +182,12 @@ pub fn plan(obj: &CasObject, offset: usize, length: Option<usize>) -> Result<Cas
             meta: render_meta(
                 obj,
                 total,
-                &format!("the whole object, {total} bytes, as a rendered image"),
+                &match delivery {
+                    Delivery::Rendered => {
+                        format!("the whole object, {total} bytes, as a rendered image")
+                    }
+                    Delivery::Bytes => format!("the whole object, {total} bytes"),
+                },
                 None,
             ),
             body: Body::Image {
@@ -373,7 +398,7 @@ mod tests {
     fn length_zero_is_metadata_only() {
         let body = "x".repeat(5000);
         let obj = text_obj(body.as_bytes(), Some("the inventory"));
-        let view = plan(&obj, 0, Some(0)).expect("a HEAD is always legal");
+        let view = plan(&obj, 0, Some(0), Delivery::Rendered).expect("a HEAD is always legal");
         assert_eq!(view.body, Body::None, "no content at length 0");
         assert!(view.meta.contains("5000"), "the total leads: {}", view.meta);
         assert!(
@@ -397,7 +422,7 @@ mod tests {
     #[test]
     fn a_missing_label_is_omitted_not_faked() {
         let obj = text_obj(b"hi", None);
-        let view = plan(&obj, 0, Some(0)).unwrap();
+        let view = plan(&obj, 0, Some(0), Delivery::Rendered).unwrap();
         assert!(
             !view.meta.contains("label:"),
             "no label line without a label: {}",
@@ -413,7 +438,7 @@ mod tests {
         let total = DEFAULT_READ_BYTES * 3;
         let body = "y".repeat(total);
         let obj = text_obj(body.as_bytes(), None);
-        let view = plan(&obj, 0, None).expect("a default read is legal");
+        let view = plan(&obj, 0, None, Delivery::Rendered).expect("a default read is legal");
         match &view.body {
             Body::Text(t) => assert_eq!(
                 t.len(),
@@ -439,8 +464,8 @@ mod tests {
             .collect();
         let obj = text_obj(body.as_bytes(), None);
 
-        let first = plan(&obj, 0, None).unwrap();
-        let second = plan(&obj, DEFAULT_READ_BYTES, None).unwrap();
+        let first = plan(&obj, 0, None, Delivery::Rendered).unwrap();
+        let second = plan(&obj, DEFAULT_READ_BYTES, None, Delivery::Rendered).unwrap();
         let (Body::Text(a), Body::Text(b)) = (&first.body, &second.body) else {
             panic!("both pages are text");
         };
@@ -463,7 +488,7 @@ mod tests {
     #[test]
     fn an_offset_past_the_end_is_an_empty_range_not_an_error() {
         let obj = text_obj(b"short", None);
-        let view = plan(&obj, 9_999, None).expect("past the end is legal");
+        let view = plan(&obj, 9_999, None, Delivery::Rendered).expect("past the end is legal");
         assert_eq!(view.body, Body::None, "nothing left to serve");
         assert!(
             view.meta.contains('5'),
@@ -478,7 +503,7 @@ mod tests {
     #[test]
     fn a_length_past_the_ceiling_is_refused_with_the_ceiling_and_the_recovery() {
         let obj = text_obj(b"small", None);
-        let err = plan(&obj, 0, Some(MAX_READ_BYTES + 1)).expect_err("past the ceiling");
+        let err = plan(&obj, 0, Some(MAX_READ_BYTES + 1), Delivery::Rendered).expect_err("past the ceiling");
         assert!(
             err.contains(&MAX_READ_BYTES.to_string()),
             "the refusal names the ceiling: {err}"
@@ -487,14 +512,14 @@ mod tests {
             err.to_lowercase().contains("offset"),
             "and the recovery is paging: {err}"
         );
-        plan(&obj, 0, Some(MAX_READ_BYTES)).expect("exactly at the ceiling is fine");
+        plan(&obj, 0, Some(MAX_READ_BYTES), Delivery::Rendered).expect("exactly at the ceiling is fine");
     }
 
     /// Textual content arrives as text a caller can use, never base64 it must decode.
     #[test]
     fn textual_content_arrives_as_text() {
         let obj = text_obj(b"line one\nline two\n", None);
-        let view = plan(&obj, 0, None).unwrap();
+        let view = plan(&obj, 0, None, Delivery::Rendered).unwrap();
         assert_eq!(view.body, Body::Text("line one\nline two\n".to_string()));
     }
 
@@ -504,7 +529,7 @@ mod tests {
     fn a_binary_range_is_base64_of_exactly_those_bytes() {
         let bytes: Vec<u8> = (0u8..=255).collect();
         let obj = png_obj(&bytes);
-        let view = plan(&obj, 10, Some(20)).unwrap();
+        let view = plan(&obj, 10, Some(20), Delivery::Rendered).unwrap();
         assert_eq!(view.body, Body::Base64(b64(&bytes[10..30])));
     }
 
@@ -514,7 +539,7 @@ mod tests {
     #[test]
     fn a_binary_object_serves_no_body_unless_a_range_is_asked_for() {
         let big = vec![7u8; INLINE_IMAGE_MAX_BYTES + 1];
-        let view = plan(&png_obj(&big), 0, None).unwrap();
+        let view = plan(&png_obj(&big), 0, None, Delivery::Rendered).unwrap();
         assert_eq!(
             view.body,
             Body::None,
@@ -533,7 +558,7 @@ mod tests {
     #[test]
     fn a_small_image_with_no_range_comes_back_as_an_image_block() {
         let bytes = vec![9u8; 1024];
-        let view = plan(&png_obj(&bytes), 0, None).unwrap();
+        let view = plan(&png_obj(&bytes), 0, None, Delivery::Rendered).unwrap();
         assert_eq!(
             view.body,
             Body::Image {
@@ -553,7 +578,7 @@ mod tests {
     #[test]
     fn an_explicit_range_on_a_small_image_returns_base64_not_an_image_block() {
         let bytes = vec![9u8; 1024];
-        let view = plan(&png_obj(&bytes), 0, Some(16)).unwrap();
+        let view = plan(&png_obj(&bytes), 0, Some(16), Delivery::Rendered).unwrap();
         assert_eq!(view.body, Body::Base64(b64(&bytes[..16])));
     }
 
@@ -568,14 +593,14 @@ mod tests {
             ..text_obj(bytes, None)
         };
         assert!(
-            plan(&on_disk, 0, Some(0))
+            plan(&on_disk, 0, Some(0), Delivery::Rendered)
                 .unwrap()
                 .meta
                 .contains("/var/lib/kaibo/cas/ab/cd/abcd.txt"),
             "disk mode names the file"
         );
         assert!(
-            !plan(&text_obj(bytes, None), 0, Some(0))
+            !plan(&text_obj(bytes, None), 0, Some(0), Delivery::Rendered)
                 .unwrap()
                 .meta
                 .contains("path:"),
@@ -611,7 +636,7 @@ mod tests {
         let bytes = b"content";
 
         let labeled = text_obj(bytes, Some("the inventory"));
-        let m = plan(&labeled, 0, Some(0)).unwrap().meta;
+        let m = plan(&labeled, 0, Some(0), Delivery::Rendered).unwrap().meta;
         assert!(m.contains("label: the inventory"), "{m}");
         assert!(
             !m.contains("provenance:"),
@@ -622,7 +647,7 @@ mod tests {
             label: None,
             ..text_obj(bytes, None)
         };
-        let m = plan(&unlabeled, 0, Some(0)).unwrap().meta;
+        let m = plan(&unlabeled, 0, Some(0), Delivery::Rendered).unwrap().meta;
         assert!(!m.contains("label:"), "no label, no line: {m}");
         assert!(
             !m.contains("provenance:"),
@@ -633,7 +658,7 @@ mod tests {
             provenance_present: false,
             ..text_obj(bytes, None)
         };
-        let m = plan(&orphaned, 0, Some(0)).unwrap().meta;
+        let m = plan(&orphaned, 0, Some(0), Delivery::Rendered).unwrap().meta;
         assert!(
             m.contains("provenance: absent"),
             "a missing record is stated: {m}"
@@ -654,7 +679,7 @@ mod tests {
     #[test]
     fn a_window_holding_no_whole_character_advances_over_the_bytes_it_was_given() {
         let obj = text_obj("é".as_bytes(), None);
-        let view = plan(&obj, 0, Some(1)).expect("a legal range");
+        let view = plan(&obj, 0, Some(1), Delivery::Rendered).expect("a legal range");
         assert_eq!(
             view.body,
             Body::Base64(b64(&[0xC3])),
@@ -678,7 +703,7 @@ mod tests {
     #[test]
     fn a_window_inside_one_character_advances_over_the_bytes_it_was_given() {
         let obj = text_obj("😀".as_bytes(), None); // F0 9F 98 80
-        let view = plan(&obj, 1, Some(2)).expect("a legal range");
+        let view = plan(&obj, 1, Some(2), Delivery::Rendered).expect("a legal range");
         assert_eq!(view.body, Body::Base64(b64(&[0x9F, 0x98])));
         assert_eq!(
             served_range(&view.meta),
@@ -708,7 +733,7 @@ mod tests {
                     steps <= total + 2,
                     "window {window}: paging did not terminate — stuck at {cursor}"
                 );
-                let view = plan(&obj, cursor, Some(window)).expect("a legal range");
+                let view = plan(&obj, cursor, Some(window), Delivery::Rendered).expect("a legal range");
                 let (from, to) = served_range(&view.meta)
                     .unwrap_or_else(|| panic!("window {window} at {cursor}: {}", view.meta));
                 assert_eq!(
@@ -744,7 +769,7 @@ mod tests {
             if cursor >= corpus.len() {
                 break;
             }
-            let view = plan(&obj, cursor, Some(3)).unwrap();
+            let view = plan(&obj, cursor, Some(3), Delivery::Rendered).unwrap();
             let (_, to) = served_range(&view.meta).unwrap();
             match &view.body {
                 Body::Text(t) => out.extend_from_slice(t.as_bytes()),
@@ -769,7 +794,7 @@ mod tests {
     /// "this object is binary" wording, which is simply not true of an empty `.txt`.
     #[test]
     fn an_empty_object_says_it_is_empty() {
-        let view = plan(&text_obj(b"", None), 0, None).unwrap();
+        let view = plan(&text_obj(b"", None), 0, None, Delivery::Rendered).unwrap();
         assert_eq!(view.body, Body::None);
         assert!(
             view.meta.contains("empty"),
@@ -792,7 +817,7 @@ mod tests {
         // Each `é` is two bytes, so a 3-byte window from 0 splits the second one.
         let body = "ééé";
         let obj = text_obj(body.as_bytes(), None);
-        let view = plan(&obj, 0, Some(3)).unwrap();
+        let view = plan(&obj, 0, Some(3), Delivery::Rendered).unwrap();
         assert_eq!(
             view.body,
             Body::Text("é".to_string()),
@@ -812,7 +837,7 @@ mod tests {
     fn undecodable_textual_bytes_fall_back_to_base64() {
         let bytes: &[u8] = &[0x66, 0x6f, 0x6f, 0xff, 0xfe, 0x62, 0x61, 0x72];
         let obj = text_obj(bytes, None);
-        let view = plan(&obj, 0, None).unwrap();
+        let view = plan(&obj, 0, None, Delivery::Rendered).unwrap();
         assert_eq!(view.body, Body::Base64(b64(bytes)));
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4243,10 +4243,11 @@ fn render_prompts_resource(config: &Config, cast: Option<&Cast>) -> String {
     out
 }
 
-/// How often a deferred `generate` job re-polls its provider. The provider owns no
-/// cadence (`MediaModel::poll` is one shot by contract); this background job does,
-/// bounded overall by `[defaults] call_deadline`.
-const GENERATE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+/// How often a deferred `generate` re-polls its provider. The provider owns no cadence
+/// (`MediaModel::poll` is one shot by contract); the waiting side does, bounded overall by
+/// `[defaults] call_deadline`. Shared with the CLI's foreground poll so one knob describes
+/// both — a caller waiting at a terminal and a background job are the same request.
+pub(crate) const GENERATE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Store every artifact of one completed generation in the media store and render the
 /// per-artifact result lines: `kaibo://cas/<digest>`, the mime, the provider seed when

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -64,6 +64,10 @@ pub use resolver::Resolver;
 // Re-exported for the CLI front door (`crate::cli`), which renders the same answer
 // footer, failure text, `kaibo://config` document, and `batch list` recency window the
 // MCP handler does.
+// The CLI reads artifacts by digest too (`kaibo cas read`), and a read's RULES —
+// what leads, what is bounded, what is never dumped as base64 — belong to one planner,
+// not to whichever front door asked.
+pub(crate) use cas_read::{plan as plan_cas_read, Body as CasBody, CasObject, Delivery};
 pub(crate) use config_resource::render_config_resource;
 // `deliberate` is the same two stages on either road, so the CLI borrows the pieces
 // rather than growing a second copy of them: how a dossier is kept and loaded, how it is
@@ -2859,6 +2863,9 @@ impl KaiboHandler {
             },
             input.offset.unwrap_or(0),
             input.length,
+            // An MCP host renders the image block; the CLI, serving bytes to a stream,
+            // passes `Bytes` so the metadata never claims a rendering that didn't happen.
+            cas_read::Delivery::Rendered,
         )
         .map_err(|e| McpError::invalid_params(e, None))?;
 
@@ -4257,7 +4264,7 @@ const GENERATE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// mid-loop (I/O, the soft cap) returns an error that NAMES the digests already
 /// stored: they exist, they were paid for, and they stay retrievable by those
 /// addresses — an error that hid them would orphan them.
-fn store_generated_artifacts(
+pub(crate) fn store_generated_artifacts(
     store: &crate::cas::MediaStore,
     artifacts: &[crate::media::MediaArtifact],
     prompt: &str,

--- a/tests/no_write_path.rs
+++ b/tests/no_write_path.rs
@@ -27,6 +27,18 @@
 //! per-file pinning below keeps exactly that property; only the *count* it must satisfy
 //! grows from one to four (1 in `store.rs` + 3 in `cas.rs`).
 //!
+//! **Blessed site 3** (2026-08-07): `kaibo cas read` writing an artifact's bytes to
+//! **stdout**. Different in kind from the other two, and worth saying why it is here at
+//! all. It creates nothing on any filesystem — stdout is a descriptor the operator's shell
+//! already opened and aimed, so this store still has no destination parameter anywhere and
+//! no model can steer it. It is blessed rather than exempted-by-cleverness because the
+//! needle (`.write_all(`) cannot tell a file from a pipe, and a guard that tried to would
+//! be the kind of regex that fails silently in the wrong direction. The bounded,
+//! base64-averse rules an MCP read follows exist to protect a *context window*; a pipe has
+//! no such budget, and a caller who asked for an image by digest expects its bytes — so
+//! this front door serves them, visibly and countably (Amy, 2026-08-07: "we do know when
+//! we might output binary and the caller likely knows they're gonna get binary").
+//!
 //! The carve-out is deliberately narrow, and this test keeps its teeth:
 //! - a blessed line is exempted **only** when its file is one of the two blessed files
 //!   *and* the line's own raw text carries that file's marker — nothing else qualifies
@@ -75,23 +87,55 @@ const FORBIDDEN: &[&str] = &[
 /// per-line property already (the marker has to be ON the offending line), so needle-
 /// pinning added no additional narrowness store.rs's single needle didn't already get for
 /// free.
-const BLESSED: &[(&str, &str)] = &[
-    (
-        "store.rs",
-        "state-dir-create: blessed by the read-only invariant amendment",
-    ),
-    (
-        "cas.rs",
-        "media-cas-write: blessed by the media CAS invariant amendment (AGENTS.md)",
-    ),
+const BLESSED: &[Blessed] = &[
+    Blessed {
+        file: "store.rs",
+        marker: "state-dir-create: blessed by the read-only invariant amendment",
+        needles: &["create_dir_all("],
+    },
+    Blessed {
+        file: "cas.rs",
+        marker: "media-cas-write: blessed by the media CAS invariant amendment (AGENTS.md)",
+        // One object write touches three seams; the `create_new` open hits two needles on
+        // one physical line.
+        needles: &[
+            "create_dir_all(",
+            "OpenOptions::",
+            ".write(",
+            ".write_all(",
+        ],
+    },
+    Blessed {
+        file: "cli.rs",
+        marker: "cas-stdout-bytes: blessed by the media CAS invariant amendment (AGENTS.md)",
+        // Handing bytes to an already-open descriptor, and nothing else. A path-taking
+        // call is a different capability and must fail here even with the marker on it.
+        needles: &[".write_all("],
+    },
 ];
+
+/// One blessed write site: which file may carry it, the marker its line must show, and
+/// **which** forbidden calls that marker excuses.
+///
+/// The needle list was reintroduced on 2026-08-07 (it had been dropped when `cas.rs`
+/// needed three needles under one marker). Without it, a marker excuses *any* forbidden
+/// call on its line, so pasting `cli.rs`'s marker onto an `fs::write(out_path, …)` would
+/// launder a caller-named destination past this guard — and the CLI is exactly where a
+/// "just write it to a file for me" flag would be proposed. Caught by
+/// `teeth_cli_writes_without_the_marker_fail`.
+struct Blessed {
+    file: &'static str,
+    marker: &'static str,
+    needles: &'static [&'static str],
+}
 
 /// The exact number of blessed marker lines expected tree-wide: 1 in `store.rs`
 /// (`create_state_dir`'s `create_dir_all`) + 3 in `cas.rs` (the shard-dir `create_dir_all`,
 /// the `create_new` open, and the `write_all` of the bytes — see `src/cas.rs`'s module
-/// doc and the count breakdown in this file's module doc). Pinned so a new write site
-/// can't silently ride in behind an existing marker.
-const EXPECTED_BLESSED_LINES: usize = 4;
+/// doc and the count breakdown in this file's module doc) + 1 in `cli.rs` (`kaibo cas
+/// read` handing an artifact's bytes to stdout). Pinned so a new write site can't
+/// silently ride in behind an existing marker.
+const EXPECTED_BLESSED_LINES: usize = 5;
 
 fn rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in std::fs::read_dir(dir).expect("read src dir") {
@@ -122,16 +166,21 @@ fn strip_line_comment(line: &str) -> &str {
     }
 }
 
-/// Is this a blessed occurrence? Exempt when `basename` matches one of [`BLESSED`]'s
-/// files and `raw_line` (comment included) carries *that file's* marker text. No needle
-/// pin: blessing is inherently per-line (the marker must be on the offending line
-/// itself), so a marker on the right line already can't drift onto an unrelated line
-/// carrying a different forbidden call — see the module doc for why `cas.rs` needs this
-/// generalization over `store.rs`'s original single `(file, needle, marker)` pin.
-fn is_blessed(basename: &str, raw_line: &str) -> bool {
+/// Is this needle blessed on this line? All three must hold: the file carries a blessing,
+/// the line's own raw text (comment included) shows that blessing's marker, and the needle
+/// is one the blessing actually excuses.
+fn is_blessed_needle(basename: &str, raw_line: &str, needle: &str) -> bool {
+    BLESSED.iter().any(|b| {
+        basename == b.file && raw_line.contains(b.marker) && b.needles.contains(&needle)
+    })
+}
+
+/// Does this line carry a blessing marker at all? Used for the tree-wide count, which
+/// pins how many blessed *lines* exist regardless of how many needles each excuses.
+fn is_blessed_line(basename: &str, raw_line: &str) -> bool {
     BLESSED
         .iter()
-        .any(|(file, marker)| basename == *file && raw_line.contains(marker))
+        .any(|b| basename == b.file && raw_line.contains(b.marker))
 }
 
 /// Forbidden needles found in one file's production code, honoring the blessed
@@ -142,7 +191,7 @@ fn scan_source(basename: &str, source: &str) -> Vec<String> {
     for raw in production_code(source).lines() {
         let code = strip_line_comment(raw);
         for needle in FORBIDDEN {
-            if code.contains(needle) && !is_blessed(basename, raw) {
+            if code.contains(needle) && !is_blessed_needle(basename, raw, needle) {
                 hits.push(needle.to_string());
             }
         }
@@ -155,7 +204,7 @@ fn scan_source(basename: &str, source: &str) -> Vec<String> {
 fn blessed_count(basename: &str, source: &str) -> usize {
     production_code(source)
         .lines()
-        .filter(|raw| is_blessed(basename, raw))
+        .filter(|raw| is_blessed_line(basename, raw))
         .count()
 }
 
@@ -207,7 +256,7 @@ fn blessed_marker_count_matches_exactly() {
     assert_eq!(
         total, EXPECTED_BLESSED_LINES,
         "expected exactly {EXPECTED_BLESSED_LINES} blessed write sites tree-wide (1 in \
-         src/store.rs + 3 in src/cas.rs), found {total}"
+         src/store.rs + 3 in src/cas.rs + 1 in src/cli.rs), found {total}"
     );
 }
 
@@ -218,7 +267,7 @@ fn blessed_marker_count_matches_exactly() {
 fn teeth_blessed_line_is_exempt() {
     let src = format!(
         "    std::fs::create_dir_all(dir) // {}\n",
-        BLESSED[0].1
+        BLESSED[0].marker
     );
     assert!(
         scan_source("store.rs", &src).is_empty(),
@@ -229,7 +278,7 @@ fn teeth_blessed_line_is_exempt() {
 /// A `create_dir_all` in any OTHER file fails, even carrying store.rs's marker text.
 #[test]
 fn teeth_create_dir_all_elsewhere_fails() {
-    let src = format!("    std::fs::create_dir_all(x) // {}\n", BLESSED[0].1);
+    let src = format!("    std::fs::create_dir_all(x) // {}\n", BLESSED[0].marker);
     assert!(
         !scan_source("server.rs", &src).is_empty(),
         "create_dir_all outside store.rs must fail even with the marker"
@@ -252,12 +301,45 @@ fn teeth_unmarked_create_dir_all_in_store_fails() {
 fn teeth_other_write_in_store_fails() {
     let src = format!(
         "    std::fs::create_dir_all(dir) // {}\n    std::fs::write(p, b)?;\n",
-        BLESSED[0].1
+        BLESSED[0].marker
     );
     let v = scan_source("store.rs", &src);
     assert!(
         v.iter().any(|s| s.contains("fs::write(")),
         "a non-blessed write in store.rs must still fail, got: {v:?}"
+    );
+}
+
+/// The blessed stdout write in `cli.rs` is exempt on its own marked line.
+#[test]
+fn teeth_cli_stdout_bytes_line_is_exempt() {
+    let src = format!("            out.write_all(&bytes[start..end]) // {}\n", BLESSED[2].marker);
+    assert!(
+        scan_source("cli.rs", &src).is_empty(),
+        "the marked stdout write in cli.rs must be exempt"
+    );
+}
+
+/// ...and an UNMARKED write in `cli.rs` still fails, as does the marked one anywhere else.
+/// The CLI is the front door most likely to grow a "just write it to a file for me" flag,
+/// so this is the direction that matters.
+#[test]
+fn teeth_cli_writes_without_the_marker_fail() {
+    assert!(
+        !scan_source("cli.rs", "    std::fs::write(out_path, &bytes)?;\n").is_empty(),
+        "an unmarked fs::write in cli.rs must fail — a --out flag is a new capability, \
+         not a variation on serving stdout"
+    );
+    let marked = format!("    std::fs::write(out_path, &bytes) // {}\n", BLESSED[2].marker);
+    assert!(
+        !scan_source("cli.rs", &marked).is_empty(),
+        "cli.rs's marker blesses the stdout needle only — it must not launder an \
+         fs::write onto a caller-named path"
+    );
+    let elsewhere = format!("    out.write_all(&bytes) // {}\n", BLESSED[2].marker);
+    assert!(
+        !scan_source("server.rs", &elsewhere).is_empty(),
+        "cli.rs's marker must not exempt a write in another file"
     );
 }
 
@@ -276,7 +358,7 @@ fn teeth_test_module_writes_are_ignored() {
 /// needles hit on one physical line, one marker), and the `.write_all(` of the bytes.
 #[test]
 fn teeth_cas_blessed_lines_are_exempt() {
-    let marker = BLESSED[1].1;
+    let marker = BLESSED[1].marker;
     let src = format!(
         "    std::fs::create_dir_all(&shard) // {marker}\n\
          \n\
@@ -319,7 +401,7 @@ fn teeth_forbidden_call_in_cas_without_marker_fails() {
 /// the pin is per-file, not a tree-wide magic comment.
 #[test]
 fn teeth_cas_marker_in_wrong_file_fails() {
-    let marker = BLESSED[1].1;
+    let marker = BLESSED[1].marker;
     let src = format!("    std::fs::create_dir_all(x) // {marker}\n");
     assert!(
         !scan_source("server.rs", &src).is_empty(),
@@ -332,8 +414,8 @@ fn teeth_cas_marker_in_wrong_file_fails() {
 /// own marker text.
 #[test]
 fn teeth_wrong_marker_for_file_fails() {
-    let store_marker = BLESSED[0].1;
-    let cas_marker = BLESSED[1].1;
+    let store_marker = BLESSED[0].marker;
+    let cas_marker = BLESSED[1].marker;
 
     let src_cas = format!("    std::fs::create_dir_all(x) // {store_marker}\n");
     assert!(


### PR DESCRIPTION
**Stacked on #131** (base `cli-parity`) — merge that first; this diff is only the media half.

The last two parity gaps. With these, every MCP tool has a CLI form except `consult_submit`/`job_wait`, which stay MCP-only on purpose: their value is work continuing inside a session that outlives the call.

## `kaibo generate`

Renders through the cast's `image` slot into kaibo's own store, prints the digests. A *deferred* provider job polls in the **foreground** — the same answer #131's direct lane got, for the same reason: there's no server here to hold a `job-N`. `--field k=v` is repeatable, and the value's own JSON syntax carries its type, so `--field n=2` sends a number and `--field size=1024x1024` a string, with nothing extra to learn.

## `kaibo cas read`

This reverses one line of `docs/config.md` — *"There is no `kaibo cas` CLI command"* — on Amy's word: *"it'll be handy, and it doesn't weaken our story."* That line was about **reach**, not opacity. What doesn't change: `read` is the only verb, and no listing, usage report, or delete can exist without an index the store deliberately doesn't keep.

The shape came from Amy's push — *"we do know when we might output binary and the caller likely knows they're gonna get binary"*:

| | `read_cas` (MCP) | `kaibo cas read` (CLI) |
|---|---|---|
| metadata | first content block | **stderr** |
| text | bounded window | **stdout** |
| binary | base64 only on an explicit range | **raw bytes on stdout** |

The MCP rules protect a **context window**; a pipe has no such budget. So `kaibo cas read <digest> > arch.png` works with no flag — verified: a 3.96 MB PNG round-trips **byte-identical** against the stored object. A `--raw` flag was designed, built, and deleted once it was clear it was a worse spelling of the default. Both surfaces still share one planner, which gained a `Delivery` mode so its metadata stops claiming *"as a rendered image"* where nothing renders.

Disk mode only, and it says so: an in-memory store is empty in a new process, so reporting "not found" would send someone hunting for a typo in an address that was never the problem.

## The invariant, deliberately and visibly

Serving those bytes is a `write_all` to stdout, which the guard can't distinguish from writing a file. So it's the **fifth blessed line** in `tests/no_write_path.rs`, pinned count 4 → 5. Writing to stdout creates nothing — it's a descriptor the operator's shell already opened and aimed — so this store still has no destination parameter anywhere, and no model can steer it.

**The guard got stricter in the same change.** The teeth test written for the new marker *failed*: blessings were pinned per-`(file, marker)` but not per-**needle**, so pasting the new marker onto an `fs::write(out_path, …)` would have laundered a caller-named destination straight through — and the CLI is exactly where a `--out FILE` flag gets proposed. Needle pinning is back, and `store.rs`/`cas.rs` now declare which calls their markers excuse.

## Tests

Four new CLI tests (field typing incl. first-`=` splitting and the refusals, no-image-slot refusal, non-digest refusal, memory-mode refusal) plus two new teeth tests on the guard. Full suite green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)