### PR TITLE
docs: adopt kaish's style guide by name, and put the changelog on a diet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,12 +209,37 @@ x86_64-unknown-linux-musl`. Verify the boundary with `cargo tree -i aws-lc-rs`
 
 ## Writing for models
 
-Every prompt, preamble, tool description, and cheatsheet is text some model reads.
-When we touch one, we **re-read the whole block and judge it holistically** — not the
-diff in isolation. The ratchet is *compression* (改善): over time a block should carry
+Every prompt, preamble, tool description, help line, and error string is text some model
+reads. When we touch one, we **re-read the whole block and judge it holistically** — not
+the diff in isolation. The ratchet is *compression* (改善): over time a block should carry
 more impact per token and avoid accreting clauses.
 
-Two audiences are optimized differently:
+**kaibo adopts kaish's `docs/style.md`** — that guide names kaibo as an adopter, and it is
+the source for *how* our prose reads: a small vocabulary, one term per concept, exact
+numbers, the constraint before the hedge, and one clause of rationale after a rule. Read it
+before writing help text or operator docs. Its weights land on kaibo like this:
+
+| Weight | kaibo files |
+|---|---|
+| Full | every tool `description` and schema param doc in `server.rs`; every clap `about`, arg doc, and `--help` line in `cli.rs`; **every error, refusal, and diagnostic string a tool or command returns** |
+| Partial — keep the terms and the published/internal boundary, relax the rest | preambles and the kaish cheatsheet (`consult/prompts.rs`, `kaish_syntax.rs`), and `///` on `pub` items |
+| Terms only, one line per bullet | `CHANGELOG.md` |
+| Terms only | `README.md`, `docs/*.md` |
+| Exempt | `docs/devlog.md` — it tells the story from a point of view, and a story needs a voice |
+
+**Error strings are full weight, and they are the highest-value prose we own.** A model
+reads a refusal far more often than it reads a description, and the refusal arrives exactly
+when the reader is stuck. Name what was refused, why, and the way out — `save_artifact`'s
+`SaveError` and `deliberate`'s inert-argument refusal are the models to copy.
+
+**Comments: published and internal are different surfaces.** A tool `description`, a schema
+param doc, and a clap arg doc all ship to a model. A `///` on a private item, a `//` line,
+and a module doc-comment do not — that is where mechanism belongs. The test is not whether
+a sentence names an internal, but whether the reader needs that internal to predict
+behavior. `src/server/dossier.rs` keeps its whole design argument in the module doc and
+ships none of it.
+
+Three audiences are optimized differently:
 
 - **Client-facing text** — the MCP server instructions and each tool's `description`
   in `server.rs`, read by the *calling* agent. Density is existential here because it's
@@ -237,30 +262,24 @@ Two audiences are optimized differently:
   instructions, read by the commercial models *we* drive, with windows in the hundreds
   of thousands to millions of tokens. Here verbosity is *licensed where it shapes
   behavior*: say it a few ways, frame positively, be explicit (see **Driving the
-  models**). Verbose to install behavior, never verbose by default. **Plain, literal
-  English**: declarative sentences, roughly one instruction each, concrete nouns, no
-  idiom, no metaphor, no em-dash clause chains. The reason is the roster — most of our
-  synths are not English-first (DeepSeek, GLM, Qwen, Kimi) and the small local models
-  already fixate on odd phrasing — so figurative English is a comprehension tax charged
-  to exactly the models we most need to work well. This is the clarity half of the
-  operator-docs bullet below, and it applies here with *more* force, not less. Plain is
-  not terse: keep the repetition that installs an obligation, drop the decoration around
-  it. `built_in_preambles_are_written_without_em_dash_clause_chains` holds the
+  models**). Verbose to install behavior, never verbose by default — plain is not terse:
+  keep the repetition that installs an obligation, drop the decoration around it. Why
+  "Subset, not slang" binds hardest here: most of our synths are not English-first
+  (DeepSeek, GLM, Qwen, Kimi) and the small local models already fixate on odd phrasing,
+  so figurative English is a comprehension tax charged to exactly the models we most need
+  to work well. `built_in_preambles_are_written_without_em_dash_clause_chains` holds the
   mechanical half.
 - **Operator-facing docs** — `docs/config.example.toml`, `docs/config.md`, `README.md`.
   The first two are **embedded in the binary** (`include_str!`) and served as
   `kaibo://config/example` and `kaibo://config/guide`, so a model reads them as often as
-  a person does. They are shipped product, not repo notes. Write them as **technical
-  reference**: state the rule, name the default, show the shape. Declarative sentences
-  over conversational asides; a table or labelled list over a paragraph that buries three
-  facts in a clause chain. No em-dash pile-ups, no rhetorical questions, no voice.
-  Someone skimming for one key should find it without reading the prose around it, and a
-  non-native English reader should not have to parse an idiom to get a default value.
-  Split the two by job: the **template** says what to type (a knob, its default, one line
-  on what it does, a pointer for the rest); the **guide** explains semantics and
-  interactions. Detail that isn't a knob belongs in the guide — the template is read
-  start to finish by whoever is configuring kaibo, so every line there is a line they pay
-  for.
+  a person does. They are shipped product, not repo notes: technical reference, not a
+  record of how we decided. State the rule, name the default, show the shape, and keep the
+  rationale to the clause after the dash — the argument behind a decision goes in the
+  devlog, and the story of the change goes in the pull request. Split the two files by
+  job: the **template** says what to type (a knob, its default, one line on what it does,
+  a pointer for the rest); the **guide** explains semantics and interactions. Detail that
+  isn't a knob belongs in the guide — the template is read start to finish by whoever is
+  configuring kaibo, so every line there is a line they pay for.
 
 ## Driving the models
 
@@ -355,9 +374,16 @@ even for a one-line doc fix.
   TLS change is a hard look), but don't skip the PR.
 - **Every user-facing change updates `CHANGELOG.md`** under the top *unreleased*
   section, in the Keep a Changelog buckets (Added / Changed / Fixed / Security / …).
-  Same "why not what" ethos as commits: write what a *user* notices, not the file
-  diff. Internal-only refactors need no entry — the git log is their record (mirrors
-  the `docs/issues.md` "delete when shipped" discipline).
+  Write what a *user* notices, not the file diff. Internal-only refactors need no entry —
+  the git log is their record (mirrors the `docs/issues.md` "delete when shipped"
+  discipline).
+- **A changelog bullet is one line: the rule, and one clause of why.** This is the one
+  place where "keep the why" does not win, because the full narrative already lives in the
+  pull request body, which becomes the merge commit. If a bullet needs three numbers and
+  three reasons, it is three bullets. **Terser over time** is a ratchet, like compression
+  in the model-facing text: when you add an entry, the paragraph-shaped ones nearby are
+  fair game to cut down, and a release is a good moment to sweep the section you are about
+  to retitle. A reader scanning for what changed should not have to read an argument.
 - **Cutting a release.** Bump `version` in `Cargo.toml`, retitle the unreleased
   section to `## [X.Y.Z] — <date>` and open a fresh empty unreleased section above it,
   then tag `vX.Y.Z` — `.github/workflows/release.yml` builds the platform matrix on a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,9 +212,7 @@ x86_64-unknown-linux-musl`. Verify the boundary with `cargo tree -i aws-lc-rs`
 
 Every prompt, preamble, tool description, help line, and error string is text some model
 reads. When we touch one, we **re-read the whole block and judge it whole** — not the diff
-by itself. Compression improves in one direction only (改善 — steady, incremental
-improvement): each time we edit a block, it should say the same thing in fewer tokens, or
-say more in the same tokens. It should not collect extra clauses.
+by itself.
 
 **kaibo adopts kaish's `docs/style.md`** — that guide names kaibo as an adopter, and it is
 the source for *how* our prose reads: a small vocabulary, one word per concept, exact
@@ -229,11 +227,6 @@ strictly its rules apply to that file — and kaibo's files sort like this.
 | Terms only, one line per bullet | `CHANGELOG.md` |
 | Terms only | `README.md`, `docs/*.md` |
 | Exempt | `docs/devlog.md` — it tells the story from one person's view, and that needs a voice |
-
-**Compression and the reason clause do not conflict.** Keep the clause when a reader who
-knows the reason can predict what happens in a case the rule does not name. Cut it when it
-only repeats the rule in other words. When the source records no reason, state the rule
-alone rather than inventing one.
 
 **Error strings carry the Full weight above — every rule in the guide applies — and they
 are the most valuable prose we own.**
@@ -392,10 +385,10 @@ even for a one-line doc fix.
 - **A changelog bullet is one line: the change, and at most one clause of reason.** The
   full reasoning belongs in the pull request body, which becomes the merge commit, so the
   bullet does not carry it. If a bullet needs three numbers and three reasons, write three
-  bullets. **Entries get shorter over time**, the same one-way standard compression follows
-  in model-facing text: when you add an entry, shorten any entry near it that runs to a
-  paragraph, and shorten the whole unreleased section before you retitle it for a release.
-  Someone scanning for what changed should not have to read an argument.
+  bullets. **Entries get shorter over time.** When you add an entry, shorten any entry near
+  it that is longer than one line, and shorten the whole unreleased section before you
+  retitle it for a release. Someone scanning for what changed should not have to read the
+  reasoning behind it.
 - **Cutting a release.** Bump `version` in `Cargo.toml`, retitle the unreleased
   section to `## [X.Y.Z] — <date>` and open a fresh empty unreleased section above it,
   then tag `vX.Y.Z` — `.github/workflows/release.yml` builds the platform matrix on a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ loop. Each consultation tool is that loop wearing different clothes:
 Both model-driven tools name their cast + answering model(s) in a provenance footer
 (`with_provenance` in `server.rs`), so a cross-model study sees which model answered.
 
-Eight `--no-<tool>` capability flags gate the surface (all on by default; `consult` also
+A `--no-<tool>` capability flag per tool gates the surface (all on by default; `consult` also
 gates `consult_submit`, `batch` gates `batch_submit`, `generate` additionally needs the
 media CAS on, and the `job_*` verbs follow their live producers — a deferred `generate`
 mints a `job-N` like the other producers). A tool also needs a cast that can **staff**
@@ -86,13 +86,10 @@ project and cannot run external commands.
   so an edit is copy-on-write) and never mounted into kaish, whose read side would
   otherwise enumerate every project's artifacts. `tests/no_write_path.rs` blesses only
   individually **marked lines**, each pinned to its file *and to the specific call it
-  excuses*, at a *pinned exact count* — five today: the store's one `create_dir_all`, the
-  three needles the CAS's O_EXCL write trips, and `kaibo cas read` handing an artifact's
-  bytes to **stdout**, which creates no file (the shell already opened and aimed that
-  descriptor) but trips the same needle. A new write site can't ride in behind an existing
-  marker, and a marker can't excuse a call it wasn't blessed for — pasting the CLI's marker
-  onto an `fs::write` to a caller-named path still fails. Every other `std::fs` mutation in
-  `src/` fails the guard.
+  excuses*, with the tree-wide total pinned to an exact count. So a new write site cannot
+  ride in behind an existing marker, and a marker cannot excuse a call it was not blessed
+  for. That test is the source for which lines are blessed and how many; read it there
+  rather than restating it here. Every other `std::fs` mutation in `src/` fails the guard.
   Anything further that must *record* or *emit* is its own individually-gated mediated
   tool, never a general filesystem escape hatch or a loosening of the four levers.
   Read-*scope* is also bounded: every call's path must canonicalize (symlinks,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,24 @@ published sentence is not whether it names an internal detail, but whether the r
 that detail to predict what kaibo does. `src/server/dossier.rs` holds its whole design
 argument in the module doc and publishes none of it.
 
+**Rulings.** Each of these answers a question the first audit of this guidance could not
+settle from the guide alone (2026-08-07, `src/cli.rs`).
+
+- **A subcommand's one-line summary is imperative**, like an example label: it sits beside
+  the command name and says what running it does. "Ask one question and exit", not "A
+  one-shot question".
+- **The 2048-character budget is `server.rs`'s alone.** It is a host truncation of MCP
+  instructions and tool descriptions. `--help` has no such limit, so a `cli.rs` line that
+  needs a second sentence to state a default or a consequence gets one.
+- **Backticks are the only markdown in a clap doc comment.** clap prints the rest
+  literally, so `**bold**` reaches the reader as asterisks.
+- **A refusal fixable only in config.toml names the exact key, then `kaibo example-config`
+  for the shape.** The CLI caller is a person or an agent with file access; both can act on
+  a key name, and neither can act on "configure it properly". Name `kaibo configure` only
+  when the fix is multi-step setup rather than one key.
+- **`family` is a kaibo term** — a model lineage from one vendor, as in "a model outside
+  your own family". About forty uses, one sense. Use it; do not paraphrase it.
+
 Three audiences are optimized differently:
 
 - **Client-facing text** — the MCP server instructions and each tool's `description`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,10 +85,14 @@ project and cannot run external commands.
   parameter for a model to aim; it is write-only (`create_new`; no unlink/truncate/rename,
   so an edit is copy-on-write) and never mounted into kaish, whose read side would
   otherwise enumerate every project's artifacts. `tests/no_write_path.rs` blesses only
-  those two files' individually **marked lines**, at a *pinned exact count* — four today,
-  since the store's one `create_dir_all` plus the CAS's O_EXCL write trips three separate
-  needles — so a new write site can't ride in behind an existing marker without failing
-  that test. Every other `std::fs` mutation in `src/` still fails the guard.
+  individually **marked lines**, each pinned to its file *and to the specific call it
+  excuses*, at a *pinned exact count* — five today: the store's one `create_dir_all`, the
+  three needles the CAS's O_EXCL write trips, and `kaibo cas read` handing an artifact's
+  bytes to **stdout**, which creates no file (the shell already opened and aimed that
+  descriptor) but trips the same needle. A new write site can't ride in behind an existing
+  marker, and a marker can't excuse a call it wasn't blessed for — pasting the CLI's marker
+  onto an `fs::write` to a caller-named path still fails. Every other `std::fs` mutation in
+  `src/` fails the guard.
   Anything further that must *record* or *emit* is its own individually-gated mediated
   tool, never a general filesystem escape hatch or a loosening of the four levers.
   Read-*scope* is also bounded: every call's path must canonicalize (symlinks,
@@ -210,34 +214,45 @@ x86_64-unknown-linux-musl`. Verify the boundary with `cargo tree -i aws-lc-rs`
 ## Writing for models
 
 Every prompt, preamble, tool description, help line, and error string is text some model
-reads. When we touch one, we **re-read the whole block and judge it holistically** — not
-the diff in isolation. The ratchet is *compression* (改善): over time a block should carry
-more impact per token and avoid accreting clauses.
+reads. When we touch one, we **re-read the whole block and judge it whole** — not the diff
+by itself. Compression improves in one direction only (改善 — steady, incremental
+improvement): each time we edit a block, it should say the same thing in fewer tokens, or
+say more in the same tokens. It should not collect extra clauses.
 
 **kaibo adopts kaish's `docs/style.md`** — that guide names kaibo as an adopter, and it is
-the source for *how* our prose reads: a small vocabulary, one term per concept, exact
-numbers, the constraint before the hedge, and one clause of rationale after a rule. Read it
-before writing help text or operator docs. Its weights land on kaibo like this:
+the source for *how* our prose reads: a small vocabulary, one word per concept, exact
+numbers, the constraint stated before any qualifier, and one clause of reason after a rule.
+Read it before you write help text or operator docs. It sorts files by *weight* — how
+strictly its rules apply to that file — and kaibo's files sort like this.
 
 | Weight | kaibo files |
 |---|---|
 | Full | every tool `description` and schema param doc in `server.rs`; every clap `about`, arg doc, and `--help` line in `cli.rs`; **every error, refusal, and diagnostic string a tool or command returns** |
-| Partial — keep the terms and the published/internal boundary, relax the rest | preambles and the kaish cheatsheet (`consult/prompts.rs`, `kaish_syntax.rs`), and `///` on `pub` items |
+| Partial — keep the terms and the published/internal boundary; relax the rest | preambles and the kaish cheatsheet (`consult/prompts.rs`, `kaish_syntax.rs`), and `///` on `pub` items |
 | Terms only, one line per bullet | `CHANGELOG.md` |
 | Terms only | `README.md`, `docs/*.md` |
-| Exempt | `docs/devlog.md` — it tells the story from a point of view, and a story needs a voice |
+| Exempt | `docs/devlog.md` — it tells the story from one person's view, and that needs a voice |
 
-**Error strings are full weight, and they are the highest-value prose we own.** A model
-reads a refusal far more often than it reads a description, and the refusal arrives exactly
-when the reader is stuck. Name what was refused, why, and the way out — `save_artifact`'s
-`SaveError` and `deliberate`'s inert-argument refusal are the models to copy.
+**Compression and the reason clause do not conflict.** Keep the clause when a reader who
+knows the reason can predict what happens in a case the rule does not name. Cut it when it
+only repeats the rule in other words. When the source records no reason, state the rule
+alone rather than inventing one.
 
-**Comments: published and internal are different surfaces.** A tool `description`, a schema
-param doc, and a clap arg doc all ship to a model. A `///` on a private item, a `//` line,
-and a module doc-comment do not — that is where mechanism belongs. The test is not whether
-a sentence names an internal, but whether the reader needs that internal to predict
-behavior. `src/server/dossier.rs` keeps its whole design argument in the module doc and
-ships none of it.
+**Error strings carry the Full weight above — every rule in the guide applies — and they
+are the most valuable prose we own.**
+A model reads a refusal more often than it reads a description, and it reads one at the
+moment it is blocked — so a refusal changes what the model does next more reliably than any
+other text we write. Name three things: what was refused, why, and what to do instead.
+`SaveError` in `src/artifact.rs` and `inert_explorer_args` in `src/server/dossier.rs` are
+the two to copy.
+
+**Some text kaibo writes reaches a model; the rest never does.** *Published* means kaibo
+sends it to a model: a tool `description`, a schema param doc, a clap arg doc, a help topic, an
+error string. Everything else is internal — a `///` on a private item, a `//` line, a
+module doc-comment — and internal is where implementation detail belongs. The test for a
+published sentence is not whether it names an internal detail, but whether the reader needs
+that detail to predict what kaibo does. `src/server/dossier.rs` holds its whole design
+argument in the module doc and publishes none of it.
 
 Three audiences are optimized differently:
 
@@ -377,13 +392,13 @@ even for a one-line doc fix.
   Write what a *user* notices, not the file diff. Internal-only refactors need no entry —
   the git log is their record (mirrors the `docs/issues.md` "delete when shipped"
   discipline).
-- **A changelog bullet is one line: the rule, and one clause of why.** This is the one
-  place where "keep the why" does not win, because the full narrative already lives in the
-  pull request body, which becomes the merge commit. If a bullet needs three numbers and
-  three reasons, it is three bullets. **Terser over time** is a ratchet, like compression
-  in the model-facing text: when you add an entry, the paragraph-shaped ones nearby are
-  fair game to cut down, and a release is a good moment to sweep the section you are about
-  to retitle. A reader scanning for what changed should not have to read an argument.
+- **A changelog bullet is one line: the change, and at most one clause of reason.** The
+  full reasoning belongs in the pull request body, which becomes the merge commit, so the
+  bullet does not carry it. If a bullet needs three numbers and three reasons, write three
+  bullets. **Entries get shorter over time**, the same one-way standard compression follows
+  in model-facing text: when you add an entry, shorten any entry near it that runs to a
+  paragraph, and shorten the whole unreleased section before you retitle it for a release.
+  Someone scanning for what changed should not have to read an argument.
 - **Cutting a release.** Bump `version` in `Cargo.toml`, retitle the unreleased
   section to `## [X.Y.Z] — <date>` and open a fresh empty unreleased section above it,
   then tag `vX.Y.Z` — `.github/workflows/release.yml` builds the platform matrix on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,44 +17,25 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
-- **`kaibo generate` and `kaibo cas read`.** The CLI can now render an image into kaibo's
-  artifact store and read anything back out of it, which completes the MCP-to-CLI parity
-  sweep. `kaibo cas read <digest> > arch.png` gives you the bytes with no flag to
-  remember: metadata goes to stderr and content to stdout, text as text and binary as raw
-  bytes, because the bounded base64 rules the MCP tool follows exist to protect a model's
-  context window and a pipe has no such budget. `read` is the only verb — the store stays
-  opaque and index-free, so there is still no listing, usage report, or delete. A
-  deferred `generate` polls in the foreground rather than handing back a handle nothing
-  could collect.
-
-- **`kaibo deliberate` on the command line, and `kaibo batch cancel`.** Deliberate was
-  MCP-only for no recorded reason on its batch lane, and for a good one on its direct
-  lane (that lane's handle lives in the running server's memory, so a one-shot process
-  would submit, exit, and take the job with it — [#82](https://github.com/tobert/kaibo/issues/82)). Both are answered now. A batch
-  cast prints the durable handle and exits, so `HANDLE=$(kaibo deliberate …)` then
-  `kaibo batch get "$HANDLE"` works across reboots; a direct cast runs the long local
-  completion in the foreground and prints the answer, telling you on stderr that it is
-  waiting. `--dossier` reuses a kept dossier with no sweep — including one built over
-  MCP, since both front doors share the same store. And the CLI could submit and list
-  batches but never stop one; `kaibo batch cancel <handle>` closes that, wording the
-  result as the request it is, since a provider finishes what is already in flight.
-
-- **`deliberate` keeps its dossier, and can reuse one.** The explorer sweep a
-  deliberation is built on is the expensive half — it can run hundreds of thousands
-  of tokens — and it used to be consumed invisibly: no way to see what the offline
-  synth actually reasoned over, and no way to ask a second model the same question
-  without paying for the sweep again. kaibo now stores the finished dossier in its
-  media CAS and names it in the reply (and in the answer when the deliberation
-  lands), so you can `read_cas` it. Pass that digest back as `dossier` and no
-  explorer runs at all: the same evidence goes to whichever cast you point at, for
-  the price of one synth — which is also the fair way to compare two synths, since
-  only the model differs. Any stored text artifact can serve as a dossier, not only
-  one `deliberate` wrote. It rides the CAS's own switch (`[cas] enabled`) with no
-  new key to turn on, a store that refuses the write costs you the record and never
-  the deliberation, and the explorer arguments (`attach`, the explorer overrides,
-  `explorer_max_turns`) are refused on a reuse call rather than silently ignored.
-  Batch deliberations now persist their handle too, with the dossier's address on
-  it, so `job_list` still leads back to the evidence after a restart.
+- **`deliberate` keeps its dossier, and `--dossier` reuses one.** The explorer sweep is
+  the expensive half of a deliberation, so it is now stored and addressable — read it back
+  with `read_cas`, or hand the digest to a second cast to reason over the same evidence for
+  the price of one synth. Rides `[cas] enabled`; no new key.
+- **A refused dossier write never fails the deliberation** — you lose the record, not the
+  answer.
+- **Batch deliberations persist their handle**, labelled with the dossier's address, so
+  `job_list` leads back to the evidence after a restart.
+- **`kaibo deliberate` on the command line.** A batch cast prints the durable handle and
+  exits (`HANDLE=$(kaibo deliberate …)`, then `kaibo batch get "$HANDLE"`); a direct cast
+  runs the long local completion in the foreground and prints the answer, because a
+  one-shot process has no server to hold a job open ([#82](https://github.com/tobert/kaibo/issues/82)).
+- **`kaibo batch cancel <handle>`** — the CLI could submit and list but never stop. The
+  wording says "requested", because a provider finishes what is already in flight.
+- **`kaibo generate`** renders into the artifact store; a deferred render polls in the
+  foreground rather than returning a handle nothing could collect.
+- **`kaibo cas read <digest>`** reads an artifact back: metadata to stderr, content to
+  stdout — text as text, binary as raw bytes, so `> arch.png` needs no flag. `read` is the
+  only verb; the store keeps no index, so there is no listing, usage report, or delete.
 
 - **kaibo warns when the media CAS is on a disk that will not survive the
   container.** A container with no volume mounted looks exactly like durable disk


### PR DESCRIPTION
kaish's `docs/style.md` states that *"kaibo and kaish-extras adopt this guide by reference as they evolve"* — but nothing in kaibo points at it, so the adoption is invisible from inside this repo. That's how I wrote 25 lines of design argument into a config reference yesterday, and why Amy had to catch it by reading the diff.

Amy: *"I want to work style.md into kaibo's CLAUDE.md focusing on help, externally-facing prose, and comments."*

## What lands

Names the guide as the source for **how** our prose reads, then maps its weights onto kaibo's own files:

| Weight | kaibo files |
|---|---|
| Full | tool `description`s and schema param docs; every clap `about`, arg doc, and `--help` line; **every error, refusal, and diagnostic string** |
| Partial | preambles, the kaish cheatsheet, `///` on `pub` items |
| Terms only, one line per bullet | `CHANGELOG.md` |
| Terms only | `README.md`, `docs/*.md` |
| Exempt | `docs/devlog.md` — it tells the story from a point of view, and a story needs a voice |

Three things the guide implies that kaibo had never written down:

- **Error strings are the highest-value prose we own.** A model reads a refusal far more often than a description, and it arrives exactly when the reader is stuck.
- **Published and internal are different surfaces.** A tool description and a clap arg doc ship to a model; a `///` on a private item does not, and that's where mechanism belongs. The test isn't whether a sentence names an internal — it's whether the reader needs it to predict behavior.
- **Rationale in operator docs stops at the clause after the dash.** The argument goes in the devlog; the story goes in the PR.

The operator-docs and agent-facing bullets shed the general rules they now duplicate, keeping only what's specific to kaibo (the 2048-char host truncation, the non-English-first synth roster, the template-vs-guide split).

## The changelog ratchet

New guidance, and the part with a ratchet: **one line per bullet — the rule, and one clause of why.** The narrative already lives in the PR body that becomes the merge commit. Terser over time: nearby paragraph-shaped entries are fair game whenever you add one, and a release is a good moment to sweep the section you're about to retitle.

Applied to today's three entries, which were exactly the shape it rules out — **39 lines → 22**, three paragraphs → eight scannable bullets. A reader scanning for what changed shouldn't have to read an argument.

Full suite green (docs only; `config.md`/`config.example.toml` are unchanged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)