### PR TITLE
Re-draw a turn the provider could not parse, below the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,8 +263,8 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
-- **One malformed tool call no longer discards the investigation** — kaibo asks the model
-  for that turn again, twice, before failing the call.
+- **One malformed tool call no longer discards the investigation** — kaibo sends that
+  request twice more before failing the call.
 - **A consultation that produced no answer no longer comes back as a successful empty
   one.** A reasoning model's final turn can carry reasoning but no answer text, and
   kaibo would dress that empty string in a provenance footer and return it as success —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,8 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **One malformed tool call no longer discards the investigation** — kaibo asks the model
+  for that turn again, twice, before failing the call.
 - **A consultation that produced no answer no longer comes back as a successful empty
   one.** A reasoning model's final turn can carry reasoning but no answer text, and
   kaibo would dress that empty string in a provenance footer and return it as success —

--- a/README.md
+++ b/README.md
@@ -684,11 +684,9 @@ named as such rather than blamed on the provider. If a provider is reliably slow
 that backend's `request_timeout_secs`. (Automatic retry/backoff belongs in the HTTP layer
 — tracked as an upstream `rig` contribution in [`docs/issues.md`](docs/issues.md).)
 
-One failure *is* repeated, because it isn't a transport failure at all: when the provider
-could not parse the tool call the model generated (Gemini's `MALFORMED_FUNCTION_CALL`),
-kaibo asks the model for that turn again, 2 more draws on the same request. A fumbled
-tool call then costs one extra call rather than the whole investigation. See
-[`docs/config.md`](docs/config.md), "Failure policy".
+One exception: when a provider cannot parse the tool call a model generated, kaibo asks
+that model for the turn twice more — otherwise a single fumbled tool call discards the
+whole investigation.
 
 **What's the cost?** `consult` spends tokens on the provider behind the chosen cast,
 so the cast is what decides. A DeepSeek-class team is inexpensive enough to reach for

--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ Telemetry is off by default and, when on, only opens an *outbound* OTLP connecti
 you configure.
 
 **What happens if a provider is overloaded or down (a 429/529, a reset, a wedged
-backend)?** kaibo does **not** retry — a single completion is bounded by the backend's
+backend)?** kaibo does **not** back off and retry — a single completion is bounded by the backend's
 `request_timeout` (default 15 min, the wall-clock for one model call) and a ≤10s
 `connect_timeout` that fails a dead endpoint fast. When a provider fails, the consult
 returns a **clean tool-result error** (`is_error`) naming the cast and the underlying
@@ -683,6 +683,12 @@ error (auth, bad request) doesn't, since a retry won't help; and a kaibo-side fa
 named as such rather than blamed on the provider. If a provider is reliably slow, raise
 that backend's `request_timeout_secs`. (Automatic retry/backoff belongs in the HTTP layer
 — tracked as an upstream `rig` contribution in [`docs/issues.md`](docs/issues.md).)
+
+One failure *is* repeated, because it isn't a transport failure at all: when the provider
+could not parse the tool call the model generated (Gemini's `MALFORMED_FUNCTION_CALL`),
+kaibo asks the model for that turn again, 2 more draws on the same request. A fumbled
+tool call then costs one extra call rather than the whole investigation. See
+[`docs/config.md`](docs/config.md), "Failure policy".
 
 **What's the cost?** `consult` spends tokens on the provider behind the chosen cast,
 so the cast is what decides. A DeepSeek-class team is inexpensive enough to reach for

--- a/docs/config.md
+++ b/docs/config.md
@@ -172,41 +172,25 @@ because a slow local model legitimately wants a longer leash than a hosted API.
 A non-streaming call cannot distinguish *wedged* from *slow but working*, so keep the
 value above your slowest legitimate single completion.
 
-#### Failure policy: one re-draw, no backoff
+#### Failure policy: no knobs
 
-kaibo repeats a provider call for exactly one reason: the provider could not parse the
-tool call the model generated. Gemini reports it as `MALFORMED_FUNCTION_CALL`, and it is
-a fumbled turn rather than a rejected request, so kaibo asks the model for that turn
-again — 2 more draws, no delay between them, on the same request. A single fumble then
-costs one extra call instead of the whole investigation. There is no knob; the bound is a
-constant (`MALFORMED_REDRAWS`).
+There is nothing to set here. kaibo has no `max_retries` and no backoff setting, so an
+overload, a rate limit, a connection reset, or a backend that hit `request_timeout` all
+fail the call. `consult`/`oneshot` return that as a clean tool-result error (`is_error`)
+naming the cast, the underlying detail, and what to do next — the text is specific to the
+failure, so it is the thing to act on.
 
-Every other failure fails the single completion. There is no backoff and no `max_retries`
-knob. A 429/503/529 overload, a connection reset, a partial stream, or a backend that
-hits `request_timeout` all fail the call, and `consult`/`oneshot` surface that as a clean
-tool-result error (`is_error`) naming the cast and the underlying detail.
+The reasoning: a consult is an *optional* augmentation, so the calling agent should
+proceed without the second opinion or call again, rather than have its own tool call fail
+at the protocol layer.
 
-The reasoning: a consult is an *optional* augmentation. The calling agent should read
-the failure and proceed without the second opinion, or call again, rather than have its
-own tool call fail at the protocol layer.
+One exception, also with no setting: when a provider cannot parse the tool call a model
+generated, kaibo asks that model for the turn twice more before failing — otherwise a
+single fumbled tool call discards the whole investigation.
 
-Failures are classified so the caller can pick a next step:
-
-| class | examples | retry advice |
-|---|---|---|
-| transient | overload, rate limit, timeout, connection reset | a manual retry may succeed |
-| malformed generation | the provider could not parse the model's tool call | the re-draws are spent; retry, or use a cast from another family |
-| empty answer | the model ran and returned no answer text | retry; a different cast often helps |
-| non-transient | auth failure, bad request | fix the config or the call |
-| kaibo-side | named as such | not a provider problem |
-
-Classification is a heuristic over the provider's error *vocabulary*, not the HTTP
-status, because rig surfaces the response body rather than the code. For a reliably slow
-backend, raise its `request_timeout_secs`. Automatic retry and backoff belong in the
-shared HTTP layer — rig ships an `ExponentialBackoff` wired only into its streaming path
-today — and landing it for the non-streaming completion path is tracked as an upstream
-contribution in `docs/issues.md`. That is a transport concern and stays separate from the
-re-draw above, which answers a model fumble.
+The one setting that helps a slow backend is `request_timeout_secs`, above. Automatic
+retry and backoff belong in the shared HTTP layer, and landing them there is tracked as
+an upstream rig contribution in `docs/issues.md`.
 
 ### Casts: `[casts.<name>]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -172,13 +172,19 @@ because a slow local model legitimately wants a longer leash than a hosted API.
 A non-streaming call cannot distinguish *wedged* from *slow but working*, so keep the
 value above your slowest legitimate single completion.
 
-#### Failure policy: no retry
+#### Failure policy: one re-draw, no backoff
 
-kaibo does not retry a failed provider call. There is no backoff and no `max_retries`
+kaibo repeats a provider call for exactly one reason: the provider could not parse the
+tool call the model generated. Gemini reports it as `MALFORMED_FUNCTION_CALL`, and it is
+a fumbled turn rather than a rejected request, so kaibo asks the model for that turn
+again — 2 more draws, no delay between them, on the same request. A single fumble then
+costs one extra call instead of the whole investigation. There is no knob; the bound is a
+constant (`MALFORMED_REDRAWS`).
+
+Every other failure fails the single completion. There is no backoff and no `max_retries`
 knob. A 429/503/529 overload, a connection reset, a partial stream, or a backend that
-hits `request_timeout` all fail the single completion, and `consult`/`oneshot` surface
-that as a clean tool-result error (`is_error`) naming the cast and the underlying
-detail.
+hits `request_timeout` all fail the call, and `consult`/`oneshot` surface that as a clean
+tool-result error (`is_error`) naming the cast and the underlying detail.
 
 The reasoning: a consult is an *optional* augmentation. The calling agent should read
 the failure and proceed without the second opinion, or call again, rather than have its
@@ -189,6 +195,8 @@ Failures are classified so the caller can pick a next step:
 | class | examples | retry advice |
 |---|---|---|
 | transient | overload, rate limit, timeout, connection reset | a manual retry may succeed |
+| malformed generation | the provider could not parse the model's tool call | the re-draws are spent; retry, or use a cast from another family |
+| empty answer | the model ran and returned no answer text | retry; a different cast often helps |
 | non-transient | auth failure, bad request | fix the config or the call |
 | kaibo-side | named as such | not a provider problem |
 
@@ -197,7 +205,8 @@ status, because rig surfaces the response body rather than the code. For a relia
 backend, raise its `request_timeout_secs`. Automatic retry and backoff belong in the
 shared HTTP layer — rig ships an `ExponentialBackoff` wired only into its streaming path
 today — and landing it for the non-streaming completion path is tracked as an upstream
-contribution in `docs/issues.md`.
+contribution in `docs/issues.md`. That is a transport concern and stays separate from the
+re-draw above, which answers a model fumble.
 
 ### Casts: `[casts.<name>]`
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,46 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-09 — the turn kaibo could not retry, and where the transcript actually goes
+
+The bug read like a policy problem and turned out to be a plumbing problem. A Gemini Flash
+explorer, deep into a `deliberate`, emitted one empty function call. Gemini answered
+`MALFORMED_FUNCTION_CALL`, the phase died, and kaibo told the caller "retrying is unlikely
+to help" — which was both wrong and expensive, because everything the explorer had read up
+to that point went with it.
+
+I went in expecting to add a retry to `run_phase` and came out having learned why that
+would not have worked. rig's agent loop hands the transcript back on the two failures kaibo
+already recovers from — `MaxTurnsError` and `PromptCancelled` both carry a `chat_history`,
+which is exactly why the turn-cap finalize and the `view_image` break can resume. A
+completion *error* carries nothing. `AgentRunner::run_model_turn` yields it straight out of
+the driver stream, `PromptError::CompletionError` has no history field, and by the time
+kaibo sees it the turns are gone. So "retry the phase" could only ever mean "pay for the
+whole investigation again to get back to where we just were" — the thing the issue was
+complaining about, spelled differently.
+
+The fix had to sit *below* the loop, and kaibo already had the shape for it. `Watched`
+wraps the model to observe each completion; `Retried` wraps it to repeat one. At that
+level the request still holds the entire transcript, so a re-draw loses nothing, and rig
+never learns the first draw happened — which also means the re-draw spends none of its turn
+budget. Two extra draws, no delay between them. The no-delay part is deliberate and is the
+whole boundary against the retry/backoff work we keep declining to hand-roll: a fumbled
+tool call and a 429 want opposite treatments, and the moment this grew a sleep it would
+have become the transport retry by accident.
+
+The part I spent longest on was what *not* to match. The OpenAI family has a near neighbor
+("Response did not contain a valid message or tool call") that plausibly belongs, and
+Gemini has a worse one — `MissingThoughtSignature`, which if it fires because a replayed
+history dropped a signature, fires on every draw, so retrying it would burn three calls on
+every single call rather than rescuing anything. Both stayed out, named in the module doc,
+waiting on a live probe. Guessing here costs real money on a failure path.
+
+Then the advice string, which is the half a caller actually reads. It now says kaibo
+already asked the model for that turn two more times — because a caller who doesn't know
+that will keep retrying by hand, and a caller who does knows to switch families instead.
+The number comes from the const rather than the prose, so the sentence cannot quietly
+become a lie.
+
 ## 2026-08-07 — finishing the CLI, and what a front door is allowed to be
 
 Amy, looking at the morning's work: *"hm did we ever say why deliberate isn't on the cli?

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -33,10 +33,10 @@ whole investigation again to get back to where we just were" — the thing the i
 complaining about, spelled differently.
 
 The fix had to sit *below* the loop, and kaibo already had the shape for it. `Watched`
-wraps the model to observe each completion; `Retried` wraps it to repeat one. At that
-level the request still holds the entire transcript, so a re-draw loses nothing, and rig
-never learns the first draw happened — which also means the re-draw spends none of its turn
-budget. Two extra draws, no delay between them. The no-delay part is deliberate and is the
+wraps the model to observe each completion; `Retried` wraps it to send one again. At that
+level the request still holds the entire transcript, so a retry loses nothing, and rig
+never learns the first attempt happened — which also means the retry spends none of its
+turn budget. Two further attempts, sent at once. Sending at once is deliberate and is the
 whole boundary against the retry/backoff work we keep declining to hand-roll: a fumbled
 tool call and a 429 want opposite treatments, and the moment this grew a sleep it would
 have become the transport retry by accident.
@@ -44,15 +44,31 @@ have become the transport retry by accident.
 The part I spent longest on was what *not* to match. The OpenAI family has a near neighbor
 ("Response did not contain a valid message or tool call") that plausibly belongs, and
 Gemini has a worse one — `MissingThoughtSignature`, which if it fires because a replayed
-history dropped a signature, fires on every draw, so retrying it would burn three calls on
-every single call rather than rescuing anything. Both stayed out, named in the module doc,
+history dropped a signature, fires on every attempt, so retrying it would burn three
+requests on every single call rather than rescuing anything. Both stayed out, named in the module doc,
 waiting on a live probe. Guessing here costs real money on a failure path.
 
 Then the advice string, which is the half a caller actually reads. It now says kaibo
-already asked the model for that turn two more times — because a caller who doesn't know
-that will keep retrying by hand, and a caller who does knows to switch families instead.
-The number comes from the const rather than the prose, so the sentence cannot quietly
-become a lie.
+already sent that request two more times and the model repeated the mistake — because a
+caller who doesn't know that will keep retrying by hand, and a caller who does knows to
+switch families instead. The number comes from the const rather than the prose, so the
+sentence cannot quietly become a lie.
+
+Two things came back from review and both were about words, not code. Amy on the config
+guide: *"config.md help needs to be clearer / easier to read. Do configurers need to know
+all that?"* — no, they did not. The section leads with "there is nothing to set here" now,
+and the failure-class table is gone: every row restated what the error string already says
+at the moment of failure, and it had already drifted out of date once. The page cannot beat
+the message kaibo speaks live, so it points at it.
+
+And on the word I had used everywhere — *"we say 'redraw', it's not clear what that
+means. I think you mean we make another request. is it specific to image models?"* Right on
+both counts. It was sampling jargon, and in a repo that generates images it collides with
+the thing `generate` actually does. It also broke our own "subset, not slang" rule at the
+place that rule bites hardest, since most of our synths are not English-first. So the whole
+vocabulary is plain now: kaibo *sends the same request again*, the noun is a *retry*, and
+the constant is `MALFORMED_RETRIES` — which also settles what the number counts, because
+"retries" says "after the first" and "redraws" never did.
 
 ## 2026-08-07 — finishing the CLI, and what a front door is allowed to be
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -282,7 +282,7 @@ kaish-vfs read API.
 ### Upstream a retry/backoff for rig's non-streaming completion path
 The provider failure *policy* is now stated, audited, and documented (README FAQ +
 `docs/config.md`, shipped): kaibo does **no** transport retry — the one repeated call is
-the re-draw of a malformed generation (`src/completion_retry.rs`), a model fumble rather
+the retry of a malformed generation (`src/completion_retry.rs`), a model fumble rather
 than an overload. One completion is bounded by the
 backend `request_timeout`/`connect_timeout`, and a provider failure surfaces as a clean
 **tool-result error** (`is_error`, `server.rs::consultation_failed`) the host can proceed

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -281,7 +281,9 @@ kaish-vfs read API.
 
 ### Upstream a retry/backoff for rig's non-streaming completion path
 The provider failure *policy* is now stated, audited, and documented (README FAQ +
-`docs/config.md`, shipped): kaibo does **no** retry; one completion is bounded by the
+`docs/config.md`, shipped): kaibo does **no** transport retry — the one repeated call is
+the re-draw of a malformed generation (`src/completion_retry.rs`), a model fumble rather
+than an overload. One completion is bounded by the
 backend `request_timeout`/`connect_timeout`, and a provider failure surfaces as a clean
 **tool-result error** (`is_error`, `server.rs::consultation_failed`) the host can proceed
 past rather than an opaque `internal_error`. What's left is the *mechanism* we chose not
@@ -306,20 +308,6 @@ longer *mislabelled* — but the cleaner fix is to spawn the driver's kernel in 
 *before* the `consult()` call (the way `orientation` already does) and map a spawn failure
 to `McpError::internal_error`, matching `run_kaish`. Low priority (kernel build is
 in-process and reliable); the classification covers the user-facing symptom today.
-
-### Turn-level retry on a malformed tool call (transient generation glitch)
-A single `MalformedFunctionCall` from a provider fails the whole phase, discarding an
-in-flight dossier/investigation — observed live: a Gemini Flash explorer died mid-
-`deliberate` emitting an *empty* function call. That's a generation glitch (the model
-fumbled one tool call), not a schema/content rejection, so the current
-`consultation_failed` advice — "retrying is unlikely to help" — is wrong for this class.
-Fix: a **bounded turn-level re-prompt (1–2 attempts)** before failing the phase, plus
-split the failure classification so a malformed-tool-call/generation glitch steers toward
-retry while a genuine schema/content rejection keeps the don't-bother advice. Seams:
-`run_phase` (`consult/engine.rs`) for the re-prompt, `render.rs::classify_failure` for the
-advice split. Distinct from the upstream rig retry/backoff entry above — that's transport-
-level 429/503 backoff; this is a mid-loop model fumble kaibo can re-prompt around itself.
-Surfaced by the DeepSeek CLI-subcommands review (2026-07-17).
 
 ### Empty answers keep happening — the guard is a backstop, not a cure
 The empty-answer guard shipped 2026-08-02 (#115, meeting #116's finish_reason plumbing and

--- a/src/completion_retry.rs
+++ b/src/completion_retry.rs
@@ -1,4 +1,4 @@
-//! One re-draw when the provider could not parse what the model generated.
+//! One retry when the provider could not parse what the model generated.
 //!
 //! There is a failure class that looks like a hard error and is really a coin that
 //! landed wrong: the model fumbled a single tool call, the provider refused to shape
@@ -16,22 +16,23 @@
 //! becomes carries **no `chat_history`** — unlike `MaxTurnsError` and
 //! `PromptCancelled`, which hand the transcript back and are exactly why kaibo can
 //! recover from a turn cap or a `view_image` break. So by the time this failure
-//! reaches [`crate::consult::run_phase`], the turns are already gone and a "retry"
+//! reaches [`crate::consult::run_phase`], the turns are already gone and a retry
 //! there could only mean re-running the phase from the first prompt: paying for the
 //! whole investigation again to reach the state we just lost. `CompletionModel` is a
-//! trait, so wrapping the model puts the re-draw *underneath* the loop, where the
+//! trait, so wrapping the model puts the retry *underneath* the loop, where the
 //! request still holds the entire transcript and rig never learns anything went
 //! wrong. [`crate::completion_watch::Watched`] is the same seam used for observation;
-//! this is its acting sibling, and it is the only thing in kaibo that repeats a
-//! provider call.
+//! this is its acting sibling, and it is the only thing in kaibo that sends a provider
+//! request twice.
 //!
-//! **Bounded, immediate, and not backoff.** [`MALFORMED_REDRAWS`] extra draws, then
-//! the error goes up as before. There is no delay between them and there must not be:
-//! a re-draw answers "the model fumbled", where a 429/503 answers "the provider is
-//! busy", and the two want opposite treatments. kaibo still does not retry a
-//! rate-limited or overloaded call — that is a transport concern tracked as an
-//! upstream rig contribution in `docs/issues.md`. The re-draw also spends none of
-//! rig's turn budget, since rig never sees the failed attempt.
+//! **What is retried, and why that is not backoff.** This retries *the model's turn*:
+//! [`MALFORMED_RETRIES`] further attempts, each sending the identical request with no
+//! wait between them, and then the error goes up as before. Sending at once is the
+//! point — the provider is not busy, one generation came out wrong, and the next
+//! sampling of the same request is a fresh chance at it. Waiting is what a *transport*
+//! failure wants, and kaibo still does not retry a rate-limited or overloaded call at
+//! all; that is tracked as an upstream rig contribution in `docs/issues.md`. The retry
+//! also spends none of rig's turn budget, since rig never sees the failed attempt.
 //!
 //! **Detection is a heuristic on the error text**, by the same necessity as
 //! `server/render.rs::classify_failure`: the reason arrives inside a formatted
@@ -42,18 +43,18 @@
 //! also means "unparseable generation", but nothing yet says whether it is a fumble
 //! or a refusal, and a wrong guess spends three calls on every refusal. Gemini's
 //! `MissingThoughtSignature` is worse: if it fires because a replayed history dropped
-//! a signature, it fires on every draw, so retrying it burns the budget on every call
-//! rather than rescuing anything. Add either one on evidence from a live probe.
+//! a signature, it fires on every attempt, so retrying it burns the budget on every
+//! call rather than rescuing anything. Add either one on evidence from a live probe.
 
 use rig_core::completion::{
     CompletionError, CompletionModel, CompletionRequest, CompletionResponse,
 };
 
-/// Extra draws one turn gets when the provider could not parse the generation, on top
-/// of the first. Two, so a turn sees three draws in the worst case: one glitch is the
-/// observed shape, a second in a row is unlucky, and a third says the request itself
-/// is the problem and the phase should fail with it.
-pub const MALFORMED_REDRAWS: usize = 2;
+/// Attempts a turn gets *after* the first, when the provider could not parse the
+/// generation. Two, so a turn costs at most three requests: one glitch is the observed
+/// shape, a second in a row is unlucky, and a third says the request itself is the
+/// problem and the phase should fail with it.
+pub const MALFORMED_RETRIES: usize = 2;
 
 /// The spellings a provider uses when it could not parse the model's tool call or the
 /// response around it, lowercased. Confirmed against the vendored rig-core 0.41
@@ -77,8 +78,8 @@ const MALFORMED_MARKERS: &[&str] = &[
 
 /// True when an error text says the provider could not parse what the model
 /// generated. Shared with `server/render.rs::classify_failure` so one vocabulary
-/// decides both the re-draw and the advice a caller finally reads — a marker added
-/// here reaches both.
+/// decides both the retry and the advice a caller finally reads — a marker added here
+/// reaches both.
 pub fn is_malformed_generation(error_text: &str) -> bool {
     let text = error_text.to_lowercase();
     MALFORMED_MARKERS.iter().any(|marker| text.contains(marker))
@@ -93,27 +94,27 @@ pub fn is_malformed_generation(error_text: &str) -> bool {
 pub struct Retried<M> {
     inner: M,
     /// The model id, for the warn event — a count of these per model is the whole
-    /// point of making the re-draw observable.
+    /// point of making the retry observable.
     model: String,
-    redraws: usize,
+    retries: usize,
 }
 
 impl<M> Retried<M> {
-    /// Wrap `model` so a malformed generation gets `redraws` further attempts.
-    pub fn new(model: M, name: impl Into<String>, redraws: usize) -> Self {
+    /// Wrap `model` so a malformed generation gets `retries` further attempts.
+    pub fn new(model: M, name: impl Into<String>, retries: usize) -> Self {
         Self {
             inner: model,
             model: name.into(),
-            redraws,
+            retries,
         }
     }
 }
 
-/// Wrap a completion model so a malformed generation is re-drawn [`MALFORMED_REDRAWS`]
-/// times — the drop-in at a phase's model call site, mirroring
+/// Wrap a completion model so a malformed generation is sent again
+/// [`MALFORMED_RETRIES`] times — the drop-in at a phase's model call site, mirroring
 /// [`watched`](crate::completion_watch::watched).
 pub fn retried<M: CompletionModel>(model: M, name: &str) -> Retried<M> {
-    Retried::new(model, name, MALFORMED_REDRAWS)
+    Retried::new(model, name, MALFORMED_RETRIES)
 }
 
 impl<M: CompletionModel> CompletionModel for Retried<M> {
@@ -135,22 +136,22 @@ impl<M: CompletionModel> CompletionModel for Retried<M> {
         &self,
         request: CompletionRequest,
     ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
-        for attempt in 1..=self.redraws {
+        for attempt in 1..=self.retries {
             match self.inner.completion(request.clone()).await {
                 Err(error) if is_malformed_generation(&error.to_string()) => {
                     tracing::warn!(
                         model = %self.model,
                         attempt,
-                        redraws = self.redraws,
+                        retries = self.retries,
                         %error,
-                        "the provider could not parse this turn's tool call — asking \
-                         the model to generate the turn again"
+                        "the provider could not parse this turn's tool call — sending \
+                         the same request again"
                     );
                 }
                 outcome => return outcome,
             }
         }
-        // The last draw, un-cloned: a further malformed generation is the phase's
+        // The last attempt, un-cloned: a further malformed generation is the phase's
         // failure now, and it goes up carrying the provider's own words.
         self.inner.completion(request).await
     }
@@ -213,11 +214,11 @@ mod tests {
         )
     }
 
-    /// A scripted model that fails its first `fail_first` draws with `error`, then
+    /// A scripted model that fails its first `fail_first` attempts with `error`, then
     /// answers. The counter is the one thing a content-driven responder cannot
-    /// express: a re-draw sends a **byte-identical** request, so attempt 1 and
-    /// attempt 2 differ in nothing but their order. Counting is therefore the
-    /// behavior under test, not a shortcut around the harness's design.
+    /// express: a retry sends a **byte-identical** request, so attempt 1 and attempt 2
+    /// differ in nothing but their order. Counting is therefore the behavior under
+    /// test, not a shortcut around the harness's design.
     fn flaky_model(
         fail_first: usize,
         error: impl Fn() -> CompletionError + Send + Sync + 'static,
@@ -225,8 +226,8 @@ mod tests {
         super::Retried<crate::test_support::ScriptedModel>,
         Arc<AtomicUsize>,
     ) {
-        let draws = Arc::new(AtomicUsize::new(0));
-        let seen = draws.clone();
+        let sent = Arc::new(AtomicUsize::new(0));
+        let seen = sent.clone();
         let client = ScriptedClient::builder()
             .on_model("m", move |_req| {
                 if seen.fetch_add(1, Ordering::SeqCst) < fail_first {
@@ -236,41 +237,41 @@ mod tests {
                 }
             })
             .build();
-        (retried(client.completion_model("m"), "m"), draws)
+        (retried(client.completion_model("m"), "m"), sent)
     }
 
-    /// The whole point: one malformed generation costs a second draw, not the turn.
+    /// The whole point: one malformed generation costs a second request, not the turn.
     #[tokio::test]
-    async fn a_malformed_generation_is_drawn_again_and_the_second_draw_answers() {
-        let (model, draws) = flaky_model(1, gemini_malformed);
-        let response = model.completion(req()).await.expect("the re-draw answers");
+    async fn a_malformed_generation_is_sent_again_and_the_second_attempt_answers() {
+        let (model, sent) = flaky_model(1, gemini_malformed);
+        let response = model.completion(req()).await.expect("the retry answers");
         assert_eq!(
-            draws.load(Ordering::SeqCst),
+            sent.load(Ordering::SeqCst),
             2,
-            "one glitch costs exactly one extra draw"
+            "one glitch costs exactly one extra request"
         );
         assert!(
             matches!(
                 response.choice.first(),
                 rig_core::completion::message::AssistantContent::Text(_)
             ),
-            "the caller gets the second draw's answer"
+            "the caller gets the second attempt's answer"
         );
     }
 
-    /// Bounded. A provider that fumbles every draw fails the turn after
-    /// [`MALFORMED_REDRAWS`] extra attempts, carrying its own words up.
+    /// Bounded. A provider that fumbles every attempt fails the turn after
+    /// [`MALFORMED_RETRIES`] further requests, carrying its own words up.
     #[tokio::test]
-    async fn re_drawing_stops_at_the_bound_and_the_provider_error_survives() {
-        let (model, draws) = flaky_model(usize::MAX, gemini_malformed);
+    async fn retrying_stops_at_the_bound_and_the_provider_error_survives() {
+        let (model, sent) = flaky_model(usize::MAX, gemini_malformed);
         let error = model
             .completion(req())
             .await
             .expect_err("a provider that always fumbles must still fail");
         assert_eq!(
-            draws.load(Ordering::SeqCst),
-            MALFORMED_REDRAWS + 1,
-            "the first draw plus MALFORMED_REDRAWS, and no more"
+            sent.load(Ordering::SeqCst),
+            MALFORMED_RETRIES + 1,
+            "the first request plus MALFORMED_RETRIES, and no more"
         );
         assert!(
             error.to_string().contains("MalformedFunctionCall"),
@@ -278,17 +279,17 @@ mod tests {
         );
     }
 
-    /// Every other failure passes straight through on the first draw. A rejected
-    /// request is not a coin that landed wrong, and asking again would spend a
+    /// Every other failure passes straight through on the first attempt. A rejected
+    /// request is not a coin that landed wrong, and sending it again would spend a
     /// caller's money to be refused twice more.
     #[tokio::test]
-    async fn a_rejected_request_is_never_drawn_again() {
-        let (model, draws) = flaky_model(usize::MAX, || provider_error("invalid_request_error"));
+    async fn a_rejected_request_is_never_sent_again() {
+        let (model, sent) = flaky_model(usize::MAX, || provider_error("invalid_request_error"));
         let error = model.completion(req()).await.expect_err("rejected");
         assert_eq!(
-            draws.load(Ordering::SeqCst),
+            sent.load(Ordering::SeqCst),
             1,
-            "a rejection costs one draw, not three"
+            "a rejection costs one request, not three"
         );
         assert!(error.to_string().contains("invalid_request_error"));
     }
@@ -319,17 +320,17 @@ mod tests {
         ] {
             assert!(
                 !is_malformed_generation(text),
-                "only a malformed generation is re-drawn: {text}"
+                "only a malformed generation is sent again: {text}"
             );
         }
     }
 
-    /// A re-draw sends the same request the failed draw sent — the transcript is what
+    /// A retry sends the same request the failed attempt sent — the transcript is what
     /// makes this recovery worth having, so losing it would defeat the module.
     #[tokio::test]
-    async fn a_re_draw_carries_the_same_request() {
-        let draws = Arc::new(AtomicUsize::new(0));
-        let seen = draws.clone();
+    async fn a_retry_sends_the_identical_request() {
+        let sent = Arc::new(AtomicUsize::new(0));
+        let seen = sent.clone();
         let client = ScriptedClient::builder()
             .on_model("m", move |_req| {
                 if seen.fetch_add(1, Ordering::SeqCst) < 1 {
@@ -348,17 +349,14 @@ mod tests {
             Message::assistant("a partial investigation"),
         ])
         .expect("two messages");
-        model
-            .completion(request)
-            .await
-            .expect("the re-draw answers");
+        model.completion(request).await.expect("the retry answers");
 
         let asked = client.requests_for("m");
-        assert_eq!(asked.len(), 2, "two draws were recorded");
+        assert_eq!(asked.len(), 2, "two requests were recorded");
         assert_eq!(
             serde_json::to_value(&asked[0].raw).unwrap_or(Value::Null),
             serde_json::to_value(&asked[1].raw).unwrap_or(Value::Null),
-            "the re-draw is the same request, transcript and all"
+            "the retry is the same request, transcript and all"
         );
     }
 }

--- a/src/completion_retry.rs
+++ b/src/completion_retry.rs
@@ -1,0 +1,364 @@
+//! One re-draw when the provider could not parse what the model generated.
+//!
+//! There is a failure class that looks like a hard error and is really a coin that
+//! landed wrong: the model fumbled a single tool call, the provider refused to shape
+//! the response, and the request that produced it is still perfectly good. Gemini
+//! names it `finishReason: MALFORMED_FUNCTION_CALL`, and rig-core 0.41 turns that into
+//! a `CompletionError::ResponseError("Gemini stopped with finish_reason=
+//! MalformedFunctionCall: …")` while parsing the response
+//! (`providers/gemini/completion.rs`, `function_call_finish_reason_error`). Observed
+//! live: a Gemini Flash explorer died on one empty function call twenty turns into a
+//! `deliberate`, and the whole investigation went with it.
+//!
+//! **Why this wraps the model instead of catching the error in the loop.** rig-agent
+//! yields a completion failure straight out of its driver stream
+//! (`agent/runner.rs::run_model_turn`), and the `PromptError::CompletionError` it
+//! becomes carries **no `chat_history`** — unlike `MaxTurnsError` and
+//! `PromptCancelled`, which hand the transcript back and are exactly why kaibo can
+//! recover from a turn cap or a `view_image` break. So by the time this failure
+//! reaches [`crate::consult::run_phase`], the turns are already gone and a "retry"
+//! there could only mean re-running the phase from the first prompt: paying for the
+//! whole investigation again to reach the state we just lost. `CompletionModel` is a
+//! trait, so wrapping the model puts the re-draw *underneath* the loop, where the
+//! request still holds the entire transcript and rig never learns anything went
+//! wrong. [`crate::completion_watch::Watched`] is the same seam used for observation;
+//! this is its acting sibling, and it is the only thing in kaibo that repeats a
+//! provider call.
+//!
+//! **Bounded, immediate, and not backoff.** [`MALFORMED_REDRAWS`] extra draws, then
+//! the error goes up as before. There is no delay between them and there must not be:
+//! a re-draw answers "the model fumbled", where a 429/503 answers "the provider is
+//! busy", and the two want opposite treatments. kaibo still does not retry a
+//! rate-limited or overloaded call — that is a transport concern tracked as an
+//! upstream rig contribution in `docs/issues.md`. The re-draw also spends none of
+//! rig's turn budget, since rig never sees the failed attempt.
+//!
+//! **Detection is a heuristic on the error text**, by the same necessity as
+//! `server/render.rs::classify_failure`: the reason arrives inside a formatted
+//! message rather than as a typed variant, so [`is_malformed_generation`] matches the
+//! spellings providers ship. Two neighbors were considered and deliberately left out.
+//! The OpenAI-family "Response did not contain a valid message or tool call"
+//! (`providers/openai/completion/mod.rs`, `deepseek.rs`, `openrouter/completion.rs`)
+//! also means "unparseable generation", but nothing yet says whether it is a fumble
+//! or a refusal, and a wrong guess spends three calls on every refusal. Gemini's
+//! `MissingThoughtSignature` is worse: if it fires because a replayed history dropped
+//! a signature, it fires on every draw, so retrying it burns the budget on every call
+//! rather than rescuing anything. Add either one on evidence from a live probe.
+
+use rig_core::completion::{
+    CompletionError, CompletionModel, CompletionRequest, CompletionResponse,
+};
+
+/// Extra draws one turn gets when the provider could not parse the generation, on top
+/// of the first. Two, so a turn sees three draws in the worst case: one glitch is the
+/// observed shape, a second in a row is unlucky, and a third says the request itself
+/// is the problem and the phase should fail with it.
+pub const MALFORMED_REDRAWS: usize = 2;
+
+/// The spellings a provider uses when it could not parse the model's tool call or the
+/// response around it, lowercased. Confirmed against the vendored rig-core 0.41
+/// sources rather than guessed:
+///
+/// - `malformedfunctioncall` / `malformedresponse` — the `{reason:?}` Debug spelling
+///   rig formats into `CompletionError::ResponseError`
+///   (`providers/gemini/completion.rs::function_call_finish_reason_error`). This is
+///   the one kaibo has seen in the wild.
+/// - `malformed_function_call` / `malformed_response` — Gemini's own
+///   `SCREAMING_SNAKE_CASE` wire values, which a gateway may forward verbatim.
+/// - `malformed function call` — Gemini's `finishMessage` prose ("malformed function
+///   call: default_api"), which a gateway may forward without the reason beside it.
+const MALFORMED_MARKERS: &[&str] = &[
+    "malformedfunctioncall",
+    "malformed_function_call",
+    "malformed function call",
+    "malformedresponse",
+    "malformed_response",
+];
+
+/// True when an error text says the provider could not parse what the model
+/// generated. Shared with `server/render.rs::classify_failure` so one vocabulary
+/// decides both the re-draw and the advice a caller finally reads — a marker added
+/// here reaches both.
+pub fn is_malformed_generation(error_text: &str) -> bool {
+    let text = error_text.to_lowercase();
+    MALFORMED_MARKERS.iter().any(|marker| text.contains(marker))
+}
+
+/// A completion model that asks again, up to a bound, when the provider could not
+/// parse the generation — and forwards every other outcome untouched.
+///
+/// Transparent on every path that is not a malformed generation: the response, the
+/// usage, the `raw_response`, and each other error are the inner model's own.
+#[derive(Clone, Debug)]
+pub struct Retried<M> {
+    inner: M,
+    /// The model id, for the warn event — a count of these per model is the whole
+    /// point of making the re-draw observable.
+    model: String,
+    redraws: usize,
+}
+
+impl<M> Retried<M> {
+    /// Wrap `model` so a malformed generation gets `redraws` further attempts.
+    pub fn new(model: M, name: impl Into<String>, redraws: usize) -> Self {
+        Self {
+            inner: model,
+            model: name.into(),
+            redraws,
+        }
+    }
+}
+
+/// Wrap a completion model so a malformed generation is re-drawn [`MALFORMED_REDRAWS`]
+/// times — the drop-in at a phase's model call site, mirroring
+/// [`watched`](crate::completion_watch::watched).
+pub fn retried<M: CompletionModel>(model: M, name: &str) -> Retried<M> {
+    Retried::new(model, name, MALFORMED_REDRAWS)
+}
+
+impl<M: CompletionModel> CompletionModel for Retried<M> {
+    type Response = M::Response;
+    type StreamingResponse = M::StreamingResponse;
+    type Client = M::Client;
+
+    /// Unreachable, and loudly so — the same contract
+    /// [`Watched::make`](crate::completion_watch::Watched) holds. `make` is only ever
+    /// called through `CompletionClient::completion_model`, and no client's
+    /// `CompletionModel` is a `Retried`; kaibo always wraps an already-built model
+    /// with [`retried`]. Building one here would have to invent a model name and a
+    /// bound nobody chose.
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        unreachable!("Retried is built by `retried(model, name)`, never by CompletionModel::make")
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        for attempt in 1..=self.redraws {
+            match self.inner.completion(request.clone()).await {
+                Err(error) if is_malformed_generation(&error.to_string()) => {
+                    tracing::warn!(
+                        model = %self.model,
+                        attempt,
+                        redraws = self.redraws,
+                        %error,
+                        "the provider could not parse this turn's tool call — asking \
+                         the model to generate the turn again"
+                    );
+                }
+                outcome => return outcome,
+            }
+        }
+        // The last draw, un-cloned: a further malformed generation is the phase's
+        // failure now, and it goes up carrying the provider's own words.
+        self.inner.completion(request).await
+    }
+
+    /// Forwarded verbatim. kaibo drives the non-streaming loop, and a streamed
+    /// malformed call arrives as a stream event rather than a failed call — a
+    /// different job than this one.
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<
+        rig_core::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
+        CompletionError,
+    > {
+        self.inner.stream(request).await
+    }
+
+    /// Forwarded: this is a provider capability, and the wrapper must not change what
+    /// rig believes the model can do.
+    fn composes_native_output_with_tools(&self) -> bool {
+        self.inner.composes_native_output_with_tools()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{provider_error, response_error, text_response, ScriptedClient};
+    use rig_core::client::CompletionClient;
+    use rig_core::completion::message::Message;
+    use rig_core::OneOrMany;
+    use serde_json::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// A one-turn request, the shape rig's agent builds for a toolless call.
+    fn req() -> CompletionRequest {
+        CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(Message::user("q")),
+            documents: Vec::new(),
+            tools: Vec::new(),
+            temperature: None,
+            max_tokens: Some(64),
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+            record_telemetry_content: false,
+        }
+    }
+
+    /// The exact text rig-core 0.41 produces for the failure this module exists for:
+    /// `function_call_finish_reason_error` formats the Debug reason and the provider's
+    /// finish message into a `ResponseError`.
+    fn gemini_malformed() -> CompletionError {
+        response_error(
+            "Gemini stopped with finish_reason=MalformedFunctionCall: malformed \
+             function call: default_api",
+        )
+    }
+
+    /// A scripted model that fails its first `fail_first` draws with `error`, then
+    /// answers. The counter is the one thing a content-driven responder cannot
+    /// express: a re-draw sends a **byte-identical** request, so attempt 1 and
+    /// attempt 2 differ in nothing but their order. Counting is therefore the
+    /// behavior under test, not a shortcut around the harness's design.
+    fn flaky_model(
+        fail_first: usize,
+        error: impl Fn() -> CompletionError + Send + Sync + 'static,
+    ) -> (
+        super::Retried<crate::test_support::ScriptedModel>,
+        Arc<AtomicUsize>,
+    ) {
+        let draws = Arc::new(AtomicUsize::new(0));
+        let seen = draws.clone();
+        let client = ScriptedClient::builder()
+            .on_model("m", move |_req| {
+                if seen.fetch_add(1, Ordering::SeqCst) < fail_first {
+                    Err(error())
+                } else {
+                    Ok(text_response("ANSWER"))
+                }
+            })
+            .build();
+        (retried(client.completion_model("m"), "m"), draws)
+    }
+
+    /// The whole point: one malformed generation costs a second draw, not the turn.
+    #[tokio::test]
+    async fn a_malformed_generation_is_drawn_again_and_the_second_draw_answers() {
+        let (model, draws) = flaky_model(1, gemini_malformed);
+        let response = model.completion(req()).await.expect("the re-draw answers");
+        assert_eq!(
+            draws.load(Ordering::SeqCst),
+            2,
+            "one glitch costs exactly one extra draw"
+        );
+        assert!(
+            matches!(
+                response.choice.first(),
+                rig_core::completion::message::AssistantContent::Text(_)
+            ),
+            "the caller gets the second draw's answer"
+        );
+    }
+
+    /// Bounded. A provider that fumbles every draw fails the turn after
+    /// [`MALFORMED_REDRAWS`] extra attempts, carrying its own words up.
+    #[tokio::test]
+    async fn re_drawing_stops_at_the_bound_and_the_provider_error_survives() {
+        let (model, draws) = flaky_model(usize::MAX, gemini_malformed);
+        let error = model
+            .completion(req())
+            .await
+            .expect_err("a provider that always fumbles must still fail");
+        assert_eq!(
+            draws.load(Ordering::SeqCst),
+            MALFORMED_REDRAWS + 1,
+            "the first draw plus MALFORMED_REDRAWS, and no more"
+        );
+        assert!(
+            error.to_string().contains("MalformedFunctionCall"),
+            "the provider's own words reach the caller: {error}"
+        );
+    }
+
+    /// Every other failure passes straight through on the first draw. A rejected
+    /// request is not a coin that landed wrong, and asking again would spend a
+    /// caller's money to be refused twice more.
+    #[tokio::test]
+    async fn a_rejected_request_is_never_drawn_again() {
+        let (model, draws) = flaky_model(usize::MAX, || provider_error("invalid_request_error"));
+        let error = model.completion(req()).await.expect_err("rejected");
+        assert_eq!(
+            draws.load(Ordering::SeqCst),
+            1,
+            "a rejection costs one draw, not three"
+        );
+        assert!(error.to_string().contains("invalid_request_error"));
+    }
+
+    /// The vocabulary, across the spellings rig-core 0.41 and Gemini's wire actually
+    /// produce — and the neighbors that must stay out of it.
+    #[test]
+    fn the_vocabulary_covers_the_shipped_spellings_and_no_more() {
+        for text in [
+            "ResponseError: Gemini stopped with finish_reason=MalformedFunctionCall: \
+             malformed function call: default_api",
+            "ResponseError: Gemini stopped with finish_reason=MalformedResponse: \
+             malformed response from provider",
+            "ProviderError: {\"finishReason\":\"MALFORMED_FUNCTION_CALL\"}",
+            "ProviderError: {\"finishReason\":\"MALFORMED_RESPONSE\"}",
+        ] {
+            assert!(
+                is_malformed_generation(text),
+                "a malformed generation must be recognized: {text}"
+            );
+        }
+        for text in [
+            "ProviderError: {\"type\":\"overloaded_error\"}",
+            "ProviderError: invalid_request_error",
+            "ResponseError: Response did not contain a valid message or tool call",
+            "ResponseError: Gemini stopped with finish_reason=MissingThoughtSignature: none",
+            "HttpError: error sending request: operation timed out",
+        ] {
+            assert!(
+                !is_malformed_generation(text),
+                "only a malformed generation is re-drawn: {text}"
+            );
+        }
+    }
+
+    /// A re-draw sends the same request the failed draw sent — the transcript is what
+    /// makes this recovery worth having, so losing it would defeat the module.
+    #[tokio::test]
+    async fn a_re_draw_carries_the_same_request() {
+        let draws = Arc::new(AtomicUsize::new(0));
+        let seen = draws.clone();
+        let client = ScriptedClient::builder()
+            .on_model("m", move |_req| {
+                if seen.fetch_add(1, Ordering::SeqCst) < 1 {
+                    Err(response_error(
+                        "Gemini stopped with finish_reason=MalformedFunctionCall: x",
+                    ))
+                } else {
+                    Ok(text_response("ANSWER"))
+                }
+            })
+            .build();
+        let model = retried(client.completion_model("m"), "m");
+        let mut request = req();
+        request.chat_history = OneOrMany::many([
+            Message::user("the question"),
+            Message::assistant("a partial investigation"),
+        ])
+        .expect("two messages");
+        model
+            .completion(request)
+            .await
+            .expect("the re-draw answers");
+
+        let asked = client.requests_for("m");
+        assert_eq!(asked.len(), 2, "two draws were recorded");
+        assert_eq!(
+            serde_json::to_value(&asked[0].raw).unwrap_or(Value::Null),
+            serde_json::to_value(&asked[1].raw).unwrap_or(Value::Null),
+            "the re-draw is the same request, transcript and all"
+        );
+    }
+}

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -1048,11 +1048,11 @@ where
         tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
     }
     let result = run_phase_loop(
-        // Two wrappers, innermost first: [`retried`] re-draws a turn the provider could
-        // not parse, then [`watched`] records the response that finally came back. A
-        // failed draw produces no response, so the log holds one record per turn either
-        // way — the order is about who resolves the failure, and the re-draw must resolve
-        // it below the loop, which loses the transcript on a completion error
+        // Two wrappers, innermost first: [`retried`] sends a turn the provider could not
+        // parse again, then [`watched`] records the response that finally came back. A
+        // failed attempt produces no response, so the log holds one record per turn either
+        // way — the order is about who resolves the failure, and the retry must resolve it
+        // below the loop, which loses the transcript on a completion error
         // (`crate::completion_retry`).
         &watched(retried(model.clone(), model_name), log.clone()),
         log,
@@ -1445,7 +1445,7 @@ where
     }
     // Same two wrappers the loop uses: a single-shot lane declares no tools, so it
     // cannot fumble a tool call, but a provider that could not shape the response
-    // (`MalformedResponse`) reaches here too and is worth the same re-draw.
+    // (`MalformedResponse`) reaches here too and is worth the same retry.
     let mut builder = watched(retried(model.clone(), model_name), log.clone())
         .completion_request(prompt)
         .preamble(preamble.to_string())
@@ -2927,21 +2927,21 @@ mod tests {
         );
     }
 
-    /// A malformed tool call mid-loop costs one extra draw, not the investigation.
+    /// A malformed tool call mid-loop costs one extra request, not the investigation.
     ///
     /// The live shape (a Gemini Flash explorer inside a `deliberate`): the model
     /// fumbles one function call, the provider refuses to shape the response, and rig
     /// hands back a `PromptError::CompletionError` carrying **no transcript** — so a
-    /// phase-level retry could only start over from the first prompt. The re-draw
-    /// lives under the loop ([`crate::completion_retry`]), where the request still
-    /// holds every turn. The proof that the investigation survived is in the third
-    /// request: it still carries the tool result the first two draws were built on,
-    /// and the answer is written from it.
+    /// phase-level retry could only start over from the first prompt. The retry lives
+    /// under the loop ([`crate::completion_retry`]), where the request still holds every
+    /// turn. The proof that the investigation survived is in the third request: it still
+    /// carries the tool result the first two attempts were built on, and the answer is
+    /// written from it.
     #[tokio::test]
-    async fn a_malformed_tool_call_mid_loop_is_re_drawn_and_the_investigation_survives() {
+    async fn a_malformed_tool_call_mid_loop_is_retried_and_the_investigation_survives() {
         use std::sync::atomic::AtomicBool;
         const MODEL: &str = "driver";
-        // A re-draw sends a byte-identical request, so "first draw of this turn" is
+        // A retry sends a byte-identical request, so "first attempt at this turn" is
         // not something a content-driven responder can read off the request — the
         // ordering IS the behavior under test. The flag is scoped to the one turn the
         // content predicate already selected.
@@ -2994,7 +2994,7 @@ mod tests {
         assert_eq!(
             asked.len(),
             3,
-            "the tool turn, the fumbled draw, and the re-draw: {:?}",
+            "the tool turn, the fumbled attempt, and the retry: {:?}",
             asked
                 .iter()
                 .map(|r| r.transcript.clone())
@@ -3002,7 +3002,7 @@ mod tests {
         );
         assert!(
             asked[2].transcript.contains("EVIDENCE"),
-            "the re-draw carries the gathered evidence, not a fresh start: {:?}",
+            "the retry carries the gathered evidence, not a fresh start: {:?}",
             asked[2].transcript
         );
     }

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -28,6 +28,7 @@ use serde_json::{json, Value};
 
 use crate::artifact::SaveArtifact;
 use crate::attach::Attachment;
+use crate::completion_retry::retried;
 use crate::completion_watch::{watched, CompletionLog, Watched};
 use crate::config::{Backend, Defaults, ModelRole, ModelSlot};
 use crate::credentials::WireKind;
@@ -1047,7 +1048,13 @@ where
         tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
     }
     let result = run_phase_loop(
-        &watched(model.clone(), log.clone()),
+        // Two wrappers, innermost first: [`retried`] re-draws a turn the provider could
+        // not parse, then [`watched`] records the response that finally came back. A
+        // failed draw produces no response, so the log holds one record per turn either
+        // way — the order is about who resolves the failure, and the re-draw must resolve
+        // it below the loop, which loses the transcript on a completion error
+        // (`crate::completion_retry`).
+        &watched(retried(model.clone(), model_name), log.clone()),
         log,
         model_name,
         preamble,
@@ -1436,7 +1443,10 @@ where
     if let Some(t) = thinking {
         tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
     }
-    let mut builder = watched(model.clone(), log.clone())
+    // Same two wrappers the loop uses: a single-shot lane declares no tools, so it
+    // cannot fumble a tool call, but a provider that could not shape the response
+    // (`MalformedResponse`) reaches here too and is worth the same re-draw.
+    let mut builder = watched(retried(model.clone(), model_name), log.clone())
         .completion_request(prompt)
         .preamble(preamble.to_string())
         .max_tokens(max_tokens);
@@ -2914,6 +2924,86 @@ mod tests {
             log.last_finish_reason().as_deref(),
             Some("end_turn"),
             "the phase's ending is one call away"
+        );
+    }
+
+    /// A malformed tool call mid-loop costs one extra draw, not the investigation.
+    ///
+    /// The live shape (a Gemini Flash explorer inside a `deliberate`): the model
+    /// fumbles one function call, the provider refuses to shape the response, and rig
+    /// hands back a `PromptError::CompletionError` carrying **no transcript** — so a
+    /// phase-level retry could only start over from the first prompt. The re-draw
+    /// lives under the loop ([`crate::completion_retry`]), where the request still
+    /// holds every turn. The proof that the investigation survived is in the third
+    /// request: it still carries the tool result the first two draws were built on,
+    /// and the answer is written from it.
+    #[tokio::test]
+    async fn a_malformed_tool_call_mid_loop_is_re_drawn_and_the_investigation_survives() {
+        use std::sync::atomic::AtomicBool;
+        const MODEL: &str = "driver";
+        // A re-draw sends a byte-identical request, so "first draw of this turn" is
+        // not something a content-driven responder can read off the request — the
+        // ordering IS the behavior under test. The flag is scoped to the one turn the
+        // content predicate already selected.
+        let fumbled = Arc::new(AtomicBool::new(false));
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, move |req| {
+                if !transcript_text(req).contains("EVIDENCE") {
+                    return Ok(tool_call_response(
+                        "c1",
+                        "run_kaish",
+                        json!({"script": "echo EVIDENCE"}),
+                    ));
+                }
+                if !fumbled.swap(true, Ordering::SeqCst) {
+                    return Err(crate::test_support::response_error(
+                        "Gemini stopped with finish_reason=MalformedFunctionCall: \
+                         malformed function call: default_api",
+                    ));
+                }
+                Ok(text_response("ANSWER: built on EVIDENCE"))
+            })
+            .build();
+
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let model = client.completion_model(MODEL);
+        let (answer, _usage) = run_phase(
+            &model,
+            MODEL,
+            "answer the question",
+            16384,
+            None,
+            Message::user("q"),
+            4,
+            None,
+            &crate::progress::NullSink,
+            || {
+                Ok(vec![traced(RunKaish::new(KaishWorker::spawn_with(
+                    &root,
+                    SandboxConfig::default(),
+                )?))])
+            },
+            false,
+        )
+        .await
+        .expect("one malformed tool call must not fail the phase");
+
+        assert_eq!(answer, "ANSWER: built on EVIDENCE");
+        let asked = client.requests_for(MODEL);
+        assert_eq!(
+            asked.len(),
+            3,
+            "the tool turn, the fumbled draw, and the re-draw: {:?}",
+            asked
+                .iter()
+                .map(|r| r.transcript.clone())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            asked[2].transcript.contains("EVIDENCE"),
+            "the re-draw carries the gathered evidence, not a fresh start: {:?}",
+            asked[2].transcript
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod attach;
 pub mod batch;
 pub mod cas;
 pub mod cli;
+pub mod completion_retry;
 pub mod completion_watch;
 pub mod config;
 pub mod consult;

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -47,6 +47,12 @@ enum FailureKind {
     TransientProvider,
     /// A non-transient model/provider error (auth, bad request). Retrying won't help.
     Provider,
+    /// The provider could not parse what the model generated — a malformed tool call,
+    /// or a response it could not shape. A fumble rather than a rejection, so it must
+    /// not inherit [`Provider`]'s "retrying is unlikely to help": kaibo has already
+    /// re-drawn the turn (`completion_retry::MALFORMED_REDRAWS`) and a fresh call gets
+    /// a fresh draw.
+    MalformedGeneration,
     /// A model ran and delivered no answer text (`consult/engine.rs::empty_answer_error`,
     /// or the forced write-up turn's own failure wrapper). A model-side outcome that the
     /// guard's diagnostics already frame as retryable — distinct from [`Provider`], whose
@@ -82,8 +88,9 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
     // The empty-answer guard's marker (`empty_answer_error` and the forced-turn failure
     // wrapper, `consult/engine.rs`). An empty answer definitionally means a model ran, so
     // it counts toward `reached_a_model`; its own classification is decided *after* the
-    // transient vocabulary below, so a forced write-up turn that died on an overload is
-    // framed transient (the more specific retry guidance) rather than generically empty.
+    // malformed and transient vocabularies below, so a forced write-up turn that died on a
+    // fumbled tool call or an overload is framed by the more specific diagnosis rather than
+    // generically empty.
     let empty_answer = s.contains("returned an empty answer");
     let reached_a_model = s.contains("model loop failed")
         || s.contains("model call failed")
@@ -91,6 +98,15 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
         || empty_answer;
     if !reached_a_model {
         return FailureKind::Internal;
+    }
+    // The provider could not parse the model's own output. Decided before the
+    // transient list because it is the more specific diagnosis and both point the
+    // caller at another call — a finish message carrying "try again" would otherwise
+    // flatten a fumble into a generic overload. The vocabulary lives in
+    // `completion_retry`, beside the re-draw that already spent its attempts on this
+    // error, so one list decides both.
+    if crate::completion_retry::is_malformed_generation(&s) {
+        return FailureKind::MalformedGeneration;
     }
     // Transient vocabulary across Anthropic / Gemini / OpenAI / DeepSeek bodies and the
     // transport layer (reqwest timeouts/resets from our own `request_timeout`).
@@ -125,12 +141,13 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
 /// augmentation: the calling agent should read a clear message and proceed *without* the
 /// second opinion — not have its own tool call fail at the JSON-RPC layer. The framing is
 /// tailored by [`classify_failure`] so the agent can drive the right next step: a
-/// transient overload/timeout invites a manual retry (kaibo does **not** retry on its own
-/// — one completion is bounded by the backend's `request_timeout`/`connect_timeout`; see
-/// the failure-policy FAQ and `docs/config.md`), a non-transient provider error doesn't,
-/// and a kaibo-side failure is named honestly rather than blamed on the provider. Setup
-/// errors *before* the model call — unknown cast, an attachment outside the boundary, a
-/// missing key — stay `McpError`, since those are the caller's to fix.
+/// transient overload/timeout invites a manual retry (kaibo does **not** back off and
+/// retry — one completion is bounded by the backend's `request_timeout`/`connect_timeout`;
+/// see the failure-policy FAQ and `docs/config.md`), a non-transient provider error
+/// doesn't, a malformed generation says the re-draws ([`crate::completion_retry`]) are
+/// already spent, and a kaibo-side failure is named honestly rather than blamed on the
+/// provider. Setup errors *before* the model call — unknown cast, an attachment outside
+/// the boundary, a missing key — stay `McpError`, since those are the caller's to fix.
 pub(super) fn consultation_failed(tool: &str, cast: &str, err: anyhow::Error) -> CallToolResult {
     CallToolResult::error(vec![ContentBlock::text(consultation_failure_text(
         tool, cast, err,
@@ -198,16 +215,27 @@ pub(crate) fn consult_answer_text(
 /// unified `job_get` wrap it without re-classifying.
 pub(crate) fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> String {
     let detail = format!("{err:#}");
+    // Built before the match, not inside it, so the other four arms stay `&'static str`:
+    // this one states the exact number of re-draws kaibo already spent, and that number is
+    // a const one edit away from making a fixed string a lie.
+    let malformed = format!(
+        "The provider could not parse a tool call this model generated — the model \
+         fumbled one turn, and the request itself is fine. kaibo already asked the model \
+         for that turn {} more times and got the same result, so retry this call, or run \
+         it on a cast from a different family.",
+        crate::completion_retry::MALFORMED_REDRAWS
+    );
     let guidance = match classify_failure(&err) {
         FailureKind::TransientProvider => {
             "This looks like a transient provider condition (overload, rate limit, or \
-             timeout). kaibo does not retry automatically — you may retry this call, or \
+             timeout). kaibo does not back off and retry — you may retry this call, or \
              proceed without the consultation."
         }
         FailureKind::Provider => {
             "The model or its provider rejected the request; retrying is unlikely to help \
              — proceed without the consultation, or check the cast and config."
         }
+        FailureKind::MalformedGeneration => &malformed,
         FailureKind::EmptyAnswer => {
             "The model ran but delivered no answer text — a model-side outcome, not a \
              kaibo bug. You may retry, and a different cast often helps; if the \
@@ -852,6 +880,46 @@ mod tests {
                 && !text.to_lowercase().contains("retry this call"),
             "a non-transient error must not invite a retry: {text}"
         );
+    }
+
+    /// A malformed generation is a fumble, not a rejection, so it must not inherit the
+    /// non-transient "retrying is unlikely to help" advice. kaibo has already re-drawn
+    /// the turn twice by the time this text is written
+    /// (`completion_retry::MALFORMED_REDRAWS`), so what remains for the caller is a
+    /// fresh call or another cast — and the advice must say which. (Live repro: a
+    /// Gemini Flash explorer emitted one empty function call mid-`deliberate` and the
+    /// whole investigation was discarded with "retrying is unlikely to help".)
+    #[test]
+    fn a_malformed_generation_steers_toward_a_retry_not_away_from_one() {
+        for body in [
+            // The tool loop, which is where it was seen.
+            "model loop failed: CompletionError: ResponseError: Gemini stopped with \
+             finish_reason=MalformedFunctionCall: malformed function call: default_api",
+            // A gateway forwarding the wire spelling instead of rig's Debug one.
+            "model loop failed: ProviderError: {\"finishReason\":\"MALFORMED_FUNCTION_CALL\"}",
+            // The single-shot direct lane wears its own marker.
+            "model call failed: ResponseError: Gemini stopped with \
+             finish_reason=MalformedResponse: malformed response from provider",
+        ] {
+            let text = answer_text(&consultation_failed(
+                "consult",
+                "gemini",
+                anyhow::anyhow!(body),
+            ));
+            let lower = text.to_lowercase();
+            assert!(
+                !lower.contains("retrying is unlikely to help"),
+                "a fumbled tool call is worth another call: {body} -> {text}"
+            );
+            assert!(
+                lower.contains("retry"),
+                "the advice must name the next step: {body} -> {text}"
+            );
+            assert!(
+                !lower.contains("kaibo-side error") && !lower.contains("please report"),
+                "a model fumble is not a kaibo bug: {body} -> {text}"
+            );
+        }
     }
 
     /// An empty-answer failure (`consult/engine.rs::empty_answer_error`) means a model

--- a/src/server/render.rs
+++ b/src/server/render.rs
@@ -50,8 +50,8 @@ enum FailureKind {
     /// The provider could not parse what the model generated — a malformed tool call,
     /// or a response it could not shape. A fumble rather than a rejection, so it must
     /// not inherit [`Provider`]'s "retrying is unlikely to help": kaibo has already
-    /// re-drawn the turn (`completion_retry::MALFORMED_REDRAWS`) and a fresh call gets
-    /// a fresh draw.
+    /// sent that request again (`completion_retry::MALFORMED_RETRIES`) and a fresh call
+    /// gets a fresh generation.
     MalformedGeneration,
     /// A model ran and delivered no answer text (`consult/engine.rs::empty_answer_error`,
     /// or the forced write-up turn's own failure wrapper). A model-side outcome that the
@@ -103,7 +103,7 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
     // transient list because it is the more specific diagnosis and both point the
     // caller at another call — a finish message carrying "try again" would otherwise
     // flatten a fumble into a generic overload. The vocabulary lives in
-    // `completion_retry`, beside the re-draw that already spent its attempts on this
+    // `completion_retry`, beside the retry that already spent its attempts on this
     // error, so one list decides both.
     if crate::completion_retry::is_malformed_generation(&s) {
         return FailureKind::MalformedGeneration;
@@ -144,7 +144,7 @@ fn classify_failure(err: &anyhow::Error) -> FailureKind {
 /// transient overload/timeout invites a manual retry (kaibo does **not** back off and
 /// retry — one completion is bounded by the backend's `request_timeout`/`connect_timeout`;
 /// see the failure-policy FAQ and `docs/config.md`), a non-transient provider error
-/// doesn't, a malformed generation says the re-draws ([`crate::completion_retry`]) are
+/// doesn't, a malformed generation says the retries ([`crate::completion_retry`]) are
 /// already spent, and a kaibo-side failure is named honestly rather than blamed on the
 /// provider. Setup errors *before* the model call — unknown cast, an attachment outside
 /// the boundary, a missing key — stay `McpError`, since those are the caller's to fix.
@@ -216,14 +216,14 @@ pub(crate) fn consult_answer_text(
 pub(crate) fn consultation_failure_text(tool: &str, cast: &str, err: anyhow::Error) -> String {
     let detail = format!("{err:#}");
     // Built before the match, not inside it, so the other four arms stay `&'static str`:
-    // this one states the exact number of re-draws kaibo already spent, and that number is
+    // this one states the exact number of retries kaibo already spent, and that number is
     // a const one edit away from making a fixed string a lie.
     let malformed = format!(
         "The provider could not parse a tool call this model generated — the model \
-         fumbled one turn, and the request itself is fine. kaibo already asked the model \
-         for that turn {} more times and got the same result, so retry this call, or run \
-         it on a cast from a different family.",
-        crate::completion_retry::MALFORMED_REDRAWS
+         fumbled one turn, and the request itself is fine. kaibo already sent that \
+         request {} more times and the model repeated the mistake, so retry this call, \
+         or run it on a cast from a different family.",
+        crate::completion_retry::MALFORMED_RETRIES
     );
     let guidance = match classify_failure(&err) {
         FailureKind::TransientProvider => {
@@ -883,9 +883,9 @@ mod tests {
     }
 
     /// A malformed generation is a fumble, not a rejection, so it must not inherit the
-    /// non-transient "retrying is unlikely to help" advice. kaibo has already re-drawn
-    /// the turn twice by the time this text is written
-    /// (`completion_retry::MALFORMED_REDRAWS`), so what remains for the caller is a
+    /// non-transient "retrying is unlikely to help" advice. kaibo has already sent that
+    /// request twice more by the time this text is written
+    /// (`completion_retry::MALFORMED_RETRIES`), so what remains for the caller is a
     /// fresh call or another cast — and the advice must say which. (Live repro: a
     /// Gemini Flash explorer emitted one empty function call mid-`deliberate` and the
     /// whole investigation was discarded with "retrying is unlikely to help".)

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -424,6 +424,16 @@ pub fn provider_error(msg: impl Into<String>) -> CompletionError {
     CompletionError::ProviderError(msg.into())
 }
 
+/// A **response-parse** error — what rig returns when the provider answered but rig
+/// could not turn the answer into a turn. Gemini's malformed function call arrives
+/// this way (`providers/gemini/completion.rs::function_call_finish_reason_error`), so
+/// this is how a test drives [`Retried`](crate::completion_retry::Retried) and the
+/// malformed-generation classification. Distinct from [`provider_error`], which is the
+/// provider's own error body.
+pub fn response_error(msg: impl Into<String>) -> CompletionError {
+    CompletionError::ResponseError(msg.into())
+}
+
 // ---- request accessors -----------------------------------------------------
 
 /// Concatenated text of every `User` message in the request history, oldest→newest,


### PR DESCRIPTION
A single `MalformedFunctionCall` failed the whole phase and discarded the in-flight
investigation, and `consultation_failed` told the caller *"retrying is unlikely to
help"* — wrong for this class. Observed live: a Gemini Flash explorer emitted one
empty function call mid-`deliberate`. Closes the P2 tracker entry "Turn-level retry on
a malformed tool call".

## How the error actually surfaces through rig

This decided the shape, so it is worth recording.

- **Gemini → rig-core.** `finishReason: MALFORMED_FUNCTION_CALL` becomes
  `CompletionError::ResponseError("Gemini stopped with
  finish_reason=MalformedFunctionCall: …")`, raised while *parsing* the response
  (`providers/gemini/completion.rs::function_call_finish_reason_error`, rig-core 0.41).
  Its siblings are `MalformedResponse`, `UnexpectedToolCall`, `MissingThoughtSignature`,
  `TooManyToolCalls`.
- **rig-core → rig-agent.** `AgentRunner::run_model_turn` (`agent/runner.rs`) yields the
  failed `send()` straight out of the driver stream; `run()` maps it to
  `PromptError::CompletionError`.
- **The finding that matters: the transcript is gone.** `PromptError::MaxTurnsError` and
  `PromptError::PromptCancelled` both carry a `chat_history` — which is exactly why
  kaibo can already recover from a turn cap and a `view_image` break.
  `PromptError::CompletionError` carries **nothing**. So by the time `run_phase` sees
  it, every turn of the investigation is unrecoverable.

**Therefore: a phase-level retry was not an option.** It could only mean re-running from
the first prompt — paying for the whole investigation again to reach the state we just
lost, which is the cost the issue was complaining about.

## The retry shape chosen

A `CompletionModel` wrapper, `Retried` (`src/completion_retry.rs`), composed at the two
sites that already build `watched(...)`: `run_phase_logged` (the tool loop) and
`run_completion` (the single-shot lanes). Innermost, so the re-draw resolves before
`Watched` observes.

Why below the loop:

- The `CompletionRequest` at that level **already holds the entire transcript**, so a
  re-draw loses nothing.
- rig never learns the failed draw happened, so the re-draw **spends none of rig's turn
  budget** — the weakness that made rig's own `on_model_turn_finished` +
  `ModelTurnAction::Retry` unsuitable for the empty-answer recovery too.
- It mirrors `Watched`, the wrapper kaibo already uses on this seam.

`MALFORMED_REDRAWS = 2` (three draws worst case). **No delay between draws**, and that
absence is load-bearing: a fumbled tool call and a 429 want opposite treatments, and a
sleep here would quietly become the transport retry/backoff that stays a deliberate
non-goal (the adjacent "Upstream a retry/backoff for rig" entry, updated to say so).

Every re-draw emits a `tracing::warn` carrying `model`, `attempt`, `redraws`, and the
provider's error, so telemetry can count occurrences per model.

## Vocabulary — and what stayed out

Detection is a heuristic on the error text, by the same necessity as `classify_failure`
(the reason arrives inside a formatted message, not a typed variant). One list,
`is_malformed_generation`, now decides **both** the re-draw and the advice a caller
finally reads.

Deliberately excluded, named in the module doc, waiting on a live probe:

- **OpenAI-family "Response did not contain a valid message or tool call"** — plausibly
  the same class, but nothing yet says whether it is a fumble or a refusal, and a wrong
  guess spends three calls on every refusal.
- **Gemini `MissingThoughtSignature`** — if it fires because a replayed history dropped a
  signature, it fires on *every* draw, so retrying would burn the budget on every call
  rather than rescue anything.

## Classification split

`FailureKind::MalformedGeneration`, checked before the transient list (more specific
diagnosis; both point at another call, so precedence only sharpens the advice). Its text
states the exact number of re-draws already spent — a caller who doesn't know that keeps
retrying by hand, and one who does knows to switch families instead. The number is
interpolated from the const, so the sentence cannot become a lie.

Genuine rejections keep the "retrying is unlikely to help" advice, unchanged. The
transient string now reads "kaibo does not **back off and** retry", which stays true now
that one class *is* repeated; README and `docs/config.md` (embedded as
`kaibo://config/guide`) were corrected the same way, and the failure-class table gained
the malformed row plus the empty-answer row it had been missing since 2026-08-02.

## Tests

Failing-first: the engine and render tests were written against the unwired code and
both failed with the real error text before the fix. Re-checked by mutation — setting
`MALFORMED_REDRAWS = 0` fails the wrapper tests.

- `consult::engine::tests::a_malformed_tool_call_mid_loop_is_re_drawn_and_the_investigation_survives`
  — the real loop, real kaish tool, a scripted Gemini malformed error on the turn after
  the tool result. Asserts the third request still carries the gathered evidence.
- `server::render::tests::a_malformed_generation_steers_toward_a_retry_not_away_from_one`
  — three spellings across both lane markers.
- `completion_retry::tests::a_malformed_generation_is_drawn_again_and_the_second_draw_answers`
- `completion_retry::tests::re_drawing_stops_at_the_bound_and_the_provider_error_survives`
- `completion_retry::tests::a_rejected_request_is_never_drawn_again`
- `completion_retry::tests::a_re_draw_carries_the_same_request`
- `completion_retry::tests::the_vocabulary_covers_the_shipped_spellings_and_no_more`

One harness note: a re-draw sends a **byte-identical** request, so "which attempt is
this" is the one thing a content-driven responder cannot read off the request. Those
tests count draws behind a content predicate — the ordering *is* the behavior under
test, not a shortcut around the harness's design. `test_support` gained one builder,
`response_error`; no harness changes.

Gates: `cargo test` full (713 lib + every integration binary) green, `cargo clippy
--all-targets` clean, build clean. `tests/no_write_path.rs` untouched and green — the
new module has no filesystem surface. rustfmt only on the edited files.

## Open questions

- The two excluded spellings above want a live probe before they are added.
- Whether 2 re-draws is the right bound is a guess from one observed incident; the warn
  event is what will answer it.
- A cast whose sampling is near-deterministic will re-draw into the same fumble three
  times. Bounded, but real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
