### PR TITLE
docs: temporary stacked-PR guidance, shipped as a stack layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,14 +398,16 @@ even for a one-line doc fix.
 - **Stacked PRs — temporary guidance (GitHub public preview, 2026-07).** When one
   change builds on another unmerged change, prefer a native GitHub stack over sibling
   PRs racing to `main` — the stack resolves their overlap once, before any merge.
-  Primer: the CLI is the `github/gh-stack` extension (installed here).
+  Primer: the CLI is `gh stack` (`gh extension install github/gh-stack`).
   `gh stack link <bottom> <top>…` retrofits open PRs or branches into a stack,
   retargeting each PR's base onto the one below; `gh stack init`/`add`/`submit` is the
   local-first path. `gh stack merge` lands a layer plus every unmerged layer below it
   in one all-or-nothing operation, and layers above a merged one rebase and retarget
   automatically — a linked stack cannot strand a PR on an already-landed base branch.
-  Layers touching the same files still need a real rebase on the branch: resolve as
-  the union in stack order, re-run the gates, push `--force-with-lease`. An
+  Layers touching the same files still need a real rebase on the branch: additive
+  docs files (changelog, tracker, devlog) resolve as the union in stack order, code
+  conflicts resolve on their logic, then re-run the gates and push
+  `--force-with-lease` (`gh stack submit` when using local tracking). An
   *unstacked* PR keeps the manual base check before merge:
   `gh pr view <N> --json baseRefName`. Delete this guidance when the harness injects
   stack awareness or the models carry the feature natively.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,20 @@ even for a one-line doc fix.
   wrote it (`/code-review`, or kaibo's own `consult`/`oneshot` aimed at the change) —
   before merge. Scale the review to the change (a doc fix is a glance; a sandbox or
   TLS change is a hard look), but don't skip the PR.
+- **Stacked PRs — temporary guidance (GitHub public preview, 2026-07).** When one
+  change builds on another unmerged change, prefer a native GitHub stack over sibling
+  PRs racing to `main` — the stack resolves their overlap once, before any merge.
+  Primer: the CLI is the `github/gh-stack` extension (installed here).
+  `gh stack link <bottom> <top>…` retrofits open PRs or branches into a stack,
+  retargeting each PR's base onto the one below; `gh stack init`/`add`/`submit` is the
+  local-first path. `gh stack merge` lands a layer plus every unmerged layer below it
+  in one all-or-nothing operation, and layers above a merged one rebase and retarget
+  automatically — a linked stack cannot strand a PR on an already-landed base branch.
+  Layers touching the same files still need a real rebase on the branch: resolve as
+  the union in stack order, re-run the gates, push `--force-with-lease`. An
+  *unstacked* PR keeps the manual base check before merge:
+  `gh pr view <N> --json baseRefName`. Delete this guidance when the harness injects
+  stack awareness or the models carry the feature natively.
 - **Every user-facing change updates `CHANGELOG.md`** under the top *unreleased*
   section, in the Keep a Changelog buckets (Added / Changed / Fixed / Security / …).
   Write what a *user* notices, not the file diff. Internal-only refactors need no entry —

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,7 +14,22 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
-## 2026-08-09 — the turn kaibo could not retry, and where the transcript actually goes
+## 2026-08-09 — the stack that reviewed itself in
+
+GitHub's stacked PRs left preview waitlists on 2026-07-30, and this PR is the trial
+run: it ships as layer 3 of kaibo's first stack (#137), on top of the two feature PRs
+below it — the primer merged by the workflow it documents. The trial was real, not
+staged: `gh stack link 135 136` retargeted a sibling PR onto its neighbor and
+surfaced their CHANGELOG/devlog overlap as a conflict *before* any merge, which is
+the #129 failure (two clean-looking siblings, broken union on main) caught at the
+right time instead of after. The union rebase, the gates, and one force-with-lease
+later, the stack merges bottom-up atomically.
+
+Amy's framing decided the shape of the guidance: temporary by declaration. It
+recommends stacks while they're new, and names its own deletion condition — when the
+harnesses inject stack awareness or the models carry the feature natively, the
+paragraph goes. Guidance that knows when to die is cheaper than guidance that
+accretes.
 
 The bug read like a policy problem and turned out to be a plumbing problem. A Gemini Flash
 explorer, deep into a `deliberate`, emitted one empty function call. Gemini answered


### PR DESCRIPTION
Layer 3 of stack #137 — temporary AGENTS.md guidance recommending native GitHub stacked PRs, shipped through the workflow it documents.

## Decisions (from the conversation with Amy)

- **Try it live first**: stack #137 was built by retrofitting the two open feature PRs (`gh stack link 135 136`), which retargeted #136 onto #135 and surfaced their docs overlap as a pre-merge conflict — the #129 failure class caught at the right time. The union rebase and gates ran on the branch; the stack merges bottom-up atomically.
- **Temporary by declaration** (Amy): the guidance "can go away in a few model generations and as harnesses inject it" — so the paragraph names its own deletion condition instead of accreting.
- **Scope**: recommends stacks for chained work, gives a five-line primer (`link` / `init`/`add`/`submit` / `merge` semantics / rebase expectations), and keeps the manual `baseRefName` pre-merge check for unstacked PRs.
- A short devlog entry rides the PR per house norm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)