### PR TITLE
docs: groom issues.md — delete two shipped entries, tighten a third, add one

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -253,31 +253,24 @@ otherwise sound. The attacker model stays narrow (a self-attack: a concurrent wr
 caller's own workspace, sub-millisecond window). Worth closing for symmetry when the model
 justifies it, but lower priority than the attachment read that one-shot-followed a symlink.
 
-### Attachment per-file streaming cap + FIFO-hang (DoS, self-attack) — count/total caps shipped
+### Attachment FIFO-hang (DoS, self-attack) — count/total/per-file caps shipped
 Surfaced by the Gemini Pro batch review of the VFS-read change (2026-06-23). These are
 **pre-existing** and all in the self-attack model (the caller owns the request and the
 workspace), so they're DoS, not confidentiality. The cheap batch-level bounds **shipped**
 (`attach::check_attachment_bounds`, wired into `resolve_attachments`): a hard cap on
 attachment *count* (`DEFAULT_MAX_ATTACHMENTS` = 64, checked before canonicalizing the list)
 and a *cumulative* byte budget (`DEFAULT_MAX_TOTAL_BYTES` = 32 MiB, the running total
-checked before each read so a batch of individually-legal files can't sum to an OOM). Two
-remain, both needing more than a pre-check:
-- **Per-file size cap is check-then-read, not streaming.** `resolve_attachments` checks
-  `std::fs::metadata` length against `read_ceiling`, then `worker.read_file` slurps the whole
-  file with **no byte cap** (`Job::Read` deliberately skips the script-output cap). A file
-  swapped for a huge one *after* the metadata check is read whole into a `Vec<u8>` → OOM,
-  bounded now only by the 32 MiB cumulative cap (so the blast radius shrank, but a single
-  swapped file up to that budget still slurps). The real fix is a *streaming* cap in the read
-  path (a `read_file` that takes a limit and aborts past `limit+1`), which needs a
-  `KaishWorker`/kaish-vfs API that bounds the read. (`classify` enforces the per-encoding cap
-  only *after* the full read, too late for memory.)
+checked before each read so a batch of individually-legal files can't sum to an OOM). The
+per-file streaming cap **shipped too**: `KaishWorker::read_file_capped(max)`
+(`sandbox.rs`) bounds the read itself via `read_range`/`File::take`, and both attachment
+resolvers (`server/resolver.rs`, `server/containment.rs`) pass their real per-file ceiling
+— a stat-then-read swap now stops at the cap instead of slurping to OOM. One remains:
 - **A special file (FIFO/device) swapped in can hang the read.** `is_file()` rejects a FIFO
   at check time, but a regular file swapped for a FIFO before the read blocks
-  `worker.read_file` indefinitely (single worker thread; `request_timeout` covers only the
-  model call, not attachment resolution). Wants an `O_NONBLOCK`/`tokio::time::timeout` bound
-  on the read. Judged rare (decided 2026-06-23) — parked unless it bites.
-Low priority (self-attack DoS). The streaming cap is the one with real teeth and needs the
-kaish-vfs read API.
+  `worker.read_file_capped` indefinitely (single worker thread; `request_timeout` covers only
+  the model call, not attachment resolution). Wants an `O_NONBLOCK`/`tokio::time::timeout`
+  bound on the read. Judged rare (decided 2026-06-23) — parked unless it bites.
+Low priority (self-attack DoS).
 
 ### Upstream a retry/backoff for rig's non-streaming completion path
 The provider failure *policy* is now stated, audited, and documented (README FAQ +
@@ -368,6 +361,25 @@ a dossier it already has, though the machinery works. Widening the gate would ad
 `deliberate` where its headline behavior — sweep, then deliberate — cannot run, which is
 worse than the gap. Left as-is on purpose; revisit if someone hits it.
 
+### Hybrid-provider casts as shipped defaults, and a 429-aware explorer story
+Field report (2026-08-09): `gpt-deliberate` failed three times at the explorer phase on
+OpenAI TPM 429s (`gpt-5.6-luna` explorer, a 200k tokens/min org ceiling) — a failed
+attempt still consumes the window, so a same-cast retry self-starves. Working fix,
+live-verified: a per-call `explorer_backend`/`explorer_model` override to a Gemini
+explorer, synth left on `gpt-5.6-sol` (batch lane). Matches a 2026-08-05 datapoint: a
+`gpt-luna` explorer TPM'd out instantly on a 16-file attach set while `gemini-flash-lite`
+built the identical dossier clean. Two threads:
+- **The mechanism is already cross-backend; the shipped defaults aren't.** A cast is
+  free to pair any backend per role (`AGENTS.md`), but `gpt-deliberate`'s built-in
+  (`docs/config.example.toml`) pins `explorer = { backend = "gpt", … }` — same family as
+  the synth. The explorer's job is cheap bulk reading, where family-match buys nothing
+  the synth's answer needs; consider giving the built-in `gpt` offline/deliberate casts
+  a cross-provider explorer (Gemini Flash, say) instead of a same-family one.
+- **A possible 429-aware explorer fallback** (auto-retarget the explorer after repeated
+  TPM 429s) cuts against the house doctrine — silent fallbacks are often a mistake, no
+  hidden retry. If built, it must be loud (named in the answer's provenance footer) and
+  probably opt-in. Decide the shape before building.
+
 ## P3 — Infra, perf, polish
 
 Two accepted-as-designed observations from the 2026-08-02 batch error-propagation audit,
@@ -419,16 +431,6 @@ rode along honestly. Deliberately deferred from the signing PR (2026-07-13, w/ A
 it changes the build invocation on all five legs (including through `cargo zigbuild`
 — compatibility unverified) and deserves its own validation dispatches. Do it when
 the audit story matters more than the extra moving part.
-
-### `KaishWorker::read_file` is unbounded — stat-then-read growth race
-`sandbox.rs` `Job::Read` slurps the whole file through the VFS with no size cap.
-Both attachment resolvers check `metadata().len()` against their cap/budget *before*
-reading, so a file that grows huge in the stat→read window gets slurped into memory
-before the post-read length check demotes/refuses it (Gemini cross-family review,
-2026-07-03). kaibo's stated adversary (the model) can't drive filesystem timing, so
-this is robustness, not an escape — but a fast-growing log file could spike memory.
-Fix shape: a capped read op on the worker (`read_file_capped(max)`) that refuses past
-the cap at the VFS layer; both resolvers pass their real ceiling.
 
 ### Attach-inline follow-ons: per-call budget, observed cost
 `inline_attach_budget` (2026-07-03, `[defaults]`/env) is server-wide only. Two
@@ -688,11 +690,6 @@ global, per the `large-token-headroom` memory. Remaining knobs on the same seam:
   warning plus an `inert_tunables` entry (`Config::effort_diagnostics`), and
   `tests/effort_wire.rs` pins the drop against a real serialized request body. Audible
   is not fixed — reasoning is still off on that wire.
-- **`thinking_style` is missing from the `inert_tunables` render** (GLM review,
-  2026-07-03): `kaibo://config` flags an inert `thinking_budget`/`effort`/
-  `temperature` per slot (`config_resource.rs`), but a `thinking_style` set on a
-  slot whose kind ignores the override (anything non-Anthropic) renders as if
-  effective. Display accuracy only; add it to the inert check alongside the others.
 
 All four provider paths have opt-in live tests (`tests/consult.rs`, `#[ignore]`d,
 gated on a key/endpoint) and passed with thinking on — the probes above extend these.


### PR DESCRIPTION
## Summary

Tracker grooming pass on `docs/issues.md` per the delete-when-shipped convention. This is the **bottom layer of a two-PR stack** — an rmcp test-harness PR will stack on top of this branch tip. Do not merge without checking in first.

### Deleted (verified fully shipped)

**1. P3 — `KaishWorker::read_file` is unbounded — stat-then-read growth race.**
The fix shape the entry asked for ("a capped read op on the worker (`read_file_capped(max)`) that refuses past the cap at the VFS layer; both resolvers pass their real ceiling") is fully in place:

- `src/sandbox.rs:544` — `KaishWorker::read_file_capped(&self, path, max_bytes)` bounds the read via `read_range(&path, Some(ReadRange::bytes(0, limit)))`, which `LocalFs` honors with `File::take(limit)` (sandbox.rs:487-490).
- `src/server/resolver.rs:583` stats `meta.len() > remaining` before calling `read_file_capped(canon.clone(), remaining + 1)` at `resolver.rs:609`.
- `src/server/containment.rs:172` stats `meta.len() > read_ceiling` before calling `read_file_capped(canon.clone(), read_cap)` at `containment.rs:213`.
- The old uncapped `read_file` method no longer exists anywhere in `src/` — `grep -rn "fn read_file\b\|\.read_file(" src/` returns nothing.
- Shipped in commit `47303ae` ("fix(attach): bound every raw read so a stat-then-read swap can't OOM"), confirmed via `git log -S"read_file_capped"`.

**2. P3 bullet — `thinking_style` missing from the `inert_tunables` render.**
`src/server/config_resource.rs:491-495`:
```rust
if t.thinking_style != ThinkingStyleOverride::Auto
    && backend.kind.wire() != Some(WireKind::Anthropic)
{
    inert.push("thinking_style");
}
```
Backed by a dedicated test, `config_render_flags_thinking_style_inert_on_a_non_anthropic_slot` (`config_resource.rs:1116`), asserting `vec!["thinking_style"]` on a DeepSeek slot. Shipped in commit `6e7c3e6` ("fix: kaibo://config now flags an inert non-Anthropic thinking_style"), matching the 2026-08-05 PR #128 claim.

### Tightened (skim pass turned up a third stale claim)

**P2 — "Attachment per-file streaming cap + FIFO-hang".** Its first bullet ("Per-file size cap is check-then-read, not streaming... needs a `KaishWorker`/kaish-vfs API that bounds the read") describes the *identical* gap closed by `read_file_capped` above — same fix, same commit. Removed that bullet, kept the still-open FIFO-hang bullet (unrelated: a swapped-in FIFO can still hang the single worker thread), and retitled the entry to reflect that the per-file cap shipped too.

### Added

**P2 — "Hybrid-provider casts as shipped defaults, and a 429-aware explorer story"** (per the coordinator, folded into this PR to avoid a same-file conflict with a second PR). Field report 2026-08-09: `gpt-deliberate`'s built-in explorer (`gpt-5.6-luna`, same family as the `gpt-5.6-sol` synth) self-starved on OpenAI's 200k TPM org ceiling — failed attempts still consume the window, so a same-cast retry can't recover. Live-verified fix: a per-call `explorer_backend`/`explorer_model` override to a Gemini explorer. Confirmed the built-in `gpt-deliberate` cast (`docs/config.example.toml:650-652`) does pin a same-family `gpt` explorer today, and that `explorer_backend`/`explorer_model` CLI overrides already exist (`src/cli.rs`) — so the cross-backend mechanism (`AGENTS.md`'s "freely cross-backend" cast design) is real, the gap is only in the shipped defaults. Names two open threads: (1) should the built-in `gpt` offline/deliberate casts default their explorer cross-provider, since family-match only matters for the synth's answer; (2) a possible 429-aware auto-retarget fallback, flagged against the house no-silent-fallbacks doctrine — any such fallback would need to be loud (named in the provenance footer) and probably opt-in.

## Test plan

- [x] `cargo build` — clean, confirms nothing references the removed doc text
- [x] Quoted the exact code lines justifying each deletion above
- [x] No `CHANGELOG.md` or `docs/devlog.md` entry — tracker grooming is internal, the git log is its record (per `AGENTS.md`)

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>