### PR TITLE
test: drive kaibo's MCP surface from an in-tree rust client — and fix the gate it found broken

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,12 @@ project and cannot run external commands.
 - **TDD.** Tests that can and will fail. The sandbox boundary gets failing-first
   tests — and we prove they actually work (e.g. mount the project writable with
   `LocalFs::new` instead of `read_only`, watch the write-denial tests fail).
+- **Tests start from a blank environment.** A test that spawns the kaibo binary
+  clears the child's env (`env_clear()`) and rebuilds only what it means — temp
+  `HOME` and XDG roots — never an enumerated `env_remove` list, which rots the day
+  a new variable ships. In-process tests inject env through `load_with`'s map, not
+  the process environment. So a developer's keys and `KAIBO_*` overrides can never
+  change what a test observes (`tests/mcp_stdio.rs` is the model).
 - **`docs/sandbox-probes.md` is the read-only/containment audit runbook.** The
   `cargo test` suites are the continuous guard; that doc is how we *live-test* the
   shipped boundary now and then (write/external/read-escape/env/path batteries via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **`--no-<tool>` gates work again over MCP.** Since the rmcp 3.0 upgrade a disabled or
+  unstaffable tool was still listed and still callable; it is now neither.
 - **`--include-report`'s help described the wrong stream.** It said the report is appended
   below the answer; it goes to stderr, so a script that piped stdout lost it silently.
 - **`--cas-max-bytes` was documented as a "soft cap".** A write past it is refused and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,6 +2145,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.12.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2564,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,12 +2917,14 @@ dependencies = [
  "futures",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "uuid",
@@ -3310,6 +3338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3584,6 +3622,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4404,6 +4443,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4414,6 +4474,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4443,6 +4514,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4505,6 +4586,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,3 +181,16 @@ tokio = { version = "1", features = ["test-util"] }
 # transport needs the type by name. Already in the tree via reqwest/rig-core — zero
 # new crates.
 bytes = "1"
+# rmcp's CLIENT half, for `tests/mcp_stdio.rs`: it spawns the real kaibo binary and
+# drives it over stdio the way a client does, so the MCP surface (handshake,
+# tools/list, tools/call, resources/read) is covered end to end in-tree. Same version
+# as the server dependency above — one rmcp in the tree, features unified.
+# `client` adds the client service loop; `transport-child-process` spawns the server
+# and wires its stdio (it pulls `tokio/process` + `process-wrap`, both pure Rust).
+# Dev-only under resolver v2, so the shipped binary's dependency graph is unchanged;
+# `cargo tree -i aws-lc-rs` and `-i mimalloc` stay empty either way (both features are
+# crypto-free — no reqwest, no TLS).
+rmcp = { version = "3.0.0-beta.5", default-features = false, features = [
+    "client",
+    "transport-child-process",
+] }

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -46,12 +46,12 @@ bump's own commit message says "No tool behavior or wire shape changed", and eve
 the tree agreed, because every test asked the handler.
 
 `tools/list` was the visible half. The expensive half is that `tools/call` reads the same
-router: a server started with `--no-run-kaish` dropped the tool from its list and then ran
-the script anyway. I confirmed that by hand before believing it. The `--no-<tool>` flags are
-the operator's capability surface — the thing you set when you want a kaibo that *cannot* do
-something — and for twelve days they were advisory. The `cast` enums and the `alwaysLoad`
-pin on `consult` were quietly gone too; they are stamped onto the instance's routes, and the
-instance's routes were not what shipped.
+router, so the gate failed on both sides at once: an operator who asked for a kaibo that
+*cannot* run a shell — `--no-run-kaish` — got one that listed `run_kaish` anyway and then
+ran the script when asked. I confirmed that by hand before believing it. Those flags are the
+operator's capability surface, and for twelve days they were advisory. The `cast` enums and
+the `alwaysLoad` pin on `consult` went the same way; they are stamped onto the instance's
+routes, and the instance's routes were not what shipped.
 
 The fix is `#[tool_handler(router = self.tool_router)]` with a comment explaining why it is
 not decoration. What I want on the record is the shape of the miss, because it will happen
@@ -66,6 +66,13 @@ The teeth were easy to show, which is its own comfort. Reverting the attribute f
 gating tests; mounting the project with `LocalFs::new` instead of `read_only` fails the write
 battery. The read-only invariant now has a proof that goes through the shipped MCP surface
 and not around it.
+
+The DeepSeek review found the gap I had left in my own lesson. Routing and meta injection are
+separate steps on the same router, so a change that keeps the routes and drops the `_meta`
+stamp would have passed everything I wrote — the front door would quietly stop being resident
+under a schema-deferring host, with no test to say so. That has its own assertion now, and it
+pins the *narrowness* too: only `consult` is pinned, because the whole point is that an unused
+tool bills nothing until someone reaches for it.
 
 ## 2026-08-09 — the stack that reviewed itself in
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,59 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-09 — the test that had to speak MCP, and the flag that had stopped working
+
+The plan was a Python script. `mcp_drive.py` would spawn kaibo, speak JSON-RPC at it, and
+finally cover the one surface every test in this tree reaches around: the wire. Amy killed
+it in a sentence — "I don't want to check in python. Let's consider how to drive a test with
+rust tests. rmcp can be a server." kaibo already depends on rmcp for the server half. The
+client half is a dev-dependency and a feature flag away.
+
+So `tests/mcp_stdio.rs` spawns `env!("CARGO_BIN_EXE_kaibo")` over `TokioChildProcess`,
+completes a real handshake, and drives the shipped binary the way a client does. Two
+choices carry it. The child's environment is *cleared* before anything is set — HOME and
+the three XDG roots point at temp dirs, and nothing from the developer's shell (a provider
+key, a `KAIBO_*`, a `RUST_LOG`) can decide what the server advertises. And each test gets
+its own process and its own dirs, so nothing is shared and nothing is ordered. A missing
+`config.toml` being a non-error by design is what makes an empty temp config dir mean
+"built-ins" rather than "broken".
+
+The first run of the tool-list assertion failed, and it failed the interesting way. I had
+written down the eleven tools a keyless kaibo advertises — read off `kaibo config`, which
+reports `live_tools`. The wire answered fourteen. `batch_submit`, `deliberate`, and
+`generate` were all there, on a server whose own startup log had just said, three times, in
+full sentences, that nothing could staff them.
+
+The cause is one attribute with a default that changed under us. `#[tool_handler]` takes a
+`router` expression; rmcp 0.16 defaulted it to `self.tool_router` — the handler's own,
+runtime-gated router — and rmcp 1.x onward defaults it to `Self::tool_router()`, a fresh one
+rebuilt from the compile-time `#[tool]` set. kaibo wrote the bare attribute, so the 0.16 →
+3.0.0-beta.5 bump on 2026-07-28 silently swapped the gated router for an ungated one. The
+bump's own commit message says "No tool behavior or wire shape changed", and every test in
+the tree agreed, because every test asked the handler.
+
+`tools/list` was the visible half. The expensive half is that `tools/call` reads the same
+router: a server started with `--no-run-kaish` dropped the tool from its list and then ran
+the script anyway. I confirmed that by hand before believing it. The `--no-<tool>` flags are
+the operator's capability surface — the thing you set when you want a kaibo that *cannot* do
+something — and for twelve days they were advisory. The `cast` enums and the `alwaysLoad`
+pin on `consult` were quietly gone too; they are stamped onto the instance's routes, and the
+instance's routes were not what shipped.
+
+The fix is `#[tool_handler(router = self.tool_router)]` with a comment explaining why it is
+not decoration. What I want on the record is the shape of the miss, because it will happen
+again in some other form: the assertion that could have caught this had to be *outside* the
+process. `advertised_tools()` reads the gated router and answers correctly no matter which
+router the wire is using, so the in-process tests were honest and useless here at the same
+time. That is the argument for this file existing. It is also why the harness pins the whole
+tool set rather than checking that `run_kaish` is present — the failure was a set that got
+bigger, and only an equality assertion notices that.
+
+The teeth were easy to show, which is its own comfort. Reverting the attribute fails the two
+gating tests; mounting the project with `LocalFs::new` instead of `read_only` fails the write
+battery. The read-only invariant now has a proof that goes through the shipped MCP surface
+and not around it.
+
 ## 2026-08-09 — the stack that reviewed itself in
 
 GitHub's stacked PRs left preview waitlists on 2026-07-30, and this PR is the trial

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -391,7 +391,8 @@ enum Job {
     /// stdout would truncate it) but never unbounded: `limit` is a hard ceiling on the
     /// bytes pulled into memory, so a file swapped between the caller's `stat` and this
     /// read cannot slurp a giant file and OOM the process — the read stops at `limit`
-    /// and the caller detects the overflow by length (see [`KaishWorker::read_file`]).
+    /// and the caller detects the overflow by length (see
+    /// [`KaishWorker::read_file_capped`]).
     /// It rides through `read_range`, which `LocalFs` honours with `File::take(limit)`
     /// (no whole-file slurp-then-slice), so the ceiling is real, not cosmetic. Same VFS
     /// as every read, so containment and read-only stay structural — an out-of-mount

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3492,7 +3492,17 @@ impl KaiboHandler {
     }
 }
 
-#[tool_handler]
+// `router = self.tool_router` is load-bearing, not decoration. The attribute's DEFAULT
+// is `Self::tool_router()` — a fresh router rebuilt from the compile-time `#[tool]` set,
+// which knows nothing about the per-instance gating `new_with_env` applied: dropped
+// routes, the injected `cast` enums, the `alwaysLoad` pin. Naming the field routes
+// `tools/list`, `tools/call`, and `get_tool` through the handler's OWN router, so what
+// the wire advertises and accepts is what `advertised_tools` reports. rmcp 0.16
+// defaulted to the field and 1.x+ defaults to the constructor, so the 0.16 → 3.0 bump
+// silently bypassed every `--no-<tool>` flag and every staffing drop. Only a test that
+// speaks MCP can catch that — a handler-side assertion reads the gated router either
+// way; see `tests/mcp_stdio.rs`.
+#[tool_handler(router = self.tool_router)]
 impl rmcp::ServerHandler for KaiboHandler {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -401,15 +401,17 @@ fn a_server_left_with_no_staffable_tools_refuses_to_start() {
     )
     .expect("write config");
 
+    // Blank environment, then rebuild only what the test means: a spawned kaibo starts
+    // from `env_clear()` so nothing from the developer's shell — a provider key, a
+    // `KAIBO_*` override — can re-staff a cast or reconfigure the server under test. An
+    // enumerated `env_remove` list rots the day a new variable ships; clearing cannot.
+    // `HOME` points at an empty temp dir so the default key-file paths resolve to
+    // nothing instead of the developer's real keyring.
+    let home = tempfile::tempdir().expect("tempdir for the child's HOME");
     let out = Command::new(env!("CARGO_BIN_EXE_kaibo"))
+        .env_clear()
+        .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", dir.path())
-        // Clear every provider key so the fixture's unreachable key files are the whole
-        // story — otherwise a developer's own environment re-staffs the casts.
-        .env_remove("ANTHROPIC_API_KEY")
-        .env_remove("DEEPSEEK_API_KEY")
-        .env_remove("GEMINI_API_KEY")
-        .env_remove("OPENROUTER_API_KEY")
-        .env_remove("OPENAI_API_KEY")
         // The two tools no cast can affect — off, so staffing decides everything.
         .args(["--no-run-kaish", "--no-list-models"])
         .output()
@@ -443,11 +445,14 @@ fn a_server_left_with_no_staffable_tools_refuses_to_start() {
 /// has to be able to catch a zero-tool misconfiguration.
 #[test]
 fn all_tools_disabled_refuses_to_start() {
-    // Isolate from the developer's real ~/.config/kaibo/config.toml: point
-    // XDG_CONFIG_HOME at an empty dir so the binary runs on built-ins and the
-    // failure under test (zero tools) is the only one in play.
+    // Blank environment, then rebuild only what the test means (see the sibling test
+    // above): built-ins only, an empty `HOME`, and no `KAIBO_*` from the developer's
+    // shell, so the failure under test (zero tools) is the only one in play.
     let empty_config = tempfile::tempdir().expect("tempdir for an isolated XDG_CONFIG_HOME");
+    let home = tempfile::tempdir().expect("tempdir for the child's HOME");
     let out = Command::new(env!("CARGO_BIN_EXE_kaibo"))
+        .env_clear()
+        .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", empty_config.path())
         .args([
             "--no-consult",

--- a/tests/mcp_stdio.rs
+++ b/tests/mcp_stdio.rs
@@ -34,7 +34,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ReadResourceRequestParams, ServerPeerInfo,
+    CallToolRequestParams, CallToolResult, ReadResourceRequestParams, ServerPeerInfo, Tool,
 };
 use rmcp::service::{RoleClient, RunningService, ServiceError, ServiceExt};
 use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
@@ -166,16 +166,23 @@ impl Server {
         (*info).clone()
     }
 
+    /// Every advertised tool as the wire carries it — schema, `_meta`, and all — sorted
+    /// by name.
+    async fn tools(&self) -> Vec<Tool> {
+        let mut tools = bounded("tools/list", self.client.list_all_tools())
+            .await
+            .expect("tools/list should succeed");
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+        tools
+    }
+
     /// Every advertised tool name, sorted.
     async fn tool_names(&self) -> Vec<String> {
-        let mut names: Vec<String> = bounded("tools/list", self.client.list_all_tools())
+        self.tools()
             .await
-            .expect("tools/list should succeed")
             .into_iter()
             .map(|t| t.name.to_string())
-            .collect();
-        names.sort();
-        names
+            .collect()
     }
 
     /// Ask the server to run a kaish script against the served root, returning whatever
@@ -411,6 +418,52 @@ async fn a_gated_tool_is_neither_advertised_nor_callable() {
     assert!(
         refusal.contains("not found"),
         "a gated tool must be refused as absent; got: {refusal}"
+    );
+
+    server.shutdown().await;
+}
+
+/// The `alwaysLoad` pin reaches the wire on `consult`, and on nothing else.
+///
+/// Routing and meta injection are separate steps on the same router
+/// (`server.rs`, `new_with_env`): the routes survive a change that drops the `_meta`
+/// stamp, so every other assertion here would still pass while the front door quietly
+/// stopped being resident under a schema-deferring host. This is the assertion that
+/// notices. It also pins the pin's *narrowness* — the whole point is that an unused
+/// tool bills nothing until the caller reaches for it.
+#[tokio::test]
+async fn consult_carries_the_always_load_pin_and_no_other_tool_does() {
+    let server = Server::start().await;
+    let tools = server.tools().await;
+
+    let consult = tools
+        .iter()
+        .find(|t| t.name == "consult")
+        .expect("`consult` is advertised on a keyless server");
+    let meta = consult
+        .meta
+        .as_ref()
+        .expect("`consult` carries `_meta` as served over MCP");
+    assert_eq!(
+        meta.get("anthropic/alwaysLoad"),
+        Some(&serde_json::Value::Bool(true)),
+        "`consult` must stay resident under a schema-deferring host; its _meta was {meta:?}"
+    );
+
+    let also_pinned: Vec<&str> = tools
+        .iter()
+        .filter(|t| t.name != "consult")
+        .filter(|t| {
+            t.meta
+                .as_ref()
+                .is_some_and(|m| m.contains_key("anthropic/alwaysLoad"))
+        })
+        .map(|t| t.name.as_ref())
+        .collect();
+    assert!(
+        also_pinned.is_empty(),
+        "only `consult` is pinned resident, so an unused tool bills nothing until it is \
+         reached for; also pinned: {also_pinned:?}"
     );
 
     server.shutdown().await;

--- a/tests/mcp_stdio.rs
+++ b/tests/mcp_stdio.rs
@@ -1,0 +1,417 @@
+//! kaibo's MCP surface, driven the way a client drives it: spawn the real binary,
+//! speak MCP over its stdio, and assert on what comes back.
+//!
+//! Every other test in this tree reaches `KaiboHandler` in-process, so the wire between
+//! a client and kaibo — `initialize`, `tools/list`, `tools/call`, `resources/read` —
+//! had no in-tree coverage. This file closes that gap with rmcp's *client* half
+//! (a dev-dependency; kaibo already ships rmcp's server half) over
+//! `TokioChildProcess`, which spawns `env!("CARGO_BIN_EXE_kaibo")` — the binary cargo
+//! built for this test run, never a hardcoded target path.
+//!
+//! Two properties make this safe to run anywhere, including CI and a laptop with a
+//! full keyring:
+//!
+//! - **Hermetic.** The child's environment is *cleared*, then rebuilt from temp dirs:
+//!   `HOME` plus every XDG root kaibo reads (`XDG_CONFIG_HOME` → `config.toml`,
+//!   `XDG_STATE_HOME` → the persistence db, `XDG_DATA_HOME` → the media CAS). Clearing
+//!   is what makes the run deterministic: no `ANTHROPIC_API_KEY`, no `KAIBO_*`, no
+//!   `RUST_LOG` from the developer's shell can change the advertised surface. A missing
+//!   `config.toml` is a non-error by design, so the empty config dir means "built-ins".
+//! - **Offline.** Nothing here needs a provider key or a socket. The model-driven tools
+//!   are listed but never called; the tool call under test is `run_kaish`, which has no
+//!   model in its loop.
+//!
+//! Shape: one server process per test, each with its own temp dirs, so tests share no
+//! state and run in any order or in parallel. Every request is wrapped in
+//! [`CALL_TIMEOUT`] — a hung server fails its own test with a readable message instead
+//! of wedging the suite.
+//!
+//! Teeth: flip an assertion (e.g. drop `run_kaish` from [`KEYLESS_TOOLS`], or expect
+//! `mkdir` to succeed) and the matching test fails.
+
+use std::future::Future;
+use std::path::Path;
+use std::time::Duration;
+
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ReadResourceRequestParams, ServerPeerInfo,
+};
+use rmcp::service::{RoleClient, RunningService, ServiceError, ServiceExt};
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use tempfile::TempDir;
+
+/// Ceiling on any single MCP request, and on the handshake. Generous on purpose: this
+/// is a hang detector, not a performance assertion, so a slow machine never flakes.
+const CALL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The exact tool surface a keyless kaibo advertises, sorted.
+///
+/// This is a *stock* install with no credentials at all: the built-in `openai-local`
+/// backend needs no key, so the casts it staffs keep `consult` / `consult_submit` /
+/// `explore` / `oneshot` (and the job verbs that collect `consult_submit`'s handles)
+/// advertised — kaibo does not check that a local server is actually listening, only
+/// that a cast can be staffed. `run_kaish`, `list_models`, and `read_cas` need no cast
+/// at all. What is *missing* is the other half of the story: `batch_submit`,
+/// `deliberate`, and `generate` all need a cast shape no built-in provides, so their
+/// routes are dropped rather than advertised-and-broken.
+const KEYLESS_TOOLS: &[&str] = &[
+    "consult",
+    "consult_submit",
+    "explore",
+    "job_cancel",
+    "job_get",
+    "job_list",
+    "job_wait",
+    "list_models",
+    "oneshot",
+    "read_cas",
+    "run_kaish",
+];
+
+/// Marker line written into the temp project's `Cargo.toml`, so a successful read is
+/// unmistakably *this* file and not the repo's own.
+const PROJECT_MARKER: &str = "kai-the-crab-was-here";
+
+/// Bound a request so a wedged server fails one test loudly instead of hanging `cargo
+/// test` until someone notices.
+async fn bounded<T>(what: &str, fut: impl Future<Output = T>) -> T {
+    match tokio::time::timeout(CALL_TIMEOUT, fut).await {
+        Ok(v) => v,
+        Err(_) => panic!("{what} did not finish within {CALL_TIMEOUT:?} — the server is hung"),
+    }
+}
+
+/// A live kaibo server plus the temp dirs it was pointed at. Dropping it kills the
+/// child (rmcp's transport does that) and removes the dirs.
+struct Server {
+    /// `HOME` and the XDG roots. Held so the dirs outlive the child.
+    _xdg: TempDir,
+    /// The project kaibo is rooted at — the only tree it may read.
+    project: TempDir,
+    client: RunningService<RoleClient, ()>,
+}
+
+impl Server {
+    /// Spawn kaibo on a fresh temp project and complete the MCP handshake.
+    async fn start() -> Self {
+        Self::start_with_args(&[]).await
+    }
+
+    /// [`start`](Self::start) with extra CLI flags — how a test asks for a different
+    /// server posture (a `--no-<tool>` gate, say).
+    ///
+    /// `--root` names the project, which also drops the invocation cwd from the allowed
+    /// set — so the kaibo checkout this test runs from is *not* readable by the server
+    /// under test, and a read that lands on the temp project can only have come from
+    /// the temp project.
+    async fn start_with_args(args: &[&str]) -> Self {
+        let xdg = TempDir::new().expect("tempdir for the child's HOME/XDG roots");
+        let project = TempDir::new().expect("tempdir for the served project");
+        std::fs::write(
+            project.path().join("Cargo.toml"),
+            format!("[package]\nname = \"{PROJECT_MARKER}\"\n"),
+        )
+        .expect("seed the temp project");
+
+        let config_home = xdg.path().join("config");
+        let state_home = xdg.path().join("state");
+        let data_home = xdg.path().join("data");
+        let home = xdg.path().join("home");
+        for dir in [&config_home, &state_home, &data_home, &home] {
+            std::fs::create_dir_all(dir).expect("create an XDG root");
+        }
+
+        let root = project.path().to_path_buf();
+        let transport = TokioChildProcess::new(
+            tokio::process::Command::new(env!("CARGO_BIN_EXE_kaibo")).configure(|cmd| {
+                // Clear first: the developer's provider keys and `KAIBO_*` overrides would
+                // otherwise decide which tools get advertised. kaibo runs no external
+                // command, so it needs nothing else from the environment.
+                cmd.env_clear()
+                    .env("HOME", &home)
+                    .env("XDG_CONFIG_HOME", &config_home)
+                    .env("XDG_STATE_HOME", &state_home)
+                    .env("XDG_DATA_HOME", &data_home)
+                    // Child logs go to the test runner's stderr; keep them to real errors.
+                    .env("RUST_LOG", "error")
+                    .arg("--root")
+                    .arg(&root)
+                    .args(args);
+            }),
+        )
+        .expect("spawn the kaibo binary");
+
+        let client = bounded("the MCP handshake", ().serve(transport))
+            .await
+            .expect("kaibo should complete `initialize` over stdio");
+
+        Self {
+            _xdg: xdg,
+            project,
+            client,
+        }
+    }
+
+    /// The project root the server was launched against.
+    fn root(&self) -> &Path {
+        self.project.path()
+    }
+
+    /// What the server said about itself at `initialize`.
+    fn handshake(&self) -> ServerPeerInfo {
+        let info = self
+            .client
+            .peer_info()
+            .expect("peer info is set once `initialize` completes");
+        (*info).clone()
+    }
+
+    /// Every advertised tool name, sorted.
+    async fn tool_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = bounded("tools/list", self.client.list_all_tools())
+            .await
+            .expect("tools/list should succeed")
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Ask the server to run a kaish script against the served root, returning whatever
+    /// `tools/call` answered — including a protocol-level refusal.
+    async fn try_run_kaish(&self, script: &str) -> Result<CallToolResult, ServiceError> {
+        let args = serde_json::json!({
+            "script": script,
+            "path": self.root().to_string_lossy(),
+        });
+        let params = CallToolRequestParams::new("run_kaish").with_arguments(
+            args.as_object()
+                .expect("the argument literal is an object")
+                .clone(),
+        );
+        bounded("tools/call run_kaish", self.client.call_tool(params)).await
+    }
+
+    /// Run a kaish script against the served root through the `run_kaish` tool, and
+    /// flatten the result to text.
+    async fn run_kaish(&self, script: &str) -> String {
+        let result = self
+            .try_run_kaish(script)
+            .await
+            .expect("tools/call run_kaish should return a result, not a protocol error");
+        result
+            .content
+            .into_iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Read one resource and flatten its text contents.
+    async fn read_resource(&self, uri: &str) -> String {
+        let params = ReadResourceRequestParams::new(uri);
+        let result = bounded("resources/read", self.client.read_resource(params))
+            .await
+            .unwrap_or_else(|e| panic!("resources/read {uri} should succeed: {e}"));
+        result
+            .contents
+            .into_iter()
+            .filter_map(|c| match c {
+                rmcp::model::ResourceContents::TextResourceContents { text, .. } => Some(text),
+                // Blob (and any future variant) is not what kaibo's config resources
+                // serve; keeping the text arm alone is the assertion.
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Close the session and let the child exit. Dropping would also kill it; doing it
+    /// explicitly keeps a test from racing the reaper on the way out.
+    async fn shutdown(self) {
+        let _ = bounded("session shutdown", self.client.cancel()).await;
+    }
+}
+
+/// `initialize` completes, kaibo names itself, and the instructions the calling agent
+/// reads carry the front-door vocabulary.
+///
+/// The instructions are the retrieval index in deferral hosts (see AGENTS.md,
+/// "Client-facing text"), so their opening words are load-bearing product, not prose.
+#[tokio::test]
+async fn handshake_names_kaibo_and_ships_read_only_instructions() {
+    let server = Server::start().await;
+    let info = server.handshake();
+
+    let implementation = info
+        .server_info
+        .expect("kaibo names its implementation at initialize");
+    assert_eq!(
+        implementation.name, "kaibo",
+        "the server must identify as kaibo, not as the rmcp crate"
+    );
+    assert_eq!(
+        implementation.version,
+        env!("CARGO_PKG_VERSION"),
+        "the advertised version must be the crate's"
+    );
+    assert!(
+        info.capabilities.tools.is_some(),
+        "kaibo advertises tools; capabilities said otherwise: {:?}",
+        info.capabilities
+    );
+    assert!(
+        info.capabilities.resources.is_some(),
+        "kaibo advertises resources; capabilities said otherwise: {:?}",
+        info.capabilities
+    );
+
+    let instructions = info
+        .instructions
+        .expect("kaibo sends instructions at initialize");
+    for word in ["read-only", "consult", "cast"] {
+        assert!(
+            instructions.contains(word),
+            "the instructions must carry the front-door word `{word}`; got: {instructions}"
+        );
+    }
+
+    server.shutdown().await;
+}
+
+/// A keyless server advertises exactly the tools it can actually staff.
+///
+/// Pinning the whole set (not "contains run_kaish") is what makes a gating regression
+/// visible: a tool that starts being advertised without a cast that can staff it, or
+/// one that silently drops off a stock install, fails here.
+#[tokio::test]
+async fn a_keyless_server_advertises_exactly_the_castless_surface() {
+    let server = Server::start().await;
+
+    assert_eq!(
+        server.tool_names().await,
+        KEYLESS_TOOLS,
+        "a keyless kaibo's advertised surface changed"
+    );
+
+    server.shutdown().await;
+}
+
+/// A real read through the shipped MCP surface: `cat -n` on a file in the served root
+/// comes back with its contents.
+#[tokio::test]
+async fn run_kaish_reads_a_file_under_the_served_root() {
+    let server = Server::start().await;
+
+    let out = server.run_kaish("cat -n Cargo.toml").await;
+
+    assert!(
+        out.contains("exit: 0"),
+        "the read should succeed; got: {out}"
+    );
+    assert!(
+        out.contains(PROJECT_MARKER),
+        "the read should return the temp project's file; got: {out}"
+    );
+
+    server.shutdown().await;
+}
+
+/// The read-only invariant, probed through MCP for the first time: every mutation is
+/// refused, and the project on disk is untouched afterwards.
+///
+/// Two assertions per case on purpose. The refusal text proves kaish said no at the VFS
+/// layer rather than failing for some unrelated reason; the filesystem check proves
+/// nothing landed even if the text ever changes.
+#[tokio::test]
+async fn run_kaish_refuses_every_write_and_the_project_is_untouched() {
+    let server = Server::start().await;
+
+    for (script, victim) in [
+        ("echo x > written.txt", "written.txt"),
+        ("mkdir made", "made"),
+        ("touch touched.txt", "touched.txt"),
+        ("rm Cargo.toml", "no-victim"),
+    ] {
+        let out = server.run_kaish(script).await;
+        assert!(
+            out.contains("read-only"),
+            "`{script}` must be refused as read-only; got: {out}"
+        );
+        assert!(
+            !out.contains("exit: 0"),
+            "`{script}` must not report success; got: {out}"
+        );
+        assert!(
+            !server.root().join(victim).exists(),
+            "`{script}` must leave nothing behind, but {victim} exists"
+        );
+    }
+
+    assert!(
+        server.root().join("Cargo.toml").exists(),
+        "the seeded file must survive `rm`"
+    );
+
+    server.shutdown().await;
+}
+
+/// The config resources round-trip: the resolved state and the shipped template both
+/// come back as text a model can read.
+#[tokio::test]
+async fn the_config_resources_round_trip() {
+    let server = Server::start().await;
+
+    let resolved = server.read_resource("kaibo://config").await;
+    assert!(
+        resolved.contains("advertised_tools"),
+        "kaibo://config reports the resolved surface; got: {resolved}"
+    );
+    assert!(
+        resolved.contains(&server.root().to_string_lossy().to_string()),
+        "kaibo://config names the served root; got: {resolved}"
+    );
+
+    let example = server.read_resource("kaibo://config/example").await;
+    assert!(
+        example.contains("[backends."),
+        "kaibo://config/example is the config.toml template; got: {example}"
+    );
+
+    server.shutdown().await;
+}
+
+/// A `--no-<tool>` flag is a capability gate on the wire, not a hint: the tool is
+/// neither advertised nor callable.
+///
+/// The second half is the one that matters and the one only an MCP-speaking test can
+/// reach. `KaiboHandler::run_kaish` is a plain method — an in-process test calls it
+/// whatever the gate says — so "did `tools/call` refuse it?" is a question about the
+/// router the handler was actually served with. This is the assertion that caught
+/// `#[tool_handler]`'s default router rebuilding an ungated one.
+#[tokio::test]
+async fn a_gated_tool_is_neither_advertised_nor_callable() {
+    let server = Server::start_with_args(&["--no-run-kaish"]).await;
+
+    let tools = server.tool_names().await;
+    assert!(
+        !tools.contains(&"run_kaish".to_string()),
+        "--no-run-kaish must drop the tool from tools/list; got {tools:?}"
+    );
+
+    let refusal = server
+        .try_run_kaish("cat Cargo.toml")
+        .await
+        .expect_err("a gated tool must refuse the call, not run it");
+    // The wording is rmcp's router, not kaibo's — a gated route simply is not there.
+    // Pin the substance (a protocol-level refusal that says the tool is absent), not
+    // rmcp's exact phrasing.
+    let refusal = refusal.to_string();
+    assert!(
+        refusal.contains("not found"),
+        "a gated tool must be refused as absent; got: {refusal}"
+    );
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
kaibo's MCP surface — the handshake, `tools/list`, `tools/call`, `resources/read` — had no
in-tree coverage. Every test reaches `KaiboHandler` in process. This adds a Rust harness
that spawns the real binary and drives it as a client, and it immediately found a live bug
in the shipped wire.

## Why Rust, not Python

The plan on the tracker was an out-of-tree `mcp_drive.py`. Amy's ruling killed it: *"I
don't want to check in python. Let's consider how to drive a test with rust tests. rmcp can
be a server."* kaibo already depends on rmcp for the server half, so the client half is a
dev-dependency away.

## The bug this found

`#[tool_handler]`'s `router` attribute has a default, and the default changed under us:

| rmcp | default `router` |
|---|---|
| 0.16 | `self.tool_router` — the handler's own, runtime-gated router |
| 1.x, 2.x, 3.x | `Self::tool_router()` — a fresh router from the compile-time `#[tool]` set |

kaibo wrote the bare attribute. The 0.16 → 3.0.0-beta.5 upgrade (569d872, 2026-07-28,
"No tool behavior or wire shape changed") therefore swapped the gated router for an ungated
one, silently:

- A keyless server advertised **14** tools while its own startup log said, three times, that
  `batch_submit` / `deliberate` / `generate` had no cast to staff them. `kaibo://config`
  reported the correct 11 in the same session.
- `tools/call` reads the same router, so **`--no-run-kaish` did not block a `run_kaish`
  call**. Confirmed by hand before believing it: the tool vanished from `tools/list` and
  then ran the script. The `--no-<tool>` flags are the operator's capability surface, and
  for twelve days they were advisory on the wire.
- The injected `cast` enums and the `anthropic/alwaysLoad` pin on `consult` are stamped onto
  the instance's routes, so those were gone too.

Fix: `#[tool_handler(router = self.tool_router)]`, with a comment saying why it is not
decoration.

**No in-process test could have caught this.** `advertised_tools()` reads the gated router
and answers correctly whichever router the wire is using — the existing gating tests were
honest and useless at the same time. That is the argument for the new file.

## Harness shape, and why

- **One file, `tests/mcp_stdio.rs`** — harness plus tests. Extending it is adding a `#[tokio::test]`;
  promoting the `Server` struct to a shared `tests/…/mod.rs` is a one-move refactor the day a
  second file wants it, and until then a shared module only buys dead-code allowances.
- **Hermetic by clearing, not by overriding.** `env_clear()` first, then `HOME` and every XDG
  root kaibo reads (`XDG_CONFIG_HOME` → config.toml, `XDG_STATE_HOME` → the state db,
  `XDG_DATA_HOME` → the media CAS) pointed at per-test temp dirs. A developer's provider key
  or a stray `KAIBO_*` would otherwise decide the advertised set, which is the thing under
  test. kaibo runs no external command, so it needs nothing else from the environment. A
  missing `config.toml` is a non-error by design, so an empty config dir means "built-ins".
- **`--root <tempdir>`**, which also drops the invocation cwd from the allowed set — so the
  kaibo checkout the tests run from is not readable by the server under test, and a
  successful read can only have come from the temp project.
- **One process per test**, own temp dirs. No shared state, no ordering, parallel-safe. Six
  spawns, whole file runs in well under a second.
- **Every request bounded** by a 60s timeout with a named message, so a hung server fails its
  own test instead of wedging the suite. Generous on purpose: a hang detector, never a
  performance assertion.
- **Pin the whole advertised set**, not "contains `run_kaish`". The failure here was a set
  that got *bigger*; only an equality assertion notices that.

## What a keyless server actually does

It starts and serves — it does not hit the nothing-advertised refusal. The built-in
`openai-local` backend needs no key, so the casts it staffs keep `consult` /
`consult_submit` / `explore` / `oneshot` (plus the job verbs that collect handles)
advertised; kaibo checks that a cast can be *staffed*, not that a local server is listening.
`run_kaish`, `list_models`, `read_cas` need no cast. `batch_submit`, `deliberate`, and
`generate` need cast shapes no built-in provides, so their routes are dropped. That set is
pinned in `KEYLESS_TOOLS`.

## Tests

- `handshake_names_kaibo_and_ships_read_only_instructions` — server info is `kaibo` at the
  crate version, tools+resources capabilities present, instructions carry `read-only`,
  `consult`, `cast`.
- `a_keyless_server_advertises_exactly_the_castless_surface` — the pinned 11.
- `a_gated_tool_is_neither_advertised_nor_callable` — `--no-run-kaish`: absent from
  `tools/list` **and** refused at `tools/call`. This is the one that caught the bug.
- `run_kaish_reads_a_file_under_the_served_root` — `cat -n Cargo.toml` returns the temp
  project's contents.
- `run_kaish_refuses_every_write_and_the_project_is_untouched` — `echo >`, `mkdir`, `touch`,
  `rm` each refused as read-only, and the filesystem is checked afterwards. The read-only
  invariant, probed through the shipped MCP surface for the first time.
- `the_config_resources_round_trip` — `kaibo://config` and `kaibo://config/example`.
- `consult_carries_the_always_load_pin_and_no_other_tool_does` — the
  `anthropic/alwaysLoad` `_meta` stamp reaches the wire on `consult`, and only there.
  Added from the review: routing and meta injection are separate steps on the same router,
  so a change that keeps the routes and drops the stamp would have passed everything else.

## Teeth (proven, then restored)

- Revert to bare `#[tool_handler]` → `a_keyless_server_advertises_exactly_the_castless_surface`
  fails with 14 vs 11, and `a_gated_tool_is_neither_advertised_nor_callable` fails.
- Mount the project with `LocalFs::new` instead of `LocalFs::read_only` →
  `run_kaish_refuses_every_write_and_the_project_is_untouched` fails on `echo x > written.txt`
  with `exit: 0`.
- Point the `_meta` injection at a name no route has →
  `consult_carries_the_always_load_pin_and_no_other_tool_does` fails on the missing `_meta`.

## Review

DeepSeek hard look: MERGE, fix confirmed, harness judged hermetic and flake-free, and the
Fixed-bucket framing confirmed honest — no structural invariant was breached, the exposure
was the operator capability boundary only. It found the `_meta` gap above, and tripped on a
devlog sentence that compressed what the operator asked for with what the wire did (the tool
was listed *and* callable, not dropped-then-run); both are addressed in `0c01d52`.

## Dependency guard

`rmcp` dev-dependency with `client` + `transport-child-process` (pulls `tokio/process` and
`process-wrap`, both pure Rust; no reqwest, no TLS). Under resolver v2 dev-dep features do
not reach the shipped binary. Verified on the branch: `cargo tree -i aws-lc-rs`,
`-i mimalloc`, and `-i openssl-sys` all report no matching packages.

## Also here

- `src/sandbox.rs`: an internal doc-comment pointed at `KaishWorker::read_file`; the method is
  `read_file_capped`. Crumb from the DeepSeek review of #139.
- `docs/devlog.md`: dated entry for the arc.
- `CHANGELOG.md`: one Fixed bullet — the gates work again over MCP.

## Gates

Full `cargo test` green (719 unit + every integration suite, 0 failures), `cargo clippy
--all-targets` clean, `tests/no_write_path.rs` green with the blessed count unchanged,
rustfmt run on the new file only (the tree is not rustfmt-clean repo-wide).

## Left open

A gated tool is refused with rmcp's own `-32602: tool not found`, which does not say *why*.
Per the house rule on refusals, kaibo could answer "`run_kaish` is disabled on this server
(`--no-run-kaish`)" — that means overriding `call_tool` rather than letting the macro
generate it, so it is its own change, not a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
