### PR TITLE
fix(mcp): serve the SEP-2549 cache fields a 2026-07-28 client requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ record. Each later release appends a new section at the top.
 
 - **`--no-<tool>` gates work again over MCP.** Since the rmcp 3.0 upgrade a disabled or
   unstaffable tool was still listed and still callable; it is now neither.
+- **A new Claude Code sees kaibo's tools again.** The client negotiates protocol
+  `2026-07-28` and requires the `ttlMs`/`cacheScope` fields on every list result; rmcp
+  negotiates that version but leaves them unset, so the client rejected the whole
+  `tools/list` — kaibo now fills them itself (`ttlMs: 0`, `cacheScope: "private"`).
 - **`--include-report`'s help described the wrong stream** — the report goes to stderr,
   so a script that piped stdout lost it silently.
 - **`--cas-max-bytes` was documented as a "soft cap"** — a write past it is refused and

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,13 +21,13 @@ use rig_core::completion::Usage;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolResult, ContentBlock, GetPromptRequestParams, GetPromptResponse, GetPromptResult,
-    Implementation, JsonObject, ListPromptsResult, ListResourceTemplatesResult,
-    ListResourcesResult, LoggingLevel, MetaObject, PaginatedRequestParams,
+    CacheScope, CallToolResult, ContentBlock, GetPromptRequestParams, GetPromptResponse,
+    GetPromptResult, Implementation, JsonObject, ListPromptsResult, ListResourceTemplatesResult,
+    ListResourcesResult, ListToolsResult, LoggingLevel, MetaObject, PaginatedRequestParams,
     ProgressNotificationParam, ProgressToken, Prompt, PromptArgument, PromptMessage,
     ProtocolVersion, ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult,
-    RequestMetaObject, Resource, ResourceContents, ResourceTemplate, Role, ServerCapabilities,
-    ServerInfo, SetLevelRequestParams,
+    RequestMetaObject, Resource, ResourceContents, ResourceTemplate, ResultType, Role,
+    ServerCapabilities, ServerInfo, SetLevelRequestParams,
 };
 use rmcp::schemars::{self, JsonSchema};
 use rmcp::service::{Peer, RequestContext};
@@ -3502,8 +3502,56 @@ impl KaiboHandler {
 // silently bypassed every `--no-<tool>` flag and every staffing drop. Only a test that
 // speaks MCP can catch that — a handler-side assertion reads the gated router either
 // way; see `tests/mcp_stdio.rs`.
+/// The SEP-2549 response-caching fields, filled when this session's negotiated
+/// protocol version requires them (`2026-07-28` and newer), absent otherwise.
+///
+/// rmcp 3.0.0-beta.5 negotiates `2026-07-28` — it is in the SDK's known-version
+/// list, and its serve loop overrides any handler attempt to answer lower — but it
+/// leaves these fields `None` on every result, and that spec version makes them
+/// REQUIRED on every list/read result. A strictly-validating client (Claude Code,
+/// observed 2026-08-10) accepts the negotiated version and then rejects the whole
+/// `tools/list` over the missing fields: zero tools, kaibo unusable until restart.
+/// So kaibo fills them itself, with the no-caching floor stated honestly:
+/// `ttlMs: 0` (immediately stale — the advertised surface is resolved per
+/// connection from env, config, and staffing, so a cached copy goes wrong exactly
+/// when it matters) and `cacheScope: private` (the surface is this user's own
+/// configuration; an intermediary must not serve it to another user). Older
+/// sessions stay on their legacy wire shape with the fields absent. Delete this
+/// when a bumped rmcp fills the fields itself; the raw-wire tests in
+/// `tests/mcp_stdio.rs` pin both sides.
+fn sep_2549_cache_fields(context: &RequestContext<RoleServer>) -> (Option<u64>, Option<CacheScope>) {
+    // ISO `YYYY-MM-DD` versions compare lexically the same as chronologically.
+    let required = context
+        .protocol_version()
+        .is_some_and(|v| v.as_str() >= ProtocolVersion::V_2026_07_28.as_str());
+    if required {
+        (Some(0), Some(CacheScope::Private))
+    } else {
+        (None, None)
+    }
+}
+
 #[tool_handler(router = self.tool_router)]
 impl rmcp::ServerHandler for KaiboHandler {
+    /// What the `#[tool_handler]` macro would generate, plus the SEP-2549 fields a
+    /// `2026-07-28` session requires — writing the method here is what suppresses
+    /// the macro's version (it skips any method the impl already has).
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        let (ttl_ms, cache_scope) = sep_2549_cache_fields(&context);
+        Ok(ListToolsResult {
+            result_type: Some(ResultType::COMPLETE),
+            tools: self.tool_router.list_all(),
+            meta: None,
+            next_cursor: None,
+            ttl_ms,
+            cache_scope,
+        })
+    }
+
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(
             ServerCapabilities::builder()
@@ -3555,10 +3603,13 @@ impl rmcp::ServerHandler for KaiboHandler {
     async fn list_resources(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
+        let (ttl_ms, cache_scope) = sep_2549_cache_fields(&context);
         Ok(ListResourcesResult {
             resources: kaibo_resources(),
+            ttl_ms,
+            cache_scope,
             ..Default::default()
         })
     }
@@ -3566,10 +3617,13 @@ impl rmcp::ServerHandler for KaiboHandler {
     async fn list_resource_templates(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
+        let (ttl_ms, cache_scope) = sep_2549_cache_fields(&context);
         Ok(ListResourceTemplatesResult {
             resource_templates: kaibo_resource_templates(),
+            ttl_ms,
+            cache_scope,
             ..Default::default()
         })
     }
@@ -3577,8 +3631,9 @@ impl rmcp::ServerHandler for KaiboHandler {
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
+        let (ttl_ms, cache_scope) = sep_2549_cache_fields(&context);
         // Compute the runtime-derived worktree set here (it needs the handler's
         // allowed_set and reflects worktrees that exist *now*); the renderer is a
         // pure function of its inputs, so it can't reach back for this itself.
@@ -3594,15 +3649,27 @@ impl rmcp::ServerHandler for KaiboHandler {
             self.live_cas_mode(),
             self.cas_ephemeral_fs,
         )
+        .map(|response| match response {
+            // SEP-2549 covers read results too; fill the same session-gated fields.
+            ReadResourceResponse::Complete(mut result) => {
+                result.ttl_ms = ttl_ms;
+                result.cache_scope = cache_scope;
+                ReadResourceResponse::Complete(result)
+            }
+            other => other,
+        })
     }
 
     async fn list_prompts(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, McpError> {
+        let (ttl_ms, cache_scope) = sep_2549_cache_fields(&context);
         Ok(ListPromptsResult {
             prompts: kaibo_prompts(),
+            ttl_ms,
+            cache_scope,
             ..Default::default()
         })
     }

--- a/tests/mcp_stdio.rs
+++ b/tests/mcp_stdio.rs
@@ -468,3 +468,181 @@ async fn consult_carries_the_always_load_pin_and_no_other_tool_does() {
 
     server.shutdown().await;
 }
+
+/// A raw JSON-RPC exchange over the binary's stdio, bypassing rmcp's client so the
+/// test controls the exact `protocolVersion` on the wire. rmcp's client always asks
+/// for its own latest, so the version-skew cases below are unreachable through it.
+///
+/// Same blank-environment rule as [`Server`]: `env_clear()`, then temp `HOME`/XDG
+/// roots, so nothing from the developer's shell shapes the server under test.
+async fn raw_initialize_then_list_tools(
+    client_version: &str,
+) -> (serde_json::Value, serde_json::Value, serde_json::Value) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let xdg = TempDir::new().expect("tempdir for the child's HOME/XDG roots");
+    let project = TempDir::new().expect("tempdir for the served project");
+    std::fs::write(project.path().join("Cargo.toml"), "[package]\n")
+        .expect("seed the temp project");
+    let home = xdg.path().join("home");
+    let config_home = xdg.path().join("config");
+    let state_home = xdg.path().join("state");
+    let data_home = xdg.path().join("data");
+    for dir in [&home, &config_home, &state_home, &data_home] {
+        std::fs::create_dir_all(dir).expect("create an XDG root");
+    }
+
+    let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_kaibo"))
+        .env_clear()
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_STATE_HOME", &state_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .env("RUST_LOG", "error")
+        .arg("--root")
+        .arg(project.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn the kaibo binary");
+
+    let mut stdin = child.stdin.take().expect("child stdin is piped");
+    let stdout = child.stdout.take().expect("child stdout is piped");
+    let mut lines = BufReader::new(stdout).lines();
+
+    async fn call(
+        stdin: &mut tokio::process::ChildStdin,
+        lines: &mut tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+        what: &str,
+        msg: serde_json::Value,
+        id: u64,
+    ) -> serde_json::Value {
+        stdin
+            .write_all(format!("{msg}\n").as_bytes())
+            .await
+            .expect("write a request line");
+        loop {
+            let line = bounded(what, lines.next_line())
+                .await
+                .expect("read a response line")
+                .unwrap_or_else(|| panic!("{what}: the server closed stdout"));
+            let value: serde_json::Value =
+                serde_json::from_str(&line).unwrap_or_else(|e| panic!("{what}: bad JSON: {e}"));
+            if value.get("id").and_then(serde_json::Value::as_u64) == Some(id) {
+                return value;
+            }
+        }
+    }
+
+    let init = call(
+        &mut stdin,
+        &mut lines,
+        "raw initialize",
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": client_version,
+                "capabilities": {},
+                "clientInfo": { "name": "raw-probe", "version": "0" }
+            }
+        }),
+        1,
+    )
+    .await;
+
+    stdin
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+        .await
+        .expect("write the initialized notification");
+
+    let tools = call(
+        &mut stdin,
+        &mut lines,
+        "raw tools/list",
+        serde_json::json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} }),
+        2,
+    )
+    .await;
+
+    let resources = call(
+        &mut stdin,
+        &mut lines,
+        "raw resources/list",
+        serde_json::json!({ "jsonrpc": "2.0", "id": 3, "method": "resources/list", "params": {} }),
+        3,
+    )
+    .await;
+
+    child.kill().await.ok();
+    (
+        init["result"].clone(),
+        tools["result"].clone(),
+        resources["result"].clone(),
+    )
+}
+
+/// A session at the newest negotiable protocol version receives every field that
+/// version's schema REQUIRES on a list result.
+///
+/// The failure this pins (live, 2026-08-10): rmcp 3.0.0-beta.5 negotiates
+/// `2026-07-28` — it is in the SDK's known-version list, and its serve loop
+/// overrides any handler attempt to answer lower — but it leaves `ttlMs` and
+/// `cacheScope` unset, which SEP-2549 makes REQUIRED on every list/read result at
+/// that version. A strictly-validating client (Claude Code) rejected the whole
+/// `tools/list` over the two missing fields: zero tools, kaibo unusable until
+/// restart. kaibo now fills them itself (`sep_2549_cache_fields`, `server/mod.rs`)
+/// with the no-caching floor: `ttlMs: 0`, `cacheScope: "private"`. Delete that
+/// helper and let this test fail when a bumped rmcp fills the fields itself.
+#[tokio::test]
+async fn a_newest_protocol_session_gets_the_fields_its_schema_requires() {
+    let (init, tools, resources) = raw_initialize_then_list_tools("2026-07-28").await;
+
+    assert_eq!(
+        init["protocolVersion"], "2026-07-28",
+        "rmcp echoes a known client version; the fix serves that contract rather \
+         than fighting the echo; got: {init}"
+    );
+
+    for (what, result) in [("tools/list", &tools), ("resources/list", &resources)] {
+        assert_eq!(
+            result["ttlMs"], 0,
+            "{what} must carry the REQUIRED `ttlMs`, as the no-caching floor; got: {result}"
+        );
+        assert_eq!(
+            result["cacheScope"], "private",
+            "{what} must carry the REQUIRED `cacheScope`; the surface is this \
+             user's own configuration; got: {result}"
+        );
+        assert_eq!(
+            result["resultType"], "complete",
+            "{what} carries the SEP-2322 discriminator at this version; got: {result}"
+        );
+    }
+    let served = tools["tools"].as_array().expect("tools/list carries a tools array");
+    assert!(
+        !served.is_empty(),
+        "the session serves the real tool surface alongside the cache fields"
+    );
+}
+
+/// A client on an older protocol version keeps the legacy wire shape — none of the
+/// newer contract's fields leak into a session whose schema does not know them.
+#[tokio::test]
+async fn an_older_protocol_session_keeps_the_legacy_wire_shape() {
+    let (init, tools, resources) = raw_initialize_then_list_tools("2025-06-18").await;
+
+    assert_eq!(
+        init["protocolVersion"], "2025-06-18",
+        "an in-range client version is echoed, not lifted or lowered; got: {init}"
+    );
+    for (what, result) in [("tools/list", &tools), ("resources/list", &resources)] {
+        for field in ["ttlMs", "cacheScope", "resultType"] {
+            assert!(
+                result.get(field).is_none(),
+                "{what}: no newer-contract `{field}` leaks into an older session; \
+                 got: {result}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
A freshly updated Claude Code negotiates MCP protocol `2026-07-28` and validates responses against that version's schema, which makes `ttlMs` and `cacheScope` REQUIRED on every list/read result (SEP-2549). rmcp 3.0.0-beta.5 negotiates the version but never fills the fields, so the client rejects the entire `tools/list` — the session shows zero kaibo tools until restart. Hit live in Amy's zorak session today (`/mcp` reconnect after a CC update); the zorak session traced the fields to rmcp and routed the diagnosis here.

## Why fill, not downgrade

The first cut pinned the negotiated version at `2025-11-25` — and its own failing test proved rmcp's serve loop overwrites the handler's answer (`negotiate_protocol_version` echoes any client version the SDK knows). A server on this rmcp cannot refuse a version it can't fulfil, so the durable fix is to fulfil it: a session-gated helper (`sep_2549_cache_fields`) fills the two fields on the four list results and `read_resource`, and older sessions keep the legacy wire shape. Values are the honest no-caching floor: `ttlMs: 0` (the advertised surface is resolved per connection from env, config, and staffing — a cached copy goes wrong exactly when it matters) and `cacheScope: "private"` (the surface is this user's own configuration).

## Coverage

Two raw JSON-RPC tests drive the binary over stdio with an exact `protocolVersion` — rmcp's own client always asks for its latest, which is why #140's rmcp-client harness couldn't reach this skew:
- `a_newest_protocol_session_gets_the_fields_its_schema_requires` — 2026-07-28 session: both fields present with the floor values, `resultType: "complete"`, real tool surface served. Fails when a bumped rmcp fills the fields itself, which is the signal to delete the helper.
- `an_older_protocol_session_keeps_the_legacy_wire_shape` — 2025-06-18 session: none of the newer-contract fields leak.

Full suite green, clippy clean. Upstream note: rmcp should fill these fields itself or let a handler cap negotiation — issue text is Amy's to file if she wants it.

Diagnosed-with: zorak session (symptom report + rmcp source trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)