### PR TITLE
feat(prompts): the explorer preamble anchors its toolset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ record. Each later release appends a new section at the top.
   started.
 - **kaibo's models work from a role, not a job description** — every preamble opens on
   who the model is on kaibo's team, and the obligation to finish rides that identity.
+- **The explorer preamble anchors its toolset** — the request's tool list is stated as
+  complete and `run_kaish` named as the one tool name every shell command rides, aimed
+  at flash-tier explorers inventing `run_*` tool names under a restricted toolset.
 - **kaibo's prompts are written in plain, literal English** — most of the models kaibo
   drives are not English-first, and figurative phrasing costs them attention.
 - **`oneshot` and `deliberate`'s direct lane are one literal request** instead of a

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -203,7 +203,9 @@ pub fn report_preamble() -> String {
          complete, accurate picture of the code a question touches, and you give that \
          picture to the synthesis agent. The synthesis agent writes the final answer \
          from what you found. So your work is to gather grounded evidence and cite it \
-         exactly. \
+         exactly. The tools named in this request are your complete set. Every shell \
+         command is one `run_kaish` call: the tool name is always `run_kaish`, and the \
+         command you want to run goes inside its `script` argument. \
          {core}\n\n\
          HOW TO READ. Read files WHOLE. `cat -n FILE` is your default command for any \
          file the question touches. One read gives you the imports, the types with \
@@ -809,6 +811,30 @@ mod tests {
         for section in ["SummaryOfFindings", "RelevantLocations", "ExplorationTrace"] {
             assert!(p.contains(section), "missing report section {section}: {p}");
         }
+    }
+
+    /// The toolset anchor: the preamble states that the request's tool list is
+    /// complete and that `run_kaish` is the one tool name every shell command rides.
+    /// Installed after a flash-tier explorer under `deliberate`'s two-tool set called
+    /// tools that do not exist (`run_sha`, `run_grail` — morphs of `run_kaish`, the
+    /// model blending "run this command" into a tool *name*). Structural wording on
+    /// purpose: the same preamble serves three toolset variants, so it asserts the
+    /// roster is complete without enumerating it.
+    #[test]
+    fn report_preamble_anchors_the_toolset() {
+        let p = report_preamble();
+        assert!(
+            p.contains("The tools named in this request are your complete set"),
+            "roster completeness is stated: {p}"
+        );
+        assert!(
+            p.contains("the tool name is always `run_kaish`"),
+            "the constant tool name is stated: {p}"
+        );
+        assert!(
+            p.contains("goes inside its `script` argument"),
+            "the name/argument split is stated: {p}"
+        );
     }
 
     /// Every synth-side phase opens on the *same role*, in the vocabulary the code


### PR DESCRIPTION
Prompt-side response to the hallucinated-tool class tracked in `docs/issues.md`: a flash-tier explorer under `deliberate`'s two-tool set twice called tools that do not exist, and both inventions (`run_sha`, `run_grail`) were morphs of `run_kaish` — the model blending "run this command" into a tool *name*. Telemetry confirmed those runs already carried thinking enabled at high effort (`gen_ai.request.thinking` on the run_phase spans), so capability/shaping wasn't the missing lever; the resident prompt never told the model the roster was closed.

Two sentences added to `report_preamble`, right after the role opening:

> The tools named in this request are your complete set. Every shell command is one `run_kaish` call: the tool name is always `run_kaish`, and the command you want to run goes inside its `script` argument.

Structural wording because the one explorer preamble serves three toolset variants (`explore′` bare, consult sweep and deliberate dossier with `attach`); positive framing per the house prompt doctrine; no em-dashes per the plain-English rule. Explorer only for now — the driver hasn't shown this failure, and the day's constant kaibo traffic is the measurement.

Amy's steer: flash should be adequate for exploration; prompts before the corrective re-prompt code fix (which stays tracked).

New test `report_preamble_anchors_the_toolset` pins both sentences; full suite green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)