### PR TITLE
chore(deps): rmcp 3.1.2, and correct what #142 says about the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ record. Each later release appends a new section at the top.
 
 ### Changed
 
+- **kaibo speaks MCP through the released rmcp 3.1.2**, off the 3.0 beta it shipped on,
+  for that line's protocol conformance fixes.
 - **The built-in deepseek and anthropic synths pin `max_tokens = 32768`** — a measured
   consult showed reasoning consuming half the completion budget before the answer
   started.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "d64a66d21a80182b35b1741997a6d2456911f54b7eb1918aa4e2382fc205268d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -298,7 +298,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.117",
  "which",
 ]
 
@@ -378,7 +378,7 @@ checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -520,7 +520,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -673,26 +673,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -751,7 +751,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -949,7 +949,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1680,7 +1680,7 @@ checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1725,7 +1725,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1744,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1956,7 +1956,7 @@ checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2012,7 +2012,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2108,7 +2108,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2437,7 +2437,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2520,7 +2520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2551,7 +2551,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2597,7 +2597,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2740,7 +2740,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2888,7 +2888,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2907,11 +2907,10 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0-beta.5"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183443f6b17ddf54d22fc37dcc2160f1e9ca09430d2be086ee2eb76b8c936412"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
- "async-trait",
  "base64 0.23.0",
  "chrono",
  "futures",
@@ -2932,15 +2931,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.0-beta.5"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f519766077846d7347a3c068a920dd702018b34fb24a46c4f1bc487a7e0dfa71"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3136,7 +3135,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3219,7 +3218,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3230,7 +3229,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3456,7 +3455,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3483,6 +3482,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,7 +3509,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3559,7 +3569,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3636,7 +3646,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3822,7 +3832,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4017,7 +4027,7 @@ checksum = "72cf1ef8779d07a7bd8dc3d34a3e8cc6f59e929ef74aedf2bf8b2dfceda59d7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4060,7 +4070,7 @@ checksum = "e3478f8f4e06133fd218ba93039765c096a7126636bca9b0893f79bcfd41adaf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4332,7 +4342,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4495,7 +4505,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4506,7 +4516,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4699,7 +4709,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4715,7 +4725,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4803,7 +4813,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4824,7 +4834,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4844,7 +4854,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4886,7 +4896,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ toml = "0.8"
 regex = "1"
 
 # MCP server (stdio only — never bind a socket; the FS is the boundary).
-rmcp = { version = "3.0.0-beta.5", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "3.1.2", features = ["server", "transport-io", "macros"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -190,7 +190,7 @@ bytes = "1"
 # Dev-only under resolver v2, so the shipped binary's dependency graph is unchanged;
 # `cargo tree -i aws-lc-rs` and `-i mimalloc` stay empty either way (both features are
 # crypto-free — no reqwest, no TLS).
-rmcp = { version = "3.0.0-beta.5", default-features = false, features = [
+rmcp = { version = "3.1.2", default-features = false, features = [
     "client",
     "transport-child-process",
 ] }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3505,20 +3505,31 @@ impl KaiboHandler {
 /// The SEP-2549 response-caching fields, filled when this session's negotiated
 /// protocol version requires them (`2026-07-28` and newer), absent otherwise.
 ///
-/// rmcp 3.0.0-beta.5 negotiates `2026-07-28` — it is in the SDK's known-version
-/// list, and its serve loop overrides any handler attempt to answer lower — but it
-/// leaves these fields `None` on every result, and that spec version makes them
-/// REQUIRED on every list/read result. A strictly-validating client (Claude Code,
-/// observed 2026-08-10) accepts the negotiated version and then rejects the whole
-/// `tools/list` over the missing fields: zero tools, kaibo unusable until restart.
-/// So kaibo fills them itself, with the no-caching floor stated honestly:
-/// `ttlMs: 0` (immediately stale — the advertised surface is resolved per
-/// connection from env, config, and staffing, so a cached copy goes wrong exactly
-/// when it matters) and `cacheScope: private` (the surface is this user's own
-/// configuration; an intermediary must not serve it to another user). Older
-/// sessions stay on their legacy wire shape with the fields absent. Delete this
-/// when a bumped rmcp fills the fields itself; the raw-wire tests in
-/// `tests/mcp_stdio.rs` pin both sides.
+/// rmcp negotiates `2026-07-28` whenever a client asks for it (the version is in the
+/// SDK's known list), and that spec version makes both fields REQUIRED on every list
+/// and read result. A strictly-validating client (Claude Code, observed 2026-08-10
+/// against rmcp 3.0.0-beta.5) accepts the negotiated version and then rejects the
+/// whole `tools/list` over the missing fields: zero tools, kaibo unusable until
+/// restart.
+///
+/// rmcp 3.1.1 fills the fields for the two results its handler macros generate
+/// (`tools/list`, `prompts/list`) and answers `cacheScope: public`. That is not
+/// kaibo's answer, and it does not reach kaibo's other results: the resource methods
+/// have no fill at all (the default `ServerHandler` bodies return `::default()`), and
+/// kaibo writes all of these methods by hand regardless. So kaibo answers for itself,
+/// with the no-caching floor stated honestly: `ttlMs: 0` (immediately stale — the
+/// advertised surface is resolved per connection from env, config, and staffing, so a
+/// cached copy goes wrong exactly when it matters) and `cacheScope: private` (the
+/// surface is this user's own configuration; an intermediary must not serve it to
+/// another user). Older sessions stay on their legacy wire shape with the fields
+/// absent, and the raw-wire tests in `tests/mcp_stdio.rs` pin both sides.
+///
+/// The alternative — refusing the version instead of fulfilling it — is available
+/// since rmcp 3.1.0 (`ServerHandler::supported_protocol_versions`, upstream #1093;
+/// on the 3.0.0-beta.5 this was written against, the serve loop overrode any handler
+/// answer). Fulfilling stays the right call: a client that asks for the newest
+/// version wants what that version's other features buy it, and the two fields cost
+/// kaibo nothing to answer truthfully.
 fn sep_2549_cache_fields(context: &RequestContext<RoleServer>) -> (Option<u64>, Option<CacheScope>) {
     // ISO `YYYY-MM-DD` versions compare lexically the same as chronologically.
     let required = context
@@ -3533,9 +3544,11 @@ fn sep_2549_cache_fields(context: &RequestContext<RoleServer>) -> (Option<u64>, 
 
 #[tool_handler(router = self.tool_router)]
 impl rmcp::ServerHandler for KaiboHandler {
-    /// What the `#[tool_handler]` macro would generate, plus the SEP-2549 fields a
-    /// `2026-07-28` session requires — writing the method here is what suppresses
-    /// the macro's version (it skips any method the impl already has).
+    /// The `#[tool_handler]` macro's own `list_tools`, with one difference: the
+    /// SEP-2549 fields answer `cacheScope: private`, where the macro answers
+    /// `public`. Writing the method here is what suppresses the macro's version (it
+    /// skips any method the impl already has), and it must keep serving
+    /// `self.tool_router` for the reason the comment above states.
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,

--- a/tests/mcp_stdio.rs
+++ b/tests/mcp_stdio.rs
@@ -585,15 +585,18 @@ async fn raw_initialize_then_list_tools(
 /// A session at the newest negotiable protocol version receives every field that
 /// version's schema REQUIRES on a list result.
 ///
-/// The failure this pins (live, 2026-08-10): rmcp 3.0.0-beta.5 negotiates
-/// `2026-07-28` — it is in the SDK's known-version list, and its serve loop
-/// overrides any handler attempt to answer lower — but it leaves `ttlMs` and
-/// `cacheScope` unset, which SEP-2549 makes REQUIRED on every list/read result at
-/// that version. A strictly-validating client (Claude Code) rejected the whole
-/// `tools/list` over the two missing fields: zero tools, kaibo unusable until
-/// restart. kaibo now fills them itself (`sep_2549_cache_fields`, `server/mod.rs`)
-/// with the no-caching floor: `ttlMs: 0`, `cacheScope: "private"`. Delete that
-/// helper and let this test fail when a bumped rmcp fills the fields itself.
+/// The failure this pins (live, 2026-08-10): rmcp negotiates `2026-07-28` whenever a
+/// client asks for it, but left `ttlMs` and `cacheScope` unset, which SEP-2549 makes
+/// REQUIRED on every list/read result at that version. A strictly-validating client
+/// (Claude Code) rejected the whole `tools/list` over the two missing fields: zero
+/// tools, kaibo unusable until restart. kaibo fills them itself
+/// (`sep_2549_cache_fields`, `server/mod.rs`) with the no-caching floor: `ttlMs: 0`,
+/// `cacheScope: "private"`.
+///
+/// A newer rmcp filling the fields is not the signal to delete that helper: 3.1.1
+/// fills only the two results its handler macros generate and answers
+/// `cacheScope: public`, which is the wrong answer for a per-user surface. This test
+/// asserts kaibo's values, so it fails if the SDK's ever start winning.
 #[tokio::test]
 async fn a_newest_protocol_session_gets_the_fields_its_schema_requires() {
     let (init, tools, resources) = raw_initialize_then_list_tools("2026-07-28").await;


### PR DESCRIPTION
Amy asked whether a newer rmcp answers the SEP-2549 gap #142 patched, rather than kaibo carrying its own fill. It does, partly — and the part it misses is why kaibo keeps its own answer.

## What rmcp 3.1.1 actually fixed

Upstream #1120, "emit cache hints from handler macros":

- The fill lives in **rmcp-macros only** (`tool_handler.rs:64-82`, `prompt_handler.rs:64-72`): `tools/list` and `prompts/list`, when the session negotiated ≥ `2026-07-28`.
- `list_resources`, `list_resource_templates`, and `read_resource` have **no fill at all** — the default `ServerHandler` bodies still return `::default()` with both fields `None` (`src/handler/server.rs:380-403`). kaibo hand-writes every one of these methods, so the macro would never reach them regardless.
- The macro answers **`cacheScope: public`** (`tests/test_handler_cache_hints.rs:79-89`). kaibo's advertised surface is resolved per connection from this user's env, config, and staffing, so `private` is the true answer; `public` would invite an intermediary to serve one user's tool list to another.

So `sep_2549_cache_fields` stays, and so does the hand-written `list_tools` that suppresses the macro's version.

## Why bump anyway

For the rest of the 3.1 line, not for the fix: recognizing the 2026 MCP methods (3.0.0), stricter protocol-metadata validation and `honor supported_protocol_versions when negotiating initialize` (3.1.0), plus auth/SSE fixes. That is conformance work aimed at exactly the kind of strict client that made kaibo's tools vanish, and beta → released is the right place to sit before a tag.

**Zero call-site changes.** The only new crates are build-time proc-macro deps (darling 0.24, syn 3.0.3, both pure Rust). `cargo tree -i` is empty for `aws-lc-rs`, `aws-lc-sys`, `openssl-sys`, and `mimalloc` (checked with `--all-features`), so the static-musl story is intact. 1073 tests pass, clippy clean on `--all-targets`.

## The tightening

#142's comments describe rmcp 3.0.0-beta.5 and are now false in two places:

- "its serve loop overrides any handler attempt to answer lower" — no longer true (3.1.0, upstream #1093). Refusing the version is available now, so the comment says why kaibo still fulfils it instead: a client asking for the newest version wants what that version's other features buy it, and the two fields cost nothing to answer truthfully.
- "Delete this when a bumped rmcp fills the fields itself" was the wrong deletion signal. A bumped rmcp fills two of the five results, with the wrong scope. The test now says so and asserts kaibo's values, so it fails if the SDK's ever start winning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)