### PR TITLE
feat(prompts): teach the span-around-a-grep-hit and `file` reading idioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ record. Each later release appends a new section at the top.
   at flash-tier explorers inventing `run_*` tool names under a restricted toolset.
 - **kaibo's prompts are written in plain, literal English** — most of the models kaibo
   drives are not English-first, and figurative phrasing costs them attention.
+- **kaibo's models read a wide span around a grep hit in a large file, and run `file`
+  on an unfamiliar one** — whole-file reading stays the default everywhere else.
 - **`oneshot` and `deliberate`'s direct lane are one literal request** instead of a
   toolless pass through the managed loop — proven request-for-request identical.
 - **Batch treats `effort` as a floor, not an override** — a slot asking deeper than the

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -212,8 +212,10 @@ pub fn report_preamble() -> String {
          their impls, the call sites, and exact line numbers together, and most source \
          files are small enough to read in a single command. Use `grep -rn PATTERN .` \
          to find WHICH files matter (`-B4 -A8` shows a preview around each match). \
-         Once grep names a file, open that file whole instead of reading only the \
-         lines around the match. A whole-file read of a very large file comes back \
+         Once grep names a file, open that file whole. When the file is large, read a \
+         wide span around each match instead, with `cat -n FILE | sed -n '120,400p'`. \
+         That returns the range and keeps the real line numbers, so your citation \
+         stays exact. A whole-file read of a very large file comes back \
          truncated (exit 3), and the truncated result still contains the start and the \
          end of the file. Read the rest in targeted spans: run `grep -n SYMBOL FILE` \
          to get the line numbers the question needs, then read a wide span around each \
@@ -810,6 +812,78 @@ mod tests {
         // against — keep the three section names in lockstep with those.
         for section in ["SummaryOfFindings", "RelevantLocations", "ExplorationTrace"] {
             assert!(p.contains(section), "missing report section {section}: {p}");
+        }
+    }
+
+    /// The follow-up to a grep hit, when the file is large: a wide span around the
+    /// match, numbered, instead of the whole file. The whole-file default is
+    /// deliberate and pinned above; this is the branch off it, so both sentences must
+    /// survive together — the preamble says "open that file whole" first and reaches
+    /// for a span second.
+    #[test]
+    fn explorer_reads_a_wide_span_around_a_grep_hit_in_a_large_file() {
+        let p = report_preamble();
+        assert!(
+            p.contains("Once grep names a file, open that file whole."),
+            "whole-file stays the default follow-up to a grep hit: {p}"
+        );
+        assert!(
+            p.contains("When the file is large, read a wide span around each match instead"),
+            "a large file gets a span around the match rather than a whole read: {p}"
+        );
+        assert!(
+            p.contains("instead, with `cat -n FILE | sed -n '120,400p'`."),
+            "the span example must be written with the range QUOTED — unquoted, kaish \
+             0.13 refuses the comma with a parse error: {p}"
+        );
+        assert!(
+            p.contains("keeps the real line numbers"),
+            "the span idiom must say why it is piped through `cat -n`, which is the \
+             exact citation: {p}"
+        );
+        let whole_at = p
+            .find("open that file whole")
+            .expect("whole-file directive");
+        let span_at = p.find("When the file is large").expect("span directive");
+        assert!(
+            whole_at < span_at,
+            "whole reads first, the span is the branch off it: {p}"
+        );
+    }
+
+    /// kaish reserves a bare comma, so `sed -n 120,400p` is a parse error on kaish
+    /// 0.13 — the version the released binary runs — while `sed -n '120,400p'` parses
+    /// on 0.13 and later alike (both forms verified live against both). Every range
+    /// kaibo puts in front of a model is therefore quoted. This sweeps every built-in
+    /// preamble and every attachment directive rather than naming one string, so a
+    /// new unquoted example anywhere in this module fails here.
+    #[test]
+    fn every_sed_range_kaibo_writes_is_quoted() {
+        for (label, text) in [
+            ("explorer", report_preamble()),
+            ("consult", consult_preamble()),
+            (
+                "oversize attachment",
+                consult_user_prompt("q", None, &[], &[oversize_attach("src/big.rs", 900_000)]),
+            ),
+            (
+                "explorer attachment directive",
+                explorer_attachment_directive(&[oversize_attach("src/big.rs", 900_000)])
+                    .expect("a text attachment produces a directive"),
+            ),
+        ] {
+            let mut seen = 0;
+            for (i, _) in text.match_indices("sed -n ") {
+                seen += 1;
+                let rest = &text[i + "sed -n ".len()..];
+                assert!(
+                    rest.starts_with('\''),
+                    "{label}: every `sed -n` range must be quoted — unquoted, kaish 0.13 \
+                     refuses the comma with a parse error and the model loses the \
+                     turn:\n{text}"
+                );
+            }
+            assert!(seen > 0, "{label} must still teach a span read:\n{text}");
         }
     }
 

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -33,11 +33,22 @@ use crate::config::{CastUsability, Config, Lane, ModelRole};
 /// prohibitions): say what reading looks like, rather than listing what is refused.
 /// Plain and literal per the agent-facing clarity rule in AGENTS.md — this block is
 /// embedded in every preamble, so an idiom here is charged to every model we drive.
+///
+/// Every `sed` range here is written **quoted**, and the rule is stated to the model
+/// rather than only demonstrated: kaish reserves a bare comma (brace expansion, lists),
+/// so `sed -n 120,400p` is a parse error on kaish 0.13 — the version the released binary
+/// runs — while the quoted form parses on 0.13 and later alike. Verified live against
+/// both. `addendum_teaches_quoted_spans_and_identifying_a_file` holds the quoting.
 pub const KAISH_SANDBOX_ADDENDUM: &str = "\
 In kaibo this shell runs over a READ-ONLY snapshot of one project, offline: writes, \
 `git`, `touch`, and external commands are refused, so your work here is reading. Read \
 files WHOLE by default with `cat -n FILE`; `grep -rn PATTERN .` finds matches whether \
-the target is a file or a directory. Each call starts at the project root; \
+the target is a file or a directory. When a grep hit lands in a large file, read a \
+wide span around it with `cat -n FILE | sed -n '120,400p'`, which returns that range \
+with its real line numbers. Quote the range, because an unquoted comma splits the \
+argument into separate words. Run `file FILE` on an unfamiliar file first; it names \
+the content as text or binary, so you know what you are about to read. \
+Each call starts at the project root; \
 there is no persistent cwd. Read the exit code: 0 is success; 3 means the output \
 was too large and came back as a head+tail sample (not a failure); 124 means the \
 script was killed for running past its time budget; 126 means blocked by the \
@@ -356,7 +367,8 @@ pub fn kaibo_sandbox_doc() -> String {
          - `grep -rn PATTERN [PATH]` — find which files matter, then open them whole\n\
          - `grep -rn -B3 -A6 PATTERN .` — preview matches in context across files\n\
          - `grep -rl PATTERN src` — just the file names that match\n\
-         - `cat -n FILE | sed -n '1200,2400p'` — a targeted wide span of a truncated giant (`grep -n SYMBOL FILE` pins where to aim)\n\n\
+         - `cat -n FILE | sed -n '1200,2400p'` — a targeted wide span of a truncated giant (`grep -n SYMBOL FILE` pins where to aim), and the follow-up to a grep hit in a large file; quote the range, because an unquoted comma splits the argument into separate words\n\
+         - `file FILE` — what a file is, text or binary, read from its content rather than its name\n\n\
          ## Read-only boundary\n\
          The project is mounted read-only and external commands are off, by \
          construction. Writes, `git`, `touch`, `spawn`/`exec`, and any external \
@@ -484,6 +496,46 @@ mod tests {
             assert!(
                 KAISH_SANDBOX_ADDENDUM.contains(needle),
                 "addendum must mention {needle:?}"
+            );
+        }
+    }
+
+    /// The two reading idioms that follow a grep hit, both verified live against the
+    /// kaish the released binary runs (0.13): a wide span around a match in a large
+    /// file, and `file` to learn what a file is before reading it. Whole-file reading
+    /// stays the default and is asserted next door; these are the follow-ups.
+    ///
+    /// The range is pinned **quoted**, by name. kaish reserves a bare comma, so
+    /// `sed -n 120,400p` is a parse error on 0.13 ("an unquoted comma splits this into
+    /// separate words") while the quoted form parses on 0.13 and later alike. A future
+    /// edit that "simplifies" the quotes away would break every model running today's
+    /// kaibo, and this is the test that catches it. The rule is also stated in prose,
+    /// not only demonstrated, so a model composing its own range gets it right.
+    #[test]
+    fn addendum_teaches_quoted_spans_and_identifying_a_file() {
+        let a = KAISH_SANDBOX_ADDENDUM;
+        assert!(
+            a.contains("`cat -n FILE | sed -n '120,400p'`"),
+            "the addendum must teach a wide span around a grep hit in a large file:\n{a}"
+        );
+        assert!(
+            a.contains("Quote the range"),
+            "the addendum must state the quoting rule, not only demonstrate it — a model \
+             composing its own range needs the rule:\n{a}"
+        );
+        assert!(
+            a.contains("`file FILE`"),
+            "the addendum must teach `file FILE` for an unfamiliar file, so a binary is \
+             identified rather than discovered by reading it:\n{a}"
+        );
+        // Structural, so it survives someone changing the example line numbers: every
+        // `sed -n` kaibo writes here is followed by a quote.
+        for (i, _) in a.match_indices("sed -n ") {
+            let rest = &a[i + "sed -n ".len()..];
+            assert!(
+                rest.starts_with('\''),
+                "every `sed -n` range must be quoted — unquoted, kaish 0.13 refuses the \
+                 comma with a parse error:\n{a}"
             );
         }
     }

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -529,7 +529,11 @@ mod tests {
              identified rather than discovered by reading it:\n{a}"
         );
         // Structural, so it survives someone changing the example line numbers: every
-        // `sed -n` kaibo writes here is followed by a quote.
+        // `sed -n` kaibo writes here is followed by a quote. The count is asserted too —
+        // a loop over zero matches passes green, so without this the whole scan would go
+        // quiet the day someone removed the last span example (caught in review, and the
+        // sibling scan in `prompts.rs` already had it).
+        let mut seen = 0;
         for (i, _) in a.match_indices("sed -n ") {
             let rest = &a[i + "sed -n ".len()..];
             assert!(
@@ -537,7 +541,13 @@ mod tests {
                 "every `sed -n` range must be quoted — unquoted, kaish 0.13 refuses the \
                  comma with a parse error:\n{a}"
             );
+            seen += 1;
         }
+        assert!(
+            seen > 0,
+            "the addendum must carry at least one `sed -n` span for the scan above to \
+             mean anything:\n{a}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two reading moves kaibo's models were never taught, added to the block every preamble embeds.

## Precise ranges, the follow-up to a grep hit

The explorer already knew `cat -n FILE | sed -n '1200,2400p'`, but only as *truncation recovery*: something you reach for after a whole read comes back as a head+tail sample (exit 3). It never learned the same command as the **proactive** move after a `grep -rn` hit lands in a large file. The addendum now says so, and the explorer's HOW TO READ block branches off its whole-file default instead of contradicting it.

**Whole-file reading stays the default, deliberately.** It is what produces the accurate `file:line` citations kaibo rewards, and the preamble still says "Read files WHOLE" three times before it offers a span. The new sentence is the branch, not a replacement, and the test asserts the order.

The span is written as `cat -n FILE | sed -n '120,400p'` rather than bare `sed -n '120,400p' FILE`, matching every other span idiom in the tree: the pipe through `cat -n` keeps the *real* line numbers in the output, so a citation off a span read is as exact as one off a whole read. Only the range is emitted either way.

## The range is written quoted, and that is load-bearing

kaish reserves a bare comma (brace expansion, lists). On **kaish 0.13** — the version `main` and the released binary run — `sed -n 120,400p` is a parse error:

```
1:29 [parse]: an unquoted comma splits this into separate words — kaish reserves `,`
(brace expansion, lists); quote a comma-bearing argument to keep it one word
```

Quoted works on 0.13 and on the unreleased 0.14 alike. Both forms were run live against both versions before any prose was written. Teaching the unquoted form would cost a turn for every model running today's kaibo, so:

- the rule is **stated to the model in prose**, not only demonstrated — a model composing its own range needs the rule, not just the example;
- two tests scan **every** `sed -n ` kaibo writes across the preambles and attachment directives, and fail unless a quote follows it. Structural on purpose: it survives someone changing the example line numbers, and it catches a future "simplification" that drops the quotes.

## `file FILE` before an unfamiliar file

So a model identifies a binary from its content instead of discovering it by dumping bytes into its own context. Verified live against the running server:

```
Cargo.toml: text (text/plain)
target/debug/kaibo: binary (application/x-executable)
```

## Placement

Both idioms went into `KAISH_SANDBOX_ADDENDUM`, which reaches the explorer preamble, the consult driver, and the internal `run_kaish` tool description through one string. Only the explorer's HOW TO READ block needed a second edit, because its "open that file whole instead of reading only the lines around the match" sentence would otherwise argue with the new guidance. The consult driver was left alone: the addendum sits above its own reading paragraph and covers it, and duplicating a sentence into every preamble is a cost charged per call.

`kaibo_sandbox_doc()` (the verbose `kaibo://kaish/sandbox` resource, a superset of the addendum) picked up a `file` bullet and the quoting rule on its span bullet, so the two stay in step.

## Checked, deliberately not changed

kaibo's model-facing text never describes conditionals as `[[ ]]` at all, so kaish 0.11's `test` builtin left nothing stale to fix. The `[[ ]]` examples that do appear in the composed contract are upstream `kaish-help`'s, which kaibo composes rather than authors — not ours to rewrite. Per the brief, no new content was invented to fill a gap that isn't hurting anyone.

## Gates

- `cargo test` — **1076 passed, 0 failed** (baseline on `main` is 1073; +3 new tests).
- `cargo clippy --all-targets` — clean.
- `rustfmt` on the two edited files only; the repo is not rustfmt-clean, so no repo-wide format. One incidental reflow of an untouched test was reverted to keep the diff on-topic.
- `built_in_preambles_are_written_without_em_dash_clause_chains` green — no em-dash clause chains, no length estimates or size targets, positive framing throughout.

Each new test was proven able to fail: unquoting the ranges in the source fails both structural tests, and deleting the new explorer sentence or the `file FILE` sentence fails its own assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
