### PR TITLE
feat(consult): answer an unknown tool call instead of failing the phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **A model calling a tool that does not exist no longer throws away the investigation**
+  — it gets a tool result naming the real toolset, and corrects itself on the next turn.
 - **`--no-<tool>` gates work again over MCP.** Since the rmcp 3.0 upgrade a disabled or
   unstaffable tool was still listed and still callable; it is now neither.
 - **A new Claude Code sees kaibo's tools again.** The client negotiates protocol

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,54 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-11 — method_missing, for models
+
+We had this tracked as "a bounded corrective re-prompt": catch `UnknownToolCall`, feed the
+error back, ask again. That's how it reads in `issues.md`, written the day the second repro
+landed. Amy reframed it in one line before I'd written any code — *"can we catch incorrect
+tool calls and return an informational error? sorta hooking method_missing"* — and the
+reframe is the whole entry, because it changes what the fix *is*. A re-prompt is kaibo
+noticing a failure and spending a model call to work around it. `method_missing` is the
+call **succeeding**, with an answer that happens to say "that's not a thing, here's what
+is". The model was already going to take another turn. It doesn't need to be asked again;
+it needs to be told something useful.
+
+Then rig had already built it. `rig-agent 0.41` ships `AgentHook::on_invalid_tool_call`
+returning an `InvalidToolCallAction`, and kaibo has implemented `AgentHook` since the
+`view_image` break work — so the fix is a second hook on a stack we already own, not new
+plumbing. This keeps happening and it keeps being worth checking first: the same lesson as
+the retry policy we decided to upstream rather than hand-roll.
+
+Four resolutions were on offer, and the interesting one to reject was `Repair` — hand rig a
+replacement name and let the call through. It is *right there*, `run_sha` → `run_kaish`
+would have worked on both observed failures, and it is a silent fallback: kaibo guessing
+what the model meant and running a command nobody asked for. A wrong guess doesn't announce
+itself. `Skip` with a reason string is strictly more information and leaves the choice where
+it belongs. Amy picked it.
+
+Two things in rig's source changed the design. Under `ToolChoice::None` rig *rejects* a
+`Skip` outright — and that is exactly the tool choice kaibo's forced write-up turn uses. So
+the hook declines there, and it declines on purpose rather than leaning on the rejection: a
+tool call during a turn that asked for prose is not a fumbled name, it's a model ignoring
+the ask, and the write-up path's own diagnostics are the better error. And when a call is
+skipped, *none* of the turn's tool calls execute — the peers come back as "not executed".
+That's a fact the model needs, because one told only that a single name was wrong will
+assume its other calls landed. So the message says the turn ran nothing and asks for the
+work again. A refusal owes the reader what was refused, why, and what to do instead; here
+"what to do instead" had a second half we would have missed by not reading the code we were
+calling.
+
+The test is the old repro. A scripted model reads a file, then calls `run_sha`, then
+answers — and deleting the `add_hook` line makes it fail with the production error
+verbatim: ``UnknownToolCall: model attempted to call unknown or disallowed tool `run_sha` ``.
+A satisfying shape for a regression test — the sabotage doesn't approximate the bug, it *is*
+the bug.
+
+What this doesn't do is lower the rate. The hook is recovery, and the `warn` it emits per
+occurrence is the first time this class is measurable at all — which is now the open half in
+`issues.md`, alongside the question of whether a model that gets the feedback actually reads
+it.
+
 ## 2026-08-09 — the test that had to speak MCP, and the flag that had stopped working
 
 The plan was a Python script. `mcp_drive.py` would spawn kaibo, speak JSON-RPC at it, and

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -39,23 +39,34 @@ what the model meant and running a command nobody asked for. A wrong guess doesn
 itself. `Skip` with a reason string is strictly more information and leaves the choice where
 it belongs. Amy picked it.
 
-Two things in rig's source changed the design. Under `ToolChoice::None` rig *rejects* a
-`Skip` outright — and that is exactly the tool choice kaibo's forced write-up turn uses. So
-the hook declines there, and it declines on purpose rather than leaning on the rejection: a
-tool call during a turn that asked for prose is not a fumbled name, it's a model ignoring
-the ask, and the write-up path's own diagnostics are the better error. And when a call is
-skipped, *none* of the turn's tool calls execute — the peers come back as "not executed".
-That's a fact the model needs, because one told only that a single name was wrong will
-assume its other calls landed. So the message says the turn ran nothing and asks for the
-work again. A refusal owes the reader what was refused, why, and what to do instead; here
-"what to do instead" had a second half we would have missed by not reading the code we were
-calling.
+Reading rig's source changed the message. When a call is skipped, *none* of the turn's tool
+calls execute — the peers come back as "not executed". That's a fact the model needs,
+because one told only that a single name was wrong will assume its other calls landed. So
+the message says the turn ran nothing and asks for the work again. A refusal owes the reader
+what was refused, why, and what to do instead; here "what to do instead" had a second half
+we would have missed by not reading the code we were calling.
 
 The test is the old repro. A scripted model reads a file, then calls `run_sha`, then
 answers — and deleting the `add_hook` line makes it fail with the production error
 verbatim: ``UnknownToolCall: model attempted to call unknown or disallowed tool `run_sha` ``.
 A satisfying shape for a regression test — the sabotage doesn't approximate the bug, it *is*
 the bug.
+
+The cross-family review (DeepSeek, dogfooding `consult`) came back sound and caught the one
+thing I'd written down wrong. I had the `ToolChoice::None` branch described as a live guard
+protecting the forced write-up turn. It isn't: `forced_finish_turn` builds its own agent and
+installs no hooks, so the hook never sees that tool choice at all. The branch is right and I
+kept it — it's the answer we'd want if that ever changed — but it is guarding a state this
+tree cannot produce, and a comment that oversells its own reach is the kind of thing that
+gets believed later. The correction is in the doc comment now, stated as plainly as the
+claim was.
+
+Its other finding was a real test gap: nothing exercised a model that names a phantom tool
+on *every* turn. The recovery costs a turn and nothing counts recoveries, so the only thing
+between a pathological model and an unbounded loop is that a skipped turn is still a turn.
+The review reasoned that through and concluded it was structurally safe. It was right, and
+now there's a test that would hang if it ever stopped being true — which is the version of
+that argument I trust.
 
 What this doesn't do is lower the rate. The hook is recovery, and the `warn` it emits per
 occurrence is the first time this class is measurable at all — which is now the open half in

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -335,26 +335,33 @@ lowered by #114's role-identity preambles; n=3 can't tell). Open work, in order:
   If that shape shows up in practice it's a different problem (answer-quality, not
   emptiness) and wants its own thinking, not a heuristic bolted onto this gate.
 
-### A hallucinated tool call fails the phase with no corrective feedback (2026-08-09)
-Repro, twice: a `deliberate` dossier sweep on explorer `deepseek-v4-flash` failed 2×
-*identically* with `UnknownToolCall: 'run_sha'` (available: `attach`, `run_kaish`),
-killing the phase before the synth spent anything; a 2026-08-05 build died the same way
-on `run_grail`. The same model runs 80+-step `consult` sweeps clean, so this is
-flash-tier-under-a-restricted-toolset behavior on long prompts, not a broken model.
-Distinct from the shipped malformed-generation retry (`src/completion_retry.rs`): that
-resends the *same* request when the provider's output failed to parse; here the request
-parsed fine — the model named a tool that does not exist — and an identical resend
-re-hallucinates (the 2× identical failure proves it). Fix shape: a bounded corrective
-re-prompt that feeds the error back into the conversation as a tool-result/user turn
-("`run_sha` is not a tool; available: `attach`, `run_kaish`") so the model can correct
-itself, with the same loud-warn-per-attempt discipline the malformed retry has.
-Workaround meanwhile: `explorer_model = "deepseek-v4-pro"` (verified working);
-`docs/casts.md` carries the operator-facing guidance, framed clinically (Amy,
-2026-08-10: no specific failures in model-readable docs). Shaping datapoint for
-the fix: the repro ran with the DeepSeek wire's defaults — `thinking` enabled
-plus `reasoning_effort: "high"` are emitted regardless of model id
-(`src/consult/shaping.rs:306`, `:457`) — so deeper thinking is not the missing
-lever; corrective feedback is.
+### A hallucinated tool call — what's left after the feedback hook (2026-08-11)
+The recovery shipped: `UnknownToolFeedbackHook` (`consult/engine.rs`) answers a tool call
+naming a tool that does not exist with a tool result naming the real toolset, so the phase
+keeps its evidence and the model corrects itself inside the budget it already had. It rides
+`run_phase`, so every tool-driven phase inherits it. What the entry was tracking that the
+hook does *not* settle:
+
+- **Incidence is still unmeasured.** The hook emits a `warn` per occurrence carrying the
+  model id and the advertised toolset, which is the telemetry this class always needed
+  (the same shape the empty-answer entry asks for). Nobody has collected it yet. The
+  interesting split is which models do this, and whether the correction *lands* — a model
+  that answers the feedback with a second phantom name is a different problem than one
+  that reads it and moves on.
+- **Prevention is untouched.** The hook is recovery. The 2026-08-09 shaping datapoint
+  stands: the repro ran with `thinking` enabled plus `reasoning_effort: "high"` emitted
+  regardless of model id (`src/consult/shaping.rs:306`, `:457`), so deeper thinking was
+  never the missing lever. Whether the explorer preamble's toolset anchoring (#143) lowers
+  the rate is measurable now that occurrences are logged.
+- **A repeat offender still burns the budget.** Each recovery costs a turn, and nothing
+  counts them. A model that names a phantom tool every turn will exhaust `max_turns`
+  recovering. Bounding it means counting per phase and escalating to `Fail` — worth doing
+  only if the warn stream shows it happening, since the alternative today (the whole
+  phase dies at the first offense) was strictly worse.
+
+`docs/casts.md`'s operator-facing guidance and the `explorer_model = "deepseek-v4-pro"`
+workaround are both still accurate, and both are now belt-and-braces rather than the only
+defense.
 
 ### Dossier durability — what's left after keep + reuse (2026-08-07)
 A finished dossier now lands in the media CAS and can be handed back as `deliberate`'s

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use rig_agent::agent::hook::{
-    AgentHook, CompletionCall, CompletionCallAction, HookContext, ToolResultAction, ToolResultEvent,
+    AgentHook, CompletionCall, CompletionCallAction, HookContext, InvalidToolCallAction,
+    InvalidToolCallContext, ToolResultAction, ToolResultEvent,
 };
 use rig_agent::agent::AgentBuilder;
 use rig_agent::completion::PromptError;
@@ -712,6 +713,133 @@ fn empty_answer_error(
     )
 }
 
+// --- a tool call naming a tool that does not exist -------------------------------
+
+/// Answers a tool call the run cannot dispatch, so the phase keeps its evidence.
+///
+/// A model sometimes emits a tool that was never advertised — `run_sha` and `run_grail`
+/// were both observed on a flash-tier explorer under a restricted toolset, each killing
+/// the phase before the synth spent anything. rig's default is fail-fast, which throws
+/// away every turn of reading already done. This hook answers the call instead: the
+/// model gets a tool result naming what it asked for and what it can actually call, and
+/// it corrects itself on the next turn inside the budget it already had.
+///
+/// **Feedback, never repair.** [`InvalidToolCallAction::Repair`] would let kaibo rename
+/// `run_sha` to `run_kaish` and dispatch it. That is a guess at intent, and a wrong guess
+/// runs a command the model did not ask for — a silent fallback, which the project
+/// refuses. Naming the real tools is strictly more information than a rename and leaves
+/// the choice with the model.
+///
+/// **The turn's other tool calls are reported, not hidden.** rig executes no tool call
+/// from a turn that had an invalid one; the peers each come back as "not executed"
+/// (`run/mod.rs` — `TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER`). So the message says the work
+/// did not run and asks for it again, because a model told only that one name was wrong
+/// would reasonably assume its other calls landed.
+///
+/// **Under [`ToolChoice::None`] it declines.** That tool choice is kaibo asking for prose
+/// — the forced write-up turn ([`forced_finish_turn`]) — so a tool call there is not a
+/// misnamed tool but a model ignoring the ask, and the write-up path's own diagnostics
+/// are the better error. rig rejects a `Skip` under that tool choice anyway; declining
+/// says so on purpose instead of leaning on a rejection.
+#[derive(Clone)]
+struct UnknownToolFeedbackHook {
+    /// The phase's model id. Carried for the `warn` event only, so telemetry can say
+    /// *which* models do this and how often — the open question this class was tracked
+    /// under.
+    model_name: Arc<str>,
+}
+
+impl UnknownToolFeedbackHook {
+    fn new(model_name: &str) -> Self {
+        Self {
+            model_name: Arc::from(model_name),
+        }
+    }
+}
+
+impl AgentHook for UnknownToolFeedbackHook {
+    async fn on_invalid_tool_call(
+        &self,
+        _ctx: &HookContext,
+        event: &InvalidToolCallContext,
+    ) -> Option<InvalidToolCallAction> {
+        let reason = unknown_tool_feedback(
+            event.tool_choice.as_ref(),
+            &event.tool_name,
+            &event.available_tools,
+            &event.allowed_tools,
+        )?;
+        tracing::warn!(
+            model = %self.model_name,
+            tool = %event.tool_name,
+            available_tools = %event.available_tools.join(", "),
+            "model called a tool that does not exist — answering it with the real toolset \
+             so the phase keeps its evidence"
+        );
+        Some(InvalidToolCallAction::Skip { reason })
+    }
+}
+
+/// The tool result an unknown tool call gets back, or `None` to leave rig's fail-fast in
+/// place.
+///
+/// Names what was refused, why, and what to do instead — the three things a refusal owes
+/// its reader, and this one is read by a model at the moment it is blocked.
+///
+/// Two cases get different corrections, because they call for different fixes. A name
+/// that is in the toolset but not permitted this turn is a *timing* problem: the tool is
+/// real and the model should wait for it. Any other name is not a tool at all.
+///
+/// The whole decision lives here rather than in [`UnknownToolFeedbackHook`] so it is
+/// testable without standing up a rig run — the hook is the one-line shell that maps this
+/// to an action.
+fn unknown_tool_feedback(
+    tool_choice: Option<&ToolChoice>,
+    tool_name: &str,
+    available: &[String],
+    allowed: &[String],
+) -> Option<String> {
+    // Under `ToolChoice::None` kaibo asked for prose, so a tool call is not a misnamed
+    // tool. See the hook's doc comment.
+    if matches!(tool_choice, Some(ToolChoice::None)) {
+        return None;
+    }
+    let list = |names: &[String]| {
+        if names.is_empty() {
+            "none".to_string()
+        } else {
+            names
+                .iter()
+                .map(|n| format!("`{n}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    };
+    let opening =
+        if available.iter().any(|n| n == tool_name) && !allowed.iter().any(|n| n == tool_name) {
+            format!(
+                "`{tool_name}` is a real tool, and it is not one you can call on this turn. \
+             The tools you can call now are: {}.",
+                list(allowed)
+            )
+        } else {
+            format!(
+                "`{tool_name}` is not a tool. The tools you can call are: {}.",
+                list(if allowed.is_empty() {
+                    available
+                } else {
+                    allowed
+                })
+            )
+        };
+    Some(format!(
+        "{opening} Nothing ran this turn: a tool call the run cannot dispatch stops the \
+         whole turn, so any other tool you called alongside this one did not run either. \
+         Call the tools above to do the work you intended, including the work you asked \
+         for in this turn."
+    ))
+}
+
 // --- an image-bearing tool result on the user-turn channel (the openai VLM path) --
 
 /// The cancellation reason [`ToolImageBreakHook`] terminates with, so [`run_phase`]
@@ -1161,6 +1289,12 @@ where
             .runner(prompt.clone())
             .history(history.clone())
             .add_hook(ToolImageBreakHook::new(break_on_tool_images))
+            // Every tool-driven phase runs through this loop, so installing the hook here
+            // is what gives the consult driver, each delegated `explore′` sweep, and the
+            // `deliberate` dossier sweep the same recovery. The toolless lanes
+            // (`oneshot`, `deliberate`'s direct synth) bypass the agent entirely via
+            // `Arm::complete` and can raise no tool call at all.
+            .add_hook(UnknownToolFeedbackHook::new(model_name))
             .max_turns(remaining)
             .run()
             .await;
@@ -3023,6 +3157,129 @@ mod tests {
         assert_eq!(answer, "done");
         assert_eq!(reported.input_tokens, 321);
         assert_eq!(reported.output_tokens, 21);
+    }
+
+    /// The recovery this whole hook exists for: a model names a tool that was never
+    /// advertised, and the phase keeps the evidence it had already gathered instead of
+    /// dying. Without [`UnknownToolFeedbackHook`] rig fails the run at the second turn
+    /// with `UnknownToolCall`, `run_phase` returns `Err`, and this `expect` fires — the
+    /// sabotage check is deleting the `add_hook` line.
+    ///
+    /// Modeled on the observed failure: `run_sha` on a flash-tier explorer, mid-sweep,
+    /// after real reading had already happened.
+    #[tokio::test]
+    async fn an_unknown_tool_call_is_answered_and_the_investigation_survives() {
+        const MODEL: &str = "driver";
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, |req| {
+                let seen = transcript_text(req);
+                // Turn 1: real work, so there is evidence worth saving.
+                if !seen.contains("EVIDENCE") {
+                    return Ok(tool_call_response(
+                        "c1",
+                        "run_kaish",
+                        json!({"script": "echo EVIDENCE"}),
+                    ));
+                }
+                // Turn 2: the hallucination. Keyed on the feedback's own words so this
+                // fires exactly once — the responder is content-driven, not counted.
+                if !seen.contains("is not a tool") {
+                    return Ok(tool_call_response("c2", "run_sha", json!({"path": "x"})));
+                }
+                // Turn 3: the model corrects itself and answers.
+                Ok(text_response("ANSWER: built on EVIDENCE"))
+            })
+            .build();
+
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let model = client.completion_model(MODEL);
+        let (answer, _usage) = run_phase(
+            &model,
+            MODEL,
+            "answer the question",
+            16384,
+            None,
+            Message::user("q"),
+            6,
+            None,
+            &crate::progress::NullSink,
+            || {
+                Ok(vec![traced(RunKaish::new(KaishWorker::spawn_with(
+                    &root,
+                    SandboxConfig::default(),
+                )?))])
+            },
+            false,
+        )
+        .await
+        .expect("a tool call naming a tool that does not exist must not fail the phase");
+
+        assert_eq!(answer, "ANSWER: built on EVIDENCE");
+
+        let asked = client.requests_for(MODEL);
+        let last = &asked[asked.len() - 1];
+        assert!(
+            last.transcript.contains("`run_sha` is not a tool"),
+            "the model must be told which name failed: {:?}",
+            last.transcript
+        );
+        assert!(
+            last.transcript.contains("`run_kaish`"),
+            "the model must be told what it CAN call: {:?}",
+            last.transcript
+        );
+        assert!(
+            last.transcript.contains("EVIDENCE"),
+            "the recovered turn keeps the evidence already gathered: {:?}",
+            last.transcript
+        );
+    }
+
+    /// The refusal names the failed name and the real toolset. Both halves matter: a
+    /// model that learns only "wrong" guesses again.
+    #[test]
+    fn the_unknown_tool_refusal_names_the_tool_and_the_toolset() {
+        let available = vec!["attach".to_string(), "run_kaish".to_string()];
+        let msg = unknown_tool_feedback(None, "run_sha", &available, &available)
+            .expect("no tool choice means kaibo answers the call");
+        assert!(msg.contains("`run_sha` is not a tool"), "{msg}");
+        assert!(msg.contains("`attach`, `run_kaish`"), "{msg}");
+        assert!(
+            msg.contains("did not run either"),
+            "the model must learn its other calls were dropped, or it will not reissue \
+             them: {msg}"
+        );
+    }
+
+    /// A real tool the turn's tool choice forbids reads differently from a name that is
+    /// not a tool at all — telling a model `attach` "is not a tool" would be a lie, and
+    /// it would go looking for a different name instead of waiting.
+    #[test]
+    fn a_real_tool_barred_this_turn_is_not_called_nonexistent() {
+        let available = vec!["attach".to_string(), "run_kaish".to_string()];
+        let allowed = vec!["run_kaish".to_string()];
+        let msg = unknown_tool_feedback(None, "attach", &available, &allowed)
+            .expect("a barred tool still gets an answer");
+        assert!(msg.contains("`attach` is a real tool"), "{msg}");
+        assert!(!msg.contains("is not a tool"), "{msg}");
+        assert!(
+            msg.contains("`run_kaish`") && !msg.contains("`attach`, `run_kaish`"),
+            "it names what is callable NOW, not the whole toolset: {msg}"
+        );
+    }
+
+    /// Under `ToolChoice::None` kaibo asked for prose, so a tool call is the model
+    /// ignoring the ask rather than fumbling a name. Declining here keeps the forced
+    /// write-up turn's own diagnostics as the error — and rig rejects a `Skip` under this
+    /// tool choice regardless, so acting would buy nothing.
+    #[test]
+    fn the_forced_write_up_turn_declines_to_answer_a_tool_call() {
+        let available = vec!["run_kaish".to_string()];
+        assert!(
+            unknown_tool_feedback(Some(&ToolChoice::None), "run_sha", &available, &[]).is_none(),
+            "a phase that asked for prose must not offer the model another tool call"
+        );
     }
 
     /// The load-bearing e2e: a scripted consult that delegates a sweep to `explore′`,

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -736,11 +736,15 @@ fn empty_answer_error(
 /// did not run and asks for it again, because a model told only that one name was wrong
 /// would reasonably assume its other calls landed.
 ///
-/// **Under [`ToolChoice::None`] it declines.** That tool choice is kaibo asking for prose
-/// — the forced write-up turn ([`forced_finish_turn`]) — so a tool call there is not a
-/// misnamed tool but a model ignoring the ask, and the write-up path's own diagnostics
-/// are the better error. rig rejects a `Skip` under that tool choice anyway; declining
-/// says so on purpose instead of leaning on a rejection.
+/// **Under [`ToolChoice::None`] it declines, and today nothing reaches that branch.** The
+/// one phase that sets that tool choice is the forced write-up turn
+/// ([`forced_finish_turn`]), which builds its own agent and installs no hooks — so the
+/// branch is guarding a state this tree cannot produce. It is kept because it is the
+/// answer we would want if the write-up path ever did install hooks: that tool choice is
+/// kaibo asking for prose, so a tool call there is a model ignoring the ask rather than
+/// misnaming a tool, and the write-up path's own diagnostics are the better error. rig
+/// rejects a `Skip` under that tool choice regardless, so the branch only ever changes
+/// which of two correct errors is raised. Do not read it as a live guard.
 #[derive(Clone)]
 struct UnknownToolFeedbackHook {
     /// The phase's model id. Carried for the `warn` event only, so telemetry can say
@@ -3270,15 +3274,79 @@ mod tests {
     }
 
     /// Under `ToolChoice::None` kaibo asked for prose, so a tool call is the model
-    /// ignoring the ask rather than fumbling a name. Declining here keeps the forced
-    /// write-up turn's own diagnostics as the error — and rig rejects a `Skip` under this
-    /// tool choice regardless, so acting would buy nothing.
+    /// ignoring the ask rather than fumbling a name. No phase reaches this branch today —
+    /// `forced_finish_turn` is the only caller that sets the tool choice and it installs
+    /// no hooks — so this pins the decision, not a live path. Named for what it asserts
+    /// rather than for a caller, because there is no caller.
     #[test]
-    fn the_forced_write_up_turn_declines_to_answer_a_tool_call() {
+    fn a_prose_only_tool_choice_is_declined_rather_than_answered() {
         let available = vec!["run_kaish".to_string()];
         assert!(
             unknown_tool_feedback(Some(&ToolChoice::None), "run_sha", &available, &[]).is_none(),
             "a phase that asked for prose must not offer the model another tool call"
+        );
+    }
+
+    /// A model that names a phantom tool on *every* turn spends the budget and stops. The
+    /// recovery costs one turn each time and nothing counts the recoveries, so the only
+    /// thing standing between a pathological model and an unbounded loop is that the
+    /// skipped turn is still a turn. This test is what proves it: with a budget of two,
+    /// two hallucinations exhaust it, and the run lands in the turn-cap finalize rather
+    /// than looping. If the skipped turn ever stopped counting, this would hang instead of
+    /// failing — so it is written with a timeout.
+    ///
+    /// Raised by the cross-family review of this change (DeepSeek, 2026-08-11), which
+    /// judged the path structurally safe but untested.
+    #[tokio::test]
+    async fn a_model_that_only_ever_names_phantom_tools_still_terminates() {
+        const MODEL: &str = "driver";
+        let client = ScriptedClient::builder()
+            .on_model(MODEL, |req| {
+                // The finalize turn is the way out: it carries `ToolChoice::None`, so the
+                // model is being asked for prose and answers.
+                if is_finalize_turn(req) {
+                    return Ok(text_response("FORCED FINAL ANSWER"));
+                }
+                Ok(tool_call_response("c", "run_sha", json!({"path": "x"})))
+            })
+            .build();
+
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let model = client.completion_model(MODEL);
+        let run = run_phase(
+            &model,
+            MODEL,
+            "answer the question",
+            16384,
+            None,
+            Message::user("q"),
+            2,
+            None,
+            &crate::progress::NullSink,
+            || {
+                Ok(vec![traced(RunKaish::new(KaishWorker::spawn_with(
+                    &root,
+                    SandboxConfig::default(),
+                )?))])
+            },
+            false,
+        );
+        let (answer, _usage) = tokio::time::timeout(Duration::from_secs(30), run)
+            .await
+            .expect("a phantom tool call every turn must exhaust the budget, not loop")
+            .expect("the turn cap must still produce an answer");
+
+        assert_eq!(answer, "FORCED FINAL ANSWER");
+        let asked = client.requests_for(MODEL);
+        assert!(
+            asked.len() <= 4,
+            "the budget of 2 must bound the recoveries, not be refreshed by them: {} turns",
+            asked.len()
+        );
+        assert!(
+            asked.iter().any(|r| r.tool_choice == Some(ToolChoice::None)),
+            "exhausting the budget must reach the forced write-up turn"
         );
     }
 


### PR DESCRIPTION
A model that named a tool which was never advertised killed the whole phase. Observed twice identically on a flash-tier explorer (`run_sha`, and `run_grail` on an earlier build), each time throwing away every turn of reading already done — before the synth had spent anything.

## The reframe is the change

`docs/issues.md` tracked this as *"a bounded corrective re-prompt"*: catch the error, feed it back, ask again. Amy reframed it before any code was written:

> can we catch incorrect tool calls and return an informational error? sorta hooking method_missing

That is a different fix. A re-prompt is kaibo noticing a failure and spending a model call to work around it. `method_missing` is the call **succeeding**, with an answer that says "that's not a thing, here's what is". The model was going to take another turn regardless. It doesn't need to be asked again; it needs to be told something useful.

And rig had already built it: `rig-agent 0.41` ships `AgentHook::on_invalid_tool_call` returning an `InvalidToolCallAction`, and kaibo has implemented `AgentHook` since the `view_image` break work. So this is a second hook on a stack we already own, not new plumbing.

## Decisions

**`Skip { reason }`, not `Repair`.** rig will let a hook rename the call and dispatch it — `run_sha` → `run_kaish` would have worked on *both* observed failures. It is also a silent fallback: kaibo guessing intent and running a command nobody asked for, where a wrong guess doesn't announce itself. Naming the real tools is strictly more information and leaves the choice with the model. Amy's call.

**It declines under `ToolChoice::None`.** That is kaibo's forced write-up turn (`forced_finish_turn`) asking for prose, so a tool call there is a model ignoring the ask rather than fumbling a name, and the write-up path's own diagnostics are the better error. rig rejects a `Skip` under that tool choice anyway — declining says so on purpose instead of leaning on the rejection.

**The message says the turn ran nothing.** Reading rig's source changed this: when any call is skipped, *none* of the turn's tool calls execute; peers come back as `TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER`. A model told only that one name was wrong would assume its other calls landed. So the refusal's "what to do instead" asks for that work again — a second half we'd have missed by not reading the code we were calling.

**Installed in `run_phase_loop`**, the seam every tool-driven phase runs through, so the consult driver, each delegated `explore′` sweep, and the `deliberate` dossier sweep all inherit it at once. The toolless lanes (`oneshot`, `deliberate`'s direct synth) bypass the agent via `Arm::complete` and can raise no tool call at all.

## Tests

The decision is a pure function (`unknown_tool_feedback`) so it tests without standing up a rig run — three unit tests cover the message, the available-but-barred case, and the `ToolChoice::None` decline.

The e2e is the original repro: a scripted model reads a file, calls `run_sha`, then answers. **Deleting the `add_hook` line fails it with the production error verbatim** — `UnknownToolCall: model attempted to call unknown or disallowed tool run_sha`. The sabotage doesn't approximate the bug, it *is* the bug.

Full suite green (727 lib + every integration suite, 0 failed), clippy clean.

## What this does not do

It is recovery, not prevention — the rate is unchanged. The `warn` per occurrence (model id + advertised toolset) is the first telemetry this class has had. `docs/issues.md` keeps the open half: incidence unmeasured, prevention untouched, and a repeat offender still burns a turn per recovery with nothing counting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
