### PR TITLE
feat(telemetry): export the logs signal, so kaibo's own events can be counted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **`[telemetry]` exports the logs signal too** — kaibo's own `tracing` events, which the
+  span tree never carried, so a warning like a model calling a tool that does not exist
+  becomes countable.
+- **`[telemetry] logs_endpoint`** — omit it and kaibo derives the sibling of `endpoint`;
+  a non-standard endpoint is a startup error naming the key, never a guessed destination.
 - **`deliberate` keeps its dossier in the media CAS, and `dossier` reuses one** — hand
   the digest to a second cast to reason over the same evidence for one synth's price.
 - **A refused dossier write never fails the deliberation** — you lose the record, not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ dependencies = [
  "libc",
  "lru",
  "opentelemetry 0.32.0",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.32.1",
  "regex",
@@ -2271,6 +2272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2354,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.4",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,8 +153,15 @@ opentelemetry_sdk = "0.32"
 # builds a plain reqwest client and uses whatever TLS the (feature-unified) reqwest
 # was compiled with — i.e. our rustls-no-provider + ring. So we keep only the
 # transport features and let TLS come from the shared reqwest above.
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "logs", "http-proto", "reqwest-blocking-client"] }
 tracing-opentelemetry = "0.33"
+# The LOGS signal's half of the bridge: `tracing` events → OTel log records. Traces
+# carry rig's spans (prompts, completions, token counts); this carries kaibo's own
+# `tracing` events, which nothing exported before — the `warn` a phase emits when a
+# model calls a tool that does not exist, and the empty-answer warn, are both only
+# events. Pure `tracing` → `opentelemetry` glue, no transport of its own: it feeds the
+# same OTLP/HTTP exporter and inherits the reqwest/TLS reasoning above.
+opentelemetry-appender-tracing = "0.32"
 
 # sha256 for the media CAS (src/cas.rs): the address IS the digest, so hashing is the
 # one operation the whole design leans on. Pure Rust, no C/asm, already in the lock
@@ -173,6 +180,10 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+# `InMemoryLogExporter`, so the logs-signal filter is proved against real exported
+# records instead of by reading the filter string back. Dev-only: `cargo build` never
+# compiles dev-dependencies, so the `testing` feature cannot reach a shipped binary.
+opentelemetry_sdk = { version = "0.32", features = ["testing"] }
 # `start_paused` tests (the deferred-generate poll loop) auto-advance tokio's clock
 # instead of really sleeping the poll interval.
 tokio = { version = "1", features = ["test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,10 @@ chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 # there. The outbound OTLP socket is allowed under stdio-only (kaibo never *binds*);
 # it stays off unless [telemetry] enables it.
 opentelemetry = "0.32"
-opentelemetry_sdk = "0.32"
+# `logs` is a default feature today and the logs signal would stop compiling without
+# it; named explicitly so a minor bump that re-sorts the defaults fails at resolve
+# time rather than by dropping a signal we ship.
+opentelemetry_sdk = { version = "0.32", features = ["logs"] }
 # No `reqwest-rustls` here: that feature pulls `reqwest/default-tls` → `reqwest/rustls`
 # → aws-lc-rs, re-introducing the C provider we just dropped. The blocking exporter
 # builds a plain reqwest client and uses whatever TLS the (feature-unified) reqwest

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -254,24 +254,30 @@ scratch_limit_bytes = 67108864
                                 # POSIX-unrestricted. A typo here is a load error.
 
 # ---------------------------------------------------------------------------
-# [telemetry] — OpenTelemetry trace export. OFF BY DEFAULT, and that default is
-# load-bearing: kaibo reads private source, and the spans rig emits carry prompts,
-# completions, and source snippets. A default run ships NOTHING. Enabling opens an
-# OUTBOUND OTLP/HTTP connection to `endpoint` — allowed under stdio-only (kaibo
-# never *binds* a socket), but a real boundary, so it's opt-in. rig already emits
-# the GenAI span tree (a tool call → each phase → each model turn, with token
-# usage); this just exports it. Transport is OTLP/HTTP + protobuf (the `/v1/traces`
-# path), reusing kaibo's reqwest — no gRPC. Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,
+# [telemetry] — OpenTelemetry export: traces and logs. OFF BY DEFAULT, and that
+# default is load-bearing: kaibo reads private source, and the spans rig emits carry
+# prompts, completions, and source snippets. A default run ships NOTHING. Enabling
+# opens an OUTBOUND OTLP/HTTP connection to `endpoint` — allowed under stdio-only
+# (kaibo never *binds* a socket), but a real boundary, so it's opt-in. rig already
+# emits the GenAI span tree (a tool call → each phase → each model turn, with token
+# usage); this just exports it. `logs` adds kaibo's own tracing events, which the
+# span tree does not carry. Transport is OTLP/HTTP + protobuf, reusing kaibo's
+# reqwest — no gRPC. Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,LOGS,LOGS_ENDPOINT,
 # TIMEOUT_SECS,SERVICE_NAME}. `headers` is file-only (a value can be a secret).
 # ---------------------------------------------------------------------------
 
 # [telemetry]
 # enabled      = true                                # default false — opt in here
 # endpoint     = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
+# logs         = true                                # default true when enabled
+# Where log records go. Omit it and kaibo derives the sibling of `endpoint` when that
+# ends in /v1/traces; any other shape is a load error rather than a guess.
+# logs_endpoint = "http://localhost:4318/v1/logs"
 # timeout_secs = 10                                  # per-export deadline; must be > 0
-# service_name = "kaibo"                             # service.name on the trace Resource
-# Extra export headers (auth for a remote collector). The VALUES are secrets — they
-# never appear in the kaibo://config render (only the header names do).
+# service_name = "kaibo"                             # service.name on both Resources
+# Extra export headers (auth for a remote collector), sent on both signals. The
+# VALUES are secrets — they never appear in the kaibo://config render (only the
+# header names do).
 # headers = { authorization = "Bearer <token>" }
 
 # ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -582,6 +582,8 @@ Everything else follows one naming rule:
 | ignore scope | `kaish.ignore.scope` *(`"enforced"` \| `"advisory"`; default `"enforced"`)* | — | — |
 | telemetry on/off | `telemetry.enabled` *(default false)* | `KAIBO_TELEMETRY_ENABLED` | — |
 | OTLP traces endpoint | `telemetry.endpoint` | `KAIBO_TELEMETRY_ENDPOINT` | — |
+| logs signal on/off | `telemetry.logs` *(default true when enabled)* | `KAIBO_TELEMETRY_LOGS` | — |
+| OTLP logs endpoint | `telemetry.logs_endpoint` *(derived from `endpoint` when omitted)* | `KAIBO_TELEMETRY_LOGS_ENDPOINT` | — |
 | export timeout (s) | `telemetry.timeout_secs` *(must be > 0)* | `KAIBO_TELEMETRY_TIMEOUT_SECS` | — |
 | trace service name | `telemetry.service_name` | `KAIBO_TELEMETRY_SERVICE_NAME` | — |
 | export headers | `telemetry.headers` *(map; file-only — values are secrets)* | — | — |
@@ -708,7 +710,7 @@ Startup validation of *which backends are usable* is tracked separately in
 `docs/issues.md`. Project-local layering (a repo-root `.kaibo.toml` merged over the user
 config) is a plausible later addition, not implemented.
 
-## Telemetry (OpenTelemetry traces)
+## Telemetry (OpenTelemetry traces and logs)
 
 **Off by default.** kaibo reads a private codebase, and the spans `rig-core` emits carry
 prompts, completions, and source snippets. A default run ships nothing off-box, so
@@ -716,11 +718,13 @@ prompts, completions, and source snippets. A default run ships nothing off-box, 
 
 ```toml
 [telemetry]
-enabled      = true                                # default false
-endpoint     = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
-timeout_secs = 10                                  # per-export deadline; must be > 0
-service_name = "kaibo"                             # service.name on the trace Resource
-headers = { authorization = "Bearer <token>" }     # file-only; values are secrets
+enabled       = true                                # default false
+endpoint      = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
+logs          = true                                # default true when enabled
+logs_endpoint = "http://localhost:4318/v1/logs"     # omit to derive from endpoint
+timeout_secs  = 10                                  # per-export deadline; must be > 0
+service_name  = "kaibo"                             # service.name on both Resources
+headers = { authorization = "Bearer <token>" }      # file-only; values are secrets
 ```
 
 **What you get.** The GenAI trace tree rig produces — a tool call → `run_phase` per
@@ -733,8 +737,25 @@ and every `gen_ai.usage.*` token count. kaibo adds:
   `view_image`, the nested `explore′`), not just that a turn happened. rig's own
   per-tool instrumentation is not reliably queryable across backends.
 
-Transport is OTLP/HTTP with protobuf on the `/v1/traces` path, reusing kaibo's
-`reqwest`. No gRPC and no second HTTP stack.
+Transport is OTLP/HTTP with protobuf, reusing kaibo's `reqwest`. No gRPC and no second
+HTTP stack.
+
+**The logs signal.** `logs` is on whenever `enabled` is, and exports kaibo's own
+`tracing` events — the diagnostics the span tree does not carry. Some of what kaibo
+reports about a run is only ever an event: the `warn` when a model calls a tool that
+does not exist and is answered with the real toolset, and the `warn` when a phase
+returns an empty answer and is forced into a write-up turn. Counting either one needs
+this signal.
+
+Records are filtered to kaibo's own `kaibo` target. rig's event-level chatter is left
+out on purpose: it repeats the prompt and completion text the traces already carry, so
+exporting it again would pay twice for the most sensitive content kaibo handles.
+
+Set `logs = false` for a collector that accepts spans but not records. Set
+`logs_endpoint` when your collector does not sit at the standard paths — kaibo derives
+the logs URL from `endpoint` only when that ends in `/v1/traces`, and **fails at startup
+naming the key** for any other shape rather than guessing a destination. A guess would
+surface only as records that never arrive.
 
 **Boundary.** Enabling opens an **outbound** OTLP connection to `endpoint`. This is
 allowed under kaibo's stdio-only invariant: kaibo can read a filesystem, so it must never
@@ -745,8 +766,10 @@ remote.
 Header **values** are secrets and never appear in the `kaibo://config` render; only the
 header *names* do, like an API-key env-var name.
 
-Logs continue to ride the `tracing` → stderr + MCP `notifications/message` path
-regardless. Telemetry adds the traces signal only.
+kaibo's events keep riding the `tracing` → stderr + MCP `notifications/message` path
+regardless; the logs signal exports them in addition, it does not move them. Metrics
+are still not exported — rig records token usage as span fields, so derive counters
+from the traces at your collector.
 
 ## Persistence: `[persistence]`
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,56 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-12 — the instrument had nowhere to report
+
+This one sat at P4 for weeks with an honest question attached: *is a logs signal worth
+the content and cost, given traces already carry the prompts and completions?* Framed
+that way the answer kept coming back "not yet", and that was right every time it was
+asked.
+
+What changed is that two parties wanted the same number. Genba — Amy's work fleet —
+asked for the unknown-tool recovery rate by name, to cite when they teach cross-model
+review. Our own tracker had been asking for the empty-answer incidence since the guard
+shipped. Both are `warn` events. Neither is a span. So the honest status of both entries
+was not "unmeasured" but *unmeasurable*: `[telemetry]` exported traces, while kaibo's
+events rode stderr and the MCP notification bridge, which the `mcp-notification-channels`
+finding already established do not reach a calling agent. We had built the instrument
+twice and never built the gauge.
+
+The day before, a provocation attempt closed the other road. Told to call a nonexistent
+tool, the local Gemma treated the name as a shell command, got kaish's `exit: 127`, found
+`checksum` in `help builtins`, and finished the task correctly. DeepSeek — the family
+that produced the phantom tool in the wild — simply declined to. **A capable model asked
+to fail on demand does not.** So there is no benchmark for this class, only passive
+collection, and passive collection needed a sink.
+
+That reframes the old question rather than answering it. The cost worry was about
+*content*: rig's spans carry prompts, completions, source snippets. But kaibo's own
+events are diagnostics kaibo writes about itself, strictly less sensitive than what an
+operator already accepted when they turned traces on. So logs ride the same opt-in — one
+`enabled`, both signals — and the layer's filter is `kaibo=info` rather than the traces
+layer's `info`. That asymmetry is the design, not an oversight: rig also emits
+event-level chatter repeating the prompt text, and exporting it again as loose log lines
+would pay twice for the most sensitive bytes we handle.
+
+The one real decision was the endpoint. Traces sit at `/v1/traces`, logs at `/v1/logs`,
+and it is tempting to just swap the suffix. But an operator whose collector lives at
+`/otlp/ingest` would then get their diagnostics posted to a URL they never chose, and
+they would discover it by the records never arriving — the exact silent failure this
+house refuses. So the derivation is scoped to the standard shape and anything else is a
+startup error naming `logs_endpoint`. Amy's ruling that same morning about `attach.rs`
+sharpened how that error reads: state the action, don't point at a tracker.
+
+Proved rather than assumed, twice over. Breaking the filter to `info` made the filter
+test fail with rig's chatter in the diff; making the derivation fall back silently made
+the refusal test fail. Then a local HTTP sink caught the real exports: two POSTs, one to
+`/v1/traces` and one to the **derived** `/v1/logs`, both carrying the probe marker. The
+offline test proves the filter; only the wire proves the record leaves the process.
+
+`docs/issues.md` keeps the metrics signal and gains a new entry — *now go collect the two
+rates*. The plumbing is no longer the blocker, which means the next honest status for
+those entries is a number or nothing.
+
 ## 2026-08-11 — method_missing, for models
 
 We had this tracked as "a bounded corrective re-prompt": catch `UnknownToolCall`, feed the

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -856,19 +856,21 @@ defaults (`credentials.rs`, `docs/config.md`). A secrets *manager* is still out 
 scope: by design the TOML references keys, never inlines them, so "point at
 `$SECRET_TOOL` output" would be a future key-source variant alongside env/file.
 
-### OTLP logs + metrics signals (deferred — traces shipped)
-The **traces** signal is in: `[telemetry]` (off by default) stands up an OTLP/HTTP
-exporter and a `tracing-opentelemetry` layer in `main.rs`, exporting the GenAI span
-tree rig already emits (`src/telemetry.rs`, `docs/config.md`). Two signals remain:
-- **Logs** — kaibo's `tracing` events (the `kaibo`-target log lines) as an OTLP
-  *logs* signal via `opentelemetry-appender-tracing`, a third layer in the same
-  registry stack. Today they still ride stderr + the MCP `notifications/message`
-  bridge only; nothing exports them.
-- **Metrics** — rig records token usage as span *fields*, not as metric
-  instruments. Real counters/histograms (tokens, per-phase latency, sweep fan-out)
-  are hand-rolled, or derived from spans at the collector. Decide which before
-  adding an `opentelemetry` metrics provider.
-Both reuse the same off-by-default `[telemetry]` gate and endpoint; the open
-question is whether the content/cost of a logs signal is worth it given traces
-already carry the prompts/completions. The session's `otlp-mcp` collector is the
-sink for a probe.
+### OTLP metrics signal (deferred — traces and logs shipped)
+**Metrics** — rig records token usage as span *fields*, not as metric instruments.
+Real counters/histograms (tokens, per-phase latency, sweep fan-out) are hand-rolled,
+or derived from spans at the collector. Decide which before adding an
+`opentelemetry` metrics provider; it reuses the same off-by-default `[telemetry]`
+gate and endpoint the other two signals do.
+
+### Now collect the two rates the logs signal was built for
+The sink shipped, so the counting can start — and until someone runs it, the two
+"incidence is unmeasured" entries above stay open on data, not on plumbing:
+- **Unknown-tool recovery rate.** Genba asked for it by name to cite when teaching
+  cross-model review. The `warn` carries the model id and the advertised toolset;
+  the split that matters is rescued-by-feedback vs. named-a-second-phantom-tool.
+  It cannot be benchmarked — a capable model asked to call a nonexistent tool
+  simply declines (measured 2026-08-11 against `openai-local` and `deepseek`), so
+  this comes from real sessions or not at all.
+- **Empty-answer incidence**, split by `finish_reason` and by
+  rescued-by-forced-turn, per that entry's first bullet.

--- a/src/config.rs
+++ b/src/config.rs
@@ -928,6 +928,15 @@ pub struct TelemetryConfig {
     pub enabled: bool,
     /// OTLP/HTTP (protobuf) traces endpoint, e.g. `http://localhost:4318/v1/traces`.
     pub endpoint: String,
+    /// Whether to export the **logs** signal alongside traces. On whenever
+    /// `enabled` is — the two ride one opt-in, because kaibo's own `tracing` events
+    /// are strictly less sensitive than the prompts and completions the traces
+    /// already carry. Turn it off for a collector that takes spans but not logs.
+    pub logs: bool,
+    /// OTLP/HTTP logs endpoint. `None` derives it from [`endpoint`](Self::endpoint)
+    /// when that ends in the standard `/v1/traces`; any other shape is a loud load
+    /// error rather than a guess (see `telemetry::resolve_logs_endpoint`).
+    pub logs_endpoint: Option<String>,
     /// Extra headers on each export request (auth for a remote collector, etc.).
     /// File-only — a header map has no clean single-env-var form.
     pub headers: BTreeMap<String, String>,
@@ -944,6 +953,8 @@ impl Default for TelemetryConfig {
             // The session's `otlp-mcp` collector and most local collectors listen
             // here; flipping `enabled` alone targets localhost, never a remote.
             endpoint: "http://localhost:4318/v1/traces".to_string(),
+            logs: true,
+            logs_endpoint: None,
             headers: BTreeMap::new(),
             timeout: Duration::from_secs(10),
             service_name: "kaibo".to_string(),
@@ -2402,6 +2413,8 @@ struct RawConfig {
 struct RawTelemetry {
     enabled: Option<bool>,
     endpoint: Option<String>,
+    logs: Option<bool>,
+    logs_endpoint: Option<String>,
     headers: Option<BTreeMap<String, String>>,
     timeout_secs: Option<u64>,
     service_name: Option<String>,
@@ -2881,6 +2894,8 @@ fn merge_telemetry(raw: RawTelemetry) -> Result<TelemetryConfig> {
     Ok(TelemetryConfig {
         enabled: raw.enabled.unwrap_or(d.enabled),
         endpoint: raw.endpoint.unwrap_or(d.endpoint),
+        logs: raw.logs.unwrap_or(d.logs),
+        logs_endpoint: raw.logs_endpoint.or(d.logs_endpoint),
         headers: raw.headers.unwrap_or(d.headers),
         timeout,
         service_name: raw.service_name.unwrap_or(d.service_name),
@@ -3223,6 +3238,18 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if let Some(v) = get("KAIBO_TELEMETRY_ENDPOINT") {
         telemetry.endpoint = Some(v);
+    }
+    if let Some(v) = get("KAIBO_TELEMETRY_LOGS") {
+        // Same on/off grammar as KAIBO_TELEMETRY_ENABLED above, and for the same
+        // reason: it must be able to turn a file-enabled logs signal back off.
+        let on = {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no"
+        };
+        telemetry.logs = Some(on);
+    }
+    if let Some(v) = get("KAIBO_TELEMETRY_LOGS_ENDPOINT") {
+        telemetry.logs_endpoint = Some(v);
     }
     if let Some(v) = get("KAIBO_TELEMETRY_TIMEOUT_SECS") {
         telemetry.timeout_secs = Some(parse_env_int("KAIBO_TELEMETRY_TIMEOUT_SECS", &v)?);
@@ -3809,7 +3836,10 @@ mod tests {
             // Explorers sweep and cite; none has shown reasoning pressure, so every
             // explorer slot inherits the [defaults] floor.
             if let Some(e) = cast.slots.get(&ModelRole::Explorer) {
-                assert_eq!(e.max_tokens, None, "explorer stays on the floor for {name:?}");
+                assert_eq!(
+                    e.max_tokens, None,
+                    "explorer stays on the floor for {name:?}"
+                );
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,17 +125,18 @@ async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
     // over config.log (unchanged), rebuilt fresh per layer.
     let kaibo_filter =
         || EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(config.log.clone()));
-    // Stand up the OTLP exporter first, so the boxed layer's subscriber type is the
+    // Stand up the OTLP exporters first, so the boxed layers' subscriber type is the
     // bare `Registry`. `None` (zero overhead) unless [telemetry] opted in; the guard
-    // flushes the batch on exit. A build error here is fatal — a misconfigured
-    // exporter is an operator mistake, surfaced loudly, not silently swallowed.
-    let (otel_layer, otel_guard) =
+    // flushes both signals' batches on exit. A build error here is fatal — a
+    // misconfigured exporter (including a logs endpoint kaibo cannot derive) is an
+    // operator mistake, surfaced loudly, not silently swallowed.
+    let (otel_layers, otel_guard) =
         match kaibo::telemetry::init::<tracing_subscriber::Registry>(&config.telemetry)? {
-            Some((layer, guard)) => (Some(layer), Some(guard)),
+            Some((layers, guard)) => (Some(layers), Some(guard)),
             None => (None, None),
         };
     tracing_subscriber::registry()
-        .with(otel_layer)
+        .with(otel_layers)
         .with(
             fmt::layer()
                 .with_writer(std::io::stderr)

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -210,6 +210,14 @@ pub(crate) fn render_config_resource(
     struct TelemetryDoc {
         enabled: bool,
         endpoint: String,
+        /// Whether kaibo's own `tracing` events export alongside the span tree.
+        logs: bool,
+        /// Where those records go, **as resolved** — the explicit `logs_endpoint` or
+        /// the one derived from `endpoint`. Absent when `logs` is off. Resolved
+        /// rather than echoed because the derivation is the part a reader can't do
+        /// in their head from the file.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        logs_endpoint: Option<String>,
         timeout_secs: u64,
         service_name: String,
         #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -570,6 +578,10 @@ pub(crate) fn render_config_resource(
     let crate::config::TelemetryConfig {
         enabled: telemetry_enabled,
         endpoint: telemetry_endpoint,
+        logs: telemetry_logs,
+        // Read through `resolve_logs_endpoint` below, which is where the derivation
+        // lives; the raw override alone would under-report where records go.
+        logs_endpoint: _,
         headers: telemetry_headers,
         timeout: telemetry_timeout,
         service_name: telemetry_service_name,
@@ -643,6 +655,13 @@ pub(crate) fn render_config_resource(
         telemetry: TelemetryDoc {
             enabled: *telemetry_enabled,
             endpoint: telemetry_endpoint.clone(),
+            logs: *telemetry_logs,
+            // A non-derivable endpoint is a fatal startup error, so a *running*
+            // server always resolves here. Reported absent rather than guessed if
+            // that ever stops being true.
+            logs_endpoint: (*telemetry_logs)
+                .then(|| crate::telemetry::resolve_logs_endpoint(&config.telemetry).ok())
+                .flatten(),
             timeout_secs: telemetry_timeout.as_secs(),
             service_name: telemetry_service_name.clone(),
             header_names: telemetry_headers.keys().cloned().collect(),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,4 +1,4 @@
-//! OpenTelemetry traces export — opt-in, off by default.
+//! OpenTelemetry export — traces and logs, opt-in, off by default.
 //!
 //! kaibo barely needs to instrument anything: rig already emits the GenAI span
 //! tree from inside its agent loop — an `invoke_agent` span per phase, a `chat`
@@ -7,8 +7,26 @@
 //! `explore′` sweeps are rig tools, so they show up as tool spans for free; the
 //! `#[instrument]`s on the four MCP handlers and on `run_phase` (see `server.rs` /
 //! `consult.rs`) just give that tree named kaibo parents. This module's whole job
-//! is to *export* it: stand up an OTLP/HTTP exporter and hand a
-//! [`tracing_opentelemetry`] layer to `main`'s subscriber registry.
+//! is to *export* it: stand up the OTLP/HTTP exporters and hand `main`'s subscriber
+//! registry the layers that feed them.
+//!
+//! ## Two signals, and why the second one exists
+//!
+//! Traces carry rig's span tree. **Logs carry kaibo's own `tracing` events**, which
+//! nothing exported before — and several things worth counting are only ever events,
+//! never spans. The two that asked for this: the `warn` a phase emits when a model
+//! calls a tool that does not exist (`consult/engine.rs`), and the `warn` when a
+//! phase returns an empty answer and is forced into a write-up turn. Both classes
+//! were tracked as "incidence unmeasured" precisely because the instrument existed
+//! and had nowhere to report.
+//!
+//! **Which events.** The traces layer admits everything at `info`, because rig's
+//! spans *are* the tree. The logs layer is deliberately narrower — `kaibo=info` —
+//! and that asymmetry is the design. rig also emits event-level chatter carrying
+//! prompt and completion text; traces already carry that content once, in a shape a
+//! backend can read, so exporting it again as loose log lines would pay twice for
+//! the most sensitive bytes kaibo handles. The logs signal is scoped to what kaibo
+//! says about itself.
 //!
 //! ## Boundaries
 //!
@@ -16,18 +34,28 @@
 //!   prompts, completions, and source snippets. A default run must ship nothing —
 //!   so [`init`] returns `Ok(None)` unless `[telemetry]` opts in. See
 //!   [`crate::config::TelemetryConfig`].
-//! - **stdio-only holds.** The exporter opens an *outbound* connection to the
-//!   collector; it never *binds* a socket. That's the line the invariant draws.
+//! - **One opt-in covers both signals.** `logs` defaults on *under* `enabled`,
+//!   because kaibo's own diagnostics are strictly less sensitive than the prompts
+//!   the traces already carry — an operator who accepted the first has no new
+//!   disclosure to weigh. `logs = false` is there for a collector that takes spans
+//!   but not records.
+//! - **The logs endpoint is derived only from the standard path shape**, never
+//!   guessed. See [`resolve_logs_endpoint`] — a misroute would be discovered only by
+//!   the records' absence, which is the silent failure this house refuses.
+//! - **stdio-only holds.** The exporters open *outbound* connections to the
+//!   collector; they never *bind* a socket. That's the line the invariant draws.
 //! - **Never the stdout channel.** Errors (a down collector, a flush timeout) go to
-//!   `tracing` → stderr, never stdout (the MCP transport). The OTel layer's own
-//!   filter excludes the `opentelemetry` target so the SDK's internal logs can't
-//!   feed back into the exporter and loop.
+//!   `tracing` → stderr, never stdout (the MCP transport). Both layers' filters
+//!   exclude the `opentelemetry` target so the SDK's internal logs can't feed back
+//!   into the exporter and loop.
 
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_otlp::{LogExporter, Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
 use tracing::Subscriber;
@@ -36,27 +64,81 @@ use tracing_subscriber::{filter::EnvFilter, Layer};
 
 use crate::config::TelemetryConfig;
 
-/// Owns the tracer provider so `main` can flush and shut it down on exit. The
-/// batch processor buffers spans off-thread; dropping the provider without a
+/// The standard OTLP/HTTP path pair. Deriving one from the other is only honest for
+/// exactly this shape; anything else is the operator's to state.
+const TRACES_PATH: &str = "/v1/traces";
+const LOGS_PATH: &str = "/v1/logs";
+
+/// What the logs layer admits. Narrower than the traces layer's `info` — see the
+/// module docs' "Which events" note for why the model stack is left out.
+const LOGS_FILTER: &str = "kaibo=info,opentelemetry=off";
+
+/// Owns the providers so `main` can flush and shut them down on exit. The batch
+/// processor buffers records off-thread; dropping a provider without a
 /// [`shutdown`](OtelGuard::shutdown) would discard whatever hasn't been exported.
 pub struct OtelGuard {
-    provider: SdkTracerProvider,
+    traces: SdkTracerProvider,
+    /// `None` when `[telemetry] logs = false` — the signal was never stood up.
+    logs: Option<SdkLoggerProvider>,
 }
 
 impl OtelGuard {
-    /// Flush buffered spans and stop the exporter. Errors are logged, not
-    /// propagated: a wedged collector must never turn a clean shutdown into a
-    /// non-zero exit, and there is nothing left to retry against.
+    /// Flush buffered spans and records, then stop the exporters. Errors are logged,
+    /// not propagated: a wedged collector must never turn a clean shutdown into a
+    /// non-zero exit, and there is nothing left to retry against. Both signals are
+    /// shut down even if the first reports an error — one bad collector must not
+    /// strand the other signal's buffer.
     pub fn shutdown(self) {
-        if let Err(e) = self.provider.shutdown() {
+        if let Err(e) = self.traces.shutdown() {
             tracing::warn!(error = %e, "OTLP trace exporter shutdown reported an error");
+        }
+        if let Some(logs) = self.logs {
+            if let Err(e) = logs.shutdown() {
+                tracing::warn!(error = %e, "OTLP log exporter shutdown reported an error");
+            }
         }
     }
 }
 
-/// The boxed tracing layer paired with the guard that flushes it on shutdown —
-/// what [`init`] returns once telemetry is enabled.
-type OtelLayer<S> = (Box<dyn Layer<S> + Send + Sync>, OtelGuard);
+/// The boxed tracing layers paired with the guard that flushes them on shutdown —
+/// what [`init`] returns once telemetry is enabled. A `Vec` because the count varies
+/// with `[telemetry] logs`, and `tracing-subscriber` layers a `Vec` as one unit.
+type OtelLayers<S> = (Vec<Box<dyn Layer<S> + Send + Sync>>, OtelGuard);
+
+/// Where the logs signal exports to: the explicit `logs_endpoint`, else the standard
+/// sibling of a standard traces endpoint.
+///
+/// The refusal in the middle is the point. A collector addressed at some other path
+/// (`/otlp/ingest`, a vendor's ingest URL) gives kaibo no way to know its logs route,
+/// and inventing one would ship kaibo's diagnostics to a URL the operator never chose
+/// — a silent misroute, discovered only by their absence. So it fails at load and
+/// names the key that fixes it.
+pub(crate) fn resolve_logs_endpoint(cfg: &TelemetryConfig) -> Result<String> {
+    if let Some(explicit) = &cfg.logs_endpoint {
+        return Ok(explicit.clone());
+    }
+    match cfg.endpoint.strip_suffix(TRACES_PATH) {
+        Some(base) => Ok(format!("{base}{LOGS_PATH}")),
+        None => bail!(
+            "[telemetry] endpoint `{}` does not end in `{TRACES_PATH}`, so the logs \
+             endpoint cannot be derived from it. Set [telemetry] logs_endpoint to the \
+             collector's OTLP/HTTP logs URL, or set logs = false to export traces only. \
+             Run `kaibo example-config` for the shape.",
+            cfg.endpoint
+        ),
+    }
+}
+
+/// The logs layer alone, over an already-built provider — the seam the filter test
+/// drives with an in-memory exporter instead of a live collector.
+fn logs_layer<S>(provider: &SdkLoggerProvider) -> Box<dyn Layer<S> + Send + Sync>
+where
+    S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
+{
+    OpenTelemetryTracingBridge::new(provider)
+        .with_filter(EnvFilter::new(LOGS_FILTER))
+        .boxed()
+}
 
 /// Build the OTLP exporter and the tracing layer that feeds it, from config.
 ///
@@ -65,13 +147,22 @@ type OtelLayer<S> = (Box<dyn Layer<S> + Send + Sync>, OtelGuard);
 /// an [`OtelGuard`] the caller must hold until after the server loop and then
 /// [`shutdown`](OtelGuard::shutdown). Generic over the subscriber so the layer can
 /// be boxed against `main`'s concrete registry type.
-pub fn init<S>(cfg: &TelemetryConfig) -> Result<Option<OtelLayer<S>>>
+pub fn init<S>(cfg: &TelemetryConfig) -> Result<Option<OtelLayers<S>>>
 where
     S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {
     if !cfg.enabled {
         return Ok(None);
     }
+
+    // Resolve before building anything: a logs endpoint we cannot derive is an
+    // operator mistake, and it should surface as a load error rather than after a
+    // tracer provider is already standing.
+    let logs_endpoint = if cfg.logs {
+        Some(resolve_logs_endpoint(cfg)?)
+    } else {
+        None
+    };
 
     // opentelemetry-otlp builds its own reqwest (blocking) client when we build the
     // exporter below, and — because reqwest is compiled `rustls-no-provider` (see
@@ -101,7 +192,7 @@ where
     // Batch processor: spans buffer off the hot path and export in the background.
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
-        .with_resource(resource)
+        .with_resource(resource.clone())
         .build();
 
     let tracer = provider.tracer("kaibo");
@@ -113,18 +204,57 @@ where
     // could feed back into the exporter and loop.
     let filter = EnvFilter::new("info,opentelemetry=off");
 
-    let layer = tracing_opentelemetry::layer()
+    let mut layers: Vec<Box<dyn Layer<S> + Send + Sync>> = vec![tracing_opentelemetry::layer()
         .with_tracer(tracer)
         .with_filter(filter)
-        .boxed();
+        .boxed()];
 
-    Ok(Some((layer, OtelGuard { provider })))
+    // The logs signal, on the same transport and the same Resource, so a backend
+    // joins a record to the span tree it happened under.
+    let logs_provider = match logs_endpoint {
+        Some(endpoint) => {
+            let exporter = LogExporter::builder()
+                .with_http()
+                .with_protocol(Protocol::HttpBinary)
+                .with_endpoint(endpoint)
+                .with_timeout(cfg.timeout)
+                .with_headers(cfg.headers.clone().into_iter().collect::<HashMap<_, _>>())
+                .build()
+                .context("building the OTLP/HTTP log exporter")?;
+            let logs_provider = SdkLoggerProvider::builder()
+                .with_batch_exporter(exporter)
+                .with_resource(resource)
+                .build();
+            layers.push(logs_layer(&logs_provider));
+            Some(logs_provider)
+        }
+        None => None,
+    };
+
+    Ok(Some((
+        layers,
+        OtelGuard {
+            traces: provider,
+            logs: logs_provider,
+        },
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_subscriber::prelude::*;
     use tracing_subscriber::Registry;
+
+    /// An enabled config pointed somewhere unroutable — these tests build and shut
+    /// down, never export, so nothing needs to be listening.
+    fn enabled() -> TelemetryConfig {
+        TelemetryConfig {
+            enabled: true,
+            endpoint: "http://127.0.0.1:4318/v1/traces".to_string(),
+            ..TelemetryConfig::default()
+        }
+    }
 
     #[test]
     fn disabled_config_installs_nothing() {
@@ -137,20 +267,143 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enabled_config_builds_a_layer_and_shuts_down() {
+    async fn enabled_config_builds_both_signals_and_shuts_down() {
         // Proves the exporter + provider + layer wiring constructs and tears down
         // with our chosen feature set (HTTP/protobuf, reqwest, batch). No network:
         // building the exporter does not connect, and shutdown of an empty buffer
         // doesn't require a reachable collector.
-        let cfg = TelemetryConfig {
-            enabled: true,
-            // Unroutable on purpose — we never export here, only build + shut down.
-            endpoint: "http://127.0.0.1:4318/v1/traces".to_string(),
-            ..TelemetryConfig::default()
-        };
-        let (_layer, guard) = init::<Registry>(&cfg)
+        let cfg = enabled();
+        assert!(cfg.logs, "guard: logs ride the same opt-in by default");
+        let (layers, guard) = init::<Registry>(&cfg)
             .unwrap()
-            .expect("enabled telemetry must yield a layer");
+            .expect("enabled telemetry must yield layers");
+        assert_eq!(
+            layers.len(),
+            2,
+            "an enabled config exports both signals: traces and logs"
+        );
         guard.shutdown();
+    }
+
+    #[tokio::test]
+    async fn logs_can_be_declined_without_losing_traces() {
+        // The escape hatch for an operator whose collector takes spans but not logs:
+        // `logs = false` drops the second signal and keeps the first.
+        let cfg = TelemetryConfig {
+            logs: false,
+            ..enabled()
+        };
+        let (layers, guard) = init::<Registry>(&cfg)
+            .unwrap()
+            .expect("traces alone still yield a layer");
+        assert_eq!(layers.len(), 1, "declining logs leaves the traces layer");
+        guard.shutdown();
+    }
+
+    #[test]
+    fn a_nonstandard_traces_endpoint_refuses_to_guess_the_logs_endpoint() {
+        // Silent fallbacks are the failure we refuse: deriving `/v1/logs` from an
+        // endpoint that is not the standard `/v1/traces` would ship kaibo's logs to a
+        // URL the operator never chose. The load fails instead, naming the key.
+        let cfg = TelemetryConfig {
+            endpoint: "http://collector.internal/otlp/ingest".to_string(),
+            ..enabled()
+        };
+        // Matched rather than `expect_err`d: the Ok arm holds boxed layers, which are
+        // not `Debug`.
+        let err = match init::<Registry>(&cfg) {
+            Ok(_) => panic!("a non-derivable endpoint must refuse, not guess"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("logs_endpoint"),
+            "the refusal must name the key that fixes it; got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_explicit_logs_endpoint_is_used_as_written() {
+        // Both signals can address different collectors; an explicit endpoint is never
+        // second-guessed against the traces one.
+        let cfg = TelemetryConfig {
+            endpoint: "http://collector.internal/otlp/ingest".to_string(),
+            logs_endpoint: Some("http://127.0.0.1:4318/v1/logs".to_string()),
+            ..enabled()
+        };
+        let (layers, guard) = init::<Registry>(&cfg)
+            .unwrap()
+            .expect("an explicit logs endpoint satisfies the derivation");
+        assert_eq!(layers.len(), 2, "both signals build");
+        guard.shutdown();
+    }
+
+    #[test]
+    fn the_standard_endpoint_derives_its_sibling() {
+        assert_eq!(
+            resolve_logs_endpoint(&enabled()).unwrap(),
+            "http://127.0.0.1:4318/v1/logs",
+            "the standard traces path derives the standard logs path"
+        );
+    }
+
+    /// The signal's whole point, and the line that keeps it cheap: kaibo's own events
+    /// are exported, and the model stack's are not.
+    ///
+    /// Why this filter is narrower than the traces layer's: that one admits everything
+    /// at `info` on purpose — rig's spans ARE the trace tree. Events are the opposite
+    /// case. rig emits event-level chatter carrying prompt and completion text, which
+    /// traces already carry once in a shape a backend can read; sending it again as
+    /// loose log lines costs export bytes and duplicates the most sensitive content
+    /// kaibo handles. So the logs signal is scoped to the `kaibo` target: the
+    /// diagnostics kaibo writes about itself, which nothing exported before.
+    #[test]
+    fn the_logs_signal_carries_kaibo_events_and_not_the_model_stack() {
+        use opentelemetry_sdk::logs::{InMemoryLogExporter, SdkLoggerProvider};
+
+        // Same process-global tracing hazard the span-capture tests document: a
+        // no-subscriber test elsewhere in this binary can cache `Interest::never()`
+        // against a callsite we need enabled. See `test_support`.
+        crate::test_support::force_multi_dispatcher();
+        let _serial = crate::test_support::CAPTURE_SERIAL
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let exporter = InMemoryLogExporter::default();
+        let provider = SdkLoggerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+
+        let sub = Registry::default().with(logs_layer::<Registry>(&provider));
+        tracing::subscriber::with_default(sub, || {
+            // The event this signal exists to deliver: the unknown-tool hook's warn
+            // (`consult/engine.rs`), which is the instrument behind the recovery-rate
+            // question and which nothing exported before.
+            tracing::warn!(
+                target: "kaibo::consult::engine",
+                model = "deepseek-v4-pro",
+                "model called a tool that does not exist"
+            );
+            // rig's event chatter: the prompt/completion content traces already carry.
+            tracing::info!(target: "rig::agent_chat", prompt = "secret source", "chat");
+            // The SDK's own logs, which would feed back into the exporter and loop.
+            tracing::info!(target: "opentelemetry", "exporter internal");
+        });
+
+        provider.force_flush().expect("flush the simple exporter");
+        let emitted = exporter.get_emitted_logs().expect("read exported records");
+        let bodies: Vec<String> = emitted
+            .iter()
+            .map(|l| format!("{:?}", l.record.body()))
+            .collect();
+
+        assert_eq!(
+            emitted.len(),
+            1,
+            "exactly kaibo's own event is exported; got: {bodies:?}"
+        );
+        assert!(
+            bodies[0].contains("tool that does not exist"),
+            "the exported record is the unknown-tool warn; got: {bodies:?}"
+        );
     }
 }

--- a/tests/telemetry_live.rs
+++ b/tests/telemetry_live.rs
@@ -1,4 +1,4 @@
-//! Live OTLP export probe — `#[ignore]`d, needs a real OTLP/HTTP collector.
+//! Live OTLP export probe (traces + logs) — `#[ignore]`d, needs a real OTLP/HTTP collector.
 //!
 //! The offline tests (`src/telemetry.rs`) prove the exporter *builds* and the gate
 //! is off-by-default, but they never push a span over a socket — so they can't catch
@@ -35,15 +35,15 @@ async fn live_export_reaches_an_otlp_collector() {
         ..TelemetryConfig::default()
     };
 
-    // Same path the binary takes: build the layer + guard, install the layer, emit a
+    // Same path the binary takes: build the layers + guard, install them, emit a
     // span (rig's spans are `info_span!`s just like this), then force-flush on
     // shutdown. If export is wired wrong this silently no-ops — so the assertion
     // lives downstream (grep the collector), the way the docstring describes.
-    let (layer, guard) = kaibo::telemetry::init::<tracing_subscriber::Registry>(&cfg)
+    let (layers, guard) = kaibo::telemetry::init::<tracing_subscriber::Registry>(&cfg)
         .expect("telemetry init must not error")
-        .expect("an enabled config must yield a layer");
+        .expect("an enabled config must yield layers");
 
-    let sub = tracing_subscriber::registry().with(layer);
+    let sub = tracing_subscriber::registry().with(layers);
     subscriber::with_default(sub, || {
         let span = tracing::info_span!(
             "kaibo_selftest_span",
@@ -52,6 +52,14 @@ async fn live_export_reaches_an_otlp_collector() {
         );
         let _enter = span.enter();
         tracing::info!(marker = MARKER, "selftest span body");
+        // The logs signal rides the same guard and the same offline gap: the unit
+        // test proves the filter, only a live run proves the record leaves the
+        // process. Emitted on the `kaibo` target, which is what that filter admits.
+        tracing::warn!(
+            target: "kaibo::telemetry",
+            marker = MARKER,
+            "selftest log record — the logs signal's half of this probe"
+        );
     });
 
     // Force-flush + stop. Without the blocking-client fix this is where the dropped


### PR DESCRIPTION
`[telemetry]` exported traces only. The span tree is rig's — prompts, completions, token usage — and it does not carry kaibo's own `tracing` events. Several things worth counting are **only ever events**: the `warn` when a model calls a tool that does not exist (`consult/engine.rs`), and the `warn` when a phase returns an empty answer and is forced into a write-up turn. Both were tracked as "incidence unmeasured", and the honest word was *unmeasurable* — the instrument existed and had no sink.

## Why now

Two parties wanted the same number, which is what moved this off P4. Genba (Amy's work fleet) asked for the unknown-tool recovery rate by name, to cite when they teach cross-model review; our own empty-answer entry wants the same sink.

The other road is closed. A provocation pass on 2026-08-11 found that a capable model asked to call a nonexistent tool simply declines — the local Gemma treated the name as a shell command, got kaish's `exit: 127`, found `checksum` in `help builtins`, and finished the task correctly; DeepSeek declined outright. **There is no benchmark for this class, only passive collection**, and passive collection needed a sink.

## Decisions

- **One opt-in covers both signals.** `logs` defaults on under `enabled`. The old deferral asked whether a logs signal was worth its content cost given traces already carry prompts — the answer is that kaibo's own diagnostics are strictly *less* sensitive than what an operator already accepted when they turned traces on. `logs = false` exists for a collector that takes spans but not records.
- **The logs filter is `kaibo=info`, narrower than the traces layer's `info`.** That asymmetry is the design, not an oversight: rig emits event-level chatter repeating prompt and completion text, and exporting it again as loose log lines would pay twice for the most sensitive bytes kaibo handles.
- **The logs endpoint is derived only from the standard shape, never guessed.** A collector at `/otlp/ingest` would otherwise get kaibo's diagnostics posted to a URL the operator never chose — discovered only by the records never arriving, which is exactly the silent failure this house refuses. Any other shape is a startup error naming `logs_endpoint`. Per Amy's ruling the same morning on `attach.rs`, the refusal states the action rather than pointing at a tracker.

## Proof, not assumption

- Broke the filter to `info` → the filter test fails with rig's chatter in the diff.
- Made the derivation fall back silently → the refusal test fails.
- A local HTTP sink caught the **real** exports: two POSTs, one to `/v1/traces` and one to the **derived** `/v1/logs`, both carrying the probe marker. The offline test proves the filter; only the wire proves the record leaves the process.
- Full suite green (733 lib + all integration), `cargo clippy --all-targets` clean.
- `cargo tree -i aws-lc-rs` and `-i mimalloc` both empty — the TLS invariant holds across the new deps (`opentelemetry-otlp`'s `logs` feature, `opentelemetry-appender-tracing`, and a dev-only `opentelemetry_sdk/testing` for the in-memory exporter).

## Tracker

`docs/issues.md` keeps the metrics signal and gains a new entry — *now go collect the two rates*. The plumbing is no longer the blocker, so the next honest status for those entries is a number or nothing.

## Review

Cross-family review by DeepSeek via kaibo's own `consult_submit`, posted as a PR comment. No diff supplied — it read the shipped source holistically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
