### PR TITLE
fix(telemetry): export from the CLI too, and fix kaish.output_bytes's wire type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ record. Each later release appends a new section at the top.
   kaibo reads the accepted rungs back out of the client on every call.
 - **New MCP resource `kaibo://config/guide`** — the configuration manual embedded in the
   binary; example / live state / guide now split by job.
+- **CLI subcommands export telemetry too**, when `[telemetry]` is configured — every
+  export flushes before the process exits, so a short-lived `kaibo consult`/`kaish`/...
+  run no longer loses its spans to `process::exit`.
 
 ### Changed
 
@@ -159,6 +162,8 @@ record. Each later release appends a new section at the top.
   those lanes.
 - **The state-db-collides-with-project-tree refusal now also names
   `--root`/`--allow-path`** — usually the right fix; the refusal itself is unchanged.
+- **`kaish.output_bytes` lands as an OTel int, not a string** — it now rides the same
+  `record_i64` path as `kaish.exit_code` instead of the untyped `record_u64` fallback.
 
 ## [0.2.0] — 2026-07-29
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,45 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-12 — the CLI never had an exporter, and a byte count wore the wrong clothes
+
+Two findings, both surfaced by measuring a real trace instead of trusting the wiring.
+Trying to watch a `kaibo consult` run from a terminal for the unknown-tool span turned
+up nothing at all — `telemetry::init` was called exactly once, inside `serve()`'s
+dispatch arm in `main.rs`. Every CLI subcommand ran with zero exporter, `[telemetry]
+enabled = true` in `config.toml` notwithstanding. Amy's ask was blunt: the CLI should
+try to do otel if it has connection info.
+
+The fix isn't "call `init` everywhere" — every CLI arm leaves through
+`std::process::exit`, which runs no destructors, so a guard merely constructed and
+dropped loses whatever the batch processor hasn't exported yet. A short `kaish -c
+"..."` finishes before the processor's own export interval would ever fire, so a naive
+fix would have shipped the same invisible loss a second time. The guard is threaded
+through explicitly instead: `main.rs` stands up telemetry once, before dispatching to
+whichever subcommand ran, and calls `.shutdown()` on it after the subcommand returns
+and before `exit`. Proved with a real subprocess against a raw TCP collector
+(`tests/telemetry_cli.rs`) rather than trusted by inspection — breaking the flush (drop
+instead of shutdown) turns the test into a clean 10-second timeout with zero
+connections ever accepted, which is exactly the failure this fix has to rule out.
+Telemetry stays off by default either way: `init_cli_telemetry` returns `None` the
+moment `[telemetry]` isn't configured, before touching the subscriber at all.
+
+The second finding came off the same trace. `kaish.exit_code` landed as an OTel int;
+`kaish.output_bytes`, same span, same shape of field, landed as a *string*. Both are
+recorded with `Span::record` — `exit_code` as `i64`, `output_bytes` as `output_bytes as
+u64` — and that cast is the whole bug. tracing-opentelemetry's span visitor implements
+`record_i64` but never got a `record_u64` override; `tracing_core::field::Visit`'s
+default for an unoverridden method falls back to `record_debug`, which stringifies. The
+fix is one word, `u64` to `i64` — a kaish output byte count is nowhere near
+`i64::MAX`. Proving it needed a different kind of test than the obvious one: a
+value-only assertion (`kaish_bytes == Some(4321)`) can't see this bug, because a test
+visitor that implements both `record_i64` and `record_u64` reads back the same value
+either way — which is exactly how the wire bug shipped unnoticed. The test that can
+fail watches *which* `Visit` method actually fires, not what it reports back.
+
+Both are wire-visible changes for anyone already consuming these traces — CHANGELOG
+entries under Added (CLI export) and Fixed (the int/string field).
+
 ## 2026-08-12 — the instrument had nowhere to report
 
 This one sat at P4 for weeks with an honest question attached: *is a logs signal worth

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -725,6 +725,72 @@ fn init_cli_logging() {
         .try_init();
 }
 
+/// [`init_cli_logging`], plus the OTLP layers `[telemetry]` asked for — the CLI's
+/// counterpart to `serve()`'s subscriber build in `main.rs`. Installing both layers
+/// in one `try_init()` call here means a subcommand's own later `init_cli_logging()`
+/// call (every `run_*` fn makes one, for callers that reach it without going through
+/// `main`) simply no-ops — `try_init` is idempotent, and the global default this
+/// function installed already carries both the stderr sink and the exporter.
+fn init_cli_logging_with_otel(
+    otel_layers: Vec<
+        Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync>,
+    >,
+) {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::registry()
+        .with(otel_layers)
+        .with(
+            fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_filter(filter),
+        )
+        .try_init();
+}
+
+/// Stand up OTLP for a CLI subcommand when `[telemetry]` is configured — Amy's ask:
+/// "CLI should try to do otel if it has connection info." Mirrors `serve()` in
+/// `main.rs`: build the exporter layers, install them alongside the CLI's normal
+/// stderr logging, and hand the guard back so `main` can flush and shut it down.
+///
+/// **`main` must hold the returned guard and call
+/// [`shutdown`](crate::telemetry::OtelGuard::shutdown) AFTER the subcommand returns
+/// and BEFORE `std::process::exit`.** Every CLI arm exits through
+/// `std::process::exit`, which skips destructors — a guard merely dropped here would
+/// discard whatever the batch processor hadn't exported yet, silently losing every
+/// span from a short CLI run. This is called once, before dispatch, so it does not
+/// know which subcommand is about to run; the OTel layers export whatever spans that
+/// subcommand's own instrumentation produces (rig's GenAI tree for a model phase,
+/// kaish-kernel's command spans for `kaish`, ...).
+///
+/// A config-load failure here returns `Ok(None)` rather than propagating: telemetry
+/// is off in that case the same as if it were never configured, and the *real* error
+/// surfaces a moment later when the subcommand makes its own `load_config` call and
+/// reports it through the normal `--json`/stderr preflight path — swallowing it here
+/// only defers where it's told, it never hides it. A telemetry-specific failure
+/// (config loads fine but the exporter itself won't build — e.g. a logs endpoint
+/// that can't be derived) is different: nothing else re-checks that, so it propagates
+/// loudly, same as the fatal build error on the `serve` path.
+pub async fn init_cli_telemetry(
+    common: &CommonArgs,
+) -> anyhow::Result<Option<crate::telemetry::OtelGuard>> {
+    let Ok(config) = load_config(common) else {
+        return Ok(None);
+    };
+    if !config.telemetry.enabled {
+        return Ok(None);
+    }
+    match crate::telemetry::init::<tracing_subscriber::Registry>(&config.telemetry)? {
+        Some((layers, guard)) => {
+            init_cli_logging_with_otel(layers);
+            Ok(Some(guard))
+        }
+        // `enabled` is checked above, so `init` cannot return `None` here — kept as a
+        // match arm rather than `.expect()` because the type is still `Option`.
+        None => Ok(None),
+    }
+}
+
 /// Print `err` to stderr and return `code` — the shared shape for a **pre-flight**
 /// rejection (usage *or* setup/containment), i.e. anything refused before the model
 /// runs. Carries the `kind`/`code` its caller classified (it renders both, so the name

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,40 +32,51 @@ async fn main() -> Result<()> {
     // subcommand); each arm consumes them alongside its own payload.
     match cli.command {
         // Bare `kaibo` and explicit `kaibo serve` both run the MCP server on the same
-        // flags — the compatibility contract for existing client configs.
+        // flags — the compatibility contract for existing client configs. `serve()`
+        // stands up its own OTLP guard and flushes it before returning (no
+        // `process::exit` on this path, so a plain `Drop` would already be safe here —
+        // it does the flush explicitly anyway, to keep both paths' shutdown visible
+        // and symmetric).
         None => serve(cli.common, cli.gates).await,
         Some(Command::Serve(gates)) => serve(cli.common, gates).await,
-        // The CLI front doors own their exit codes (0 answer / 2 usage / 3 setup /
-        // 4 consultation failure; kaish passes through its own code), so they return a
-        // code and we exit on it.
-        Some(Command::Consult(args)) => {
-            std::process::exit(kaibo::cli::run_consult(cli.common, args).await)
+        // Every other subcommand is a CLI front door: it owns its exit code (0 answer
+        // / 2 usage / 3 setup / 4 consultation failure; kaish passes through its own
+        // code) and always leaves through `std::process::exit`, which runs no
+        // destructors. So telemetry is stood up here, BEFORE the subcommand runs, and
+        // flushed here, AFTER it returns but BEFORE `exit` — a guard merely dropped
+        // at the end of this block would never run (`exit` skips it) and every
+        // buffered span from the run would be lost silently. `init_cli_telemetry`
+        // returns `None` (the common case: telemetry unconfigured) without installing
+        // anything, so a default CLI run is unchanged.
+        Some(command) => {
+            let otel_guard = kaibo::cli::init_cli_telemetry(&cli.common).await?;
+            let code = run_command(cli.common, command).await;
+            if let Some(guard) = otel_guard {
+                guard.shutdown();
+            }
+            std::process::exit(code);
         }
-        Some(Command::Oneshot(args)) => {
-            std::process::exit(kaibo::cli::run_oneshot(cli.common, args).await)
-        }
-        Some(Command::Explore(args)) => {
-            std::process::exit(kaibo::cli::run_explore(cli.common, args).await)
-        }
-        Some(Command::Deliberate(args)) => {
-            std::process::exit(kaibo::cli::run_deliberate(cli.common, args).await)
-        }
-        Some(Command::Kaish(args)) => {
-            std::process::exit(kaibo::cli::run_kaish(cli.common, args).await)
-        }
-        Some(Command::Batch(args)) => {
-            std::process::exit(kaibo::cli::run_batch(cli.common, args).await)
-        }
-        Some(Command::Generate(args)) => {
-            std::process::exit(kaibo::cli::run_generate(cli.common, args).await)
-        }
-        Some(Command::Cas(args)) => std::process::exit(kaibo::cli::run_cas(cli.common, args).await),
-        Some(Command::Models(args)) => {
-            std::process::exit(kaibo::cli::run_models(cli.common, args).await)
-        }
-        Some(Command::Config) => std::process::exit(kaibo::cli::run_config(cli.common)),
-        Some(Command::Configure(args)) => std::process::exit(kaibo::cli::run_configure(args.goal)),
-        Some(Command::ExampleConfig) => std::process::exit(kaibo::cli::run_example_config()),
+    }
+}
+
+/// Dispatch a non-`serve` subcommand to its CLI front door and return its exit code.
+/// Split out of `main` so telemetry setup/flush (see [`main`]) wraps every arm in one
+/// place instead of being repeated per-arm.
+async fn run_command(common: CommonArgs, command: Command) -> i32 {
+    match command {
+        Command::Serve(_) => unreachable!("serve is dispatched directly in main, before this fn"),
+        Command::Consult(args) => kaibo::cli::run_consult(common, args).await,
+        Command::Oneshot(args) => kaibo::cli::run_oneshot(common, args).await,
+        Command::Explore(args) => kaibo::cli::run_explore(common, args).await,
+        Command::Deliberate(args) => kaibo::cli::run_deliberate(common, args).await,
+        Command::Kaish(args) => kaibo::cli::run_kaish(common, args).await,
+        Command::Batch(args) => kaibo::cli::run_batch(common, args).await,
+        Command::Generate(args) => kaibo::cli::run_generate(common, args).await,
+        Command::Cas(args) => kaibo::cli::run_cas(common, args).await,
+        Command::Models(args) => kaibo::cli::run_models(common, args).await,
+        Command::Config => kaibo::cli::run_config(common),
+        Command::Configure(args) => kaibo::cli::run_configure(args.goal),
+        Command::ExampleConfig => kaibo::cli::run_example_config(),
     }
 }
 

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -63,7 +63,16 @@ where
 pub(crate) fn record_kaish_result(exit_code: i64, output_bytes: usize) {
     let span = Span::current();
     span.record("kaish.exit_code", exit_code);
-    span.record("kaish.output_bytes", output_bytes as u64);
+    // i64, not u64: tracing-opentelemetry's span visitor implements `record_i64` but
+    // has no `record_u64` override, and `tracing_core::field::Visit::record_u64`'s
+    // default implementation falls back to `record_debug` when a visitor doesn't
+    // override it — which stringifies the value into an OTel `stringValue` attribute
+    // instead of an `intValue`. `kaish.exit_code` above is already `i64` and lands as
+    // an int; casting `output_bytes` to `i64` here (never `u64`) sends it through the
+    // same `record_i64` path so it lands as an int too. `usize as i64` is safe: a
+    // kaish output byte count is bounded by `output_limit_bytes`, nowhere near
+    // `i64::MAX`.
+    span.record("kaish.output_bytes", output_bytes as i64);
 }
 
 /// Erase a typed tool into a span-wrapped [`DynamicTool`] — the toolset-assembly
@@ -258,15 +267,15 @@ mod tests {
                 _ => {}
             }
         }
-        // `run_kaish`'s result fields arrive as native numbers, not strings.
+        // `run_kaish`'s result fields arrive as native numbers, not strings — both as
+        // `i64` (see the cast comment on `record_kaish_result`), so both are grabbed
+        // here rather than one landing in a `record_u64` override this visitor
+        // deliberately does not implement.
         fn record_i64(&mut self, f: &tracing::field::Field, v: i64) {
-            if f.name() == "kaish.exit_code" {
-                self.kaish_exit = Some(v);
-            }
-        }
-        fn record_u64(&mut self, f: &tracing::field::Field, v: u64) {
-            if f.name() == "kaish.output_bytes" {
-                self.kaish_bytes = Some(v);
+            match f.name() {
+                "kaish.exit_code" => self.kaish_exit = Some(v),
+                "kaish.output_bytes" => self.kaish_bytes = Some(v as u64),
+                _ => {}
             }
         }
         // `%summary`/`%name` record via Display, which arrives as a debug value.
@@ -489,6 +498,94 @@ mod tests {
                     && s.kaish_exit == Some(3)
                     && s.kaish_bytes == Some(4321)),
                 "the tool span must carry kaish.exit_code=3 and kaish.output_bytes=4321"
+            );
+        });
+    }
+
+    /// The type on the wire, not just the value: `kaish.output_bytes` must be
+    /// recorded through `Visit::record_i64`, the same method `kaish.exit_code` goes
+    /// through — never `record_u64`. This is the field-type bug confirmed on a real
+    /// exported trace (`kaish.exit_code -> {"intValue": "3"}`,
+    /// `kaish.output_bytes -> {"stringValue": "1608"}`): tracing-opentelemetry's span
+    /// visitor implements `record_i64` but has no `record_u64` override, so a u64
+    /// recording falls through to `Visit::record_u64`'s default (`record_debug`) and
+    /// ships as a string attribute. A value-only assertion (as in the test above)
+    /// cannot see this — a `u64` recording of `4321` and an `i64` recording of `4321`
+    /// both read back as `Some(4321)` through a visitor that implements both methods,
+    /// which is exactly why the wire bug shipped unnoticed. This test watches which
+    /// `Visit` method actually fires instead.
+    #[test]
+    fn kaish_output_bytes_is_recorded_as_i64_not_u64() {
+        #[derive(Default)]
+        struct TypeProbe {
+            exit_code_via_i64: bool,
+            output_bytes_via_i64: bool,
+            output_bytes_via_u64: bool,
+        }
+        impl tracing::field::Visit for TypeProbe {
+            fn record_i64(&mut self, field: &tracing::field::Field, _value: i64) {
+                match field.name() {
+                    "kaish.exit_code" => self.exit_code_via_i64 = true,
+                    "kaish.output_bytes" => self.output_bytes_via_i64 = true,
+                    _ => {}
+                }
+            }
+            fn record_u64(&mut self, field: &tracing::field::Field, _value: u64) {
+                if field.name() == "kaish.output_bytes" {
+                    self.output_bytes_via_u64 = true;
+                }
+            }
+            fn record_debug(
+                &mut self,
+                _field: &tracing::field::Field,
+                _value: &dyn std::fmt::Debug,
+            ) {
+                // Deliberately blank: a debug-only visitor can't tell string from
+                // int, which is the whole failure mode under test. This override
+                // exists only so the default `record_i64`/`record_u64` -> `record_debug`
+                // fallback in `tracing_core::field::Visit` doesn't panic (its default
+                // body is a no-op already, but naming it keeps the probe's intent
+                // explicit: we watch the typed methods, not the debug fallback).
+            }
+        }
+
+        struct ProbeLayer(Arc<Mutex<TypeProbe>>);
+        impl<S: tracing::Subscriber + for<'a> LookupSpan<'a>> Layer<S> for ProbeLayer {
+            fn on_record(
+                &self,
+                _id: &tracing::Id,
+                values: &tracing::span::Record<'_>,
+                _ctx: Context<'_, S>,
+            ) {
+                values.record(&mut *self.0.lock().unwrap());
+            }
+        }
+
+        serialized_capture(async {
+            let probe = Arc::new(Mutex::new(TypeProbe::default()));
+            let sub = tracing_subscriber::registry().with(ProbeLayer(Arc::clone(&probe)));
+            let _g = tracing::subscriber::set_default(sub);
+
+            let span = tracing::info_span!(
+                "tool",
+                "kaish.exit_code" = tracing::field::Empty,
+                "kaish.output_bytes" = tracing::field::Empty,
+            );
+            let _enter = span.enter();
+            record_kaish_result(3, 4321);
+            drop(_enter);
+            drop(_g);
+
+            let probe = probe.lock().unwrap();
+            assert!(
+                probe.exit_code_via_i64,
+                "kaish.exit_code must be recorded via record_i64"
+            );
+            assert!(
+                probe.output_bytes_via_i64 && !probe.output_bytes_via_u64,
+                "kaish.output_bytes must be recorded via record_i64 (matching \
+                 kaish.exit_code), not record_u64 — a u64 recording is the bug that \
+                 shipped kaish.output_bytes as a string attribute on the wire"
             );
         });
     }

--- a/tests/telemetry_cli.rs
+++ b/tests/telemetry_cli.rs
@@ -1,0 +1,241 @@
+//! The CLI path exports telemetry too, and actually flushes it — end to end, over a
+//! real socket, driving the real binary the way a terminal user does.
+//!
+//! Before this file's fix, `kaibo::telemetry::init` was called only from `serve()`
+//! (`src/main.rs`), inside the MCP-server dispatch arm — every CLI subcommand
+//! (`consult`, `kaish`, ...) ran with no exporter at all, so a terminal `kaibo kaish`
+//! shipped nothing even with `[telemetry] enabled = true` in `config.toml`. The
+//! offline unit tests in `src/telemetry.rs` prove the exporter *builds*; they can't
+//! prove the CLI actually *reaches* it, and they can't catch the specific footgun
+//! this fix has to dodge: every CLI arm leaves through `std::process::exit`, which
+//! runs no destructors, so a guard that is merely constructed and dropped (rather
+//! than explicitly `.shutdown()`-ed before the exit call) would silently lose every
+//! span the batch processor hasn't exported yet. A short-lived `kaish -c "echo hi"`
+//! finishes and would exit before the processor's own export interval ever fires —
+//! so the only way to prove the flush works is to watch a real request land on a
+//! real socket, from a real spawned process, the way `tests/openai_images_transport.rs`
+//! and `tests/llm_timeout.rs` do for other transports.
+//!
+//! Hermetic like `tests/mcp_stdio.rs`: `env_clear()`, then rebuild only `HOME` and
+//! `XDG_CONFIG_HOME` from temp dirs, so nothing in the developer's shell (a stray
+//! `KAIBO_*`, an inherited `RUST_LOG`) can change what's under test.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::Command;
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// One captured HTTP request: the request line and the body length the client
+/// declared (protobuf, not JSON — we don't need to decode it, only prove it arrived).
+struct Captured {
+    request_line: String,
+    content_type: Option<String>,
+    body_len: usize,
+}
+
+/// Accept exactly one HTTP exchange on an ephemeral port, hand back a 200 with an
+/// empty (still-valid) protobuf body, and surrender the captured request over the
+/// returned receiver. Runs on its own OS thread so it can accept while the test's
+/// main thread blocks on the child process via `Command::output()`.
+fn one_shot_collector() -> (u16, mpsc::Receiver<Captured>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let (mut sock, _) = match listener.accept() {
+            Ok(pair) => pair,
+            // No connection ever arrived (the flush regressed): let the receiver's
+            // `recv_timeout` in the test report that, rather than panicking a
+            // detached thread where the message wouldn't surface.
+            Err(_) => return,
+        };
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let n = match sock.read(&mut chunk) {
+                Ok(0) | Err(_) => return,
+                Ok(n) => n,
+            };
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+            if buf.len() > 1 << 20 {
+                return; // a request head this large is not one of ours
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+        let content_length: usize = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse().unwrap_or(0))
+            })
+            .unwrap_or(0);
+        while buf.len() < head_end + content_length {
+            let mut chunk = [0u8; 4096];
+            match sock.read(&mut chunk) {
+                Ok(0) | Err(_) => return,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            }
+        }
+        let content_type = head.lines().find_map(|l| {
+            l.to_ascii_lowercase()
+                .strip_prefix("content-type:")
+                .map(|v| v.trim().to_string())
+        });
+        let response = b"HTTP/1.1 200 OK\r\ncontent-type: application/x-protobuf\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+        let _ = sock.write_all(response);
+        let _ = sock.shutdown(std::net::Shutdown::Both);
+        let _ = tx.send(Captured {
+            request_line: head.lines().next().unwrap_or("").to_string(),
+            content_type,
+            body_len: content_length,
+        });
+    });
+    (port, rx)
+}
+
+/// Spawn the real binary as `kaibo kaish -c "echo …"` against a hermetic `HOME` /
+/// `XDG_CONFIG_HOME`, with `[telemetry] enabled = true` pointed at `port`. Returns
+/// once the process exits — the point in time at which every buffered span must
+/// already be on the wire, if the flush-before-exit fix is in place.
+fn run_kaish_with_telemetry(port: u16, logs: bool) -> std::process::Output {
+    let xdg_home = tempfile::tempdir().expect("tempdir for HOME/XDG_CONFIG_HOME");
+    let home = xdg_home.path().join("home");
+    let config_dir = xdg_home.path().join("config").join("kaibo");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            r#"
+            [telemetry]
+            enabled = true
+            endpoint = "http://127.0.0.1:{port}/v1/traces"
+            logs = {logs}
+            service_name = "kaibo-cli-otel-test"
+            "#,
+        ),
+    )
+    .expect("write config.toml");
+
+    let project = tempfile::tempdir().expect("tempdir for the --root project");
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"p\"\n",
+    )
+    .unwrap();
+
+    Command::new(env!("CARGO_BIN_EXE_kaibo"))
+        .env_clear()
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", xdg_home.path().join("config"))
+        .args([
+            "--root",
+            project.path().to_str().unwrap(),
+            "kaish",
+            "-c",
+            "echo cli-otel-flush-probe",
+        ])
+        .output()
+        .expect("spawn the kaibo binary")
+}
+
+/// The teeth: a CLI `kaish` run with telemetry configured must deliver a trace
+/// export to the collector before the process exits, not merely construct an
+/// exporter it never flushes. Proven by breaking the fix (dropping the guard
+/// instead of calling `.shutdown()`) and watching this test time out with no
+/// connection ever accepted — see the devlog/PR for that run.
+#[test]
+fn cli_kaish_flushes_a_trace_export_before_the_process_exits() {
+    let (port, rx) = one_shot_collector();
+
+    let out = run_kaish_with_telemetry(port, false);
+    assert!(
+        out.status.success(),
+        "the script itself must have run cleanly: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("cli-otel-flush-probe"),
+        "the script's own output must still reach stdout unchanged"
+    );
+
+    let captured = rx.recv_timeout(Duration::from_secs(10)).expect(
+        "no OTLP export reached the collector within 10s after the CLI process \
+             exited — the flush-before-exit wiring regressed (a dropped-not-shutdown \
+             guard loses every buffered span to std::process::exit)",
+    );
+    assert_eq!(
+        captured.request_line, "POST /v1/traces HTTP/1.1",
+        "the exporter must POST to the configured traces path"
+    );
+    assert_eq!(
+        captured.content_type.as_deref(),
+        Some("application/x-protobuf"),
+        "OTLP/HTTP protobuf, the transport kaibo is pinned to"
+    );
+    assert!(
+        captured.body_len > 0,
+        "the exported request must carry actual span bytes, not an empty POST"
+    );
+}
+
+/// A default CLI run (no `[telemetry]` in config.toml) must ship nothing — telemetry
+/// stays off by default even though `init_cli_telemetry` now runs unconditionally
+/// ahead of every subcommand. Proven by pointing a would-be collector at a real port
+/// and confirming nothing ever connects.
+#[test]
+fn cli_kaish_without_telemetry_configured_dials_nothing() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking so the accept below can poll instead of hang");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    let xdg_home = tempfile::tempdir().expect("tempdir for HOME/XDG_CONFIG_HOME");
+    let home = xdg_home.path().join("home");
+    let config_dir = xdg_home.path().join("config").join("kaibo");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    // No config.toml at all: `Config::load` treats that as "use the built-in
+    // defaults", and the built-in default has `[telemetry] enabled = false`.
+    let project = tempfile::tempdir().expect("tempdir for the --root project");
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"p\"\n",
+    )
+    .unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_kaibo"))
+        .env_clear()
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", xdg_home.path().join("config"))
+        .args([
+            "--root",
+            project.path().to_str().unwrap(),
+            "kaish",
+            "-c",
+            "echo no-telemetry-probe",
+        ])
+        .output()
+        .expect("spawn the kaibo binary");
+    assert!(
+        out.status.success(),
+        "the script itself must still run cleanly"
+    );
+
+    // Give a regression a fair chance to dial in before we declare it clean — a
+    // false pass here (checking immediately, before any export would have had time
+    // to land) would be worse than a slow test. Nothing else in this hermetic test
+    // process holds `port`, so any connection here can only be from the child.
+    std::thread::sleep(Duration::from_millis(500));
+    assert!(
+        listener.accept().is_err(),
+        "telemetry OFF (the default) must dial no socket at all (port {port})"
+    );
+}


### PR DESCRIPTION
## Summary

Two bugs found by measuring a real trace instead of trusting the wiring, both flagged by Amy.

1. **CLI subcommands emitted no telemetry at all.** `kaibo::telemetry::init` was called only from `serve()`'s dispatch arm in `main.rs` — `kaibo consult`/`kaish`/... from a terminal shipped nothing even with `[telemetry] enabled = true`. Amy's ask, verbatim: "CLI should try to do otel if it has connection info."

   `main.rs` now calls `kaibo::cli::init_cli_telemetry` once before dispatching to whichever subcommand ran, and calls `.shutdown()` on the returned guard *after* the subcommand returns and *before* `std::process::exit`. That ordering matters: every CLI arm exits through `process::exit`, which runs no destructors, so a guard merely dropped (rather than explicitly shut down) would silently lose every span the batch processor hadn't exported yet — and a short `kaish -c "..."` finishes well before the processor's own export interval would ever fire on its own. Telemetry stays off by default: an unconfigured `[telemetry]` (or a config-load failure) short-circuits `init_cli_telemetry` to `None` before touching the subscriber at all, so a default CLI run is unchanged.

2. **`kaish.output_bytes` recorded as a string attribute while `kaish.exit_code` recorded as an int**, confirmed on the wire from a real trace (`kaish.exit_code -> {"intValue": "3"}`, `kaish.output_bytes -> {"stringValue": "1608"}`). Both go through `Span::record` in `record_kaish_result` (`src/tool_span.rs`) — `exit_code` as `i64`, `output_bytes` as `output_bytes as u64` — and that cast was the whole bug: `tracing-opentelemetry`'s span visitor implements `record_i64` but has no `record_u64` override, and `tracing_core::field::Visit`'s default for an unoverridden method falls back to `record_debug`, which stringifies. Fix is one word, `u64` → `i64` (a kaish output byte count is nowhere near `i64::MAX`).

## Testing

- `tests/telemetry_cli.rs` — spawns the real binary as `kaibo kaish -c "..."` against a hermetic `HOME`/`XDG_CONFIG_HOME`, with `[telemetry]` pointed at a raw `TcpListener` this test stands up as a one-shot HTTP/protobuf collector. Asserts a real `POST /v1/traces` with a non-empty protobuf body lands *after* the child process has already exited — the actual proof the flush works, not just that the code compiles. A sibling test confirms telemetry OFF (the default) dials no socket at all.
  - **Proved it can fail**: temporarily replaced `guard.shutdown()` with a bare `drop(guard)` and reran — the test failed with a clean 10s timeout and zero connections ever accepted, exactly the failure mode the fix rules out. Restored and reran green.
- `src/tool_span.rs` — added `kaish_output_bytes_is_recorded_as_i64_not_u64`, which watches *which* `tracing::field::Visit` method fires (`record_i64` vs `record_u64`) rather than only the value read back. A value-only assertion can't see this bug: a probe visitor implementing both methods reads back the same number either way, which is exactly how the string-vs-int bug shipped unnoticed the first time.
  - **Proved it can fail**: reverted the cast to `u64`, reran — both the new type test and the existing `run_kaish_records_exit_code_and_output_bytes` test failed (the latter's `Grab` visitor needed updating too, since it now expects the value through `record_i64`). Restored and reran green.

`cargo test` (734+ tests across lib/integration suites) and `cargo clippy --all-targets` are both clean. `cargo tree -i aws-lc-rs` / `-i mimalloc` both come back empty (TLS invariant intact — no OTel/reqwest change touched that surface). rustfmt run only on the files this PR edited.

## Changelog / devlog

- `CHANGELOG.md`: one line each under Added (CLI export) and Fixed (the int/string field), per the "shorter over time" discipline.
- `docs/devlog.md`: fuller narrative of both findings and why the naive fix for each would have shipped invisibly a second time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)