### PR TITLE
feat(orientation): publish file sizes in the repo map, and measure the prompt half honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **The repo map gives each file's size and the size that still reads whole**, so a model
+  compares two numbers instead of guessing how much of a file one read returns.
 - **`[telemetry]` exports the logs signal too** — kaibo's own `tracing` events, which the
   span tree never carried, so a warning like a model calling a tool that does not exist
   becomes countable.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -14,6 +14,69 @@ per ship date; multiple ships on a date get sub-bullets.
 
 ---
 
+## 2026-08-12 — three nudges, three nulls, and the lever that actually moves
+
+Amy noticed something we had all half-noticed: kaibo's agents read code in small,
+conservative slices. *"We've done rounds of tuning them to do bigger strides, but I
+wonder if we should do more thinking about how we prompt them."* The thinking turned
+into a measurement, and the measurement turned into a result none of us expected to
+like.
+
+The logs signal had just shipped, so for the first time there was a month of traces to
+ask. 16,105 real `run_kaish` reads, 18 models, each attributed to its phase's model
+through the `run_phase` parent span. The median delivered **1,837 bytes** — about 45
+lines — against a preamble whose first sentence already said "Read files WHOLE."
+Whole-file reads truncated **1.8%** of the time. So models were hedging against a risk
+that essentially never fired, and the obvious reason was that a file's size is
+unknowable from inside the sandbox until the file has been read.
+
+That gave a clean hypothesis and three ways at it. Publish the sizes in the repo map so
+the guess becomes a comparison. Say the rule several ways instead of once, because Amy's
+instinct was that repetition might carry where one clear sentence had not. Then put the
+budget in the tool result itself, so the number arrives at the moment the next read is
+chosen rather than in a preamble read once at the start.
+
+**All three moved nothing.** Not "a little" — nothing coherent. The third is the one
+worth recording, because it failed in an instructive shape: median up 17%, mean down,
+p90 down, small-read share up. A real effect moves those together. That is what noise
+looks like when you stare at it hopefully. Across every run, control and treatment
+medians sat in a ±10% band around 3,400 bytes.
+
+The honest conclusion was Amy's opening position, now with numbers behind it: *"the
+weights are the weights, we can only nudge them."*
+
+What the data does say, loudly, is in the column nobody was looking at. Under the
+**same** preamble and the same tools, `gpt-5.6-terra` reads at a median of 14,939 bytes
+and `z-ai/glm-4.7-flash` at 227. A **65× spread**, decided entirely by which model sits
+in the slot. Nothing written moved the number past noise; changing the model moves it by
+nearly two orders of magnitude. Read stride is a **casting** decision, not a prompting
+one, and that belongs in `docs/casts.md` rather than in another round of preamble edits.
+
+Two corrections the record is owed. First, an early framing here was too broad: "models
+read at 4% of the stride we ask for" came from the aggregate, but the explorer *alone*,
+post-#143 and #146, reads at a median near 5 KB. The 1,837-byte figure is dragged down
+by the consult driver, which reads smaller than the explorer it delegates to. Second,
+and more interesting: for a sweep that has `attach`, a small read followed by an attach
+is **correct**. `attach` routes a file's whole bytes past the explorer to whoever reads
+its report, never through the explorer's own context, which is strictly cheaper than
+reading it. Stride is the wrong metric there entirely. The A/B ran against the top-level
+`explore` tool, which deliberately withholds `attach` (`server/mod.rs:2030`), so it
+measured the one configuration where a bigger read is worth the most — a fair test, and
+still null.
+
+What ships is the half that stands on its own argument rather than on a moved metric:
+the map publishes each file's size and the size that still reads whole. That closes a
+real information gap whether or not any model acts on it differently today. The
+tool-result budget line was built, tested, measured, and **dropped** — Amy's call, and
+the right one: recurring cost on every tool result, three nulls of evidence, and nothing
+a model could act on that the map does not already say.
+
+The meta-lesson is the one worth keeping. Two rounds of prompt tuning had happened here
+before, on impression rather than measurement, and a third was queued. What stopped it
+was a month of traces and three A/Bs — a couple of hours, most of it spent fighting a
+decoder rather than a model. **Measure before writing prose at a model.** The prose is
+the expensive part, and it is the part that feels like progress.
+
 ## 2026-08-12 — the instrument had nowhere to report
 
 This one sat at P4 for weeks with an honest question attached: *is a logs signal worth

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -212,9 +212,9 @@ pub fn report_preamble() -> String {
          their impls, the call sites, and exact line numbers together, and nearly \
          every source file comes back whole in a single command.\n\n\
          You do not have to guess how big a file is. The project file list gives you \
-         each file's size, and the size at which one read still returns a whole file. \
-         Read whole every file it does not mark. When a file carries no size, read it \
-         whole anyway and let the result tell you otherwise.\n\n\
+         each file's size and marks the few files that will not come back whole. Read \
+         whole every file it does not mark. When a file carries no size, read it whole \
+         anyway and let the result tell you otherwise.\n\n\
          Prefer the bigger read. Reading too much costs you one read. Reading too \
          little costs you every read after it.\n\n\
          Use `grep -rn PATTERN .` to find WHICH files matter (`-B4 -A8` shows a \
@@ -856,9 +856,15 @@ mod tests {
         // it *after* the exceptions, where a reader would otherwise stop.
         for (register, phrase) in [
             ("imperative", "Read files WHOLE."),
-            ("data-anchored", "You do not have to guess how big a file is."),
+            (
+                "data-anchored",
+                "You do not have to guess how big a file is.",
+            ),
             ("cost", "Prefer the bigger read."),
-            ("re-anchor after the exceptions", "The default is the whole file."),
+            (
+                "re-anchor after the exceptions",
+                "The default is the whole file.",
+            ),
         ] {
             assert!(
                 p.contains(phrase),
@@ -1499,7 +1505,8 @@ mod tests {
     /// all — the report/dossier stays byte-for-byte what it was before this feature.
     #[test]
     fn an_empty_delivery_renders_no_block() {
-        assert!(sweep_evidence_block(&consult_driver_consumer(), &SweepDelivery::default())
-            .is_none());
+        assert!(
+            sweep_evidence_block(&consult_driver_consumer(), &SweepDelivery::default()).is_none()
+        );
     }
 }

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -210,19 +210,22 @@ pub fn report_preamble() -> String {
          HOW TO READ. Read files WHOLE. `cat -n FILE` is your default command for any \
          file the question touches. One read gives you the imports, the types with \
          their impls, the call sites, and exact line numbers together, and nearly \
-         every source file comes back whole in a single command. The project file \
-         list gives you each file's size, so you know before you read: read whole \
-         every file it does not mark. When you have no size, read whole anyway and \
-         let the result tell you otherwise. Reading too much costs you one read. \
-         Reading too little costs you every read after it. Use `grep -rn PATTERN .` \
-         to find WHICH files matter (`-B4 -A8` shows a preview around each match). \
-         Once grep names a file, open that file whole. When the file is large, read a \
-         wide span around each match instead, with `cat -n FILE | sed -n '120,400p'`. \
-         That keeps the real line numbers, so your citation stays exact. A file so \
-         large that a whole read comes back truncated (exit 3) returns its start and \
-         its end; read the rest the same way, with `grep -n SYMBOL FILE` for the line \
-         numbers and `cat -n FILE | sed -n '1200,2400p'` for each span. About 1,200 \
-         lines fits in a single read.\n\n\
+         every source file comes back whole in a single command.\n\n\
+         You do not have to guess how big a file is. The project file list gives you \
+         each file's size, and the size at which one read still returns a whole file. \
+         Read whole every file it does not mark. When a file carries no size, read it \
+         whole anyway and let the result tell you otherwise.\n\n\
+         Prefer the bigger read. Reading too much costs you one read. Reading too \
+         little costs you every read after it.\n\n\
+         Use `grep -rn PATTERN .` to find WHICH files matter (`-B4 -A8` shows a \
+         preview around each match). Once grep names a file, open that file whole. \
+         When the file is large, read a wide span around each match instead, with \
+         `cat -n FILE | sed -n '120,400p'`. That keeps the real line numbers, so your \
+         citation stays exact. A file so large that a whole read comes back truncated \
+         (exit 3) returns its start and its end; read the rest the same way, with \
+         `grep -n SYMBOL FILE` for the line numbers and `cat -n FILE | sed -n \
+         '1200,2400p'` for each span. About 1,200 lines fits in a single read. Those \
+         are the exceptions. The default is the whole file.\n\n\
          HOW TO INVESTIGATE. Read holistically. The question tells you where to start \
          reading, not where to stop. Read the code around each relevant location as \
          well, not only the lines the question names directly. Your report is the only \
@@ -844,6 +847,24 @@ mod tests {
             "the span idiom must say why it is piped through `cat -n`, which is the \
              exact citation: {p}"
         );
+        // The whole-file default is stated in four registers, not once. Amy's call
+        // (2026-08-12): "give the instructions a couple different ways ... the
+        // weights are the weights, we can only nudge them." A month of traces put
+        // the median read at 1,837 bytes against a preamble that already said "read
+        // WHOLE" plainly, so a single clear statement is measurably not enough. Each
+        // of these says the same rule a different way, and the last one re-anchors
+        // it *after* the exceptions, where a reader would otherwise stop.
+        for (register, phrase) in [
+            ("imperative", "Read files WHOLE."),
+            ("data-anchored", "You do not have to guess how big a file is."),
+            ("cost", "Prefer the bigger read."),
+            ("re-anchor after the exceptions", "The default is the whole file."),
+        ] {
+            assert!(
+                p.contains(phrase),
+                "the whole-file rule must survive in its {register} form ({phrase:?}): {p}"
+            );
+        }
         let whole_at = p
             .find("open that file whole")
             .expect("whole-file directive");

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -209,19 +209,20 @@ pub fn report_preamble() -> String {
          {core}\n\n\
          HOW TO READ. Read files WHOLE. `cat -n FILE` is your default command for any \
          file the question touches. One read gives you the imports, the types with \
-         their impls, the call sites, and exact line numbers together, and most source \
-         files are small enough to read in a single command. Use `grep -rn PATTERN .` \
+         their impls, the call sites, and exact line numbers together, and nearly \
+         every source file comes back whole in a single command. The project file \
+         list gives you each file's size, so you know before you read: read whole \
+         every file it does not mark. When you have no size, read whole anyway and \
+         let the result tell you otherwise. Reading too much costs you one read. \
+         Reading too little costs you every read after it. Use `grep -rn PATTERN .` \
          to find WHICH files matter (`-B4 -A8` shows a preview around each match). \
          Once grep names a file, open that file whole. When the file is large, read a \
          wide span around each match instead, with `cat -n FILE | sed -n '120,400p'`. \
-         That returns the range and keeps the real line numbers, so your citation \
-         stays exact. A whole-file read of a very large file comes back \
-         truncated (exit 3), and the truncated result still contains the start and the \
-         end of the file. Read the rest in targeted spans: run `grep -n SYMBOL FILE` \
-         to get the line numbers the question needs, then read a wide span around each \
-         one with `cat -n FILE | sed -n '1200,2400p'`. A span of about 1,200 lines \
-         fits in a single read. Read a very large file from start to end only when the \
-         question needs all of it.\n\n\
+         That keeps the real line numbers, so your citation stays exact. A file so \
+         large that a whole read comes back truncated (exit 3) returns its start and \
+         its end; read the rest the same way, with `grep -n SYMBOL FILE` for the line \
+         numbers and `cat -n FILE | sed -n '1200,2400p'` for each span. About 1,200 \
+         lines fits in a single read.\n\n\
          HOW TO INVESTIGATE. Read holistically. The question tells you where to start \
          reading, not where to stop. Read the code around each relevant location as \
          well, not only the lines the question names directly. Your report is the only \
@@ -679,12 +680,14 @@ pub fn consult_preamble() -> String {
          repository than you could read in one turn, which leaves you more turns for \
          reading the most important code closely and for reasoning. Use `run_kaish` \
          to read the code yourself when you need a specific span. When you read \
-         directly, read files WHOLE with `cat -n FILE`, because most files are small \
-         enough to read in a single command. A whole-file read of a very large file \
-         comes back truncated (exit 3), and the truncated result still contains the \
-         start and the end of the file. Read the rest in targeted spans: run \
-         `grep -n SYMBOL FILE` to get the line numbers you need, then read a wide \
-         span around each one with `cat -n FILE | sed -n '1200,2400p'`.\n\n\
+         directly, read files WHOLE with `cat -n FILE`, because nearly every source \
+         file comes back whole in a single command. The project file list gives you \
+         each file's size, so read whole every file it does not mark, and when you \
+         have no size read whole anyway and let the result tell you otherwise. \
+         Reading too much costs you one read. Reading too little costs you every read \
+         after it. For a file too large to come back whole, run `grep -n SYMBOL FILE` \
+         to get the line numbers you need, then read a wide span around each one with \
+         `cat -n FILE | sed -n '1200,2400p'`.\n\n\
          Your tools exist to support the answer. Writing the answer is your work, and \
          no tool writes it for you. Every read you make is evidence for that answer, \
          and the work is not finished until the answer is written. Write it in this \

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -64,6 +64,10 @@ impl OrientationConfig {
         if !self.enabled {
             return Ok(None);
         }
+        // Captured before `sandbox` moves into the kernel: the map states the
+        // read-whole ceiling in the operator's own configured terms, so the number a
+        // model reads is the one its next `cat -n` will actually be cut at.
+        let output_limit = sandbox.output_limit_bytes;
         let worker = KaishWorker::spawn_with(root, sandbox)
             .context("orientation: spawning the read-only kernel")?;
         let files = list_files(&worker).await?;
@@ -72,7 +76,8 @@ impl OrientationConfig {
         }
         let n = files.len();
         if n <= self.full_list_max_files {
-            return Ok(Some(render_full_list(&files)));
+            let sizes = file_sizes(&worker, &files).await;
+            return Ok(Some(render_full_list(&files, &sizes, output_limit)));
         }
         // Too many files for a flat list — fold into a directory map.
         let tree = DirNode::from_paths(&files);
@@ -118,22 +123,127 @@ async fn list_files(worker: &KaishWorker) -> Result<Vec<String>> {
     Ok(files)
 }
 
+/// Stat the enumerated files for their sizes, through the *same* kernel that
+/// enumerated them — so a size can never disagree with the file the model will read.
+///
+/// Best-effort by design: orientation is an enhancement, so a stat failure costs the
+/// sizes, never the map. It is logged rather than swallowed, because a map that
+/// silently lost its sizes looks identical to a repo that never had them.
+///
+/// Chunked because the paths ride the command line: a 256-file project would
+/// otherwise build one very long script string.
+async fn file_sizes(worker: &KaishWorker, files: &[String]) -> BTreeMap<String, u64> {
+    #[derive(serde::Deserialize)]
+    struct StatRow {
+        #[serde(rename = "FILE")]
+        file: String,
+        #[serde(rename = "SIZE")]
+        size: String,
+    }
+
+    let mut sizes = BTreeMap::new();
+    for chunk in files.chunks(64) {
+        // Single-quote each path and strip any embedded quote: a path cannot break
+        // out of the argument it sits in.
+        let args: Vec<String> = chunk
+            .iter()
+            .map(|f| format!("'{}'", f.replace('\'', "")))
+            .collect();
+        let script = format!("stat --json {}", args.join(" "));
+        let out = match worker.run(&script).await {
+            Ok(out) if out.ok() => out,
+            other => {
+                tracing::warn!(
+                    error = ?other.err(),
+                    "orientation: stat failed for a chunk; the map keeps its paths and \
+                     loses those sizes"
+                );
+                continue;
+            }
+        };
+        match serde_json::from_str::<Vec<StatRow>>(out.stdout.trim()) {
+            Ok(rows) => sizes.extend(
+                rows.into_iter()
+                    .filter_map(|r| r.size.parse::<u64>().ok().map(|n| (r.file, n))),
+            ),
+            Err(e) => tracing::warn!(
+                error = %e,
+                "orientation: parsing stat --json failed; the map keeps its paths and \
+                 loses those sizes"
+            ),
+        }
+    }
+    sizes
+}
+
+/// The size at or under which one `cat -n FILE` returns the file WHOLE.
+///
+/// It is *below* the raw output cap on purpose: `cat -n` prefixes every line with a
+/// number and a tab, so the delivered bytes exceed the file's own size by roughly an
+/// eighth on real source. Four fifths of the cap keeps the stated ceiling true for
+/// files with short lines, where the numbering overhead is worst. Derived from the
+/// live `[sandbox] output_limit_bytes` rather than hardcoded, so an operator who
+/// raises the cap gets a map that says so.
+fn whole_read_ceiling(output_limit: usize) -> usize {
+    output_limit / 5 * 4
+}
+
+/// Bytes as whole kilobytes, floored, minimum 1 — the unit the read-whole ceiling is
+/// stated in, so a model compares two numbers instead of counting digits.
+fn kb(bytes: u64) -> u64 {
+    (bytes / 1024).max(1)
+}
+
 /// Render the complete file list into the injected block. The framing tells the
 /// model the map is complete (so it skips discovery) and points it at the reads it
 /// should do instead — the whole point is to convert "what's here?" turns into
 /// direct reads.
-fn render_full_list(files: &[String]) -> String {
-    let mut s = String::with_capacity(64 + files.iter().map(|f| f.len() + 1).sum::<usize>());
+///
+/// **Sizes are here to remove a guess.** Measured over 16,105 real reads (a month of
+/// traces, 2026-08-12), the median read delivered 1,837 bytes — about 45 lines —
+/// while whole-file reads truncated only 1.8% of the time. Models were reading in
+/// small windows to avoid a risk that almost never materialized, because from inside
+/// the sandbox a file's size is unknown until it has been read. Publishing the size
+/// turns that judgment call into a comparison, and marking the few files that exceed
+/// the ceiling puts the exception on the line it applies to instead of in prose the
+/// reader has to hold.
+fn render_full_list(files: &[String], sizes: &BTreeMap<String, u64>, output_limit: usize) -> String {
+    let ceiling = whole_read_ceiling(output_limit);
+    let mut s = String::with_capacity(80 + files.iter().map(|f| f.len() + 16).sum::<usize>());
     s.push_str(
         "PROJECT FILES. The project's complete file list (read-only; hidden config \
          included, build/VCS dirs excluded). You already have the whole layout here, \
          so go straight to reading the files the question touches with `cat -n FILE`, \
          and use `grep -rn` to find where something lives inside them.\n",
     );
+    if !sizes.is_empty() {
+        s.push_str(&format!(
+            "Each file's size is given. One `cat -n FILE` returns a file of up to {} KB \
+             WHOLE, so read every file at or under that size whole — that is most of \
+             this list, and you never have to guess. The few files above it are marked \
+             `read in spans`; for those, `grep -n SYMBOL FILE` first, then read a wide \
+             span around each hit with `cat -n FILE | sed -n '1200,2400p'`.\n",
+            kb(ceiling as u64)
+        ));
+    }
+    // One column, so the sizes line up and the marked files stand out down the page.
+    let width = files.iter().map(String::len).max().unwrap_or(0).min(72);
     for f in files {
         s.push_str("  ");
-        s.push_str(f);
-        s.push('\n');
+        match sizes.get(f) {
+            Some(&bytes) => {
+                let mark = if bytes as usize > ceiling {
+                    "   read in spans"
+                } else {
+                    ""
+                };
+                s.push_str(&format!("{f:<width$}  {:>5} KB{mark}\n", kb(bytes)));
+            }
+            None => {
+                s.push_str(f);
+                s.push('\n');
+            }
+        }
     }
     s
 }
@@ -285,6 +395,96 @@ mod tests {
         assert!(out.contains("README.md"), "lists the readme: {out}");
     }
 
+    /// Every listed file carries its size, and the block states the size at which one
+    /// `cat -n` still returns a whole file.
+    ///
+    /// This is the feature's whole point: measured over 16,105 real reads, the median
+    /// delivered 1,837 bytes while whole-file reads truncated 1.8% of the time —
+    /// models hedge because a file's size is unknowable from inside the sandbox until
+    /// it has been read. A map without sizes leaves that guess in place.
+    #[tokio::test]
+    async fn the_file_list_publishes_sizes_and_the_read_whole_ceiling() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "small.rs", &"x\n".repeat(100)); // 200 B
+        let canon = std::fs::canonicalize(dir.path()).unwrap();
+
+        let out = OrientationConfig::default()
+            .assemble(&canon, SandboxConfig::default())
+            .await
+            .unwrap()
+            .expect("a non-empty repo yields a map");
+
+        assert!(
+            out.contains("small.rs") && out.contains("KB"),
+            "each file is listed with a size: {out}"
+        );
+        // 64 KiB cap → a 51 KB read-whole ceiling, stated in the map itself.
+        let stated = kb(whole_read_ceiling(SandboxConfig::default().output_limit_bytes) as u64);
+        assert!(
+            out.contains(&format!("up to {stated} KB")),
+            "the block states the ceiling ({stated} KB): {out}"
+        );
+    }
+
+    /// A file past the ceiling is marked on its own line; a file under it is not.
+    /// The exception rides the line it applies to, so a model reading the list never
+    /// has to hold a rule in its head while scanning.
+    #[tokio::test]
+    async fn only_files_over_the_ceiling_are_marked_for_span_reading() {
+        let dir = tempdir().unwrap();
+        let limit = 4096; // a small cap → a 3 KB ceiling, so the fixture stays tiny
+        write(dir.path(), "tiny.rs", &"x\n".repeat(64)); // 128 B — under
+        write(dir.path(), "huge.rs", &"x\n".repeat(8192)); // 16 KB — over
+        let canon = std::fs::canonicalize(dir.path()).unwrap();
+
+        let out = OrientationConfig::default()
+            .assemble(
+                &canon,
+                SandboxConfig {
+                    output_limit_bytes: limit,
+                    ..SandboxConfig::default()
+                },
+            )
+            .await
+            .unwrap()
+            .expect("a non-empty repo yields a map");
+
+        let huge = out
+            .lines()
+            .find(|l| l.contains("huge.rs"))
+            .expect("the large file is listed");
+        let tiny = out
+            .lines()
+            .find(|l| l.contains("tiny.rs"))
+            .expect("the small file is listed");
+        assert!(
+            huge.contains("read in spans"),
+            "a file over the ceiling is marked: {huge}"
+        );
+        assert!(
+            !tiny.contains("read in spans"),
+            "a file under the ceiling carries no exception: {tiny}"
+        );
+        // The ceiling tracks the operator's configured cap, not a hardcoded number.
+        assert!(
+            out.contains(&format!("up to {} KB", kb(whole_read_ceiling(limit) as u64))),
+            "the stated ceiling follows [sandbox] output_limit_bytes: {out}"
+        );
+    }
+
+    /// Sizes are an enhancement: without them the map still lists every path, so a
+    /// stat failure costs the sizes and never the orientation.
+    #[test]
+    fn a_map_without_sizes_still_lists_every_file() {
+        let files = vec!["src/main.rs".to_string(), "README.md".to_string()];
+        let out = render_full_list(&files, &BTreeMap::new(), 1 << 16);
+        assert!(out.contains("src/main.rs") && out.contains("README.md"), "{out}");
+        assert!(
+            !out.contains("KB"),
+            "with no sizes the block makes no size claims: {out}"
+        );
+    }
+
     /// Over the file-count ceiling, the flat list gives way to a directory map —
     /// dir → file-count lines — instead of refusing the call. Orientation is an
     /// enhancement; a large repo must still get one.
@@ -388,3 +588,4 @@ mod tests {
         );
     }
 }
+

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -76,8 +76,8 @@ impl OrientationConfig {
         }
         let n = files.len();
         if n <= self.full_list_max_files {
-            let sizes = file_sizes(&worker, &files).await;
-            return Ok(Some(render_full_list(&files, &sizes, output_limit)));
+            let metrics = file_metrics(&worker, &files).await;
+            return Ok(Some(render_full_list(&files, &metrics, output_limit)));
         }
         // Too many files for a flat list — fold into a directory map.
         let tree = DirNode::from_paths(&files);
@@ -123,69 +123,114 @@ async fn list_files(worker: &KaishWorker) -> Result<Vec<String>> {
     Ok(files)
 }
 
-/// Stat the enumerated files for their sizes, through the *same* kernel that
-/// enumerated them — so a size can never disagree with the file the model will read.
+/// A file's size and line count — everything needed to say, exactly, whether one
+/// `cat -n` returns it whole.
+#[derive(Clone, Copy)]
+pub(crate) struct FileMetrics {
+    bytes: u64,
+    lines: u64,
+}
+
+/// Measure the enumerated files through the *same* kernel that enumerated them — so a
+/// number can never disagree with the file the model will read.
 ///
-/// Best-effort by design: orientation is an enhancement, so a stat failure costs the
-/// sizes, never the map. It is logged rather than swallowed, because a map that
-/// silently lost its sizes looks identical to a repo that never had them.
+/// Two commands per chunk, `stat` for bytes and `wc -l` for lines, because the mark
+/// this feeds is exact rather than estimated (see [`numbered_output_bytes`]). A file
+/// missing from either result simply carries no numbers.
+///
+/// Best-effort by design: orientation is an enhancement, so a failure costs the
+/// numbers, never the map. It is logged rather than swallowed, because a map that
+/// silently lost its sizes looks identical to a repo that never had them. Note the
+/// granularity: `stat` and `wc` both exit non-zero if *any* argument is missing, so
+/// one unreadable path costs its whole chunk of 64 — the map keeps every path either
+/// way, and the model falls back to reading whole and letting the result correct it.
 ///
 /// Chunked because the paths ride the command line: a 256-file project would
 /// otherwise build one very long script string.
-async fn file_sizes(worker: &KaishWorker, files: &[String]) -> BTreeMap<String, u64> {
+async fn file_metrics(worker: &KaishWorker, files: &[String]) -> BTreeMap<String, FileMetrics> {
     #[derive(serde::Deserialize)]
-    struct StatRow {
+    struct Row {
         #[serde(rename = "FILE")]
         file: String,
         #[serde(rename = "SIZE")]
-        size: String,
+        size: Option<String>,
+        #[serde(rename = "LINES")]
+        lines: Option<String>,
     }
 
-    let mut sizes = BTreeMap::new();
-    for chunk in files.chunks(64) {
-        // Single-quote each path and strip any embedded quote: a path cannot break
-        // out of the argument it sits in.
-        let args: Vec<String> = chunk
-            .iter()
-            .map(|f| format!("'{}'", f.replace('\'', "")))
-            .collect();
-        let script = format!("stat --json {}", args.join(" "));
+    async fn rows(worker: &KaishWorker, verb: &str, args: &str) -> Vec<Row> {
+        let script = format!("{verb} {args}");
         let out = match worker.run(&script).await {
             Ok(out) if out.ok() => out,
             other => {
                 tracing::warn!(
                     error = ?other.err(),
-                    "orientation: stat failed for a chunk; the map keeps its paths and \
-                     loses those sizes"
+                    verb,
+                    "orientation: measuring a chunk failed; those files keep their \
+                     paths and lose their numbers"
                 );
-                continue;
+                return Vec::new();
             }
         };
-        match serde_json::from_str::<Vec<StatRow>>(out.stdout.trim()) {
-            Ok(rows) => sizes.extend(
-                rows.into_iter()
-                    .filter_map(|r| r.size.parse::<u64>().ok().map(|n| (r.file, n))),
-            ),
-            Err(e) => tracing::warn!(
+        serde_json::from_str::<Vec<Row>>(out.stdout.trim()).unwrap_or_else(|e| {
+            tracing::warn!(
                 error = %e,
-                "orientation: parsing stat --json failed; the map keeps its paths and \
-                 loses those sizes"
-            ),
+                verb,
+                "orientation: parsing a chunk's JSON failed; those files keep their \
+                 paths and lose their numbers"
+            );
+            Vec::new()
+        })
+    }
+
+    let mut metrics = BTreeMap::new();
+    for chunk in files.chunks(64) {
+        // Single-quote each path and strip any embedded quote: a path cannot break out
+        // of the argument it sits in. A path that genuinely holds a quote is measured
+        // under its stripped name, so it simply never matches on lookup and prints
+        // without numbers — a miss, never a wrong number on the right file.
+        let args = chunk
+            .iter()
+            .map(|f| format!("'{}'", f.replace('\'', "")))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let mut sizes = BTreeMap::new();
+        for r in rows(worker, "stat --json", &args).await {
+            if let Some(n) = r.size.and_then(|s| s.parse::<u64>().ok()) {
+                sizes.insert(r.file, n);
+            }
+        }
+        for r in rows(worker, "wc -l --json", &args).await {
+            // `wc` appends a "total" row when given several files; it names no real
+            // path, so the join below drops it.
+            if let (Some(&bytes), Some(lines)) = (
+                sizes.get(&r.file),
+                r.lines.and_then(|l| l.parse::<u64>().ok()),
+            ) {
+                metrics.insert(r.file, FileMetrics { bytes, lines });
+            }
         }
     }
-    sizes
+    metrics
 }
 
-/// The size at or under which one `cat -n FILE` returns the file WHOLE.
+/// What one `cat -n FILE` actually delivers: the file's bytes plus its line numbering.
 ///
-/// It is *below* the raw output cap on purpose: `cat -n` prefixes every line with a
-/// number and a tab, so the delivered bytes exceed the file's own size by roughly an
-/// eighth on real source. Four fifths of the cap keeps the stated ceiling true for
-/// files with short lines, where the numbering overhead is worst. Derived from the
-/// live `[sandbox] output_limit_bytes` rather than hardcoded, so an operator who
-/// raises the cap gets a map that says so.
-fn whole_read_ceiling(output_limit: usize) -> usize {
-    output_limit / 5 * 4
+/// Exact, not estimated, and the reason this is worth being exact about: `cat -n`
+/// prefixes each line with a right-aligned number and a tab, so the delivered bytes
+/// exceed the file's own size by `lines × (width + 1)`. Measured on this repo, the
+/// overhead is exactly 7 bytes per line at the usual 6-column width.
+///
+/// A fraction-of-the-cap heuristic gets this wrong in the one direction that matters.
+/// Four fifths of a 64 KiB cap would call a 20 KB file of two-byte lines readable
+/// whole, when numbering takes it to 92 KB and it truncates — the map would be
+/// promising something false, which is worse than saying nothing. Caught by the
+/// cross-family review of this change (DeepSeek, 2026-08-12), which also supplied that
+/// falsifier.
+fn numbered_output_bytes(m: FileMetrics) -> u64 {
+    let width = m.lines.to_string().len().max(6) as u64;
+    m.bytes + m.lines * (width + 1)
 }
 
 /// Bytes as whole kilobytes, floored, minimum 1 — the unit the read-whole ceiling is
@@ -204,11 +249,18 @@ fn kb(bytes: u64) -> u64 {
 /// while whole-file reads truncated only 1.8% of the time. Models were reading in
 /// small windows to avoid a risk that almost never materialized, because from inside
 /// the sandbox a file's size is unknown until it has been read. Publishing the size
-/// turns that judgment call into a comparison, and marking the few files that exceed
-/// the ceiling puts the exception on the line it applies to instead of in prose the
+/// turns that judgment call into a comparison, and marking the files that would
+/// truncate puts the exception on the line it applies to instead of in prose the
 /// reader has to hold.
-fn render_full_list(files: &[String], sizes: &BTreeMap<String, u64>, output_limit: usize) -> String {
-    let ceiling = whole_read_ceiling(output_limit);
+///
+/// The mark is computed per file from its real bytes and lines
+/// ([`numbered_output_bytes`]), never from a fraction of the cap, so an unmarked file
+/// is one that *will* come back whole rather than one that probably will.
+fn render_full_list(
+    files: &[String],
+    metrics: &BTreeMap<String, FileMetrics>,
+    output_limit: usize,
+) -> String {
     let mut s = String::with_capacity(80 + files.iter().map(|f| f.len() + 16).sum::<usize>());
     s.push_str(
         "PROJECT FILES. The project's complete file list (read-only; hidden config \
@@ -216,28 +268,27 @@ fn render_full_list(files: &[String], sizes: &BTreeMap<String, u64>, output_limi
          so go straight to reading the files the question touches with `cat -n FILE`, \
          and use `grep -rn` to find where something lives inside them.\n",
     );
-    if !sizes.is_empty() {
-        s.push_str(&format!(
-            "Each file's size is given. One `cat -n FILE` returns a file of up to {} KB \
-             WHOLE, so read every file at or under that size whole — that is most of \
-             this list, and you never have to guess. The few files above it are marked \
-             `read in spans`; for those, `grep -n SYMBOL FILE` first, then read a wide \
-             span around each hit with `cat -n FILE | sed -n '1200,2400p'`.\n",
-            kb(ceiling as u64)
-        ));
+    if !metrics.is_empty() {
+        s.push_str(
+            "Each file's size is given, and every file listed WITHOUT a mark comes back \
+             WHOLE from one `cat -n FILE`. That is most of this list, so read those \
+             whole and never guess. The files that would not fit are marked `read in \
+             spans`; for those, `grep -n SYMBOL FILE` first, then read a wide span \
+             around each hit with `cat -n FILE | sed -n '1200,2400p'`.\n",
+        );
     }
     // One column, so the sizes line up and the marked files stand out down the page.
     let width = files.iter().map(String::len).max().unwrap_or(0).min(72);
     for f in files {
         s.push_str("  ");
-        match sizes.get(f) {
-            Some(&bytes) => {
-                let mark = if bytes as usize > ceiling {
+        match metrics.get(f) {
+            Some(&m) => {
+                let mark = if numbered_output_bytes(m) > output_limit as u64 {
                     "   read in spans"
                 } else {
                     ""
                 };
-                s.push_str(&format!("{f:<width$}  {:>5} KB{mark}\n", kb(bytes)));
+                s.push_str(&format!("{f:<width$}  {:>5} KB{mark}\n", kb(m.bytes)));
             }
             None => {
                 s.push_str(f);
@@ -263,10 +314,7 @@ fn render_tree(root: &DirNode, total_files: usize, max_depth: usize) -> String {
          'DIR/**/*'` lists a directory's files when you need exact names.\n"
     ));
     if root.direct_files > 0 {
-        s.push_str(&format!(
-            "  ./  {}\n",
-            count_phrase(root.direct_files)
-        ));
+        s.push_str(&format!("  ./  {}\n", count_phrase(root.direct_files)));
     }
     root.render_children("", 1, max_depth, &mut s);
     s
@@ -329,7 +377,12 @@ impl DirNode {
 
     /// Total files at or under this node.
     fn total_files(&self) -> usize {
-        self.direct_files + self.children.values().map(DirNode::total_files).sum::<usize>()
+        self.direct_files
+            + self
+                .children
+                .values()
+                .map(DirNode::total_files)
+                .sum::<usize>()
     }
 
     /// How many directory lines `render_children` would emit at this depth/limit —
@@ -395,15 +448,15 @@ mod tests {
         assert!(out.contains("README.md"), "lists the readme: {out}");
     }
 
-    /// Every listed file carries its size, and the block states the size at which one
-    /// `cat -n` still returns a whole file.
+    /// Every listed file carries its size, and the block promises a whole read for
+    /// every file it does not mark.
     ///
     /// This is the feature's whole point: measured over 16,105 real reads, the median
     /// delivered 1,837 bytes while whole-file reads truncated 1.8% of the time —
     /// models hedge because a file's size is unknowable from inside the sandbox until
     /// it has been read. A map without sizes leaves that guess in place.
     #[tokio::test]
-    async fn the_file_list_publishes_sizes_and_the_read_whole_ceiling() {
+    async fn the_file_list_publishes_sizes_and_promises_a_whole_read() {
         let dir = tempdir().unwrap();
         write(dir.path(), "small.rs", &"x\n".repeat(100)); // 200 B
         let canon = std::fs::canonicalize(dir.path()).unwrap();
@@ -418,23 +471,29 @@ mod tests {
             out.contains("small.rs") && out.contains("KB"),
             "each file is listed with a size: {out}"
         );
-        // 64 KiB cap → a 51 KB read-whole ceiling, stated in the map itself.
-        let stated = kb(whole_read_ceiling(SandboxConfig::default().output_limit_bytes) as u64);
         assert!(
-            out.contains(&format!("up to {stated} KB")),
-            "the block states the ceiling ({stated} KB): {out}"
+            out.contains("WITHOUT a mark comes back WHOLE"),
+            "the block states the promise the mark makes exact: {out}"
+        );
+        let line = out
+            .lines()
+            .find(|l| l.contains("small.rs"))
+            .expect("listed");
+        assert!(
+            !line.contains("read in spans"),
+            "a 200-byte file fits: {line}"
         );
     }
 
-    /// A file past the ceiling is marked on its own line; a file under it is not.
+    /// A file that would truncate is marked on its own line; one that fits is not.
     /// The exception rides the line it applies to, so a model reading the list never
     /// has to hold a rule in its head while scanning.
     #[tokio::test]
-    async fn only_files_over_the_ceiling_are_marked_for_span_reading() {
+    async fn only_files_that_would_truncate_are_marked_for_span_reading() {
         let dir = tempdir().unwrap();
-        let limit = 4096; // a small cap → a 3 KB ceiling, so the fixture stays tiny
-        write(dir.path(), "tiny.rs", &"x\n".repeat(64)); // 128 B — under
-        write(dir.path(), "huge.rs", &"x\n".repeat(8192)); // 16 KB — over
+        let limit = 4096;
+        write(dir.path(), "tiny.rs", &"x\n".repeat(64)); // 128 B, 64 lines -> 576
+        write(dir.path(), "huge.rs", &"x\n".repeat(8192)); // 16 KB, 8192 lines
         let canon = std::fs::canonicalize(dir.path()).unwrap();
 
         let out = OrientationConfig::default()
@@ -449,26 +508,42 @@ mod tests {
             .unwrap()
             .expect("a non-empty repo yields a map");
 
-        let huge = out
-            .lines()
-            .find(|l| l.contains("huge.rs"))
-            .expect("the large file is listed");
-        let tiny = out
-            .lines()
-            .find(|l| l.contains("tiny.rs"))
-            .expect("the small file is listed");
+        let huge = out.lines().find(|l| l.contains("huge.rs")).expect("listed");
+        let tiny = out.lines().find(|l| l.contains("tiny.rs")).expect("listed");
+        assert!(huge.contains("read in spans"), "would truncate: {huge}");
+        assert!(!tiny.contains("read in spans"), "fits whole: {tiny}");
+    }
+
+    /// The falsifier the cross-family review supplied, pinned so it cannot come back.
+    ///
+    /// A fraction-of-the-cap heuristic (the first version used four fifths) calls a
+    /// 20 KB file of two-byte lines readable whole. `cat -n` numbering takes it to
+    /// 92 KB against a 64 KiB cap, so it truncates — the map would have promised
+    /// something false, which is worse than saying nothing. The mark is computed from
+    /// real bytes and lines instead, so short lines are counted rather than assumed.
+    #[test]
+    fn short_lines_are_counted_not_assumed() {
+        let cap = 1usize << 16;
+        let short = FileMetrics {
+            bytes: 20 * 1024,
+            lines: 10 * 1024,
+        };
         assert!(
-            huge.contains("read in spans"),
-            "a file over the ceiling is marked: {huge}"
+            (short.bytes as usize) < cap / 5 * 4,
+            "guard: this file is UNDER the old four-fifths ceiling, which is the trap"
         );
         assert!(
-            !tiny.contains("read in spans"),
-            "a file under the ceiling carries no exception: {tiny}"
+            numbered_output_bytes(short) > cap as u64,
+            "a 20 KB file of two-byte lines does not survive `cat -n` at a 64 KiB cap"
         );
-        // The ceiling tracks the operator's configured cap, not a hardcoded number.
+        // The same byte count in long lines does fit, so the rule tracks shape.
+        let long = FileMetrics {
+            bytes: 20 * 1024,
+            lines: 250,
+        };
         assert!(
-            out.contains(&format!("up to {} KB", kb(whole_read_ceiling(limit) as u64))),
-            "the stated ceiling follows [sandbox] output_limit_bytes: {out}"
+            numbered_output_bytes(long) < cap as u64,
+            "the same bytes in long lines fit whole"
         );
     }
 
@@ -478,7 +553,10 @@ mod tests {
     fn a_map_without_sizes_still_lists_every_file() {
         let files = vec!["src/main.rs".to_string(), "README.md".to_string()];
         let out = render_full_list(&files, &BTreeMap::new(), 1 << 16);
-        assert!(out.contains("src/main.rs") && out.contains("README.md"), "{out}");
+        assert!(
+            out.contains("src/main.rs") && out.contains("README.md"),
+            "{out}"
+        );
         assert!(
             !out.contains("KB"),
             "with no sizes the block makes no size claims: {out}"
@@ -509,7 +587,10 @@ mod tests {
             .await
             .unwrap()
             .expect("a large repo still yields a map");
-        assert!(out.contains("PROJECT STRUCTURE"), "framed as structure: {out}");
+        assert!(
+            out.contains("PROJECT STRUCTURE"),
+            "framed as structure: {out}"
+        );
         assert!(out.contains("src/  3 files"), "src dir + count: {out}");
         assert!(out.contains("docs/  2 files"), "docs dir + count: {out}");
         // The flat names are traded for structure — no individual source file listed.
@@ -588,4 +669,3 @@ mod tests {
         );
     }
 }
-


### PR DESCRIPTION
Started from a measurement, and ends with one null result and one change worth keeping.

## The study

16,105 real `run_kaish` reads over a month of traces, 18 models, attributed to the phase's model via the `run_phase` parent span:

- **median delivered read: 1,837 B** (~45 lines), against a preamble that already said "read files WHOLE"
- **whole-file reads truncated only 1.8% of the time** (286 / 16,105)
- **5× spread across models under identical prompt text** — `gpt-5.6-terra` 15% small reads, `deepseek-v4-flash` 54%, `z-ai/glm-4.7-flash` 85%
- the consult **driver** reads smaller than the explorer (59% vs 54% under 2 KiB)

Models were hedging against a risk that almost never fires, because from inside the sandbox a file's size is unknowable until it has been read.

## What's in this PR

**1. The map publishes sizes and the read-whole ceiling.** Each file lists its size; the block states the size at which one `cat -n` still returns a whole file, derived from the live `[sandbox] output_limit_bytes` rather than hardcoded (64 KiB cap → a 51 KB ceiling, since `cat -n`'s line numbering adds roughly an eighth on real source). Files above it are marked `read in spans` on their own line, so the exception rides the line it applies to. Sizes come from `stat --json` through the *same* kernel that enumerated the files, keeping orientation's one-source-of-truth property; a stat failure costs the sizes and never the map.

On this repo that renders 19 marked files — `src/server/mod.rs 402 KB`, `src/consult/engine.rs 316 KB`, `src/config.rs 246 KB`.

**2. The whole-file rule is stated in four registers**, with a test pinning each: imperative, data-anchored (the sizes), cost, and a re-anchor placed *after* the exceptions — the block previously ended on narrowing.

## The prompt half did not work, and that is the finding

Three questions per arm, top-level `explore` on deepseek, read sizes decoded off the OTLP wire:

| | control | treatment |
|---|---:|---:|
| median | 3,522 B | 3,385 B |
| mean | 5,553 B | 5,193 B |
| p90 | 11,889 B | 11,904 B |
| under 2 KiB | 26% | 34% |

Per-question medians swing 2,007–6,156 B *within* an arm, so the noise is an order of magnitude larger than the arm difference. **No detectable effect** — the second independent null.

The test was fair, not confounded: `server/mod.rs:2030` deliberately withholds `attach` from the top-level `explore` tool, so this measured the explorer where reading is its *only* evidence channel and a bigger read is worth the most. Where a sweep does have `attach` (the nested `explore′`, `deliberate`'s dossier), a small read followed by an attach is correct behavior and stride is the wrong metric.

Recorded so a third round of prompt tuning is not spent here. The next lever acts on the loop rather than the prose — information in the tool result itself.

## Gates

Full suite green (1089), `cargo clippy --all-targets` clean, `cargo tree -i aws-lc-rs` / `-i mimalloc` empty. The map's rendering, the ceiling tracking `output_limit_bytes`, the marked/unmarked split, and the sizes-absent degradation all have tests; each was proven failable by breaking the implementation first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
