### PR TITLE
fix(prose): tell models the exit code a refused write actually has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ record. Each later release appends a new section at the top.
   CAS, so one project's team cannot enumerate another's artifacts.
 - **Model listings show each model's output ceiling** beside the context window — size a
   synth slot's `max_tokens` from it.
+- **Model listings mark which models reason**, read from the provider's own catalog, so
+  picking a thinking model costs no guesswork and no API call of your own.
 - **The explorer can hand whole files to whoever reads its report** — an `attach` tool
   routes real bytes (images too) into the driver's context or the `deliberate` dossier,
   governed by `[defaults] max_attachments`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ record. Each later release appends a new section at the top.
 
 ### Changed
 
+- **Reasoning is on by default on every OpenAI-compatible backend** — kaibo sends
+  `reasoning_effort`, so a thinking model behind a gateway or a local server no longer
+  answers thin.
+- **`thinking_style = "off"` turns reasoning off on any provider** — the escape hatch for
+  a server that rejects an unknown parameter instead of ignoring it.
 - **kaibo speaks MCP through the released rmcp 3.1.2**, off the 3.0 beta it shipped on,
   for that line's protocol conformance fixes.
 - **kaibo runs on kaish 0.14**, which stopped holding state for its embedders — the shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **kaibo told models the wrong exit code for a refused write.** Six descriptions said
+  `126` meant blocked; a refused write exits `1` with `permission denied: filesystem is
+  read-only`, and an external command exits `127`.
 - **A model calling a tool that does not exist no longer throws away the investigation**
   — it gets a tool result naming the real toolset, and corrects itself on the next turn.
 - **`--no-<tool>` gates work again over MCP.** Since the rmcp 3.0 upgrade a disabled or

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/README.md
+++ b/README.md
@@ -321,9 +321,12 @@ of parsing prose: `0` an answer, `2` a usage error (bad flag, unknown or
 wrong-for-the-tool cast), `3` a setup/containment rejection (a path outside
 the allowed set, a missing provider key), `4` the work ran and failed at
 runtime (a provider error, a model-loop failure). `kaibo kaish` is the one
-exception — it passes through kaish's own exit code (`0` ok, `126` blocked,
-`124` timed out) instead, since a script branches on *that* to know what the
-sandboxed command did. The same table is in `kaibo --help`.
+exception — it passes through kaish's own exit code (`0` ok, `1` the command
+failed, `124` timed out, `127` command not found) instead, since a script
+branches on *that* to know what the sandboxed command did. A refused write is an
+ordinary failure: it exits `1` and prints `permission denied: filesystem is
+read-only`, so branch on the message when you need to tell a refusal from a
+mistake. The same table is in `kaibo --help`.
 
 The shared flags (`--root`, `--allow-path`, `--cast`, `--config`, house-rules
 files, …) work before or after the subcommand and are documented in `kaibo

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -150,8 +150,11 @@ top_p                = 0.95
 explorer_effort = "high"
 synth_effort    = "high"
 
-# Force the Anthropic thinking shape ("auto" | "adaptive" | "budget") instead of
-# the built-in model classifier — the escape hatch for a new or misclassified id.
+# Force the thinking shape ("auto" | "adaptive" | "budget" | "off") instead of the
+# built-in classifier. adaptive/budget are Anthropic tiers — the escape hatch for a
+# new or misclassified id. "off" sends no reasoning parameter on ANY provider: set it
+# for a server that REJECTS unknown parameters instead of ignoring them (reasoning is
+# on by default everywhere else). See docs/config.md.
 thinking_style = "auto"
 
 # Per-request LLM deadline (seconds): the wall-clock ceiling on ONE completion

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -222,9 +222,11 @@ output_limit_bytes = 65536   # per-script output cap (64 KiB); exit 3 + head/tai
 # (StorageFull), never silently eating host RAM. Default 64 MiB; must be > 0 — there
 # is no "unbounded" setting, an unbounded scratch is the bug this prevents.
 scratch_limit_bytes = 67108864
-# Builtins to shadow-block ON TOP OF the read-only denylist (exit 126 if invoked).
-# This only makes the box STRICTER — it can't re-enable the read-only denylist
-# (git/touch/spawn/exec/kill/mktemp), and the dangerous axes aren't compiled in.
+# Builtins to shadow-block on top of the structural boundary (exit 126 if invoked).
+# This is the ONLY thing in kaibo that produces 126, and it is empty by default — a
+# refused write is not this, it exits 1 at the read-only mount.
+# Setting it only makes the box STRICTER. It cannot loosen anything: writes are
+# refused by the mount, and git/spawn/exec are not compiled in at all.
 # A name that isn't a real builtin is a loud startup error, not a silent no-op.
 # disable_builtins = ["grep", "find"]
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -273,7 +273,7 @@ Global tunables every slot falls back to. Per-slot overrides are documented abov
 | `synth_temperature` | 0.3 | `[0.0, 2.0]` |
 | `top_p` | 0.95 | `(0.0, 1.0]` |
 | `explorer_effort` / `synth_effort` | `"high"` | passthrough string |
-| `thinking_style` | `"auto"` | `auto` \| `adaptive` \| `budget` |
+| `thinking_style` | `"auto"` | `auto` \| `adaptive` \| `budget` \| `off` |
 | `request_timeout_secs` | 900 | > 0 |
 | `call_deadline_secs` | 3600 | > 0 |
 | `explorer_max_turns` | 100 | — |
@@ -358,11 +358,27 @@ the cast and slot, and `kaibo://config` lists `effort` under that slot's
 `inert_tunables`. The inherited built-in `"high"` stays quiet: every local cast inherits
 it onto a toggle-less wire, so warning there would be noise on every ordinary setup.
 
-**`thinking_style`.** Forces the Anthropic thinking shape instead of the built-in
-classifier. `auto` picks adaptive for Opus 4.6+, Sonnet 4.6, and Fable 5, and
-enabled-budget for older models plus Haiku 4.5. Set `adaptive` or `budget` when a new or
-misclassified model ships. A no-op for non-Anthropic kinds; an unknown value is a load
+**`thinking_style`.** Forces the thinking shape instead of the built-in classifier.
+`auto` picks adaptive for Opus 4.6+, Sonnet 4.6, and Fable 5, and enabled-budget for
+older models plus Haiku 4.5. Set `adaptive` or `budget` when a new or misclassified
+Anthropic model ships; those two are no-ops for other kinds. An unknown value is a load
 error.
+
+`off` is different: it applies to **every** provider and sends no reasoning parameter at
+all. Reasoning is on by default wherever a model can do it, because a thinking model
+asked to answer thin gives noticeably worse results — so `off` is the deliberate opt-out,
+not a tuning knob.
+
+Reach for it when a server **rejects** a parameter rather than ignoring it. Most
+OpenAI-compatible servers drop fields they do not know, and kaibo sends the portable
+`reasoning_effort` spelling for exactly that reason; but a strict gateway validates the
+whole body and refuses. Crusoe answers `403 Request blocked: parameter 'X' is not
+allowed`. That failure is loud and names the parameter, and kaibo passes the provider's
+message through to the calling agent, so the fix is one config line rather than a
+mystery. Note the rungs are per **model**, not per gateway — a provider may take
+`max` on one model and cap at `high` on another, and kaibo keeps no allowlist, so a
+rung a model does not take comes back as that provider's own error naming what it
+does take.
 
 **`call_deadline_secs`.** Whole-call wall-clock ceiling on an interactive
 `consult`/`explore`/`oneshot`, and the backstop for when the per-request

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1435,7 +1435,12 @@ const OPENAI_INPUT_FILENAME: &str = "kaibo-batch-input.jsonl";
 pub fn openai_batch_shaping(model: &str, tunables: &SlotTunables) -> (u64, Option<Value>) {
     let max_tokens = tunables.max_tokens.max(BATCH_MAX_TOKENS_FLOOR);
     let params =
-        crate::consult::hosted_openai_responses_params(model, None, batch_effort(&tunables.effort));
+        crate::consult::hosted_openai_responses_params(
+            model,
+            None,
+            batch_effort(&tunables.effort),
+            tunables.thinking_style,
+        );
     (max_tokens, params)
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,7 +80,9 @@ EXIT CODES
        worker infra crash
 
 `kaibo kaish` is the one exception: it exits with kaish's own code instead of
-this table (0 ok, 126 blocked, 124 timed out).";
+this table (0 ok, 1 the command failed, 124 timed out, 127 command not found).
+A refused write exits 1 and names itself on stderr: `permission denied:
+filesystem is read-only`.";
 
 /// kaibo — read-only codebase consultation from a model outside your own
 /// family. Ask a question; a synthesis agent (DeepSeek, Gemini, Anthropic, OpenRouter,
@@ -2414,7 +2416,8 @@ pub async fn run_kaish(common: CommonArgs, args: KaishArgs) -> i32 {
             eprintln!(
                 "kaibo: the kaish shell failed while running your script, so its output is \
                  incomplete: {e:#}. This is a kaibo failure, not a script error — a script's \
-                 own exit codes are 0, 126 (blocked), and 124 (timed out)."
+                 own exit codes are 0 (ok), 1 (the command failed, which is also how a \
+                 refused write reports), 124 (timed out), and 127 (command not found)."
             );
             EXIT_CONSULT_FAILURE
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,7 +21,8 @@
 //!   failure, or a `kaish` worker infra crash). So an agent branches on the code without
 //!   parsing prose. (An arg-parse error is clap's: usage on stderr, exit 2, nothing on
 //!   stdout — the envelope is guaranteed only once args parse. And `kaibo kaish` passes
-//!   through kaish's own exit code on a normal run — 0/126 blocked/124 timed out.)
+//!   through kaish's own exit code on a normal run — 0 ok/1 failed/124 timed out/127
+//!   not found.)
 //!
 //! `--help` is model-facing text: an agent reads it the way an MCP client reads a
 //! tool description, so the top-level `about` front-loads what kaibo is and every
@@ -81,8 +82,8 @@ EXIT CODES
 
 `kaibo kaish` is the one exception: it exits with kaish's own code instead of
 this table (0 ok, 1 the command failed, 124 timed out, 127 command not found).
-A refused write exits 1 and names itself on stderr: `permission denied:
-filesystem is read-only`.";
+A refused write exits 1 and prints `permission denied: filesystem is
+read-only` on stderr.";
 
 /// kaibo — read-only codebase consultation from a model outside your own
 /// family. Ask a question; a synthesis agent (DeepSeek, Gemini, Anthropic, OpenRouter,
@@ -500,7 +501,8 @@ pub struct DeliberateArgs {
 
 /// `kaibo kaish` — one non-interactive kaish command through the same READ-ONLY sandbox
 /// the `run_kaish` MCP tool uses. Scriptable single execution only: no readline, no
-/// REPL. The process exits with kaish's own exit code (0 ok, 126 blocked, 124 timed out).
+/// REPL. The process exits with kaish's own exit code (0 ok, 1 the command failed,
+/// 124 timed out, 127 command not found).
 #[derive(Args, Debug)]
 pub struct KaishArgs {
     /// The kaish (sh-like) script to run against the read-only project. Required — kaibo
@@ -2318,7 +2320,8 @@ async fn cas_read_inner(args: &CasReadArgs, resolver: &Resolver) -> Result<i32, 
 
 /// Run `kaibo kaish -c 'SCRIPT'` — one non-interactive execution through the read-only
 /// sandbox. stdout carries the script's stdout, stderr its stderr, and the process exits
-/// with kaish's own exit code (0 ok, 126 blocked, 124 timed out). A missing `-c` is a
+/// with kaish's own exit code (0 ok, 1 the command failed, 124 timed out, 127 command
+/// not found). A missing `-c` is a
 /// usage error (exit 2); a bad `--path` is a setup rejection (exit 3).
 pub async fn run_kaish(common: CommonArgs, args: KaishArgs) -> i32 {
     init_cli_logging();

--- a/src/config.rs
+++ b/src/config.rs
@@ -4500,8 +4500,10 @@ mod tests {
             cfg.effort_diagnostics()
         );
 
-        // The same cast, with the effort written on the slot: now it is a claim the
-        // operator made, and it goes nowhere.
+        // The same cast, with the effort written on the slot AND reasoning switched
+        // off: now it is a claim the operator made, and it goes nowhere. `thinking_style
+        // = "off"` is what makes it inert — an openai-compatible backend carries
+        // `reasoning_effort`, so without the off-switch this slot would ship.
         let cfg = Config::from_toml_str(
             r#"
             [backends.lab]
@@ -4510,7 +4512,7 @@ mod tests {
             key_optional = true
 
             [casts.zorak]
-            synth = { backend = "lab", id = "gemma", effort = "xhigh" }
+            synth = { backend = "lab", id = "gemma", effort = "xhigh", thinking_style = "off" }
             "#,
         )
         .unwrap();
@@ -4537,6 +4539,7 @@ mod tests {
             r#"
             [defaults]
             synth_effort = "low"
+            thinking_style = "off"
 
             [backends.lab]
             kind = "openai"
@@ -4553,7 +4556,9 @@ mod tests {
         assert_eq!(
             zorak.len(),
             1,
-            "the defaults effort is reported too: {inert:?}"
+            "a [defaults] effort is reported too, not just a per-slot one — here it is \
+             inert because [defaults] thinking_style = off turns reasoning off for every \
+             cast at once: {inert:?}"
         );
         assert_eq!(zorak[0].disposition.configured, "low");
         assert_eq!(zorak[0].disposition.source, EffortSource::Defaults);
@@ -4689,8 +4694,11 @@ mod tests {
             [casts.batch-off]
             synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "none" }
 
-            [casts.dropped]
+            [casts.local-thinks]
             synth = { backend = "lab", id = "gemma", effort = "xhigh" }
+
+            [casts.dropped]
+            synth = { backend = "lab", id = "gemma", effort = "xhigh", thinking_style = "off" }
             "#,
         )
         .unwrap();
@@ -4724,7 +4732,20 @@ mod tests {
             EffortFate::SentAsOff,
             "a DEPTH floor must leave an explicit reasoning-off alone on the batch lane too"
         );
-        assert_eq!(fate("dropped"), EffortFate::NoSink);
+        assert_eq!(
+            fate("local-thinks"),
+            EffortFate::Sent,
+            "an OpenAI-compatible backend carries `reasoning_effort`, so a local slot's \
+             effort reaches the server — this is the whole point of the openai wire \
+             reasoning by default"
+        );
+        assert_eq!(
+            fate("dropped"),
+            EffortFate::NoSink,
+            "`thinking_style = off` is now the only way a slot has no sink: it is the \
+             operator saying send nothing, for a server that rejects the parameter \
+             instead of ignoring it"
+        );
 
         // Only the last two are things the operator needs to hear about.
         let diagnosed: Vec<String> = cfg
@@ -4732,7 +4753,8 @@ mod tests {
             .into_iter()
             .map(|d| d.cast)
             .filter(|c| {
-                ["plain", "off", "newer", "lifted", "dropped", "batch-off"].contains(&c.as_str())
+                ["plain", "off", "newer", "lifted", "dropped", "batch-off", "local-thinks"]
+                    .contains(&c.as_str())
             })
             .collect();
         assert_eq!(

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -318,7 +318,12 @@ impl Arm {
         // request shape.
         let responses_wire = backend.uses_responses_wire();
         let params = if responses_wire {
-            super::shaping::hosted_openai_responses_params(&slot.id, Some(t.top_p), &t.effort)
+            super::shaping::hosted_openai_responses_params(
+                &slot.id,
+                Some(t.top_p),
+                &t.effort,
+                t.thinking_style,
+            )
         } else {
             params
         };

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -212,7 +212,23 @@ enum ThinkingStyle {
     /// thinkingLevel) and silently drops it for a model that has no reasoning knob, so
     /// emitting it unconditionally is safe.
     OpenRouterEffort,
-    /// No request-time toggle (the generic OpenAI path).
+    /// Bare `{reasoning_effort:<role>}`, with no `thinking` block beside it — the
+    /// OpenAI Chat Completions spelling the OpenAI-compatible field has settled on.
+    /// Hosted gateways, vLLM, and llama.cpp read this key, and a server that does not
+    /// know it ignores an unknown JSON field.
+    ///
+    /// Deliberately *not* [`ThinkingStyle::DeepSeekEffort`], which pairs the same key
+    /// with a `thinking` object. That pairing is DeepSeek's own and does not travel:
+    /// Crusoe validates the body against an allowlist and answers `403 Request
+    /// blocked: parameter 'thinking' is not allowed`, so borrowing the DeepSeek shape
+    /// fails the whole call instead of degrading (measured 2026-08-13).
+    ///
+    /// `none` rides through as `reasoning_effort: "none"` rather than being omitted:
+    /// that is this wire's own off-switch, and omitting the key leaves the model's
+    /// default on.
+    EffortOnly,
+    /// No request-time toggle. Reached when an operator sets `thinking_style = "off"`,
+    /// and on a media wire, which builds no completion request at all.
     None,
 }
 
@@ -235,6 +251,9 @@ pub enum ThinkingStyleOverride {
     Auto,
     Adaptive,
     Budget,
+    /// Send no reasoning parameter at all, on any provider. The escape hatch for a
+    /// server that rejects unknown fields instead of ignoring them.
+    Off,
 }
 
 impl std::str::FromStr for ThinkingStyleOverride {
@@ -244,8 +263,9 @@ impl std::str::FromStr for ThinkingStyleOverride {
             "auto" => Ok(Self::Auto),
             "adaptive" => Ok(Self::Adaptive),
             "budget" => Ok(Self::Budget),
+            "off" => Ok(Self::Off),
             other => Err(anyhow!(
-                "thinking_style {other:?} is not one of auto|adaptive|budget"
+                "thinking_style {other:?} is not one of auto|adaptive|budget|off"
             )),
         }
     }
@@ -284,12 +304,34 @@ impl ModelShape {
                 sampling_placement: SamplingPlacement::TopLevel,
             };
         };
+        // `off` is the operator's reasoning kill-switch and outranks every wire: a
+        // server that refuses the parameter needs kaibo to send nothing at all, and
+        // that answer cannot depend on which provider it pretends to be.
+        if ovr == ThinkingStyleOverride::Off {
+            let (sampling_under_thinking, sampling_placement) = match wire {
+                WireKind::Gemini => (true, SamplingPlacement::GeminiGenerationConfig),
+                _ => (true, SamplingPlacement::TopLevel),
+            };
+            return Self {
+                thinking: ThinkingStyle::None,
+                sampling_under_thinking,
+                sampling_placement,
+            };
+        }
         let thinking = match wire {
             WireKind::Anthropic => {
                 let adaptive = match ovr {
                     ThinkingStyleOverride::Auto => is_anthropic_adaptive(model),
                     ThinkingStyleOverride::Adaptive => true,
                     ThinkingStyleOverride::Budget => false,
+                    // `Off` returned above, before any wire was consulted. Panicking
+                    // rather than picking a tier is deliberate: if that early return is
+                    // ever removed, an operator who asked for no reasoning would
+                    // silently get Anthropic thinking billed instead, and a loud test
+                    // failure is the only way that gets noticed.
+                    ThinkingStyleOverride::Off => {
+                        unreachable!("thinking_style = off is answered before the wire match")
+                    }
                 };
                 if adaptive {
                     ThinkingStyle::AnthropicAdaptive
@@ -305,7 +347,7 @@ impl ModelShape {
             WireKind::Gemini => ThinkingStyle::GeminiLevel,
             WireKind::DeepSeek => ThinkingStyle::DeepSeekEffort,
             WireKind::OpenRouter => ThinkingStyle::OpenRouterEffort,
-            WireKind::Openai => ThinkingStyle::None,
+            WireKind::Openai => ThinkingStyle::EffortOnly,
         };
         let (sampling_under_thinking, sampling_placement) = match wire {
             WireKind::Anthropic => (false, SamplingPlacement::TopLevel),
@@ -344,6 +386,7 @@ impl ModelShape {
                 | ThinkingStyle::GeminiLevel
                 | ThinkingStyle::DeepSeekEffort
                 | ThinkingStyle::OpenRouterEffort
+                | ThinkingStyle::EffortOnly
         )
     }
 
@@ -488,6 +531,11 @@ impl ModelShape {
                 } else {
                     obj.insert("reasoning".into(), json!({ "effort": effort }));
                 }
+            }
+            ThinkingStyle::EffortOnly => {
+                // One key, nothing beside it. `none` is sent rather than omitted —
+                // it is this wire's off-switch, not an absence.
+                obj.insert("reasoning_effort".into(), json!(effort));
             }
             ThinkingStyle::None => {}
         }

--- a/src/consult/shaping.rs
+++ b/src/consult/shaping.rs
@@ -595,9 +595,15 @@ pub fn hosted_openai_responses_params(
     model: &str,
     top_p: Option<f64>,
     effort: &str,
+    style: ThinkingStyleOverride,
 ) -> Option<Value> {
     let mut obj = serde_json::Map::new();
-    if hosted_openai_accepts_reasoning(model) {
+    // `off` has to be honored here too, and it is easy to miss: this function does not
+    // build on [`ModelShape`], it REPLACES that blob at the call site, so the early
+    // return in `ModelShape::resolve` never reaches the Responses wire. Without this
+    // check an operator who switched reasoning off still got `reasoning:{effort}` on
+    // every gpt-5 slot — silently, because the setting looked honored everywhere else.
+    if hosted_openai_accepts_reasoning(model) && style != ThinkingStyleOverride::Off {
         obj.insert("reasoning".into(), json!({ "effort": effort }));
     }
     if hosted_openai_accepts_sampling(model) {
@@ -639,7 +645,7 @@ pub fn effort_sinks(
     responses_wire: bool,
 ) -> bool {
     if responses_wire {
-        return hosted_openai_accepts_reasoning(model);
+        return style != ThinkingStyleOverride::Off && hosted_openai_accepts_reasoning(model);
     }
     ModelShape::resolve(kind, model, style).sinks_effort()
 }
@@ -978,7 +984,7 @@ mod tests {
     /// `/chat/completions` shape, which stays toggle-less for local servers.
     #[test]
     fn hosted_openai_responses_params_are_model_aware_about_sampling() {
-        let params = hosted_openai_responses_params("gpt-5.6-sol", Some(0.95), DEFAULT_EFFORT)
+        let params = hosted_openai_responses_params("gpt-5.6-sol", Some(0.95), DEFAULT_EFFORT, ThinkingStyleOverride::Auto)
             .expect("hosted OpenAI sends Responses params");
         assert_eq!(
             params["reasoning"]["effort"], "high",
@@ -997,7 +1003,7 @@ mod tests {
             "Responses maps core max_tokens to max_output_tokens itself"
         );
 
-        let params = hosted_openai_responses_params("gpt-4.1-mini", Some(0.95), "low")
+        let params = hosted_openai_responses_params("gpt-4.1-mini", Some(0.95), "low", ThinkingStyleOverride::Auto)
             .expect("older chat GPT families keep sampling");
         assert!(
             params.get("reasoning").is_none(),
@@ -1013,7 +1019,7 @@ mod tests {
             "known sampling-compatible GPT families keep typed temperature"
         );
 
-        let params = hosted_openai_responses_params("gpt-5.6-sol", None, "none").unwrap();
+        let params = hosted_openai_responses_params("gpt-5.6-sol", None, "none", ThinkingStyleOverride::Auto).unwrap();
         assert_eq!(
             params["reasoning"]["effort"], "none",
             "the explicit no-reasoning effort passes through to rig's Responses enum"
@@ -1021,7 +1027,7 @@ mod tests {
         assert!(params.get("top_p").is_none());
 
         assert!(
-            hosted_openai_responses_params("unknown-openai-model", Some(0.95), "high").is_none(),
+            hosted_openai_responses_params("unknown-openai-model", Some(0.95), "high", ThinkingStyleOverride::Auto).is_none(),
             "unknown hosted models get no guessed provider-specific params"
         );
     }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -80,6 +80,31 @@ pub struct DiscoveredModel {
     /// the endpoint doesn't advertise pricing on `/models` (only `Openai`-wire kinds
     /// do today; see [`parse_openai_models`]).
     pub pricing: Option<ModelPricing>,
+    /// Does this model take a reasoning parameter, per the provider's own catalog?
+    /// `Some(true)`/`Some(false)` when the endpoint publishes a parameter list,
+    /// `None` when it publishes none — an unknown, never a "no".
+    ///
+    /// Read from `supported_parameters`, which OpenRouter and vLLM-backed gateways
+    /// both ship. It answers *whether*, never *which rungs*: no catalog publishes the
+    /// ladder, and it moves per model (Crusoe takes `max` on DeepSeek-V4-Flash and
+    /// caps at `high` on Nemotron-Omni-Reasoning). A rung a model refuses comes back
+    /// as the provider's own error naming what it accepts, which is why kaibo keeps
+    /// no allowlist — see [`crate::consult::EffortWire`].
+    pub reasoning: Option<bool>,
+}
+
+/// Whether a catalog entry says this model takes a reasoning parameter.
+///
+/// Matched against the spellings the OpenAI-compatible field actually ships:
+/// `reasoning_effort` (vLLM and hosted gateways), plus OpenRouter's `reasoning` and
+/// `include_reasoning`. A catalog with no `supported_parameters` at all answers `None`
+/// — kaibo reports "unknown", never "unsupported", because a missing list is a silent
+/// endpoint rather than a negative claim.
+fn parse_reasoning_support(item: &Value) -> Option<bool> {
+    let params = item.get("supported_parameters")?.as_array()?;
+    Some(params.iter().filter_map(Value::as_str).any(|p| {
+        matches!(p, "reasoning_effort" | "reasoning" | "include_reasoning")
+    }))
 }
 
 /// Per-token price, kept as the provider's own string (fractional USD/token) rather
@@ -243,6 +268,7 @@ pub fn parse_openai_models(v: &Value) -> Vec<DiscoveredModel> {
                 .and_then(|tp| tp.get("max_completion_tokens"))
                 .and_then(Value::as_u64),
             pricing: parse_openai_pricing(item),
+            reasoning: parse_reasoning_support(item),
             raw: item.clone(),
         })
         .collect()
@@ -303,6 +329,7 @@ pub fn parse_anthropic_models(v: &Value) -> Vec<DiscoveredModel> {
             // Anthropic's `/v1/models` advertises neither pricing nor an output ceiling.
             output_ceiling: None,
             pricing: None,
+            reasoning: None,
             raw: item.clone(),
         })
         .collect()
@@ -329,6 +356,7 @@ pub fn parse_gemini_models(v: &Value) -> Vec<DiscoveredModel> {
                 output_ceiling: item.get("outputTokenLimit").and_then(Value::as_u64),
                 // Gemini's `/v1beta/models` doesn't advertise pricing.
                 pricing: None,
+                reasoning: None,
                 raw: item.clone(),
             }
         })
@@ -510,6 +538,9 @@ pub fn render_models(results: &BTreeMap<String, Result<Vec<DiscoveredModel>, Str
                     }
                     if !limits.is_empty() {
                         line.push_str(&format!(" ({})", limits.join(", ")));
+                    }
+                    if m.reasoning == Some(true) {
+                        line.push_str(" [reasoning]");
                     }
                     if let Some(p) = &m.pricing {
                         let mut parts = Vec::new();
@@ -1058,6 +1089,7 @@ mod tests {
                     input: Some("0.0000015".to_string()),
                     output: Some("0.000006".to_string()),
                 }),
+                reasoning: None,
                 raw: serde_json::json!({"id": "m1"}),
             }]),
         );
@@ -1094,6 +1126,7 @@ mod tests {
                 context_window: None,
                 output_ceiling: Some(16_384),
                 pricing: None,
+                reasoning: None,
                 raw: serde_json::json!({"id": "m1"}),
             }]),
         );
@@ -1114,6 +1147,7 @@ mod tests {
                 context_window: None,
                 output_ceiling: None,
                 pricing: None,
+                reasoning: None,
                 raw: serde_json::json!({"id": "m1"}),
             }]),
         );
@@ -1142,6 +1176,7 @@ mod tests {
                     input: Some("0.000001".to_string()),
                     output: None,
                 }),
+                reasoning: None,
                 raw: serde_json::json!({"id": "m1", "extra": "field"}),
             }]),
         );
@@ -1182,6 +1217,7 @@ mod tests {
                 context_window: None,
                 output_ceiling: None,
                 pricing: None,
+                reasoning: None,
                 raw: serde_json::json!({"id": "m1"}),
             }]),
         );
@@ -1256,4 +1292,72 @@ mod tests {
         assert_eq!(models[0].raw["pricing"], serde_json::json!({}));
     }
 
+}
+
+#[cfg(test)]
+mod reasoning_support_tests {
+    use super::*;
+
+    /// The catalog answers *whether* a model reasons, never *which rungs* it takes.
+    ///
+    /// A missing `supported_parameters` is `None` — unknown, not "no". The distinction
+    /// matters because most endpoints publish no parameter list at all, and rendering
+    /// those as unsupported would tell an operator the opposite of the truth.
+    #[test]
+    fn reasoning_support_reads_the_catalog_and_admits_when_it_cannot() {
+        let takes = serde_json::json!({
+            "id": "m",
+            "supported_parameters": ["temperature", "reasoning_effort", "top_p"]
+        });
+        assert_eq!(parse_reasoning_support(&takes), Some(true));
+
+        // OpenRouter's spellings, not vLLM's.
+        let openrouter = serde_json::json!({ "id": "m", "supported_parameters": ["reasoning"] });
+        assert_eq!(parse_reasoning_support(&openrouter), Some(true));
+
+        let listed_without = serde_json::json!({
+            "id": "m",
+            "supported_parameters": ["temperature", "top_p"]
+        });
+        assert_eq!(
+            parse_reasoning_support(&listed_without),
+            Some(false),
+            "a published list that omits it IS a negative claim"
+        );
+
+        let silent = serde_json::json!({ "id": "m" });
+        assert_eq!(
+            parse_reasoning_support(&silent),
+            None,
+            "no list at all is UNKNOWN — reporting `false` here would state the \
+             opposite of the truth for every endpoint that publishes nothing"
+        );
+    }
+
+    /// Only a positive answer earns a marker: an unknown must not read as a "no", and
+    /// a line cluttered with `[reasoning: unknown]` on every plain endpoint is noise.
+    #[test]
+    fn only_a_known_reasoning_model_is_marked() {
+        let mk = |reasoning| DiscoveredModel {
+            id: "m".into(),
+            display_name: None,
+            created: None,
+            context_window: None,
+            output_ceiling: None,
+            pricing: None,
+            reasoning,
+            raw: serde_json::json!({}),
+        };
+        let render = |r| {
+            let mut results = BTreeMap::new();
+            results.insert("b".to_string(), Ok(vec![mk(r)]));
+            render_models(&results)
+        };
+        assert!(render(Some(true)).contains("[reasoning]"));
+        assert!(!render(Some(false)).contains("[reasoning]"));
+        assert!(
+            !render(None).contains("[reasoning]"),
+            "unknown must not render as either answer"
+        );
+    }
 }

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -379,6 +379,7 @@ pub fn kaibo_sandbox_doc() -> String {
          config disables none, so you will rarely see this\n\
          - `127` — command not found. Every external command answers this way, which \
          is what makes the host unreachable from here\n\
+         - `130` — the script was cancelled\n\
          - other non-zero — the script itself failed\n\n\
          ## Learn more kaish\n\
          These `kaibo://kaish/*` resources mirror kaish's own help, so you can go \

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -367,7 +367,8 @@ pub fn kaibo_sandbox_doc() -> String {
          ## Exit codes\n\
          The code tells you the shape of the outcome; the message tells you which \
          outcome it was. A refused write and an ordinary mistake both exit `1`, so \
-         read the stderr line — a refusal names itself.\n\
+         read the stderr line: a refusal says `permission denied: filesystem is \
+         read-only`.\n\
          - `0` — success\n\
          - `1` — the command failed. A refused write is one of these, and its message \
          reads `permission denied: filesystem is read-only`\n\

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -52,9 +52,12 @@ the content as text or binary, so you know what you are about to read. \
 Each call starts at the project root; \
 there is no persistent cwd. Read the exit code: 0 is success; 3 means the output \
 was too large and came back as a head+tail sample (not a failure); 124 means the \
-script was killed for running past its time budget; 126 means blocked by the \
-read-only sandbox; 127 is command-not-found; any other non-zero means the script \
-itself failed. To learn more, run `help`, `help syntax`, or `help <builtin>` in any \
+script was killed for running past its time budget; 127 is command-not-found, which \
+is how every external command answers here; 1 is an ordinary failure, and a refused \
+write is one of those — its message reads `permission denied: filesystem is \
+read-only`. Read the message and not only the code, because that sentence is what \
+tells a refusal apart from a mistake. \
+To learn more, run `help`, `help syntax`, or `help <builtin>` in any \
 script, or read the `kaibo://kaish/*` resources.";
 
 /// The canonical kaish operating contract, sourced from `kaish-help` so kaibo
@@ -362,13 +365,19 @@ pub fn kaibo_sandbox_doc() -> String {
          command are refused. This is the product: read freely, expect no write to \
          land.\n\n\
          ## Exit codes\n\
+         The code tells you the shape of the outcome; the message tells you which \
+         outcome it was. A refused write and an ordinary mistake both exit `1`, so \
+         read the stderr line — a refusal names itself.\n\
          - `0` — success\n\
+         - `1` — the command failed. A refused write is one of these, and its message \
+         reads `permission denied: filesystem is read-only`\n\
          - `3` — output exceeded the cap and was truncated to a head+tail sample \
          (not a failure; the full output is not returned)\n\
          - `124` — killed for exceeding the per-exec time budget\n\
-         - `126` — blocked by the read-only sandbox (collides with POSIX \
-         \"not executable\" — read the message to be sure)\n\
-         - `127` — command not found\n\
+         - `126` — a builtin the operator disabled in kaibo's config; the default \
+         config disables none, so you will rarely see this\n\
+         - `127` — command not found. Every external command answers this way, which \
+         is what makes the host unreachable from here\n\
          - other non-zero — the script itself failed\n\n\
          ## Learn more kaish\n\
          These `kaibo://kaish/*` resources mirror kaish's own help, so you can go \
@@ -474,17 +483,38 @@ mod tests {
         );
     }
 
+    /// The two things the synth preamble rewards (exact `file:line`) and the exit codes
+    /// an automated caller will misread without help. These are kaibo's own, so they live
+    /// in the addendum — kaish-help cannot know them.
+    ///
+    /// The negative assertion is the load-bearing one. Until 2026-08-13 all six of kaibo's
+    /// exit-code descriptions said `126` meant "blocked by the read-only sandbox". Nothing
+    /// emits 126 for a refused write: the read-only mount is structural and refuses with
+    /// the VFS's own `1` (`a14c7e7` moved it there in June 2026, and the prose never
+    /// followed), while 126 belongs to an operator-disabled builtin that the default
+    /// config never produces. A model told to branch on 126 to detect a refusal would
+    /// never detect one, and would read `1` as its own command failing. So this pins the
+    /// true discriminator — the message — and pins that the false code cannot come back.
     #[test]
     fn addendum_states_the_exit_code_contract_and_line_browsing() {
-        // The two things the synth preamble rewards (exact file:line) and the two
-        // codes an automated caller will misread without help. These are kaibo's,
-        // so they live in the addendum (kaish-help can't know our 126/124).
-        for needle in ["cat -n", "grep -rn", "126", "124"] {
+        for needle in [
+            "cat -n",
+            "grep -rn",
+            "124",
+            "127",
+            "permission denied: filesystem is read-only",
+        ] {
             assert!(
                 KAISH_SANDBOX_ADDENDUM.contains(needle),
                 "addendum must mention {needle:?}"
             );
         }
+        assert!(
+            !KAISH_SANDBOX_ADDENDUM.contains("126"),
+            "the addendum must not teach 126 as the blocked code — a refused write exits 1 \
+             and names itself, and 126 only fires for an operator-disabled builtin:\n{}",
+            KAISH_SANDBOX_ADDENDUM
+        );
     }
 
     /// The two reading idioms that follow a grep hit: a wide span around a match in a

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -63,12 +63,15 @@ impl Tool for Blocked {
     }
 
     async fn execute(&self, _args: ToolArgs, _ctx: &mut dyn ToolCtx) -> ExecResult {
-        // Exit **126** = "blocked by the read-only sandbox". Distinct from the
-        // kernel's other non-zero codes a caller may see: 124 = killed for
+        // Exit **126** = a builtin an operator disabled in config. NOT the read-only
+        // refusal: the mount refuses a write structurally, with the VFS's own exit 1
+        // and `permission denied: filesystem is read-only`. Conflating the two is the
+        // error six published strings carried for two months; keep them apart here.
+        // The kernel's other non-zero codes a caller may see: 124 = killed for
         // exceeding [`KAISH_EXEC_TIMEOUT`], 130 = cancelled, 127 = command not
         // found, and any other non-zero = the script itself failed. 126 also
         // collides with POSIX "not executable", so an automated caller must read
-        // the message, not just the code, to classify a sandbox block.
+        // the message, not just the code, to classify a block.
         ExecResult::failure(
             126,
             format!(

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -101,7 +101,8 @@ fn apply_disabled_builtins(registry: &mut ToolRegistry, disable: &[String]) {
 /// this long; the budget exists so a hung provider script or a pathological loop
 /// can't wedge the single serial worker thread (there's no `max_turns` braking a
 /// caller-facing `run_kaish`). On elapse the kernel cancels and the script exits
-/// **124** — distinct from 126 (a builtin refused by the read-only sandbox). 30s
+/// **124** — distinct from 1 (a write the read-only mount refused) and from 126 (a
+/// builtin an operator disabled in config). 30s
 /// matches a patient MCP caller while still bounding a runaway.
 pub const KAISH_EXEC_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -935,8 +935,9 @@ mod tests {
         );
         assert_eq!(
             inert("oai", "synth"),
-            vec!["thinking_budget", "effort"],
-            "openai sends neither thinking knob; temperature it does send"
+            vec!["thinking_budget"],
+            "an openai-compatible wire carries `reasoning_effort`, so effort SHIPS; only \
+             a token budget has no sink there, and temperature it does send"
         );
         assert_eq!(
             inert("ant_budget", "explorer"),
@@ -1054,7 +1055,8 @@ mod tests {
             base_url = "http://127.0.0.1:8080/v1"
             key_optional = true
 
-            # Toggle-less wire: the defaults effort lands nowhere and must be flagged.
+            # An openai-compatible wire: the defaults effort DOES reach it, but the
+            # [defaults] thinking_style tier does not — only Anthropic reads a tier.
             [casts.lab_cast]
             synth = "lab/gemma"
 
@@ -1101,10 +1103,10 @@ mod tests {
         };
         assert_eq!(
             inert("lab_cast", "synth"),
-            vec!["effort", "thinking_style"],
-            "a [defaults] effort on a toggle-less wire is just as inert as a slot one, \
-             and the [defaults] thinking_style forced onto a non-Anthropic wire is \
-             equally never consulted"
+            vec!["thinking_style"],
+            "a [defaults] effort now REACHES an openai-compatible wire, so it is no \
+             longer inert; the [defaults] thinking_style tier forced onto a \
+             non-Anthropic wire still is, because only Anthropic reads a tier"
         );
         assert_eq!(
             inert("forced", "synth"),
@@ -1220,9 +1222,11 @@ mod tests {
             [casts.bat_off]
             synth = { backend = "anthropic", id = "claude-opus-4-8", lane = "batch", effort = "none" }
 
-            # No reasoning field at all — the drop.
+            # Reasoning switched off — the drop. An openai-compatible wire carries
+            # `reasoning_effort` on its own, so `thinking_style = "off"` is what makes
+            # this slot's effort go nowhere.
             [casts.lab_cast]
-            synth = { backend = "lab", id = "gemma", effort = "xhigh" }
+            synth = { backend = "lab", id = "gemma", effort = "xhigh", thinking_style = "off" }
 
             # Carries it fine.
             [casts.ds]

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -496,8 +496,13 @@ pub(crate) fn render_config_resource(
                         // `Auto` stays quiet: it is the no-override default and behaves
                         // identically to an absent override on every wire, Anthropic
                         // included.
-                        if t.thinking_style != ThinkingStyleOverride::Auto
-                            && backend.kind.wire() != Some(WireKind::Anthropic)
+                        // `Off` is honored on EVERY wire (it short-circuits before the
+                        // per-wire match), so it is never inert — only the Anthropic
+                        // TIERS are, and only away from Anthropic.
+                        if matches!(
+                            t.thinking_style,
+                            ThinkingStyleOverride::Adaptive | ThinkingStyleOverride::Budget
+                        ) && backend.kind.wire() != Some(WireKind::Anthropic)
                         {
                             inert.push("thinking_style");
                         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2523,9 +2523,10 @@ impl KaiboHandler {
         description = "Run a kaish (sh-like) script against the READ-ONLY project; \
             returns exit code + stdout + stderr. Read generously with line numbers — \
             `cat -n FILE` for a whole file, `grep -rn PATTERN .` to locate across \
-            files — and compose builtins with pipes (grep/jq/awk/find/...). Writes \
-            and external commands are refused (exit 126 = blocked, 124 = timed out); \
-            each call starts fresh at the project root. See `kaibo://kaish/*` (or \
+            files — and compose builtins with pipes (grep/jq/awk/find/...). Writes are \
+            refused (exit 1, stderr `permission denied: filesystem is read-only`) and \
+            external commands are unreachable (exit 127); 124 = timed out. \
+            Each call starts fresh at the project root. See `kaibo://kaish/*` (or \
             `help` in the script) for idioms and the bash habits that don't carry over."
     )]
     pub async fn run_kaish(
@@ -4208,9 +4209,11 @@ A few habits from `bash` that *won't* carry over here — reach for the kaish fo
   want to split, use the `split` builtin; that's the deliberate form.
 - Adjacent tokens don't paste together — quote to join: `\"$dir/file.txt\"`, not
   `$dir/file.txt`.
-- This shell is **read-only**: a write, a redirect that would create a file, or an
-  external command is refused (exit 126 = blocked by the sandbox; 124 = killed for running
-  too long). That's the boundary working, not a bug — read freely, and don't try to mutate.
+- This shell is **read-only**: a write or a redirect that would create a file is refused
+  with exit `1` and the message `permission denied: filesystem is read-only`; an external
+  command is unreachable and exits `127`. That's the boundary working, not a bug — read
+  freely, and don't try to mutate. Refusals and ordinary failures share exit `1`, so read
+  the stderr line when you need to tell them apart.
 
 Learn more without spending a turn: the `kaibo://kaish/*` resources (syntax, builtins,
 vfs, scatter, …) and `kaibo://kaish/sandbox`, or run `help` / `help syntax` /
@@ -8169,10 +8172,23 @@ enabled = false
         }
     }
 
+    /// The sandbox resource is where the exit-code taxonomy is stated in full, so unlike
+    /// the terse addendum it *does* carry `126` — correctly, as the operator-disabled
+    /// builtin case. What it must also carry is the refusal's real signature, since a
+    /// refused write and an ordinary failure share exit `1` and only the message
+    /// separates them.
     #[test]
     fn reads_the_sandbox_doc_with_the_idioms_and_codes() {
         let text = read_text(SANDBOX_URI, &[]);
-        for needle in ["cat -n", "grep", "read-only", "126", "124"] {
+        for needle in [
+            "cat -n",
+            "grep",
+            "read-only",
+            "126",
+            "124",
+            "127",
+            "permission denied: filesystem is read-only",
+        ] {
             assert!(text.contains(needle), "sandbox doc must mention {needle:?}");
         }
     }
@@ -8210,7 +8226,7 @@ enabled = false
             "backend/provider-id", // the batch handle shape
             "fire-and-forget",     // the async-workflow framing
             "read-only",           // the kaish shell boundary
-            "126",                 // the exit-code contract
+            "permission denied: filesystem is read-only", // how a refusal names itself
             "worktree",            // attach/path reaches a followed git worktree
             "Reviewing a change",  // prefer whole files over a diff for review
             "view_image",          // consult opens an attached image with view_image

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -9,7 +9,7 @@
 //! always `ok`, because a non-zero *script* exit is normal output handed to the model,
 //! not a tool failure (see `explorer.rs`). So the span carries two more optional fields
 //! a tool may fill about its result: `kaish.exit_code` (the script's exit — `3` is the
-//! head+tail truncation, `124` a timeout, `126` blocked) and `kaish.output_bytes` (the
+//! head+tail truncation, `124` a timeout, `127` not found) and `kaish.output_bytes` (the
 //! delivered stdout size). Recorded by `run_kaish` via [`record_kaish_result`]; left
 //! empty (and thus unexported) by every other tool. This is what lets a trace tell a
 //! `cat -n` that *truncated* and forced narrow re-reads from one the model chose to

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -246,8 +246,24 @@ fn request_params_places_sampling_where_each_wire_format_wants_it() {
     assert_eq!(d["temperature"], 0.3);
     assert_eq!(d["top_p"], 0.95);
 
-    // Nothing set anywhere → None (the leaf passes no additional_params at all).
-    assert!(request_params(ProviderKind::Openai, "m", 0, None, None).is_none());
+    // No sampling, no budget — but the openai wire still asks for reasoning, so the
+    // blob is not empty. `reasoning_effort` alone is the whole of it.
+    let o = request_params(ProviderKind::Openai, "m", 0, None, None)
+        .expect("the openai wire carries reasoning_effort even with no sampling set");
+    assert_eq!(o["reasoning_effort"], "high");
+    assert_eq!(
+        o.as_object().map(|m| m.len()),
+        Some(1),
+        "nothing rides along beside it: {o}"
+    );
+
+    // Reasoning off is what empties it — then the leaf passes no additional_params.
+    assert!(
+        ModelShape::resolve(ProviderKind::Openai, "m", ThinkingStyleOverride::Off)
+            .to_params(0, None, None, DEFAULT_EFFORT)
+            .is_none(),
+        "thinking_style = off leaves nothing to send"
+    );
 }
 
 #[test]
@@ -496,12 +512,49 @@ fn deepseek_v4_toggles_thinking_with_reasoning_effort() {
 }
 
 #[test]
-fn the_generic_openai_path_sends_no_thinking_toggle() {
-    // The local Gemma default (its --reasoning-format auto) already reasons, and
-    // there's no portable toggle across arbitrary OpenAI-compatible endpoints: None.
+fn the_generic_openai_path_asks_for_reasoning_by_default() {
+    // Reasoning is ON by default wherever a model can do it. `reasoning_effort` is the
+    // spelling the OpenAI-compatible field settled on, so kaibo sends it to any such
+    // endpoint rather than leaving a reasoning model running thin.
+    let p = thinking_params(ProviderKind::Openai, "Gemma-4-E4B-it-GGUF", THINKING_BUDGET)
+        .expect("the openai-compatible wire carries reasoning_effort");
+    assert_eq!(p["reasoning_effort"], "high");
+    // One key, alone. DeepSeek pairs `reasoning_effort` with a `thinking` object, and
+    // borrowing that pairing is what a strict gateway refuses outright — Crusoe answers
+    // `403 Request blocked: parameter 'thinking' is not allowed`, failing the call
+    // instead of ignoring the field.
     assert!(
-        thinking_params(ProviderKind::Openai, "Gemma-4-E4B-it-GGUF", THINKING_BUDGET).is_none()
+        p.get("thinking").is_none(),
+        "no `thinking` block on this wire — a strict gateway 403s the whole request: {p}"
     );
+    assert!(p.get("reasoning").is_none(), "that shape is OpenRouter's: {p}");
+}
+
+#[test]
+fn thinking_style_off_sends_no_reasoning_parameter_on_any_wire() {
+    // The escape hatch for a server that rejects unknown fields instead of ignoring
+    // them. It has to answer for every wire, not just the openai one, because the
+    // operator is saying "send nothing" — not "pick a different dialect".
+    for (kind, model) in [
+        (ProviderKind::Openai, "Gemma-4-E4B-it-GGUF"),
+        (ProviderKind::DeepSeek, "deepseek-v4-pro"),
+        (ProviderKind::Anthropic, "claude-sonnet-4-6"),
+        (ProviderKind::Gemini, "gemini-3.5-flash"),
+        (ProviderKind::OpenRouter, "z-ai/glm-5.2"),
+    ] {
+        let shape = ModelShape::resolve(kind, model, ThinkingStyleOverride::Off);
+        let p = shape.to_params(THINKING_BUDGET, None, None, DEFAULT_EFFORT);
+        let has_reasoning = p.as_ref().is_some_and(|v| {
+            ["thinking", "reasoning", "reasoning_effort", "output_config"]
+                .iter()
+                .any(|k| v.get(k).is_some())
+                || v.pointer("/generationConfig/thinkingConfig").is_some()
+        });
+        assert!(
+            !has_reasoning,
+            "{kind:?}/{model}: thinking_style = off must send no reasoning parameter, got {p:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -5,8 +5,9 @@ use std::sync::{Arc, Mutex};
 
 use kaibo::config::{default_models, Config, Defaults, ModelRole, ModelSlot};
 use kaibo::consult::{
-    consult, consult_user_prompt, oneshot, request_params, thinking_params, Arm, ConsultConfig,
-    ModelCaps, ModelShape, PhaseContext, ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
+    consult, consult_user_prompt, effort_sinks, hosted_openai_responses_params, oneshot,
+    request_params, thinking_params, Arm, ConsultConfig, ModelCaps, ModelShape, PhaseContext,
+    ThinkingStyleOverride, DEFAULT_EFFORT, THINKING_BUDGET,
 };
 use kaibo::credentials::{load, ProviderKind};
 use serde_json::{json, Value};
@@ -528,6 +529,40 @@ fn the_generic_openai_path_asks_for_reasoning_by_default() {
         "no `thinking` block on this wire — a strict gateway 403s the whole request: {p}"
     );
     assert!(p.get("reasoning").is_none(), "that shape is OpenRouter's: {p}");
+}
+
+/// The off-switch on the **Responses** wire, checked where the request is really built.
+///
+/// The sibling test below calls `ModelShape::to_params` directly, and that is exactly
+/// why it missed this: on a Responses-wire backend the engine *discards* that blob and
+/// replaces it with `hosted_openai_responses_params`, so a `to_params`-level assertion
+/// proves nothing about what gets sent. The first version of this feature shipped with
+/// `thinking_style = "off"` silently ignored on every hosted gpt-5 slot, green tests and
+/// all — found by a cross-family review reading the call site instead of the unit.
+#[test]
+fn thinking_style_off_reaches_the_responses_wire_too() {
+    // Reasoning is on for this model by default...
+    let on = hosted_openai_responses_params("gpt-5.6-sol", None, "high", ThinkingStyleOverride::Auto)
+        .expect("a gpt-5 model takes reasoning");
+    assert_eq!(on["reasoning"]["effort"], "high");
+
+    // ...and `off` must remove it here, not merely in the shape the engine throws away.
+    let off = hosted_openai_responses_params("gpt-5.6-sol", None, "high", ThinkingStyleOverride::Off);
+    assert!(
+        off.as_ref().and_then(|v| v.get("reasoning")).is_none(),
+        "thinking_style = off must silence the Responses wire, got {off:?}"
+    );
+
+    // And the reporting has to agree, or kaibo would say effort ships while it does not.
+    assert!(
+        !effort_sinks(
+            ProviderKind::Openai,
+            "gpt-5.6-sol",
+            ThinkingStyleOverride::Off,
+            true,
+        ),
+        "with reasoning off, the Responses wire has no effort sink to report"
+    );
 }
 
 #[test]

--- a/tests/effort_wire.rs
+++ b/tests/effort_wire.rs
@@ -160,7 +160,12 @@ impl Path {
     /// than production does.
     fn shaped(&self, effort: &str) -> Option<Value> {
         if self.responses_wire() {
-            return hosted_openai_responses_params(self.model(), None, effort);
+            return hosted_openai_responses_params(
+                self.model(),
+                None,
+                effort,
+                ThinkingStyleOverride::Auto,
+            );
         }
         ModelShape::resolve(self.kind(), self.model(), ThinkingStyleOverride::Auto)
             .to_params(8192, None, None, effort)

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -442,3 +442,57 @@ async fn oversize_output_never_spills_to_the_host() {
         "kaibo's kernels run in-memory truncation, never disk spill"
     );
 }
+
+/// The exact refusal kaibo's prose quotes to models, bound to what the sandbox
+/// actually says.
+///
+/// Six published strings — the preamble addendum, the `kaibo://kaish/sandbox`
+/// resource, `kaibo --help`, the `kaibo kaish` failure message, the MCP `run_kaish`
+/// tool description, and `kaibo://tools` — tell a reader that a refused write exits
+/// `1` and identifies itself with `permission denied: filesystem is read-only`. That
+/// sentence is how a model tells a refusal from its own mistake, since both exit 1.
+///
+/// **kaibo does not own that string — kaish-kernel does.** Every other test here
+/// asserts the loose `contains("read-only")`, and the tests beside the prose assert
+/// only that kaibo's *own* text contains the sentence. So before this test, a kaish
+/// release that reworded the message would leave every assertion green while all six
+/// published strings quietly began lying. This is the one place the quote is checked
+/// against the shell, so a rewording upstream fails here, loudly, at the bump.
+///
+/// It pins the code too: `1`, not 126. The prose said 126 for two months because
+/// nothing tied the claim to behavior.
+#[tokio::test(flavor = "current_thread")]
+async fn a_refused_write_exits_1_with_the_message_our_prose_quotes() {
+    const QUOTED: &str = "permission denied: filesystem is read-only";
+
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("keep.txt"), "hi").unwrap();
+    let kernel = build_readonly_kernel(dir.path()).unwrap();
+
+    // One case per builtin family kaibo's prose calls a "write": a redirect, a
+    // create, a directory, and a delete. Each must agree on both halves.
+    for script in [
+        "echo pwned > newfile.txt",
+        "touch newfile.txt",
+        "mkdir newdir",
+        "rm keep.txt",
+    ] {
+        let r = run(&kernel, script).await.unwrap();
+        assert_eq!(
+            r.code, 1,
+            "`{script}` must exit 1 — kaibo's published exit-code contract says a \
+             refused write is an ordinary failure, not 126. Got {r:?}"
+        );
+        assert!(
+            r.err.contains(QUOTED),
+            "`{script}` must refuse with the exact sentence kaibo quotes to models, \
+             {QUOTED:?}. If kaish reworded this, six published strings are now wrong — \
+             fix them together with this test. Got {r:?}"
+        );
+    }
+
+    assert!(
+        dir.path().join("keep.txt").exists(),
+        "the read-only mount must not have deleted a real file"
+    );
+}


### PR DESCRIPTION
The polish PR ahead of 0.3 — Amy's plan: land the exit-code correction here, run kaibo reviews against it, and keep adding polish until release.

## The defect

Six of kaibo's exit-code descriptions told models `126` means "blocked by the read-only sandbox". **Nothing emits 126 for a refused write.**

Measured on this branch: `rm`, `touch`, `mkdir`, `cp`, a redirect, `tee`, and `sed -i` all exit **1** with `permission denied: filesystem is read-only`. External commands exit **127**. Nothing produced 126. It survives only for a builtin an operator disables via `[sandbox].disable_builtins`, which the default config never does.

Cause is kaibo-internal, not kaish drift: `a14c7e7` (2026-06-08) retired the 126-emitting denylist once kaish closed the underlying leaks, moving refusal to the structural VFS mount and its exit 1. The prose never followed, across all six sites, for over two months.

**Why it is worse than a wrong number:** the text invited an automated caller to branch on 126 to distinguish "the sandbox refused you" from "your command failed". A model doing that never detects a refusal and reads exit 1 as its own mistake. Full-weight prose under the style guide — and the worst-placed copy was the outer MCP `run_kaish` tool description, resident in every session.

We had it right twice in writing: `docs/sandbox-probes.md`'s exit table is correct, and `tests/sandbox.rs`'s own doc-comment says the refusal is structural now. Only the text handed to models was wrong.

## The sites

| file | surface |
|---|---|
| `src/kaish_syntax.rs` | `KAISH_SANDBOX_ADDENDUM` — in **every** preamble and the internal `run_kaish` tool |
| `src/kaish_syntax.rs` | `kaibo_sandbox_doc()` — the `kaibo://kaish/sandbox` resource |
| `src/cli.rs` | `EXIT_CODES_HELP` — `kaibo --help` |
| `src/cli.rs` | the `kaibo kaish` infra-failure message |
| `src/server/mod.rs` | the **outer MCP** `run_kaish` tool description |
| `src/server/mod.rs` | `TOOLS_DOC` — the `kaibo://tools` resource |

None shared a constant, so a partial fix would have left the rest lying.

## What they say now

The code gives the shape; the message gives the outcome. A refusal and an ordinary failure share exit 1, so the discriminator named is the stderr line — stable, specific, and true. The terse addendum carries the common cases and drops 126 entirely; the sandbox resource, where completeness is affordable, keeps 126 described truthfully as the operator-disabled case.

## The choice

Rewrite the prose rather than route the structural refusal through 126. Exit 1 already carries an unambiguous message so nothing is lost; changing an exit code is a published-contract change on the eve of 0.3; and the alternative means kaibo substituting a code kaish did not emit — the silent rewrite we avoid elsewhere. The counter-argument is real and worth recording: "read the message" is a weaker contract for a machine than a dedicated code.

## Guards

The tests that pinned 126 as a *required* needle now pin the truth, and the addendum's assertion is **inverted** to forbid the false code — the same shape that caught a merge silently re-introducing the comma rule earlier today. Sabotage-checked: putting 126 back turns it red.

1094 tests pass, clippy `--all-targets` clean, and the new prose was verified against the live shell rather than against a changelog.

## Also

Drops the `GEMINI.md` symlink — a third pointer to `AGENTS.md` with no reference anywhere in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)