### PR TITLE
fix(wire): repair the vLLM response rig-core cannot decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **A complete answer from a vLLM-served model no longer arrives as a provider error** —
+  vLLM sends both `reasoning` and `reasoning_content`, which rig-core cannot decode, so
+  kaibo repairs the body before it is parsed.
 - **kaibo told models the wrong exit code for a refused write.** Six descriptions said
   `126` meant blocked; a refused write exits `1` saying `permission denied: filesystem is
   read-only`, and an external command exits `127`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,10 @@ serde_json = "1"
 # base64 string (the only channel that lands image parts in model context). Already
 # in the tree transitively via rig-core; named here so the dep is ours, not implicit.
 base64 = "0.22"
+# rig's `HttpClientExt` is typed in `bytes::Bytes`, so `wire_repair`'s transport
+# wrapper needs the type by name. Already in the tree via reqwest/rig-core — zero new
+# crates; named here so the dep is ours, not implicit.
+bytes = "1"
 # XDG config.toml: named provider profiles + tunables. `deny_unknown_fields` on the
 # raw structs turns a typo'd key into a startup error rather than a silent no-op.
 toml = "0.8"
@@ -190,11 +194,6 @@ opentelemetry_sdk = { version = "0.32", features = ["testing"] }
 # `start_paused` tests (the deferred-generate poll loop) auto-advance tokio's clock
 # instead of really sleeping the poll interval.
 tokio = { version = "1", features = ["test-util"] }
-# Request-body capture in `tests/effort_wire.rs` and `test_support::CaptureHttp`:
-# rig's `HttpClientExt` trait is typed in `bytes::Bytes`, so implementing a fake
-# transport needs the type by name. Already in the tree via reqwest/rig-core — zero
-# new crates.
-bytes = "1"
 # rmcp's CLIENT half, for `tests/mcp_stdio.rs`: it spawns the real kaibo binary and
 # drives it over stdio the way a client does, so the MCP surface (handshake,
 # tools/list, tools/call, resources/read) is covered end to end in-tree. Same version

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -471,10 +471,15 @@ impl Arm {
                         caps,
                     ))
                 } else {
+                    // The chat-completions wire is where vLLM sends both reasoning
+                    // spellings on one message, which rig-core 0.41 cannot decode
+                    // (`crate::wire_repair`). Only this wire carries the `choices`
+                    // shape the repair recognizes, so only this client is wrapped —
+                    // the Responses builder above keeps the bare client.
                     let client = openai::CompletionsClient::builder()
                         .api_key(&key)
                         .base_url(&base_url)
-                        .http_client(http)
+                        .http_client(crate::wire_repair::Repaired::new(http))
                         .build()
                         .map_err(|e| anyhow!("openai client init at {base_url}: {e}"))?;
                     Ok(Self::new(client, &slot.id, t.max_tokens, params, caps))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub mod telemetry;
 pub mod tls;
 pub mod tool_span;
 pub mod view_image;
+pub mod wire_repair;
 pub mod worktree;
 
 /// A scripted, offline stand-in for a provider client, for driving the consult loop

--- a/src/wire_repair.rs
+++ b/src/wire_repair.rs
@@ -58,12 +58,19 @@ const ALIAS: &str = "reasoning";
 /// It covers every body that is not JSON, is not an object, has no `choices`, or holds
 /// only one of the two keys — including the Responses wire, whose payload has no
 /// `choices` at all.
+///
+/// Two shapes it declines to repair even though rig would fail on them, both requiring
+/// a serializer no provider is known to use: a key spelled with a `\u` escape, which the
+/// literal scan below cannot see, and a body holding a number outside `i64`/`u64`, which
+/// `serde_json` cannot represent without `arbitrary_precision`. Each leaves the caller
+/// exactly where it was before this module existed.
 pub fn repair_duplicate_reasoning(body: &[u8]) -> Option<Bytes> {
-    // Both keys must appear literally before it is worth parsing. Every response
-    // pays this scan and almost none pay the parse; `reasoning_content` contains
-    // `reasoning`, so the cheap test is one `find` for each spelling's quoted key.
+    // Both keys must appear literally before it is worth parsing. Every OpenAI chat
+    // response pays this scan and almost none pay the parse. The needles carry their
+    // quotes because `reasoning_content` starts with `reasoning`: quoted, `"reasoning"`
+    // does not occur inside `"reasoning_content"`, so the two tests stay independent.
     let looks_relevant =
-        memchr_contains(body, b"\"reasoning_content\"") && memchr_contains(body, b"\"reasoning\"");
+        contains_bytes(body, b"\"reasoning_content\"") && contains_bytes(body, b"\"reasoning\"");
     if !looks_relevant {
         return None;
     }
@@ -107,7 +114,7 @@ pub fn repair_duplicate_reasoning(body: &[u8]) -> Option<Bytes> {
 }
 
 /// Substring search over raw bytes, without pulling a dependency for it.
-fn memchr_contains(haystack: &[u8], needle: &[u8]) -> bool {
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
     haystack
         .windows(needle.len())
         .any(|window| window == needle)
@@ -208,9 +215,120 @@ mod tests {
             "rig-core 0.41 cannot decode both reasoning spellings — if this now \
                          decodes, rig fixed it upstream and `wire_repair` can be deleted",
         );
+        // The `expect_err` above is the deletion trigger on its own. This second
+        // assertion is deliberately pinned to rig's wording so the test also fails
+        // when the payload starts failing for a *different* reason — a decode that
+        // breaks on something else is news, and silently satisfying the trigger with
+        // an unrelated error would hide it.
         assert!(
             err.to_string().contains("duplicate field"),
             "expected the duplicate-field decode failure, got: {err}"
+        );
+    }
+
+    /// A canned transport: one response body, whatever was asked. Enough to drive
+    /// [`Repaired::send`] end to end without a network.
+    #[derive(Clone, Debug, Default)]
+    struct CannedHttp(Vec<u8>);
+
+    impl HttpClientExt for CannedHttp {
+        fn send<T, U>(
+            &self,
+            _req: Request<T>,
+        ) -> impl std::future::Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+        where
+            T: Into<Bytes> + Send,
+            U: From<Bytes> + Send + 'static,
+        {
+            let body = Bytes::from(self.0.clone());
+            async move {
+                let lazy: LazyBody<U> = Box::pin(async move { Ok(U::from(body)) });
+                Response::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(lazy)
+                    .map_err(http_client::Error::Protocol)
+            }
+        }
+
+        // Unreachable for a completion, but the trait requires them. `async fn` can't
+        // express the trait's `+ Send + 'static` return bound, so the desugared form
+        // stays — the same constraint `test_support::CaptureHttp` documents.
+        #[allow(clippy::manual_async_fn)]
+        fn send_multipart<U>(
+            &self,
+            _req: Request<http_client::MultipartForm>,
+        ) -> impl std::future::Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+        where
+            U: From<Bytes> + Send + 'static,
+        {
+            async move { Err(http_client::Error::StreamEnded) }
+        }
+
+        #[allow(clippy::manual_async_fn)]
+        fn send_streaming<T>(
+            &self,
+            _req: Request<T>,
+        ) -> impl std::future::Future<Output = http_client::Result<http_client::StreamingResponse>> + Send
+        where
+            T: Into<Bytes> + Send,
+        {
+            async move { Err(http_client::Error::StreamEnded) }
+        }
+    }
+
+    /// The seam itself, which is the whole reason this module is a wrapper rather
+    /// than a function: bytes go through [`Repaired::send`] and come out decodable by
+    /// rig, with the status and headers the inner transport set.
+    #[tokio::test]
+    async fn the_wrapper_hands_rig_a_body_rig_can_decode() {
+        let client = Repaired::new(CannedHttp(CAPTURED_VLLM.as_bytes().to_vec()));
+        let request = Request::builder()
+            .method("POST")
+            .uri("https://vllm.example/v1/chat/completions")
+            .body(Vec::<u8>::new())
+            .unwrap();
+
+        let response = client
+            .send::<Vec<u8>, Bytes>(request)
+            .await
+            .expect("the canned transport answers");
+        assert_eq!(response.status(), 200, "the inner status must survive");
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json",
+            "the inner headers must survive"
+        );
+
+        let bytes = response.into_body().await.expect("the body resolves");
+        decodes_with_rig(&bytes).expect(
+            "the wrapper must hand rig a decodable body — this is the property the \
+             whole module exists to provide",
+        );
+    }
+
+    /// A body with nothing to repair reaches rig byte-for-byte. The wrapper must be
+    /// transparent, not merely correct on the one shape it fixes.
+    #[tokio::test]
+    async fn the_wrapper_forwards_an_untouched_body_verbatim() {
+        const CLEAN: &str = r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#;
+        let client = Repaired::new(CannedHttp(CLEAN.as_bytes().to_vec()));
+        let request = Request::builder()
+            .uri("https://vllm.example/v1/chat/completions")
+            .body(Vec::<u8>::new())
+            .unwrap();
+
+        let bytes = client
+            .send::<Vec<u8>, Bytes>(request)
+            .await
+            .expect("the canned transport answers")
+            .into_body()
+            .await
+            .expect("the body resolves");
+        assert_eq!(
+            bytes,
+            Bytes::from(CLEAN),
+            "an unrepaired body must be byte-identical"
         );
     }
 

--- a/src/wire_repair.rs
+++ b/src/wire_repair.rs
@@ -1,0 +1,306 @@
+//! Repairing one provider response shape rig-core cannot decode.
+//!
+//! vLLM serves a chat-completions assistant message carrying **both** spellings of
+//! the reasoning field:
+//!
+//! ```json
+//! {"role":"assistant","content":"391","reasoning":null,"reasoning_content":null}
+//! ```
+//!
+//! rig-core 0.41 declares one field for the two
+//! (`#[serde(rename = "reasoning_content", alias = "reasoning")]`,
+//! `providers/openai/completion/mod.rs`), so both keys land on the same field and
+//! serde raises `duplicate field \`reasoning_content\``. The decode failure does not
+//! surface as a decode failure: rig's `ApiResponse` is untagged, so a body that fails
+//! the success shape falls through to the error arm, and `from_http_response`
+//! preserves a 2xx as `CompletionError::ProviderResponse`. A complete answer with
+//! `finish_reason: "stop"` reaches the caller as a hard provider error.
+//!
+//! Measured 2026-08-13 against Crusoe (`Qwen/Qwen3-235B-A22B-Instruct-2507`), and the
+//! same call fails identically on kaibo 0.2.0 — this is latent, not a regression. It
+//! is also not a Crusoe quirk: the emitter is vLLM, so every vLLM-backed
+//! OpenAI-compatible endpoint carries it (Together, Fireworks, self-hosted).
+//!
+//! **Why this repairs the response instead of the request.** Nothing kaibo can put on
+//! the request stops a server from sending both keys — the shape is the server's, not
+//! a reply to an option we set. The decode happens inside rig, so the last place kaibo
+//! owns the bytes is the HTTP client it already injects (`Arm::from_slot` passes its
+//! own client to every provider builder). [`Repaired`] is that seam: a transparent
+//! [`HttpClientExt`] that hands rig a body rig can parse.
+//!
+//! **The repair is narrow on purpose.** [`repair_duplicate_reasoning`] changes a body
+//! only when one message object holds both keys — the exact shape that fails — and
+//! returns `None` for everything else, so an unrecognized body reaches rig byte-for-byte.
+//! It never invents a field, never drops a field that carries text unless the other
+//! spelling carries the same text, and logs at `warn` on the one path where two
+//! different non-null values force a choice. A body kaibo does not understand is a body
+//! kaibo does not touch.
+//!
+//! **Revisit at the next rig bump.** Amy, 2026-08-13: *"we will work around and revisit
+//! next time we bump rig."* If rig learns to accept both spellings, this module and its
+//! call sites in [`crate::consult::engine`] go away — [`repairs_nothing_when_rig_can_already_decode`]
+//! is the test that will say so, because it decodes the captured payload with rig's own
+//! type and fails the day rig stops needing help.
+
+use bytes::Bytes;
+use rig_core::http_client::{self, HttpClientExt, LazyBody, Request, Response};
+use serde_json::Value;
+
+/// The canonical spelling — rig's `rename`, and what the repair keeps.
+const CANONICAL: &str = "reasoning_content";
+/// The alias rig also accepts, and the key the repair removes when both are present.
+const ALIAS: &str = "reasoning";
+
+/// Rewrite a chat-completions body that carries both reasoning spellings on one
+/// message, or `None` when there is nothing to repair.
+///
+/// `None` is the overwhelmingly common answer and means *hand rig the original bytes*.
+/// It covers every body that is not JSON, is not an object, has no `choices`, or holds
+/// only one of the two keys — including the Responses wire, whose payload has no
+/// `choices` at all.
+pub fn repair_duplicate_reasoning(body: &[u8]) -> Option<Bytes> {
+    // Both keys must appear literally before it is worth parsing. Every response
+    // pays this scan and almost none pay the parse; `reasoning_content` contains
+    // `reasoning`, so the cheap test is one `find` for each spelling's quoted key.
+    let looks_relevant =
+        memchr_contains(body, b"\"reasoning_content\"") && memchr_contains(body, b"\"reasoning\"");
+    if !looks_relevant {
+        return None;
+    }
+
+    let mut doc: Value = serde_json::from_slice(body).ok()?;
+    let choices = doc.get_mut("choices")?.as_array_mut()?;
+
+    let mut repaired = false;
+    for choice in choices.iter_mut() {
+        let Some(message) = choice.get_mut("message").and_then(Value::as_object_mut) else {
+            continue;
+        };
+        if !(message.contains_key(CANONICAL) && message.contains_key(ALIAS)) {
+            continue;
+        }
+        let alias = message.get(ALIAS).cloned().unwrap_or(Value::Null);
+        let canonical = message.get(CANONICAL).cloned().unwrap_or(Value::Null);
+        // Keep whichever spelling actually carries the reasoning. When only the alias
+        // does, its text is promoted onto the canonical key rather than discarded —
+        // dropping it would lose a block rig would otherwise have surfaced.
+        if canonical.is_null() && !alias.is_null() {
+            message.insert(CANONICAL.to_string(), alias.clone());
+        } else if !canonical.is_null() && !alias.is_null() && canonical != alias {
+            // Two different reasoning texts on one message. Undefined by every
+            // provider doc we have; the canonical spelling wins because that is the
+            // field rig names, and the choice is logged because it discards text.
+            tracing::warn!(
+                "provider sent different `reasoning` and `reasoning_content` values on one \
+                 message; keeping `reasoning_content`"
+            );
+        }
+        message.remove(ALIAS);
+        repaired = true;
+    }
+
+    if !repaired {
+        return None;
+    }
+    tracing::debug!("repaired a response carrying both reasoning spellings");
+    serde_json::to_vec(&doc).ok().map(Bytes::from)
+}
+
+/// Substring search over raw bytes, without pulling a dependency for it.
+fn memchr_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+/// An [`HttpClientExt`] that repairs a response body rig-core cannot decode, and is
+/// otherwise the inner client exactly.
+///
+/// Transparent on every other path: the request, the status, the headers, and each
+/// error are the inner client's own, and a body with nothing to repair is forwarded
+/// byte-for-byte.
+///
+/// `Default` is required by rig: its client builders bound the HTTP backend on it, so
+/// a wrapper without it cannot be injected at all.
+#[derive(Clone, Debug, Default)]
+pub struct Repaired<H> {
+    inner: H,
+}
+
+impl<H> Repaired<H> {
+    /// Wrap `inner` so a chat-completions body carrying both reasoning spellings is
+    /// repaired before rig parses it.
+    pub fn new(inner: H) -> Self {
+        Self { inner }
+    }
+}
+
+impl<H: HttpClientExt + Clone> HttpClientExt for Repaired<H> {
+    fn send<T, U>(
+        &self,
+        req: Request<T>,
+    ) -> impl std::future::Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+    where
+        T: Into<Bytes> + Send,
+        U: From<Bytes> + Send + 'static,
+    {
+        // Ask the inner client for `Bytes` rather than `U`: the repair needs the raw
+        // body, and `U: From<Bytes>` lets us build the caller's type afterwards either
+        // way. This is why the wrapper can sit under a generic provider client.
+        let inner = self.inner.send::<T, Bytes>(req);
+        async move {
+            let response = inner.await?;
+            let (parts, body) = response.into_parts();
+            let repaired: LazyBody<U> = Box::pin(async move {
+                let bytes = body.await?;
+                let bytes = repair_duplicate_reasoning(&bytes).unwrap_or(bytes);
+                Ok(U::from(bytes))
+            });
+            Ok(Response::from_parts(parts, repaired))
+        }
+    }
+
+    // Neither path below carries a chat-completions body: kaibo never streams (rig's
+    // prompt loop is non-streaming) and never posts a multipart form on a completion.
+    // They forward untouched so the wrapper stays a drop-in for the whole trait.
+    fn send_multipart<U>(
+        &self,
+        req: Request<http_client::MultipartForm>,
+    ) -> impl std::future::Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+    where
+        U: From<Bytes> + Send + 'static,
+    {
+        self.inner.send_multipart::<U>(req)
+    }
+
+    fn send_streaming<T>(
+        &self,
+        req: Request<T>,
+    ) -> impl std::future::Future<Output = http_client::Result<http_client::StreamingResponse>> + Send
+    where
+        T: Into<Bytes> + Send,
+    {
+        self.inner.send_streaming(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig_core::providers::openai::completion::CompletionResponse;
+
+    /// The response captured live from Crusoe on 2026-08-13, verbatim apart from
+    /// shortening the answer text. Both reasoning spellings, both null,
+    /// `finish_reason: "stop"` — a complete answer rig-core 0.41 refuses to decode.
+    const CAPTURED_VLLM: &str = r#"{"id":"chatcmpl-fde1dc7d99a24bb1911e3c1355595ea1","object":"chat.completion","created":1786650747,"model":"Qwen/Qwen3-235B-A22B-Instruct-2507","choices":[{"index":0,"message":{"role":"assistant","content":"391","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":163,"total_tokens":221,"completion_tokens":58,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}"#;
+
+    fn decodes_with_rig(body: &[u8]) -> Result<CompletionResponse, serde_json::Error> {
+        serde_json::from_slice::<CompletionResponse>(body)
+    }
+
+    /// The bug, stated as a test: rig cannot decode what vLLM sent. This is the
+    /// failing-first assertion the repair exists to satisfy — and the guard that says
+    /// when the workaround can be deleted. If a rig bump makes this decode on its own,
+    /// this test fails and [`Repaired`] should go.
+    #[test]
+    fn repairs_nothing_when_rig_can_already_decode() {
+        let err = decodes_with_rig(CAPTURED_VLLM.as_bytes()).expect_err(
+            "rig-core 0.41 cannot decode both reasoning spellings — if this now \
+                         decodes, rig fixed it upstream and `wire_repair` can be deleted",
+        );
+        assert!(
+            err.to_string().contains("duplicate field"),
+            "expected the duplicate-field decode failure, got: {err}"
+        );
+    }
+
+    #[test]
+    fn the_captured_vllm_response_decodes_after_repair() {
+        let repaired = repair_duplicate_reasoning(CAPTURED_VLLM.as_bytes())
+            .expect("the captured body carries both spellings, so it must be repaired");
+        let decoded = decodes_with_rig(&repaired).expect("rig decodes the repaired body");
+        // The answer survived the repair — the whole point is that this text was
+        // never lost, only unreachable. rig re-serializes `content` as typed blocks,
+        // so the text is read out of the first one rather than off a bare string.
+        let json = serde_json::to_value(&decoded).unwrap();
+        assert_eq!(json["choices"][0]["message"]["content"][0]["text"], "391");
+        assert_eq!(json["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[test]
+    fn a_body_with_one_spelling_is_left_alone() {
+        for body in [
+            r#"{"choices":[{"message":{"role":"assistant","content":"x","reasoning_content":"why"}}]}"#,
+            r#"{"choices":[{"message":{"role":"assistant","content":"x","reasoning":"why"}}]}"#,
+            r#"{"choices":[{"message":{"role":"assistant","content":"x"}}]}"#,
+        ] {
+            assert!(
+                repair_duplicate_reasoning(body.as_bytes()).is_none(),
+                "nothing to repair in {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_body_that_is_not_a_chat_completion_is_left_alone() {
+        for body in [
+            // Not JSON at all.
+            "<html>502 Bad Gateway</html>",
+            // JSON, but no `choices` — the Responses wire, and every error envelope.
+            r#"{"error":{"message":"reasoning and reasoning_content are unsupported"}}"#,
+            r#"{"output":[{"content":[{"text":"hi"}]}]}"#,
+            // `choices` present but not an array of message objects.
+            r#"{"choices":"reasoning_content and reasoning"}"#,
+        ] {
+            assert!(
+                repair_duplicate_reasoning(body.as_bytes()).is_none(),
+                "nothing to repair in {body}"
+            );
+        }
+    }
+
+    /// The alias carrying the only reasoning text is promoted, not discarded — rig
+    /// would have surfaced that block, so the repair must not cost the caller a
+    /// reasoning trace.
+    #[test]
+    fn reasoning_text_on_the_alias_survives_under_the_canonical_key() {
+        let body = r#"{"choices":[{"message":{"role":"assistant","content":"x","reasoning":"because","reasoning_content":null}}]}"#;
+        let repaired = repair_duplicate_reasoning(body.as_bytes()).expect("both keys present");
+        let doc: Value = serde_json::from_slice(&repaired).unwrap();
+        let message = &doc["choices"][0]["message"];
+        assert_eq!(message["reasoning_content"], "because");
+        assert!(
+            message.get("reasoning").is_none(),
+            "the duplicate key must be gone, or rig still fails to decode"
+        );
+    }
+
+    #[test]
+    fn the_canonical_spelling_wins_when_both_carry_different_text() {
+        let body = r#"{"choices":[{"message":{"role":"assistant","content":"x","reasoning":"alias text","reasoning_content":"canonical text"}}]}"#;
+        let repaired = repair_duplicate_reasoning(body.as_bytes()).expect("both keys present");
+        let doc: Value = serde_json::from_slice(&repaired).unwrap();
+        assert_eq!(
+            doc["choices"][0]["message"]["reasoning_content"],
+            "canonical text"
+        );
+    }
+
+    /// Every choice is repaired, not just the first — rig decodes the whole array, so
+    /// a duplicate key on choice 2 fails the decode exactly as one on choice 0 does.
+    #[test]
+    fn every_choice_is_repaired() {
+        let body = r#"{"choices":[
+            {"message":{"role":"assistant","content":"a","reasoning":null,"reasoning_content":null}},
+            {"message":{"role":"assistant","content":"b","reasoning":null,"reasoning_content":null}}
+        ]}"#;
+        let repaired = repair_duplicate_reasoning(body.as_bytes()).expect("both keys present");
+        let doc: Value = serde_json::from_slice(&repaired).unwrap();
+        for i in 0..2 {
+            assert!(
+                doc["choices"][i]["message"].get("reasoning").is_none(),
+                "choice {i} still carries the duplicate key"
+            );
+        }
+    }
+}


### PR DESCRIPTION
A call to a vLLM-served model returned a complete answer — `finish_reason: "stop"`, the text right there in the body — and kaibo handed the caller a hard provider error. Reported by the **lfm2d lane** against Crusoe; reproduced here on `crusoe-thrift` (`Qwen/Qwen3-235B-A22B-Instruct-2507`).

Amy asked to **try 0.3.0 before tagging it**. This is what that found, and it is why the tag waited: gates were green, probes were stamped, reviews were applied, and one live `oneshot` found what none of that could.

## The bug

vLLM emits **both** spellings of the reasoning field on one assistant message:

```json
{"role":"assistant","content":"391","reasoning":null,"reasoning_content":null}
```

rig-core 0.41 declares one field for the two (`rename = "reasoning_content"`, `alias = "reasoning"`), so serde raises `duplicate field`. The failure does not *look* like a decode failure on the way out: rig's `ApiResponse` is untagged, so a body that misses the success shape falls through to the error arm, and `from_http_response` preserves a 2xx as `CompletionError::ProviderResponse`.

Proven rather than argued — the captured payload was deserialized against **rig's own type**: both spellings present = `duplicate field`, either one alone = OK.

**Not a regression.** The installed 0.2.0 binary fails identically on the same call. Latent, not introduced by reasoning-on-by-default — the failing model is non-reasoning and both fields are `null`.

**Not a Crusoe quirk.** The emitter is vLLM, so every vLLM-backed OpenAI-compatible endpoint carries it: Together, Fireworks, self-hosted.

## Decisions

**Repair the response, not the request.** Nothing kaibo can send stops a server from emitting both keys — the shape is the server's, not an answer to an option we set. The decode happens inside rig, so the last bytes kaibo owns are in the HTTP client it already injects via `.http_client(..)`. `Repaired` is that seam: the transport-side sibling of `Watched` and `Retried`.

**Narrow, and silent only where silence is correct.** The repair fires on the one shape that fails and returns the original bytes for everything else, so an unfamiliar body reaches rig byte-for-byte. Reasoning text carried only on the alias is **promoted, not dropped**. The one case that must discard text — two different non-null values — logs a warning rather than choosing quietly. Only the chat-completions client is wrapped; the Responses builder keeps the bare client, since its payload has no `choices` for the repair to recognize.

**No upstream report yet.** Amy: *"we will work around and revisit next time we bump rig."* The module doc carries that condition, and `repairs_nothing_when_rig_can_already_decode` is the trigger — it decodes the captured payload with rig's own type and **fails the day rig no longer needs help**, which is the day this module gets deleted.

## Verification

| gate | result |
|---|---|
| `cargo test` | **1106 passed, 0 failed** |
| `cargo clippy --all-targets` | clean |
| sabotage check | stubbing the repair to `None` turns **4 of the 7** new tests red, and leaves the deletion guard correctly green |

Live, against the call that actually failed:

- `oneshot --cast crusoe-thrift` — **was** `ProviderResponseError: status 200 OK`, **now** answers
- full multi-turn `consult --cast crusoe-thrift` — answers, having read the new module through the tool loop
- `crusoe`, `crusoe-ds4`, `crusoe-nemotron` — still answer as before

## Changelog

Lands in the `[0.3.0]` section rather than Unreleased, since that section is written but not yet tagged — same as #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)