### PR TITLE
fix(server): detach the MCP server from its launching terminal's process group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,13 +177,14 @@ opentelemetry-appender-tracing = "0.32"
 # so it's ours, not implicit, matching how the other deps above are documented.
 sha2 = "0.10"
 
-# Local-filesystem validation for the persistence store (src/store.rs): turso's
-# multiprocess-WAL mode is unsupported on network filesystems (NFS/CIFS), where a
-# shared open can silently lose writes. On Linux we `statfs` the state dir and refuse a
-# known network fs magic. libc is already in the tree transitively (getrandom); named
-# here only under a Linux target so no new build cost lands on any platform, and no
-# heavy dependency is added for this check.
-[target.'cfg(target_os = "linux")'.dependencies]
+# libc is already in the tree transitively (getrandom); named here explicitly, scoped
+# to unix only so no new build cost lands on Windows. Two uses: local-filesystem
+# validation for the persistence store (src/store.rs, Linux-only `statfs` — turso's
+# multiprocess-WAL mode is unsupported on network filesystems, where a shared open can
+# silently lose writes) and detaching the MCP server from its launching terminal's
+# process group at startup (src/main.rs `setsid` — a job-control stop on that terminal
+# must not freeze the server too).
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,21 @@ async fn run_command(common: CommonArgs, command: Command) -> i32 {
 /// is byte-for-byte what it was before the CLI restructure. `common` carries the shared
 /// flags; `gates` the serve-only `--no-<tool>` toggles.
 async fn serve(common: CommonArgs, gates: ServeGates) -> Result<()> {
+    // The server's lifecycle belongs to whatever MCP client holds the stdio pipe, not to
+    // the terminal that client happens to be running in. Left in the launching terminal's
+    // process group, a stray job-control stop (Ctrl-Z, a backgrounded tab) freezes this
+    // process too — and if that catches turso mid-checkpoint, a live sibling can end up
+    // writing against a WAL the frozen one left half-rewritten. That is how a "short read
+    // on WAL frame" corruption showed up in the wild (2026-08-14): two kaibo processes sat
+    // stopped for most of a day after their parent `claude` session was suspended and
+    // abandoned in its terminal tab. `setsid` moves us into our own session so the
+    // launching terminal's job control can no longer reach us; shutdown then depends only
+    // on the peer closing stdio (or an explicit kill), which is already the intended MCP
+    // lifecycle. A failure here just means we're already a session/group leader — nothing
+    // to detach from, not worth failing startup over.
+    #[cfg(unix)]
+    let _ = unsafe { libc::setsid() };
+
     // Load config before logging so `server.log` can set the filter. A config error
     // is fatal and must be visible even though tracing isn't up yet — go to stderr.
     let config_path = common


### PR DESCRIPTION
## Summary
- A job-control stop on the terminal running an MCP client (Ctrl-Z, a backgrounded tab) previously froze kaibo too, since the server inherited that terminal's process group.
- If the freeze lands mid-checkpoint, a live sibling process can end up writing against a WAL the frozen one left half-rewritten — this is how a "short read on WAL frame" corruption on the shared state db turned up in the wild, traced back to two kaibo processes that sat stopped for most of a day after their parent client session was suspended and abandoned.
- `setsid()` at the top of `serve()` moves the server into its own session at startup, so the launching terminal's job control can no longer reach it. Shutdown then depends only on the peer closing stdio or an explicit kill — already the intended MCP server lifecycle.
- `libc`'s target scope widens from Linux-only to all unix, since `setsid` is POSIX. The existing Linux-only `statfs` check in `store.rs` keeps its own narrower `cfg` guard, so nothing changes there.

## Test plan
- [x] `cargo build --release` — clean
- [x] Spawned the built binary directly and confirmed via `ps` that its PGID differs from the launching shell's and it has no controlling tty (`??`) — the detach takes effect
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)