### PR TITLE
feat(config): declared-only key sources + api_key_cmd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,10 @@ with a hosted synth; a call picks its team with the `cast` arg. Backends and cas
 `config.toml`, `KAIBO_*` env, then CLI flags (precedence: per-call > CLI > env > file >
 built-in); a missing config file is a non-error. See `docs/config.md`, and
 `docs/casts.md` for the backends/casts design rationale. kaibo never modifies the
-project and cannot run external commands.
+project and runs no external command except the one its own config declares —
+`api_key_cmd`, the operator-side key fetch: argv-only, stdin closed, time-boxed,
+output never logged, unreachable from the model-facing shell (see the operator
+surface rule in the invariants).
 
 ## Invariants — do not weaken without a failing-first test
 
@@ -106,6 +109,13 @@ project and cannot run external commands.
   projects, so surfacing it to a cast is a cross-project leak. Concretely — **model-facing
   kaish never grows `jobs`/`ps` or any kaibo-state builtin**; operator job/state visibility
   lives only in the tools (MCP, CLI, later the REPL), never in the shell we hand a model.
+  The one operator-side *resolve* surface — the config-declared `api_key_cmd` (a backend's
+  key from a command like `op read`; note this is a READ surface, unlike the store/CAS
+  record/emit surfaces) — follows the same line: config-gated, argv-only (no shell),
+  stdin closed, `KEY_CMD_TIMEOUT`-bounded, output never logged, and reachable only
+  through `Backend::resolve_key` at client construction, which the model-facing kaish
+  (sandbox lever 3, unchanged) can never reach. The model can *trigger* it by calling a
+  tool on a cmd-backed backend, but cannot control its argv or environment.
 - **Persistence engine (turso) — do not weaken.** Pure-Rust `turso`, **exact-pinned**
   (`=0.7.x` — `.db-tshm` format and API both drift between releases) with
   **`default-features = false`** (defaults pull mimalloc's global-allocator hijack + fts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ record. Each later release appends a new section at the top.
 - **`[telemetry] capture_content`** — off by default, so exported spans carry no prompts,
   completions, or tool payloads.
 - **`[telemetry] capture`** — export one named attribute without exporting all of them.
+- **Backend keys can come from a command** — `[backends.<name>] api_key_cmd = ["op",
+  "read", "op://Vault/Item/Field"]` runs the declared command (no shell, stdin closed,
+  30s ceiling, output never logged) and uses its trimmed stdout as the API key: a
+  1Password / `pass` / `gh auth token` credential without a secret in a file.
+- **Key sources are declared, never seeded** — the built-in backends no longer read
+  `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` / etc. out of the box; an operator names
+  the source (`api_key_env`, `api_key_file`, or `api_key_cmd`) in config.toml once, and
+  `api_key_file` + `api_key_cmd` together is a load error naming both.
 
 ### Changed
 
@@ -84,6 +92,12 @@ record. Each later release appends a new section at the top.
   rendered poll and as `submitted` in `batch get --json`.
 - **A failed batch now names the cast that ran it**, the provenance footer a completed
   batch already carried.
+- **Setup guidance steers toward declaring a key source in config.toml** (with
+  `kaibo example-config` for the shape) instead of exporting an env var.
+- **Breaking: an upgrading operator must add a key source to every backend they use** —
+  the built-ins no longer seed one, so a cast built on an undeclared backend silently
+  drops out of the roster; add `api_key_env`/`api_key_file`/`api_key_cmd` per backend to
+  bring it back (`kaibo example-config` shows the shapes).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ and keep stdin open:
 claude mcp add kaibo -- docker run --rm -i \
   -u "$(id -u):$(id -g)" \
   -v "$PWD:/work:ro" \
+  -v "$HOME/.config/kaibo:/config:ro" -e XDG_CONFIG_HOME=/config \
   -e DEEPSEEK_API_KEY \
   ghcr.io/tobert/kaibo:latest
 ```
@@ -197,8 +198,10 @@ claude mcp add kaibo -- docker run --rm -i \
   no shell to debug into.
 - `-u` runs the container as you so the mount's file permissions line up;
   podman users want `--userns=keep-id` in its place.
-- Pass provider keys by name (`-e DEEPSEEK_API_KEY`) — the value rides your
-  shell environment, never your MCP config.
+- Declare the key source, then pass the value: the `-v "$HOME/.config/kaibo:/config:ro"`
+  mount ships your `config.toml` with e.g. `api_key_env = "DEEPSEEK_API_KEY"`, and
+  `-e DEEPSEEK_API_KEY` carries the value from your shell (kaibo reads no key env var
+  that config.toml doesn't declare).
 - The `:ro` mount is an OS-enforced belt under kaibo's own read-only sandbox:
   kaibo never writes to your project either way, this just makes the kernel agree.
 
@@ -237,12 +240,11 @@ for you:
       //   "args": ["--config", "/path/to/config.toml"]   // use an explicit config file
       "args": [],
       // The consulted models need provider keys — but don't put them here; this
-      // file tends to get committed. Leave `env` empty and kaibo reads keys from
-      // your shell environment (ANTHROPIC_API_KEY, DEEPSEEK_API_KEY,
-      // GEMINI_API_KEY, OPENROUTER_API_KEY, …), or point a backend at a key FILE
-      // via `api_key_file` in config.toml. Config stores only the env-var NAME or
-      // the file PATH — never the secret. A missing key only matters when you
-      // actually call a cast that needs it.
+      // file tends to get committed. Leave `env` empty and give the cast's backend a
+      // DECLARED key source in config.toml: `api_key_env = "ANTHROPIC_API_KEY"` (the
+      // value rides your shell environment), `api_key_file`, or `api_key_cmd`.
+      // Config stores only the source NAME/PATH/argv — never the secret. A missing
+      // key only matters when you actually call a cast that needs it.
       "env": {}
     }
   }

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -24,13 +24,16 @@
 # ---------------------------------------------------------------------------
 # With nothing configured, kaibo starts fine and `run_kaish` works immediately —
 # the read-only shell needs no model. `consult` / `oneshot` need a
-# provider key on the default cast (`anthropic` out of the box). Give it one the
-# private way — kaibo reads the key at startup, so it never enters your chat:
-#   env:   export ANTHROPIC_API_KEY=sk-...     (or DEEPSEEK_/GEMINI_/OPENROUTER_/OPENAI_…)
-#   file:  printf %s 'sk-...' > ~/.anthropic-key.txt   (env wins over file)
-# Don't paste the key to the model — set the env var or key file in your shell.
-# Then RECONNECT the kaibo MCP server so it re-reads the environment and this file
-# (keys are read once at startup; in Claude Code: run /mcp and reconnect kaibo).
+# provider key on the default cast (`anthropic` out of the box). Give it one by
+# DECLARING a key source in this file — kaibo seeds none; the value stays out of
+# the config, so it never enters your chat:
+#   env:     api_key_env = "ANTHROPIC_API_KEY"    then export ANTHROPIC_API_KEY=sk-...
+#   file:    api_key_file = "~/.anthropic-key.txt" then printf %s 'sk-...' > that file
+#   command: api_key_cmd = ["op", "read", "op://Vault/Kaibo/Anthropic-key"]   (no shell)
+# Don't paste the key to the model — declare the source in config.toml and set
+# the actual value in your shell / vault. Then RECONNECT the kaibo MCP server so it
+# re-reads the environment and this file (keys are read once at startup; in Claude
+# Code: run /mcp and reconnect kaibo).
 # Prefer another provider? Pass cast="<backend-or-cast>" per call, or set
 # `cast` below.
 #
@@ -399,10 +402,15 @@ scratch_limit_bytes = 67108864
 # only. The rest describes the wire (endpoint, key source, per-request deadline).
 # Models live on cast slots, never here.
 #
-# Keys are referenced, never inlined: api_key_env names an env var, api_key_file a
-# path (~ ok). env wins over file. key_optional=true falls back to a placeholder
-# bearer token (keyless local servers). base_url is legal on the openai kind
-# (required for a new backend), the anthropic and gemini kinds (optional —
+# Keys are referenced, never inlined, and every source is DECLARED — kaibo seeds
+# none, so a backend reads only what you write here. Three sources, env winning over
+# the single file/command source: api_key_env names an env var, api_key_file a path
+# whose contents (trimmed) are the key (~ ok on the path), api_key_cmd a command whose
+# stdout (trimmed) is the key (raw argv — no shell, stdin closed, 30s ceiling).
+# A backend declares at most one of api_key_file and api_key_cmd — both = load error.
+# key_optional=true falls
+# back to a placeholder bearer token (keyless local servers). base_url is legal on
+# the openai kind (required for a new backend), the anthropic and gemini kinds (optional —
 # unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com),
 # and the media kinds (optional — unset dials api.stability.ai for stability,
 # api.openai.com/v1 for openai-images, generativelanguage.googleapis.com for
@@ -413,11 +421,12 @@ scratch_limit_bytes = 67108864
 # base_url at load (rig fixes those endpoints).
 # ---------------------------------------------------------------------------
 
-# --- The five built-ins, shown COMMENTED OUT with their current defaults. They
-#     ship in code already — kaibo runs with all five even when this whole file is
-#     absent — so uncomment one only to CHANGE something (a gateway base_url, a
-#     different key file, ...); these blocks are illustrative, not required
-#     configuration to copy verbatim. Their alias names (claude, google, local,
+# --- The five built-ins, shown COMMENTED OUT with their current models. They ship
+#     in code already — kaibo runs with all five even when this whole file is
+#     absent — but unlike the key wiring, kaibo seeds NO key source: uncomment one
+#     to CHANGE something (a gateway base_url, a different key source), and note the
+#     key lines below are the conventional sources to DECLARE, not defaults that
+#     exist without them. The alias names (claude, google, local,
 #     lemonade, gemma, gemma4) are reserved at both levels regardless of whether
 #     you uncomment them — naming a new backend or cast after one is a loud
 #     collision error. ---
@@ -426,6 +435,7 @@ scratch_limit_bytes = 67108864
 # kind = "anthropic"
 # api_key_env  = "ANTHROPIC_API_KEY"
 # api_key_file = "~/.anthropic-key.txt"
+# api_key_cmd  = ["op", "read", "op://Vault/Kaibo/Anthropic-key"]   # OR a command; see below
 # Uncomment to dial an Anthropic-Messages-API-compatible gateway/proxy (e.g. a
 # corporate LLM gateway) instead of api.anthropic.com directly. Optional —
 # unlike the openai kind, unset still resolves to rig's built-in endpoint.
@@ -475,8 +485,9 @@ scratch_limit_bytes = 67108864
 # key_optional = true                          # keyless local default → placeholder
 
 # --- New backends: any number of openai-kind endpoints, each its own connection.
-#     A new backend must declare its `kind`; it seeds that kind's default key
-#     sources, then your fields apply on top. A new openai-kind backend must also
+#     A new backend must declare its `kind`; it carries NO key source — declare one
+#     (api_key_env / api_key_file / api_key_cmd) — and your fields apply on top of
+#     the kind's non-key defaults. A new openai-kind backend must also
 #     set `base_url` (the OPENAI_BASE_URL / local-default fallback belongs to the
 #     built-in `openai-local` backend alone — a forgotten base_url is a load error, not
 #     a silent dial of the wrong server). ---
@@ -513,6 +524,18 @@ kind = "openai"
 base_url = "https://llm-gateway.example.internal/v1"
 api_key_env = "GATEWAY_API_KEY"
 wire = "responses"
+
+# A key from a command — `api_key_cmd`: the command's stdout, trimmed, is the key.
+# Raw argv, NO shell (no pipes/redirection/$VAR — wrap a pipeline in a script and
+# name the script). The child inherits kaibo's env, gets a CLOSED stdin (so an
+# interactive unlock prompt fails fast instead of hanging), a 30s ceiling, and its
+# output is never logged. 1Password (`op read op://Vault/Item/Field`) is the
+# natural fit; `pass show`, `gh auth token`, a vault CLI all work. A backend may
+# declare api_key_file OR api_key_cmd, never both — env (api_key_env) still wins
+# when set, so CI can override the vault with a one-off env var.
+[backends.vault-keyed]
+kind = "deepseek"
+api_key_cmd = ["op", "read", "op://Vault/Kaibo/Deepseek-key"]
 
 # ---------------------------------------------------------------------------
 # [casts.<name>] — COMPOSITIONS: role → model, freely spanning backends. This is

--- a/docs/config.md
+++ b/docs/config.md
@@ -88,8 +88,11 @@ by re-declaration.
   `https://generativelanguage.googleapis.com`. Gemini has no images endpoint: image
   generation is `models/{model}:generateContent`, the same call as text, with the
   requested modalities naming what comes back — which is why this is a separate kind
-  from `gemini`, so a cast slot knows which use it points at. Same key as `gemini`
-  (`GEMINI_API_KEY` / `~/.gemini-api-key`). It takes input images and has no named
+  from `gemini`, so a cast slot knows which use it points at. Declared-only, like
+  every kind (see Key resolution below): kaibo seeds no source, but shares
+  `gemini`'s conventional names (`GEMINI_API_KEY` / `~/.gemini-api-key`) — declaring
+  the same `api_key_env` on both backends points them at one Google credential
+  instead of minting a second name. It takes input images and has no named
   operations, so `generate`'s `op` is refused on it.
 - **`kind = "openai-images"`** — optional. Unset dials hosted OpenAI
   (`https://api.openai.com/v1`). Set, it points the same wire at any server speaking
@@ -105,10 +108,11 @@ by re-declaration.
 - **`kind = "dashscope"`** — optional. Unset dials DashScope's shared international
   root (`https://dashscope-intl.aliyuncs.com`); a dedicated-endpoint subscription
   sets its own host. Give it a bare host, not a path — the client appends the
-  multimodal-generation route. The key is required, from its own sources
-  (`DASHSCOPE_API_KEY` / `~/.dashscope-key`, not shared with the `openai` kind):
-  every DashScope endpoint is keyed, and one credential name per account beats one
-  per protocol when the same host also serves text. This kind is **media-only** — a
+  multimodal-generation route. The key is required, and — declared-only like every
+  kind (see Key resolution below) — kaibo seeds no source; its own conventional
+  names (`DASHSCOPE_API_KEY` / `~/.dashscope-key`, not shared with the `openai`
+  kind) are one credential name per account, not one per protocol when the same
+  host also serves text. This kind is **media-only** — a
   qwen or deepseek model on a DashScope host belongs on a `kind = "openai"` backend
   pointed at `<host>/compatible-mode/v1`, configured beside this one. DashScope
   returns artifacts as presigned links, so kaibo fetches each over TLS and stores

--- a/docs/config.md
+++ b/docs/config.md
@@ -97,9 +97,11 @@ by re-declaration.
 - **`kind = "openai-images"`** — optional. Unset dials hosted OpenAI
   (`https://api.openai.com/v1`). Set, it points the same wire at any server speaking
   `/v1/images/generations` — a local stable-diffusion.cpp `sd-server`
-  (`base_url = "http://localhost:1234/v1"`) is the expected local case. Key sources
-  are shared with the `openai` kind (the same `OPENAI_API_KEY` / `~/.openai-key`),
-  but the key is **required by default**: the default endpoint is hosted, so a
+  (`base_url = "http://localhost:1234/v1"`) is the expected local case. Declared-only,
+  like every kind (see Key resolution below): kaibo seeds no source, but shares the
+  `openai` kind's conventional names (`OPENAI_API_KEY` / `~/.openai-key`) — one OpenAI
+  credential, not two to maintain, if you declare the same `api_key_env` on both. The
+  key is **required by default**: the default endpoint is hosted, so a
   keyless seed would send a placeholder bearer to a paid API and 401 on the first
   call instead of failing loudly at setup. A keyless local `sd-server` backend sets
   `key_optional = true` beside its local `base_url`. The `generate` tool's
@@ -157,6 +159,16 @@ wrote (a fresh built-in backend has no key source until one is declared). A back
 may declare at most one of `api_key_file` and `api_key_cmd` — both is a load error
 naming both fields; env may still be declared beside either, and wins when set.
 
+**Upgrading from a kaibo that seeded built-in keys.** Older kaibo read
+`ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` and the matching env var / dotfile for
+every built-in backend without being told to. That seeding is gone: a built-in
+backend with no declared source now has no key, `resolve_key` refuses it, and the
+handshake roster drops every cast built on it. Add one `api_key_env`, `api_key_file`,
+or `api_key_cmd` line per backend you use (`kaibo example-config` shows the shapes,
+and the Built-in registry table below still lists each one's conventional env var
+and dotfile name) — those names still work as *values* for the fields, they are
+just no longer assumed.
+
 **Secrets never appear inline in the TOML** — only the *name* of an env var, the
 *path* to a key file, or the *argv* of a key command (a vault item path is a
 pointer, not the secret it resolves to). A config file should be safe to commit or
@@ -168,8 +180,12 @@ kaibo's environment (where `op` finds its session, gpg-agent serves `pass`), but
 stdin is closed (it must never read the MCP stdio stream — a prompting tool fails
 fast instead), its stdout is the key, trimmed, and it is given a 30s ceiling
 (`KEY_CMD_TIMEOUT`): a hung or oversized-emitter is killed/refused, loudly, and its
-output is never logged. 1Password's `op read "op://Vault/Item/Field"`, `pass show`,
-`gh auth token`, and any vault CLI fit this contract unchanged.
+output is never logged. A nonzero exit names the exit status and how many bytes the
+command wrote to stderr, never stderr's content — a wrapper script traced with
+`set -x`, or a tool that echoes the secret on its own failure path, can put the key
+on stderr as easily as stdout, so don't trace a key command. 1Password's `op read
+"op://Vault/Item/Field"`, `pass show`, `gh auth token`, and any vault CLI fit this
+contract unchanged.
 
 `key_optional = true` substitutes a placeholder when no key is found, which is the
 keyless local-server case. The placeholder fits the auth style: an empty query key for
@@ -183,11 +199,14 @@ source is classified `Present` by `key_status` without being run (there is no ch
 offline check for a command — the same asymmetry as an unread key file; a typo'd
 binary name surfaces loudly at the first resolve).
 
-**Timing.** Keys resolve lazily, when the backend is first used to build a client, not at
-config load. A missing or broken key source on a backend no call touches never
-surfaces. A key command therefore runs once per client build and the key lives for
-that client's lifetime — a rotated vault item is picked up at the next client build,
-not on the next call.
+**Timing.** Keys resolve lazily, when a backend is used to build a client, not at
+config load, and are never cached: every client build resolves fresh. A missing or
+broken key source on a backend no call touches never surfaces. This makes the cost of
+`api_key_cmd` a per-*role* cost, not a per-*call* one: one `consult` (or `oneshot`,
+`batch_submit`, …) call builds a client for each cast role it uses — synth and
+explorer, for a two-role cast — so a command-backed key runs once per role, an `op
+read` and a 1Password audit-log entry each. A rotated vault item is picked up at the
+very next build, at the cost of running the command again on every one.
 
 #### `kind = "openrouter"` specifics
 
@@ -483,13 +502,17 @@ behavioral guard rather than a memory one (the per-file and cumulative byte caps
 Five backends and five same-named single-backend casts ship in code, plus two batch
 casts. This is why a missing config file is not an error.
 
-| backend | kind | base_url | key env / file | aliases |
+| backend | kind | base_url | conventional key env / file (declare to use) | aliases |
 |---|---|---|---|---|
 | `anthropic` | anthropic | — *(optional)* | `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` | `claude` |
 | `deepseek` | deepseek | — | `DEEPSEEK_API_KEY` / `~/.deepseek-key` | — |
 | `gemini` | gemini | — *(optional, host root)* | `GEMINI_API_KEY` / `~/.gemini-api-key` | `google` |
 | `openrouter` | openrouter | — *(fixed)* | `OPENROUTER_API_KEY` / `~/.openrouter-key` | — |
 | `openai-local` | openai | `http://localhost:13305/api/v1` | `OPENAI_API_KEY` / `~/.openai-key` *(optional)* | `local`, `lemonade`, `gemma`, `gemma4` |
+
+None of these are seeded (see Key resolution above): a built-in backend has no key
+source until you declare `api_key_env`/`api_key_file` naming one of these values, or
+`api_key_cmd` for a vault command instead.
 
 No built-in sets `wire`. It matters only for a new openai-kind backend whose endpoint is
 not OpenAI Platform's own but should still take the Responses shape; see

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,8 +57,9 @@ Connection settings only. Models are never declared here.
 | `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` \| `gemini-images` \| `dashscope` | required on a new backend | closed enum; selects client + request shape (`stability`, `openai-images`, `gemini-images`, and `dashscope` are the media kinds — image slots only) |
 | `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini` and the media kinds; load error elsewhere |
 | `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
-| `api_key_env` | env var *name* | seeded from `kind` | env source, checked first |
-| `api_key_file` | path | seeded from `kind` | file source, checked second |
+| `api_key_env` | env var *name* | unset — declared by you | env source, checked first |
+| `api_key_file` | path | unset — declared by you | file source, checked second (mutually exclusive with `api_key_cmd`) |
+| `api_key_cmd` | argv array | unset — declared by you | command source: stdout, trimmed, is the key (no shell, 30s ceiling, stdin closed) |
 | `key_optional` | bool | `true` for `openai`, else `false` | allows a placeholder token |
 | `data_collection` | `deny` \| `allow` | `deny` | `kind = "openrouter"` only; load error elsewhere |
 | `request_timeout_secs` | integer > 0 | `[defaults]` value (900) | per-single-completion ceiling |
@@ -144,21 +145,45 @@ proxy `/v1/batches` or the Files API.
 
 #### Key resolution
 
-A backend resolves its key from `api_key_env`, then `api_key_file`. Env wins.
+A backend resolves its key from its **declared** sources — `api_key_env` (an env var
+*name*), `api_key_file` (a path), or `api_key_cmd` (a command whose stdout is the key) —
+with env winning over the file/command source. Every source is declared in
+`config.toml`: kaibo seeds none of them, so the loader does exactly what the operator
+wrote (a fresh built-in backend has no key source until one is declared). A backend
+may declare at most one of `api_key_file` and `api_key_cmd` — both is a load error
+naming both fields; env may still be declared beside either, and wins when set.
 
-**Secrets never appear inline in the TOML** — only the *name* of an env var or the
-*path* to a key file. A config file should be safe to commit or paste.
+**Secrets never appear inline in the TOML** — only the *name* of an env var, the
+*path* to a key file, or the *argv* of a key command (a vault item path is a
+pointer, not the secret it resolves to). A config file should be safe to commit or
+paste.
+
+`api_key_cmd` runs the command with raw argv — no shell, no `$VAR`/`~` expansion in
+its elements (wrap a pipeline in a script and name the script). The child inherits
+kaibo's environment (where `op` finds its session, gpg-agent serves `pass`), but its
+stdin is closed (it must never read the MCP stdio stream — a prompting tool fails
+fast instead), its stdout is the key, trimmed, and it is given a 30s ceiling
+(`KEY_CMD_TIMEOUT`): a hung or oversized-emitter is killed/refused, loudly, and its
+output is never logged. 1Password's `op read "op://Vault/Item/Field"`, `pass show`,
+`gh auth token`, and any vault CLI fit this contract unchanged.
 
 `key_optional = true` substitutes a placeholder when no key is found, which is the
 keyless local-server case. The placeholder fits the auth style: an empty query key for
 Gemini, a non-empty bearer for header-auth backends (`src/credentials.rs`).
 
-A key file that is *present but broken* (empty, unreadable, a directory) is a loud error
-even on a keyless backend, because present-but-wrong is a mistake rather than "keyless".
-Only a genuinely absent file falls back.
+A key source that is *present but broken* (an empty/unreadable key file; a command
+that exits nonzero, prints nothing, prints non-UTF-8 or oversized output, or times
+out) is a loud error even on a keyless backend, because present-but-wrong is a
+mistake rather than "keyless". Only a genuinely absent source falls back. The command
+source is classified `Present` by `key_status` without being run (there is no cheap
+offline check for a command — the same asymmetry as an unread key file; a typo'd
+binary name surfaces loudly at the first resolve).
 
 **Timing.** Keys resolve lazily, when the backend is first used to build a client, not at
-config load. A missing or broken key on a backend no call touches never surfaces.
+config load. A missing or broken key source on a backend no call touches never
+surfaces. A key command therefore runs once per client build and the key lives for
+that client's lifetime — a rotated vault item is picked up at the next client build,
+not on the next call.
 
 #### `kind = "openrouter"` specifics
 
@@ -641,8 +666,9 @@ Everything else follows one naming rule:
 
 - **Provider key vars stay native.** `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
   `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, and `OPENAI_API_KEY` are not renamed to
-  `KAIBO_*`, because people and CI expect those names. A backend points at one via
-  `api_key_env`.
+  `KAIBO_*`, because people and CI expect those names. A backend points at one by
+  declaring `api_key_env` in its stanza (kaibo reads no key env var that isn't
+  declared).
 - **`OPENAI_BASE_URL` is kept** as a backward-compatible override for any openai-kind
   backend with no explicit `base_url`. New backends use the `base_url` config key.
 
@@ -1565,17 +1591,18 @@ local-default fallback applied; the raw configured value, when set, for the anth
 gemini kinds; and nothing for every other kind.
 
 **Secret-safety contract.** `kaibo://config` includes key *source metadata* — the env var
-name and file path an operator configured — and never the resolved key value. Keys resolve
-lazily at call time and are never cached in the `Config` struct, so the render function has
-no field holding a secret.
+name, file path, or key command argv an operator configured — and never the resolved
+key value. Keys resolve lazily at call time and are never cached in the `Config` struct,
+so the render function has no field holding a secret.
 
 The render destructures `Backend`, `ModelSlot`, `Defaults`, `ToolGating`, and
 `SandboxConfig` exhaustively, so a new field is a compile error at the render site. That
 makes rendering a field an explicit decision, subject to secret review, rather than a
 silent omission.
 
-`api_key_env` and `api_key_file` are included on purpose: an operator debugging a
-missing-key error needs to see which source the backend points at.
+`api_key_env`, `api_key_file`, and `api_key_cmd` are included on purpose: an operator
+debugging a missing-key error needs to see which source the backend points at (a vault
+item path in argv is a pointer, like the env var name — it never resolves a value).
 
 ## CLI mirrors
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -2359,6 +2359,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -650,11 +650,17 @@ pub struct Backend {
     /// -compatible gateway/proxy). A `Some` on any other keyed kind is rejected
     /// at load (rig fixes those endpoints).
     pub base_url: Option<String>,
-    /// Env var to read the API key from (checked before `api_key_file`).
+    /// Env var to read the API key from (checked before the file/command source).
     pub api_key_env: Option<String>,
     /// Key-file path, stored already `$VAR`/`~`-expanded (resolved once at load in
     /// `from_toml_str`). Used when the env var is unset/blank.
     pub api_key_file: Option<String>,
+    /// A command whose stdout is the API key: raw argv (`["op", "read",
+    /// "op://Vault/Item/Field"]`), run with no shell, stdin nulled, time-boxed
+    /// ([`credentials::KEY_CMD_TIMEOUT`]), output never logged. Declared only — kaibo
+    /// never seeds one — and mutually exclusive with `api_key_file` (a load error if
+    /// both are declared); env (`api_key_env`) still wins when set.
+    pub api_key_cmd: Option<Vec<String>>,
     /// When true, a missing key falls back to a placeholder bearer token instead of
     /// erroring (the keyless local-server case).
     pub key_optional: bool,
@@ -677,22 +683,32 @@ pub struct Backend {
 }
 
 impl Backend {
-    /// Resolve this backend's bearer token: configured env var (wins, when set and
-    /// non-blank), then the key file, then — if `key_optional` — a placeholder, else
-    /// a loud error.
+    /// Resolve this backend's bearer token: declared env var (wins, when set and
+    /// non-blank), then the declared file, then the declared command, then — if
+    /// `key_optional` — a placeholder, else a loud error. Every source is declared in
+    /// config.toml — kaibo seeds none of them — and a backend declares at most one of
+    /// file and command (enforced at load).
     ///
-    /// A *present but broken* key file (empty, unreadable, a directory) is a loud
-    /// error even for a `key_optional` backend: a key that's there but wrong is a
-    /// mistake, not "keyless". Only a genuinely absent file falls back. This is the
+    /// A *present but broken* key source (file empty/unreadable/a directory; command
+    /// exiting nonzero, empty, oversized, non-UTF-8, or timing out) is a loud error
+    /// even for a `key_optional` backend: a key that's there but wrong is a mistake,
+    /// not "keyless". Only a genuinely absent source falls back. This is the
     /// no-silent-fallback directive — we don't quietly send a placeholder when the
     /// user clearly meant to provide a key.
     pub fn resolve_key(&self) -> Result<String> {
+        // The env lookup is the only ambient read in the chain; the file/command
+        // arms read declared config, so the real-environment call is the trivial
+        // wrapper and the injected variant is the testable, pure one (`key_status`
+        // mirrors this exact split).
+        self.resolve_key_where(|name| std::env::var(name).ok())
+    }
+
+    /// The full resolution chain with the env lookup injected — the pure sibling of
+    /// [`resolve_key`](Self::resolve_key), testable without touching the real
+    /// environment (the same discipline `key_status` already follows).
+    pub fn resolve_key_where(&self, get_env: impl Fn(&str) -> Option<String>) -> Result<String> {
         // env wins, when set and non-blank.
-        if let Some(v) = self
-            .api_key_env
-            .as_deref()
-            .and_then(|name| std::env::var(name).ok())
-        {
+        if let Some(v) = self.api_key_env.as_deref().and_then(get_env) {
             let v = v.trim();
             if !v.is_empty() {
                 return Ok(v.to_string());
@@ -710,7 +726,19 @@ impl Backend {
             }
         }
 
-        // No env, no existing file.
+        // then a declared key command, run once. Raw argv, no shell: resolved by the
+        // same lazy rule as the file (first client build), inheriting kaibo's env
+        // (where e.g. `op` finds its session), stdout trimmed and never logged.
+        if let Some(args) = &self.api_key_cmd {
+            return credentials::resolve_key_from_cmd(
+                args,
+                credentials::KEY_CMD_TIMEOUT,
+                &[],
+            )
+            .with_context(|| format!("resolving key for backend {:?}", self.name));
+        }
+
+        // No env, no declared file or command.
         if self.key_optional {
             // Transport-shaped stand-in: a non-empty bearer for header-auth kinds,
             // the empty string for Gemini's `?key=` query auth (see
@@ -720,11 +748,11 @@ impl Backend {
             Ok(self.kind.placeholder_key().to_string())
         } else {
             Err(anyhow!(
-                "backend {:?} has no API key: env {} unset and key file {} absent — \
-                 set one, or key_optional = true only for a keyless endpoint",
+                "backend {:?} has no API key: no key source declared — set \
+                 api_key_env, api_key_file, or api_key_cmd in config.toml, or \
+                 key_optional = true only for a keyless endpoint (`kaibo example-config` \
+                 shows the shapes)",
                 self.name,
-                self.api_key_env.as_deref().unwrap_or("(none)"),
-                self.api_key_file.as_deref().unwrap_or("(none)"),
             ))
         }
     }
@@ -788,15 +816,16 @@ impl Backend {
 
     /// Whether this backend has a usable credential, judged *without* committing to a
     /// network call or pulling the secret into the answer path — the non-fatal sibling
-    /// of [`resolve_key`](Self::resolve_key). It mirrors the same precedence (env var,
-    /// then key file, then `key_optional`) but reports a verdict instead of returning
-    /// the secret or erroring. The env lookup is injected so the classification is
-    /// testable without touching the real environment.
+    /// of [`resolve_key`](Self::resolve_key). It mirrors the same precedence (declared
+    /// env var, then the declared file or command, then `key_optional`) but reports a
+    /// verdict instead of returning the secret or erroring. The env lookup is injected
+    /// so the classification is testable without touching the real environment.
     ///
-    /// A *present-but-broken* key file still reads as [`KeyStatus::Present`] here: it's
-    /// a configured credential, and `resolve_key` is the one that surfaces its breakage
-    /// loudly at call time. We deliberately don't read the file's contents — existence
-    /// is enough to say "the user set this up".
+    /// A *present-but-broken* key source still reads as [`KeyStatus::Present`] here: a
+    /// configured credential, and `resolve_key` is the one that surfaces its breakage
+    /// loudly at call time. The file's contents are never read (existence is enough);
+    /// a command is never run (there is no cheap offline equivalent of `exists()` —
+    /// a typo'd binary name passes classification and fails at the first resolve).
     pub fn key_status(&self, get_env: impl Fn(&str) -> Option<String>) -> KeyStatus {
         // env wins, when set and non-blank — same rule as resolve_key.
         if let Some(name) = self.api_key_env.as_deref() {
@@ -806,12 +835,18 @@ impl Backend {
                 }
             }
         }
-        // then a configured key file, if it exists (contents unread — see above). The
+        // then a declared key file, if it exists (contents unread — see above). The
         // path was `$VAR`/`~`-expanded once at load, so it's used verbatim here.
         if let Some(file) = self.api_key_file.as_deref().map(PathBuf::from) {
             if file.exists() {
                 return KeyStatus::Present;
             }
+        }
+        // then a declared key command — Present by declaration, never run (there is no
+        // cheap offline check for a command; a broken or typo'd one surfaces loudly at
+        // the first `resolve_key`, exactly like a broken key file).
+        if self.api_key_cmd.is_some() {
+            return KeyStatus::Present;
         }
         if self.key_optional {
             KeyStatus::Placeholder
@@ -1801,12 +1836,41 @@ impl Config {
 
         // Expand `$VAR`/`${VAR}` and a leading `~` in each backend's `api_key_file` — the
         // same uniform rule `root`/`allow_paths` get, so a portable `$XDG_CONFIG_HOME/key`
-        // (or the built-in `~/.gemini-api-key`) resolves per-environment. Done once here,
-        // loudly on an undefined/empty/non-UTF-8 variable, so the use-sites
+        // resolves per-environment. Done once here, loudly on an
+        // undefined/empty/non-UTF-8 variable, so the use-sites
         // (`resolve_key`/`key_status`) read an already-resolved path and stay infallible —
         // `key_status` feeds the offline cast-usability classifiers, which can't take a
-        // `Result`. Absolute/plain paths pass through unchanged.
+        // `Result`. Absolute/plain paths pass through unchanged. (A key *command*'s argv
+        // is deliberately NOT expanded — no shell, no interpolation, by design.)
         for b in backends.values_mut() {
+            // Declared-only key sources: a backend may declare a key file OR a key
+            // command, never both — two declared sources is an ambiguity worth a loud
+            // error (there is no precedence between them to silently pick). Checked on
+            // the MERGED backend — after `apply_to` overlays have run, so a source
+            // arriving from the builtin template or an earlier stanza cannot dodge the
+            // check — which is why it lives in the post-merge loop, not in `apply_to`
+            // itself. (Today no later layer can declare a backend source — the builtin
+            // template seeds none and env/CLI carry no stanzas — but the check is
+            // placement-proof by construction, and the single-stanza tests pin it.)
+            if b.api_key_file.is_some() && b.api_key_cmd.is_some() {
+                bail!(
+                    "backend {:?} declares both api_key_file and api_key_cmd — \
+                     declare one key source (env can still override it)",
+                    b.name,
+                );
+            }
+            // An empty argv names no executable — a typo, not an intent. `[""]` is
+            // left alone (it fails loudly at the first resolve, like any missing
+            // binary); the empty ARRAY cannot even spawn and is caught here.
+            if let Some(args) = &b.api_key_cmd {
+                if args.is_empty() {
+                    bail!(
+                        "backend {:?}: api_key_cmd = [] names no executable — \
+                         give it at least the command to run",
+                        b.name,
+                    );
+                }
+            }
             if let Some(f) = b.api_key_file.as_deref() {
                 let expanded = expand_path(f)?;
                 let what = format!("backend {:?} api_key_file", b.name);
@@ -2275,7 +2339,12 @@ fn builtin_aliases(name: &str) -> Vec<String> {
     v.iter().map(|s| s.to_string()).collect()
 }
 
-/// A fresh backend template for `kind`, carrying that kind's default key source.
+/// A fresh backend template for `kind`, carrying NO key source — a backend's sources
+/// are declared in config.toml, never seeded, so the loader's semantics are exactly
+/// what the operator wrote (the old seeded env-var/dotfile defaults made the built-ins
+/// implicitly depend on conventions nobody declared). `key_optional` still follows the
+/// kind: the `openai` wire is keyless by default (a placeholder for the local server),
+/// every keyed kind requires a declared source before `resolve_key` can succeed.
 /// New file backends start here, then apply their overrides.
 fn backend_template(kind: ProviderKind, defaults: &Defaults) -> Backend {
     Backend {
@@ -2286,8 +2355,9 @@ fn backend_template(kind: ProviderKind, defaults: &Defaults) -> Backend {
         // pure. Every keyed kind except anthropic and gemini rejects an explicit
         // base_url at load (see the validation loop above); theirs is optional.
         base_url: None,
-        api_key_env: Some(kind.env_var().to_string()),
-        api_key_file: Some(format!("~/{}", kind.key_file_name())),
+        api_key_env: None,
+        api_key_file: None,
+        api_key_cmd: None,
         key_optional: kind.key_optional(),
         request_timeout: defaults.request_timeout,
         // Deny is the only safe default: kaibo's prompts carry source code, and
@@ -2679,6 +2749,7 @@ struct RawBackend {
     base_url: Option<String>,
     api_key_env: Option<String>,
     api_key_file: Option<String>,
+    api_key_cmd: Option<Vec<String>>,
     key_optional: Option<bool>,
     request_timeout_secs: Option<u64>,
     data_collection: Option<String>,
@@ -2712,6 +2783,9 @@ impl RawBackend {
         }
         if let Some(v) = &self.api_key_file {
             b.api_key_file = Some(v.clone());
+        }
+        if let Some(v) = &self.api_key_cmd {
+            b.api_key_cmd = Some(v.clone());
         }
         if let Some(v) = self.key_optional {
             b.key_optional = v;
@@ -3995,10 +4069,15 @@ mod tests {
         let s = cast.require_slot(ModelRole::Synth).unwrap();
         assert_eq!((e.backend.as_str(), e.id.as_str()), ("anthropic", explorer));
         assert_eq!((s.backend.as_str(), s.id.as_str()), ("anthropic", synth));
-        // Connection details ride the backend, with today's key sources.
+        // Connection details ride the backend; key sources are DECLARED, never
+        // seeded — a fresh built-in has none, so `key_status` reads Missing until
+        // the operator declares api_key_env / api_key_file / api_key_cmd. This is
+        // the declared-only rule: the loader does exactly what the operator wrote.
         let b = cfg.resolve_backend("anthropic").unwrap();
         assert_eq!(b.kind, ProviderKind::Anthropic);
-        assert_eq!(b.api_key_env.as_deref(), Some("ANTHROPIC_API_KEY"));
+        assert_eq!(b.api_key_env, None);
+        assert_eq!(b.api_key_file, None);
+        assert_eq!(b.api_key_cmd, None);
         assert!(!b.key_optional);
     }
 
@@ -4060,8 +4139,9 @@ mod tests {
         }
     }
 
-    /// The OpenRouter built-in: a keyed backend (OPENROUTER_API_KEY, no configurable
-    /// base URL) and a Qwen cast — a family we can't reach directly. Explorer is the
+    /// The OpenRouter built-in: a keyed gateway (no configurable base URL — the
+    /// endpoint is rig's; a key source is declared by the operator, never seeded)
+    /// and a Qwen cast — a family we can't reach directly. Explorer is the
     /// multimodal flash (vision pinned on, since OpenRouter's classifier defaults false),
     /// synth is the text-only flagship `qwen3.7-max` (no vision pin — classifier's false
     /// stands). Pins the whole built-in so a bad default fails here, not mid-call.
@@ -4088,7 +4168,9 @@ mod tests {
 
         let b = cfg.resolve_backend("openrouter").unwrap();
         assert_eq!(b.kind, ProviderKind::OpenRouter);
-        assert_eq!(b.api_key_env.as_deref(), Some("OPENROUTER_API_KEY"));
+        // Declared-only: no seeded env var, no seeded file, no seeded command.
+        assert_eq!(b.api_key_env, None);
+        assert_eq!(b.api_key_cmd, None);
         assert!(!b.key_optional, "OpenRouter is a keyed gateway");
         assert!(
             b.base_url.is_none(),
@@ -4439,20 +4521,29 @@ mod tests {
 
     // --- usability: the unconfigured-install signal ---------------------------
     //
-    // These point every keyed backend's `api_key_file` at a path that cannot exist,
-    // so the verdict depends ONLY on the injected env lookup — never on whether the
-    // test machine happens to have ~/.anthropic-key.txt. (Amy keeps real key files;
-    // a naive built-in test would pass on her box and fail in CI, or vice versa.)
+    // These point every keyed backend's key sources at something that cannot
+    // produce a key — api_key_file at a path that cannot exist, api_key_env DECLARED
+    // but never set by an injected lookup — so the verdict depends ONLY on the env
+    // map each test injects, never on whether the test machine happens to have
+    // ~/.anthropic-key.txt or a real ANTHROPIC_API_KEY. (Amy keeps real key files
+    // and real keys; a naive built-in test would pass on her box and fail in CI,
+    // or vice versa.) Declared-only: api_key_env is a config line here, exactly as
+    // this feature now requires.
     const NO_KEY_FILES: &str = r#"
         [backends.anthropic]
+        api_key_env = "ANTHROPIC_API_KEY"
         api_key_file = "/nonexistent-kaibo-test/anthropic"
         [backends.deepseek]
+        api_key_env = "DEEPSEEK_API_KEY"
         api_key_file = "/nonexistent-kaibo-test/deepseek"
         [backends.gemini]
+        api_key_env = "GEMINI_API_KEY"
         api_key_file = "/nonexistent-kaibo-test/gemini"
         [backends.openrouter]
+        api_key_env = "OPENROUTER_API_KEY"
         api_key_file = "/nonexistent-kaibo-test/openrouter"
         [backends.openai-local]
+        api_key_env = "OPENAI_API_KEY"
         api_key_file = "/nonexistent-kaibo-test/openai"
     "#;
 
@@ -4471,8 +4562,9 @@ mod tests {
         );
     }
 
-    /// The same config flips to Ready the moment the env var carries a key — so an
-    /// env-only setup (no config file) is never nagged.
+    /// The same config flips to Ready the moment the DECLARED env var carries a
+    /// key — an env-based setup means declaring `api_key_env` once, then exporting
+    /// the variable in the shell (the value itself stays out of the config).
     #[test]
     fn cast_usability_ready_when_env_key_present() {
         let cfg = Config::from_toml_str(&format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -695,6 +695,11 @@ impl Backend {
     /// not "keyless". Only a genuinely absent source falls back. This is the
     /// no-silent-fallback directive — we don't quietly send a placeholder when the
     /// user clearly meant to provide a key.
+    ///
+    /// No caching: this runs on every client build, not once per process or once per
+    /// call. A `consult` call builds one client per cast role (synth and explorer),
+    /// so a command-backed key spawns once per role — twice for a two-role cast, an
+    /// `op read` and a 1Password audit-log entry each time, not once for the call.
     pub fn resolve_key(&self) -> Result<String> {
         // The env lookup is the only ambient read in the chain; the file/command
         // arms read declared config, so the real-environment call is the trivial
@@ -726,16 +731,13 @@ impl Backend {
             }
         }
 
-        // then a declared key command, run once. Raw argv, no shell: resolved by the
-        // same lazy rule as the file (first client build), inheriting kaibo's env
-        // (where e.g. `op` finds its session), stdout trimmed and never logged.
+        // then a declared key command. Raw argv, no shell, and no caching: this runs
+        // on every call to resolve_key, i.e. every client build — see the doc above —
+        // inheriting kaibo's env (where e.g. `op` finds its session), stdout trimmed
+        // and never logged.
         if let Some(args) = &self.api_key_cmd {
-            return credentials::resolve_key_from_cmd(
-                args,
-                credentials::KEY_CMD_TIMEOUT,
-                &[],
-            )
-            .with_context(|| format!("resolving key for backend {:?}", self.name));
+            return credentials::resolve_key_from_cmd(args, credentials::KEY_CMD_TIMEOUT, &[])
+                .with_context(|| format!("resolving key for backend {:?}", self.name));
         }
 
         // No env, no declared file or command.

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -5958,6 +5958,7 @@ mod tests {
             base_url: Some("http://localhost:13305/api/v1".into()),
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6010,6 +6011,7 @@ mod tests {
             base_url: Some(crate::credentials::HOSTED_OPENAI_BASE_URL.into()),
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6072,6 +6074,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6149,6 +6152,7 @@ mod tests {
             base_url: Some("https://llm-gateway.example.internal/v1".into()),
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6195,6 +6199,7 @@ mod tests {
             base_url: Some(crate::credentials::HOSTED_OPENAI_BASE_URL.into()),
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6237,6 +6242,7 @@ mod tests {
             base_url: Some("https://gateway.example.ts.net".into()),
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6271,6 +6277,7 @@ mod tests {
             base_url: Some("https://llm-gateway.example.internal".into()),
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: true,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6309,6 +6316,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: Some(key_file.to_str().unwrap().to_string()),
+            api_key_cmd: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6357,6 +6365,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: Some(key_file.to_str().unwrap().to_string()),
+            api_key_cmd: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: crate::config::DataCollection::Allow,
@@ -6393,6 +6402,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: Some(key_file.to_str().unwrap().to_string()),
+            api_key_cmd: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6420,6 +6430,47 @@ mod tests {
         assert_eq!(
             params["provider"]["data_collection"], "deny",
             "the privacy pin coexists with the disable"
+        );
+    }
+
+    /// A key from a DECLARED COMMAND reaches the arm exactly like a key-file key:
+    /// `Arm::from_slot` runs the command once at construction (the lazy
+    /// client-build resolution), trims its stdout, and builds the rig client with
+    /// it. The stub is invoked by absolute path — no PATH dependence.
+    #[cfg(unix)]
+    #[test]
+    fn openrouter_arm_builds_from_a_declared_key_command() {
+        let defaults = crate::config::Defaults::default();
+        let dir = tempfile::tempdir().unwrap();
+        let stub = dir.path().join("op-stub");
+        std::fs::write(&stub, "#!/bin/sh\nprintf 'sk-or-from-cmd\\n'\n").unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let backend = crate::config::Backend {
+            name: "openrouter".into(),
+            kind: ProviderKind::OpenRouter,
+            base_url: None,
+            api_key_env: None,
+            api_key_file: None,
+            api_key_cmd: Some(vec![
+                stub.to_string_lossy().into_owned(),
+                "op://Vault/Kaibo/OpenRouter".into(),
+            ]),
+            key_optional: false,
+            request_timeout: Duration::from_secs(30),
+            data_collection: Default::default(),
+            wire: None,
+        };
+        let slot = ModelSlot::bare("openrouter", "~anthropic/claude-sonnet-latest");
+        let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
+            .expect("a keyed openrouter arm builds from a key command");
+        assert_eq!(arm.model, "~anthropic/claude-sonnet-latest");
+        let params = arm.params.expect("the openrouter arm always sends params");
+        assert_eq!(
+            params["reasoning"]["effort"], defaults.synth_effort,
+            "thinking-on default survives a command-sourced key"
         );
     }
 
@@ -6518,6 +6569,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),
@@ -6550,6 +6602,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: Default::default(),

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -14,10 +14,16 @@
 //! local keyless server) rather than tied to a hosted service. Its key is
 //! *optional* — `OPENAI_API_KEY` / `~/.openai-key` when talking to a keyed
 //! endpoint, or a placeholder ([`PLACEHOLDER_OPENAI_KEY`]) for the keyless local
-//! default. Per-backend resolution (env → key-file → placeholder) lives on
-//! `Backend::resolve_key` (`config.rs`); this module is the pure key/base-url core.
+//! default. Per-backend resolution (env → declared file/command → placeholder) lives
+//! on `Backend::resolve_key` (`config.rs`), whose sources are ALL declared in
+//! config.toml — never seeded — plus [`resolve_key_from_cmd`] for the operator-side
+//! command source (`api_key_cmd`, e.g. `op read`). This module is the pure
+//! key/base-url core.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -408,6 +414,170 @@ pub fn resolve(env_value: Option<&str>, key_file: &Path) -> Result<String> {
             key_file.display()
         )),
         Err(e) => Err(e).with_context(|| format!("reading key-file {}", key_file.display())),
+    }
+}
+
+/// Cap on a key command's stdout: refuse, not trim, past this. A key is a line;
+/// a command that prints a log is misbehaving, not "verbose".
+pub const KEY_CMD_MAX_OUTPUT: usize = 64 * 1024;
+
+/// Wall-clock ceiling on a key command. A child that hangs — an unlock prompt (a
+/// null stdin means we cannot answer one), a cold agent — must not wedge key
+/// resolution. Lazy client-build resolution makes this a pathological-case guard:
+/// with an unlocked session, `op read` finishes in a few hundred milliseconds.
+pub const KEY_CMD_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Run a declared key command and return its stdout as the key.
+///
+/// `args` is raw argv — no shell, no `$VAR`/`~` expansion: the config layer never
+/// interpolates command elements, and neither do we. The child inherits kaibo's
+/// environment (where e.g. `op` finds its session or gpg-agent serves `pass`);
+/// `extra_env` is the test seam — unit tests inject through it instead of mutating
+/// the process environment.
+///
+/// All three stdio streams are pinned. Stdin is nulled: the child must never read
+/// the MCP stdio stream kaibo runs on, and a prompting tool fails fast instead of
+/// hanging on a TTY that does not exist. Stdout and stderr are piped and captured —
+/// stdout IS the key, stderr feeds failure errors only — so nothing a child prints
+/// can leak into kaibo's own stdout or a log.
+///
+/// The key is stdout, trimmed (key-file semantics). Empty, non-UTF-8, or
+/// over-[`KEY_CMD_MAX_OUTPUT`] output, a nonzero exit, a spawn failure, and a
+/// timeout are all loud errors — the no-silent-fallback rule: a declared-but-broken
+/// command never degrades to a placeholder.
+pub fn resolve_key_from_cmd(
+    args: &[String],
+    timeout: Duration,
+    extra_env: &[(&str, &str)],
+) -> Result<String> {
+    let mut cmd = std::process::Command::new(&args[0]);
+    cmd.args(&args[1..])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if !extra_env.is_empty() {
+        cmd.envs(extra_env.iter().copied());
+    }
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("spawning key command {:?}", args[0]))?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("key command stdout not piped")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("key command stderr not piped")?;
+
+    // Drain both pipes on reader threads so a verbose child can never wedge the
+    // pipe; `read_capped` buffers only the first ~cap bytes and drains the rest.
+    let reader_stdout = std::thread::spawn(move || read_capped(stdout, KEY_CMD_MAX_OUTPUT));
+    let reader_stderr = std::thread::spawn(move || read_capped(stderr, KEY_CMD_MAX_OUTPUT));
+
+    // Wait for exit under a hard deadline; kill and report on timeout.
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(anyhow!(
+                    "key command {:?} did not exit within {:.1}s and was killed — \
+                     stdin is closed, so an interactive unlock prompt cannot be \
+                     answered (unlock the tool once, or point it at a key that \
+                     needs no prompt)",
+                    args[0],
+                    timeout.as_secs_f64(),
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(e) => return Err(e).context("waiting for the key command"),
+        }
+    };
+
+    let out = reader_stdout
+        .join()
+        .map_err(|_| anyhow!("key command stdout reader panicked"))?;
+    let err = reader_stderr
+        .join()
+        .map_err(|_| anyhow!("key command stderr reader panicked"))?;
+
+    // A nonzero exit is the primary failure: name it and the child's own stderr
+    // tail ("Vault is locked"), never its stdout — a broken command may print
+    // anything to stdout, including part of an unrelated buffer.
+    if !status.success() {
+        let tail: String = String::from_utf8_lossy(&err)
+            .trim()
+            .chars()
+            .rev()
+            .take(512)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        let suffix = if tail.is_empty() {
+            "".to_string()
+        } else {
+            format!(" — {tail}")
+        };
+        return Err(anyhow!(
+            "key command {:?} exited with {status}{suffix}: fix the command or \
+             the secret it reads (its stdout must be the key)",
+            args[0],
+        ));
+    }
+
+    // Refuse, not trim: a key is a single value, not a log.
+    if out.len() > KEY_CMD_MAX_OUTPUT {
+        return Err(anyhow!(
+            "key command {:?} printed more than {} bytes of output — a key is a \
+             single value; point the command at a field that prints one",
+            args[0],
+            KEY_CMD_MAX_OUTPUT,
+        ));
+    }
+
+    // Strict UTF-8, never lossy: a binary field (an `op read` of a file-type
+    // item) is a mistake to surface, not to mangle into a key.
+    let out = String::from_utf8(out).with_context(|| {
+        format!(
+            "key command {:?} printed non-UTF-8 output — the key must be text \
+             (a base64'd binary field? wrap it in a script that decodes)",
+            args[0]
+        )
+    })?;
+    let key = out.trim();
+    if key.is_empty() {
+        return Err(anyhow!(
+            "key command {:?} printed nothing — the command must print the key \
+             to stdout",
+            args[0]
+        ));
+    }
+    Ok(key.to_string())
+}
+
+/// Read a pipe to EOF, buffering roughly the first `cap` bytes and draining the
+/// rest — a stopped reader would wedge the child's pipe, turning a verbose child
+/// into a hang instead of a loud refusal.
+fn read_capped(mut r: impl Read, cap: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(cap.min(65536));
+    let mut chunk = [0u8; 8192];
+    loop {
+        match r.read(&mut chunk) {
+            Ok(0) => return buf,
+            Ok(n) => {
+                if buf.len() <= cap {
+                    let room = cap + 1 - buf.len();
+                    buf.extend_from_slice(&chunk[..n.min(room)]);
+                }
+            }
+            // A signal can interrupt a read; retry it, the child is still ours.
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => return buf,
+        }
     }
 }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -430,27 +430,44 @@ pub const KEY_CMD_TIMEOUT: Duration = Duration::from_secs(30);
 /// Run a declared key command and return its stdout as the key.
 ///
 /// `args` is raw argv — no shell, no `$VAR`/`~` expansion: the config layer never
-/// interpolates command elements, and neither do we. The child inherits kaibo's
-/// environment (where e.g. `op` finds its session or gpg-agent serves `pass`);
-/// `extra_env` is the test seam — unit tests inject through it instead of mutating
-/// the process environment.
+/// interpolates command elements, and neither do we. An empty `args` names no
+/// executable — config load already refuses `api_key_cmd = []`, but this is a
+/// `pub fn` a direct caller can reach without going through config, so it returns
+/// the same loud error rather than panicking on `args[0]`. The child inherits
+/// kaibo's environment (where e.g. `op` finds its session or gpg-agent serves
+/// `pass`); `extra_env` is the test seam — unit tests inject through it instead of
+/// mutating the process environment.
 ///
 /// All three stdio streams are pinned. Stdin is nulled: the child must never read
 /// the MCP stdio stream kaibo runs on, and a prompting tool fails fast instead of
 /// hanging on a TTY that does not exist. Stdout and stderr are piped and captured —
-/// stdout IS the key, stderr feeds failure errors only — so nothing a child prints
-/// can leak into kaibo's own stdout or a log.
+/// stdout IS the key, so nothing a child prints there can leak into kaibo's own
+/// stdout or a log. Stderr is captured too, but never quoted into an error or a log:
+/// a wrapper script traced with `set -x`, or a tool that echoes the secret on its
+/// own failure path, can put the key on stderr as easily as stdout, so a failure
+/// names only the exit status and a byte count, never stderr's content.
 ///
 /// The key is stdout, trimmed (key-file semantics). Empty, non-UTF-8, or
 /// over-[`KEY_CMD_MAX_OUTPUT`] output, a nonzero exit, a spawn failure, and a
 /// timeout are all loud errors — the no-silent-fallback rule: a declared-but-broken
 /// command never degrades to a placeholder.
+///
+/// No caching: this runs fresh on every call, and [`crate::config::Backend::resolve_key`]
+/// has no memoization either, so a caller that builds a client per cast role —
+/// `consult`'s synth and explorer, say — runs this command once per role, not once
+/// per top-level call.
 pub fn resolve_key_from_cmd(
     args: &[String],
     timeout: Duration,
     extra_env: &[(&str, &str)],
 ) -> Result<String> {
-    let mut cmd = std::process::Command::new(&args[0]);
+    let Some(program) = args.first() else {
+        return Err(anyhow!(
+            "api_key_cmd names no executable — give it at least the command to \
+             run (`kaibo example-config` shows the shape)"
+        ));
+    };
+    let mut cmd = std::process::Command::new(program);
     cmd.args(&args[1..])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -460,7 +477,7 @@ pub fn resolve_key_from_cmd(
     }
     let mut child = cmd
         .spawn()
-        .with_context(|| format!("spawning key command {:?}", args[0]))?;
+        .with_context(|| format!("spawning key command {:?}", program))?;
     let stdout = child
         .stdout
         .take()
@@ -488,7 +505,7 @@ pub fn resolve_key_from_cmd(
                      stdin is closed, so an interactive unlock prompt cannot be \
                      answered (unlock the tool once, or point it at a key that \
                      needs no prompt)",
-                    args[0],
+                    program,
                     timeout.as_secs_f64(),
                 ));
             }
@@ -504,28 +521,18 @@ pub fn resolve_key_from_cmd(
         .join()
         .map_err(|_| anyhow!("key command stderr reader panicked"))?;
 
-    // A nonzero exit is the primary failure: name it and the child's own stderr
-    // tail ("Vault is locked"), never its stdout — a broken command may print
-    // anything to stdout, including part of an unrelated buffer.
+    // A nonzero exit is the primary failure: name it and how much stderr the
+    // child wrote, never stderr's content — stderr can carry the secret itself
+    // (a wrapper script run with `set -x`, or a tool that echoes on its own
+    // failure path), so it is suppressed exactly where stdout already is.
     if !status.success() {
-        let tail: String = String::from_utf8_lossy(&err)
-            .trim()
-            .chars()
-            .rev()
-            .take(512)
-            .collect::<String>()
-            .chars()
-            .rev()
-            .collect();
-        let suffix = if tail.is_empty() {
-            "".to_string()
-        } else {
-            format!(" — {tail}")
-        };
         return Err(anyhow!(
-            "key command {:?} exited with {status}{suffix}: fix the command or \
-             the secret it reads (its stdout must be the key)",
-            args[0],
+            "key command {:?} exited with {status} ({} bytes on stderr, \
+             suppressed — stderr can carry the secret itself): run the command \
+             directly to see why it failed, then fix it or the secret it reads \
+             (its stdout must be the key)",
+            program,
+            err.len(),
         ));
     }
 
@@ -534,7 +541,7 @@ pub fn resolve_key_from_cmd(
         return Err(anyhow!(
             "key command {:?} printed more than {} bytes of output — a key is a \
              single value; point the command at a field that prints one",
-            args[0],
+            program,
             KEY_CMD_MAX_OUTPUT,
         ));
     }
@@ -545,7 +552,7 @@ pub fn resolve_key_from_cmd(
         format!(
             "key command {:?} printed non-UTF-8 output — the key must be text \
              (a base64'd binary field? wrap it in a script that decodes)",
-            args[0]
+            program
         )
     })?;
     let key = out.trim();
@@ -553,7 +560,7 @@ pub fn resolve_key_from_cmd(
         return Err(anyhow!(
             "key command {:?} printed nothing — the command must print the key \
              to stdout",
-            args[0]
+            program
         ));
     }
     Ok(key.to_string())

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -628,6 +628,7 @@ mod tests {
             base_url: None,
             api_key_env: None,
             api_key_file: None,
+            api_key_cmd: None,
             key_optional: false,
             request_timeout: Duration::from_secs(30),
             data_collection: DataCollection::default(),

--- a/src/kaish_syntax.rs
+++ b/src/kaish_syntax.rs
@@ -134,10 +134,13 @@ fn kaibo_lead() -> &'static str {
 }
 
 /// The setup-guidance block prepended to the instructions when the default cast has
-/// no usable provider (a fresh `cargo install` with no key set). Steers toward an env
-/// var or a key file — *never* pasting the key into the chat — names the default cast's
-/// backends and their key sources, points at the example resource, and reminds the user
-/// to reconnect the server (which only re-reads the environment and config at startup).
+/// no usable provider (a fresh `cargo install` with no key source declared). Steers
+/// toward DECLARING a key source in config.toml (api_key_env / api_key_file /
+/// api_key_cmd) — *never* pasting the key into the chat — names the default cast's
+/// backends and whatever source each already carries (else the kind's conventional
+/// env var, since conventions are exactly what guidance may name), points at the
+/// example resource, and reminds the user to reconnect the server (which only
+/// re-reads the environment and config at startup).
 ///
 /// Positive framing: it leads with what *works now* (`run_kaish` needs no provider) and
 /// what to do, not a wall of "you can't". Best-effort on the backend list — if the
@@ -149,14 +152,25 @@ fn setup_section(config: &Config) -> String {
         for slot in cast.slots.values() {
             if let Ok(b) = config.resolve_backend(&slot.backend) {
                 if seen.insert(b.name.clone()) {
-                    let env = b.api_key_env.as_deref().unwrap_or("(none)");
-                    let file = b.api_key_file.as_deref().unwrap_or("(none)");
+                    // Name what's already declared (and why it's still missing), else
+                    // the kind's conventional env var — the line an operator can act on.
+                    let declared = match (&b.api_key_env, &b.api_key_file, &b.api_key_cmd) {
+                        (Some(env), _, _) => format!("declared env `{env}` is unset"),
+                        (None, Some(f), _) => format!("declared key file `{f}` is absent"),
+                        // A cmd-backed backend is always `key_status` Present (never
+                        // run to classify), so this arm renders only in a partial-setup
+                        // cast (some other slot's backend is Missing) — and the message
+                        // stays neutral: the command itself is fine, it just has not
+                        // run yet.
+                        (None, None, Some(_)) => "declared key command (runs on first use)".into(),
+                        (None, None, None) => {
+                            format!("declare `api_key_env = \"{}\"`", b.kind.env_var())
+                        }
+                    };
                     lines.push(format!(
-                        "  - backend `{}` ({}) — set env `{}`, or write the key to `{}`",
+                        "  - backend `{}` ({}) — {declared}",
                         b.name,
                         b.kind.canonical_name(),
-                        env,
-                        file
                     ));
                 }
             }
@@ -171,16 +185,16 @@ fn setup_section(config: &Config) -> String {
     format!(
         "## Setup needed — no model provider configured\n\
          kaibo's default cast `{cast}` has no usable API key, so `consult`/`oneshot` \
-         can't reach a model. `run_kaish` works now (read-only shell, no model) to \
-         browse the code meanwhile.\n\n\
-         Give the cast a key via an **environment variable** or **key file** — kaibo \
-         reads either at startup, kept out of the chat (set in your shell, never \
-         pasted here):\n\
+         can't reach a model — but `run_kaish` works now (read-only shell, no model) \
+         to browse the code meanwhile.\n\n\
+         Key sources are declared, never assumed: add one to config.toml — an env var \
+         name (`api_key_env`), a key file path (`api_key_file`), or a command that \
+         prints the key (`api_key_cmd`). The value lives outside the config, so the \
+         secret stays out of the chat (set it in your shell, never paste it here):\n\
          {backends}\n\n\
-         Then **reconnect the kaibo MCP server** so it re-reads the environment \
-         (Claude Code: `/mcp`; other hosts: their own reload). Prefer another \
-         provider? The annotated `kaibo://config/example` resource (→ \
-         `~/.config/kaibo/config.toml`) shows every backend and cast.",
+         Then **reconnect the kaibo MCP server** so it re-reads config and env \
+         (Claude Code: `/mcp`). `kaibo example-config` prints the template \
+         (`kaibo://config/example`).",
         cast = config.default_cast,
     )
 }
@@ -330,15 +344,16 @@ pub fn kaibo_instructions_with_scope(
         "{setup}{lead}\n\n\
          {casts}\
          ## Scope\n\
-         Read-only, always: kaibo never writes and cannot run external commands. A \
+         Read-only, always: kaibo never writes your project, and runs only the \
+         key-fetch command your config declares (`api_key_cmd`, stdin closed, never \
+         logged). A \
          per-call `path` must canonicalize to at-or-under one of these allowed \
          trees{worktree_note}:\n\n\
          {root_line}\n\
          - **Allowed trees:**\n\
          {allowed_lines}\n\n\
-         More without spending a turn: `kaibo://config` (full config — casts, backends, \
-         tools, limits), `kaibo://tools` (attachments, overrides, async), \
-         `kaibo://kaish/*` (shell idioms)."
+         More without spending a turn: `kaibo://config`, `kaibo://tools`, \
+         `kaibo://kaish/*`."
     )
 }
 

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -314,6 +314,12 @@ pub(crate) fn render_config_resource(
         /// unset/blank. The PATH, not its contents.
         #[serde(skip_serializing_if = "Option::is_none")]
         api_key_file: Option<String>,
+        /// The declared key command's argv (e.g. `["op", "read", "op://Vault/Item/Field"]`)
+        /// — the reference, not the value it prints. Rendered because it is a configured
+        /// source pointer like `api_key_env`/`api_key_file`; the command's stdout (the
+        /// actual key) never appears here.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        api_key_cmd: Option<Vec<String>>,
         /// True when a missing key falls back to a placeholder (keyless endpoint).
         key_optional: bool,
         request_timeout_secs: u64,
@@ -389,6 +395,7 @@ pub(crate) fn render_config_resource(
                 base_url,
                 api_key_env,
                 api_key_file,
+                api_key_cmd,
                 key_optional,
                 request_timeout,
                 data_collection,
@@ -405,6 +412,9 @@ pub(crate) fn render_config_resource(
                 // KEY SOURCE ONLY — env var name or file path, never the value.
                 api_key_env: api_key_env.clone(),
                 api_key_file: api_key_file.clone(),
+                // The command's argv is a source pointer too: the vault path it reads,
+                // not the key it prints.
+                api_key_cmd: api_key_cmd.clone(),
                 key_optional: *key_optional,
                 request_timeout_secs: request_timeout.as_secs(),
                 data_collection: (*kind == crate::credentials::ProviderKind::OpenRouter).then_some(
@@ -1405,7 +1415,21 @@ mod tests {
     /// slots rendered as "backend/id" carrying resolved caps.
     #[test]
     fn config_resource_renders_expected_fields() {
-        let config = Config::builtin();
+        // Declared-only key sources: give the built-in anthropic backend an env
+        // source and add a command-sourced backend, so the render's key-source
+        // promise (sources visible, values never) has something to render.
+        let config = Config::from_toml_str(
+            r#"
+            [backends.anthropic]
+            api_key_env = "ANTHROPIC_API_KEY"
+
+            [backends.vault]
+            kind = "openai"
+            base_url = "http://localhost:9/v1"
+            api_key_cmd = ["op", "read", "op://Vault/Kaibo/OpenAI-key"]
+            "#,
+        )
+        .unwrap();
         let allowed = vec![std::path::PathBuf::from("/tmp/test-allowed")];
         let body = render_config_resource(
             &config,
@@ -1478,11 +1502,16 @@ mod tests {
             deepseek_synth.contains("vision = false"),
             "deepseek slot carries resolved vision=false:\n{deepseek_synth}"
         );
-        // Key SOURCES (env var name / file path) must appear — operators configured
-        // them and need to see them for diagnostics.
+        // Key SOURCES (env var name / file path / command argv) must appear —
+        // operators configured them and need to see them for diagnostics. The
+        // rendered argv is a vault path, a pointer like the env var name, never a key.
         assert!(
             body.contains("ANTHROPIC_API_KEY"),
             "config resource must show key source env var names:\n{body}"
+        );
+        assert!(
+            body.contains("api_key_cmd") && body.contains("op://Vault/Kaibo/OpenAI-key"),
+            "config resource must show the declared key command's argv:\n{body}"
         );
         // Telemetry state is part of the resolved runtime: an operator must be able
         // to see whether kaibo is shipping spans off-box and to where.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4071,10 +4071,13 @@ model listing (the `list_models` tool, or `kaibo models` on the CLI) and set tha
 slot's `max_tokens` from the ceiling, because reasoning bills into the same completion \
 budget as the answer. Some providers publish no ceiling; there, look it up in the \
 provider's own model documentation.
-4. Keep secrets in the environment or a key file. A backend names an env var \
-(`api_key_env`) or a key-file path (`api_key_file`); the TOML carries the name or path, \
-the secret stays outside it. Tell me which env vars to set or files to write, and let \
-me put the keys in myself.
+4. Keep secrets out of the config. A backend stanza DECLARES a key source — an env \
+var name (`api_key_env`), a key-file path (`api_key_file`), or a command whose \
+stdout is the key (`api_key_cmd`, e.g. `[\"op\", \"read\", \"op://Vault/Item/Field\"]`) — \
+and kaibo seeds none of them, so nothing works until one is declared. The TOML \
+carries the name, path, or argv; the VALUE stays in the env, file, or vault (the \
+key command runs with stdin closed, a 30-second ceiling, and its output is never \
+logged). Tell me which sources to declare, and let me put the keys in myself.
 5. (Optional) Read scope. By default kaibo reads only the project tree (plus linked git \
 worktrees) and only ever *reads* it — never writes to your project. To let the team see \
 a scratch space — a \

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2468,13 +2468,15 @@ fn persistence_cli_wins_over_lower_layers() {
 
 // --- the dashscope kind --------------------------------------------------------
 
-/// The `dashscope` kind parses from TOML and seeds its OWN key sources —
-/// deliberately not shared with the `openai` completion kind, even though the same
-/// DashScope host serves text on an OpenAI-compatible route. An operator running
+/// The `dashscope` kind parses from TOML. Declared-only, like every other kind: the
+/// operator names `api_key_env`/`api_key_file`/`api_key_cmd` themselves — kaibo
+/// seeds nothing, not even DashScope's OWN conventional env var / key file names
+/// (deliberately not shared with the `openai` completion kind, even though the same
+/// DashScope host serves text on an OpenAI-compatible route — an operator running
 /// both wires against one account wants one credential name per account, not one per
-/// protocol. The key is required: this kind has no keyless target.
+/// protocol). The key is required: this kind has no keyless target.
 #[test]
-fn dashscope_backend_parses_and_seeds_its_own_key_sources() {
+fn dashscope_backend_parses_without_seeding_key_sources() {
     let c = Config::from_toml_str(
         r#"
         [backends.wan]
@@ -2484,14 +2486,10 @@ fn dashscope_backend_parses_and_seeds_its_own_key_sources() {
     .expect("the dashscope kind must parse");
     let b = c.backends.get("wan").expect("backend exists");
     assert_eq!(b.kind, kaibo::credentials::ProviderKind::DashScope);
-    assert_eq!(b.api_key_env.as_deref(), Some("DASHSCOPE_API_KEY"));
-    assert!(
-        b.api_key_file
-            .as_deref()
-            .is_some_and(|f| f.ends_with("/.dashscope-key")),
-        "the key file is DashScope's own, not the openai kind's, got: {:?}",
-        b.api_key_file
-    );
+    // Declared-only: a fresh media stanza declares its own source or fails loudly.
+    assert_eq!(b.api_key_env, None);
+    assert_eq!(b.api_key_file, None);
+    assert_eq!(b.api_key_cmd, None);
     assert!(
         !b.key_optional,
         "key_optional seeds FALSE — every DashScope endpoint is keyed"
@@ -2701,16 +2699,19 @@ fn no_otel_environment_leaves_telemetry_off() {
 
 // --- the gemini-images kind ------------------------------------------------------
 
-/// The `gemini-images` kind parses and **shares `gemini`'s key sources** — one Google
-/// credential per account, not one per use of the endpoint. That sharing is the
-/// difference from `dashscope`, which deliberately keeps its own: there the two wires
-/// are separate protocols against one host, whereas here they are literally the same
-/// endpoint asked for a different modality.
-///
-/// The key is required: the default target is Google's hosted service, so a keyless
-/// seed would 401 on the first paid call instead of failing at load.
+/// The `gemini-images` kind parses. Declared-only, like every other kind: kaibo
+/// seeds no key source, even though `gemini-images` **shares `gemini`'s conventional
+/// env var and key-file names** (`credentials::ProviderKind::env_var`/
+/// `key_file_name`) — one Google credential per account, not one per use of the
+/// endpoint, so an operator who declares `api_key_env = "GEMINI_API_KEY"` on both
+/// backends points them at the same key. That sharing is the difference from
+/// `dashscope`, which keeps its own conventional names: there the two wires are
+/// separate protocols against one host, whereas here they are literally the same
+/// endpoint asked for a different modality. The key is required: the default target
+/// is Google's hosted service, so a keyless seed would 401 on the first paid call
+/// instead of failing at load.
 #[test]
-fn gemini_images_backend_parses_and_shares_the_gemini_key_sources() {
+fn gemini_images_backend_parses_without_seeding_key_sources() {
     let c = Config::from_toml_str(
         r#"
         [backends.gimg]
@@ -2720,14 +2721,10 @@ fn gemini_images_backend_parses_and_shares_the_gemini_key_sources() {
     .expect("the gemini-images kind must parse");
     let b = c.backends.get("gimg").expect("backend exists");
     assert_eq!(b.kind, kaibo::credentials::ProviderKind::GeminiImages);
-    assert_eq!(b.api_key_env.as_deref(), Some("GEMINI_API_KEY"));
-    assert!(
-        b.api_key_file
-            .as_deref()
-            .is_some_and(|f| f.ends_with("/.gemini-api-key")),
-        "it shares the `gemini` key file rather than minting a second name, got: {:?}",
-        b.api_key_file
-    );
+    // Declared-only: a fresh media stanza declares its own source or fails loudly.
+    assert_eq!(b.api_key_env, None);
+    assert_eq!(b.api_key_file, None);
+    assert_eq!(b.api_key_cmd, None);
     assert!(
         !b.key_optional,
         "the default target is Google's hosted service, so the key is required"
@@ -2909,7 +2906,10 @@ fn declared_env_wins_over_the_cmd_without_running_it() {
 
     // Negative control: env absent → the command runs and its stdout is the key.
     let key = b.resolve_key_where(|_| None).expect("cmd source resolves");
-    assert_eq!(key, "cmd-key", "the stub prints 'cmd-key' in the no-env case");
+    assert_eq!(
+        key, "cmd-key",
+        "the stub prints 'cmd-key' in the no-env case"
+    );
     assert!(
         sentinel.exists(),
         "the no-env arm must actually run the command"

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1286,6 +1286,7 @@ fn local_backend(api_key_file: Option<String>, key_optional: bool) -> Backend {
         base_url: Some("http://localhost:1/v1".into()),
         api_key_env: Some("KAIBO_TEST_DEFINITELY_UNSET_KEY".into()),
         api_key_file,
+        api_key_cmd: None,
         key_optional,
         request_timeout: Duration::from_secs(900),
         data_collection: Default::default(),
@@ -1314,6 +1315,7 @@ fn key_optional_gemini_backend_resolves_to_an_empty_query_key() {
         base_url: Some("http://gateway.internal".into()),
         api_key_env: Some("KAIBO_TEST_DEFINITELY_UNSET_KEY".into()),
         api_key_file: None,
+        api_key_cmd: None,
         key_optional: true,
         request_timeout: Duration::from_secs(900),
         data_collection: Default::default(),
@@ -1362,6 +1364,7 @@ fn required_key_with_no_source_is_an_error() {
         base_url: None,
         api_key_env: Some("KAIBO_TEST_DEFINITELY_UNSET_KEY".into()),
         api_key_file: None,
+        api_key_cmd: None,
         key_optional: false,
         request_timeout: Duration::from_secs(900),
         data_collection: Default::default(),
@@ -1970,16 +1973,17 @@ fn an_image_slot_cannot_point_at_a_completion_backend() {
 
 // --- the openai-images kind ---------------------------------------------------
 
-/// The `openai-images` kind parses from TOML and seeds its defaults: the same key
-/// sources as the `openai` completion kind (`OPENAI_API_KEY` / `~/.openai-key`),
-/// but the key is REQUIRED. This kind's default endpoint is hosted OpenAI, so a
-/// keyless seed would let a minimal stanza load clean, staff `generate`, and then
-/// send `Bearer no-auth` to api.openai.com — a 401 on the first paid call instead
-/// of a loud config gap (the or-gpt cross-family review's posture reversal,
-/// 2026-08-03). A keyless local sd-server opts in with `key_optional = true`
-/// beside its explicit local `base_url`.
+/// The `openai-images` kind parses from TOML. Declared-only: it carries NO key
+/// source — the operator declares api_key_env / api_key_file / api_key_cmd (the
+/// `openai` completion kind's conventions are what they'd likely name, but kaibo
+/// seeds nothing) — and the key is REQUIRED by default: this kind's default endpoint
+/// is hosted OpenAI, so a keyless seed would let a minimal stanza load clean, staff
+/// `generate`, and then send `Bearer no-auth` to api.openai.com — a 401 on the
+/// first paid call instead of a loud config gap (the or-gpt cross-family review's
+/// posture reversal, 2026-08-03). A keyless local sd-server opts in with
+/// `key_optional = true` beside its explicit local `base_url`.
 #[test]
-fn openai_images_backend_parses_and_seeds_openai_key_sources() {
+fn openai_images_parses_without_seeding_key_sources() {
     let c = Config::from_toml_str(
         r#"
         [backends.imgs]
@@ -1989,14 +1993,10 @@ fn openai_images_backend_parses_and_seeds_openai_key_sources() {
     .expect("the openai-images kind must parse");
     let b = c.backends.get("imgs").expect("backend exists");
     assert_eq!(b.kind, kaibo::credentials::ProviderKind::OpenAiImages);
-    assert_eq!(b.api_key_env.as_deref(), Some("OPENAI_API_KEY"));
-    assert!(
-        b.api_key_file
-            .as_deref()
-            .is_some_and(|f| f.ends_with("/.openai-key")),
-        "the key file mirrors the openai completion kind's, got: {:?}",
-        b.api_key_file
-    );
+    // Declared-only: a fresh media stanza declares its own source or fails loudly.
+    assert_eq!(b.api_key_env, None);
+    assert_eq!(b.api_key_file, None);
+    assert_eq!(b.api_key_cmd, None);
     assert!(
         !b.key_optional,
         "key_optional seeds FALSE — the default endpoint is hosted, so a missing \
@@ -2774,4 +2774,240 @@ fn a_reasoning_slot_cannot_point_at_a_gemini_images_backend() {
             "the error names the slot, the kind, and its class, got: {msg}"
         );
     }
+}
+
+// --- api_key_cmd: the declared command source --------------------------------
+//
+// Load-time rules (XOR, empty argv, no expansion) and resolve-time behavior
+// (env wins without running it, cmd resolves on a keyless backend). The stub
+// scripts are invoked by absolute path, Unix-only.
+
+#[cfg(unix)]
+fn cmd_stub(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let p = dir.join(name);
+    std::fs::write(&p, format!("#!/bin/sh\n{body}\n")).unwrap();
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    p
+}
+
+/// A backend may declare a key file OR a key command — both is an ambiguity with
+/// no sensible precedence, refused at load (the operator picks; env still overrides).
+#[test]
+fn file_and_cmd_declared_together_is_a_load_error() {
+    let err = Config::from_toml_str(
+        r#"
+        [backends.vault]
+        kind = "anthropic"
+        api_key_file = "/some/key"
+        api_key_cmd = ["op", "read", "op://Vault/Item"]
+        "#,
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("api_key_file") && msg.contains("api_key_cmd"),
+        "the load error must name both declared sources, got: {msg}"
+    );
+}
+
+/// An empty argv names no executable — a typo, not an intent.
+#[test]
+fn an_empty_api_key_cmd_is_a_load_error() {
+    let err = Config::from_toml_str(
+        r#"
+        [backends.vault]
+        kind = "anthropic"
+        api_key_cmd = []
+        "#,
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("api_key_cmd") && msg.contains("executable"),
+        "the load error must name the field and the fix, got: {msg}"
+    );
+}
+
+/// Unlike `api_key_file`, a key command's argv is NEVER `$VAR`/`~`-expanded —
+/// no shell, no interpolation, by design. A literal `$HOME` stays literal.
+#[test]
+fn api_key_cmd_argv_is_not_var_expanded() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.vault]
+        kind = "anthropic"
+        api_key_cmd = ["$HOME/bin/op", "op://Vault/Item"]
+        "#,
+    )
+    .unwrap();
+    let b = c.resolve_backend("vault").unwrap();
+    assert_eq!(
+        b.api_key_cmd.as_deref(),
+        Some(&["$HOME/bin/op".to_string(), "op://Vault/Item".to_string()][..]),
+        "argv elements pass through load untouched — expansion is the command's own business"
+    );
+}
+
+/// `key_status` reads a declared command as Present WITHOUT running it — there is
+/// no cheap offline equivalent of `exists()` for a command, so a typo'd binary
+/// name passes classification and fails loudly at the first resolve instead.
+#[test]
+fn key_status_reads_a_declared_cmd_as_present_without_running_it() {
+    let b = Backend {
+        name: "vault".into(),
+        kind: ProviderKind::Anthropic,
+        base_url: None,
+        api_key_env: Some("KAIBO_TEST_DEFINITELY_UNSET_KEY".into()),
+        api_key_file: None,
+        api_key_cmd: Some(vec!["/nonexistent-kaibo-test/op".into()]),
+        key_optional: false,
+        request_timeout: Duration::from_secs(900),
+        data_collection: Default::default(),
+        wire: None,
+    };
+    assert_eq!(b.key_status(|_| None), kaibo::config::KeyStatus::Present);
+}
+
+/// The declared env source wins over the command WITHOUT running it — the
+/// sentinel oracle: the stub touches a file only if it runs, so "env key came
+/// back AND the sentinel is absent" proves the command never spawned. The
+/// no-env arm is the negative control (the command runs then).
+#[cfg(unix)]
+#[test]
+fn declared_env_wins_over_the_cmd_without_running_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let sentinel = dir.path().join("sentinel");
+    let stub = cmd_stub(
+        dir.path(),
+        "op-stub",
+        &format!("touch {}; printf 'cmd-key\\n'", sentinel.display()),
+    );
+    let b = Backend {
+        name: "vault".into(),
+        kind: ProviderKind::Anthropic,
+        base_url: None,
+        api_key_env: Some("KAIBO_TEST_CMD_ENV".into()),
+        api_key_file: None,
+        api_key_cmd: Some(vec![stub.to_string_lossy().into_owned()]),
+        key_optional: false,
+        request_timeout: Duration::from_secs(900),
+        data_collection: Default::default(),
+        wire: None,
+    };
+
+    // Env present: the injected lookup (the `resolve_key_where` seam, mirroring
+    // `key_status`'s) wins, and the command never spawns.
+    let key = b
+        .resolve_key_where(|n| (n == "KAIBO_TEST_CMD_ENV").then(|| "env-key".into()))
+        .expect("env source wins");
+    assert_eq!(key, "env-key");
+    assert!(
+        !sentinel.exists(),
+        "the command must not run when the env source resolves"
+    );
+
+    // Negative control: env absent → the command runs and its stdout is the key.
+    let key = b.resolve_key_where(|_| None).expect("cmd source resolves");
+    assert_eq!(key, "cmd-key", "the stub prints 'cmd-key' in the no-env case");
+    assert!(
+        sentinel.exists(),
+        "the no-env arm must actually run the command"
+    );
+}
+
+/// A keyless backend can pull a real key from a command: the cmd arm sits before
+/// the `key_optional` placeholder, so a declared command is used even when the
+/// backend would otherwise fall back to keyless.
+#[cfg(unix)]
+#[test]
+fn a_declared_key_cmd_resolves_even_on_a_key_optional_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    let stub = cmd_stub(dir.path(), "op-stub", "printf 'sk-local\\n'");
+    let b = Backend {
+        name: "local".into(),
+        kind: ProviderKind::Openai,
+        base_url: Some("http://localhost:1/v1".into()),
+        api_key_env: None,
+        api_key_file: None,
+        api_key_cmd: Some(vec![stub.to_string_lossy().into_owned()]),
+        key_optional: true,
+        request_timeout: Duration::from_secs(900),
+        data_collection: Default::default(),
+        wire: None,
+    };
+    let key = b.resolve_key().expect("cmd runs before the placeholder");
+    assert_eq!(key, "sk-local");
+}
+
+/// The stream-isolation property at the binary level (the plan's MCP-stdio test):
+/// a key command's stdout is captured AS THE KEY, never inherited into kaibo's own
+/// stdout — which, in an MCP server, IS the protocol stream. The stub prints a
+/// marker key; a real `oneshot` against a dead endpoint resolves the key (the
+/// command runs), then fails on the transport — so a leaked child stdout would put
+/// LEAK-KEY-123 in kaibo's stdout, and its absence alongside a transport failure
+/// proves the pin. Child env is rebuilt from scratch (blank-env discipline); the
+/// stub runs by absolute path, so no PATH is needed.
+#[cfg(unix)]
+#[test]
+fn a_key_commands_stdout_never_reaches_kaibos_own_stdout() {
+    let xdg = tempfile::tempdir().unwrap();
+    let home = xdg.path().join("home");
+    let config_home = xdg.path().join("config");
+    std::fs::create_dir_all(config_home.join("kaibo")).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+
+    let stub = xdg.path().join("op-stub");
+    std::fs::write(&stub, "#!/bin/sh\nprintf 'LEAK-KEY-123\\n'\n").unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    std::fs::write(
+        config_home.join("kaibo/config.toml"),
+        format!(
+            "[backends.vault]\nkind = \"openai\"\nbase_url = \"http://127.0.0.1:1/v1\"\napi_key_cmd = [\"{}\"]\n\n[casts.vault-cast]\nsynth = \"vault/deepseek-v4-flash\"\n",
+            stub.display()
+        ),
+    )
+    .unwrap();
+
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"p\"\n",
+    )
+    .unwrap();
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_kaibo"))
+        .env_clear()
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_STATE_HOME", xdg.path().join("state"))
+        .env("XDG_DATA_HOME", xdg.path().join("data"))
+        .args([
+            "--root",
+            project.path().to_str().unwrap(),
+            "oneshot",
+            "--cast",
+            "vault-cast",
+            "hi",
+        ])
+        .output()
+        .expect("spawn the kaibo binary");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stdout.contains("LEAK-KEY-123"),
+        "the key command's stdout must be captured, not inherited into kaibo's own \
+         stdout:\n{stdout}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("refused")
+            || stderr.to_lowercase().contains("failed")
+            || stderr.to_lowercase().contains("error"),
+        "the run must fail on the dead transport AFTER resolving the key (proving the \
+         command ran):\n{stderr}"
+    );
 }

--- a/tests/credentials.rs
+++ b/tests/credentials.rs
@@ -325,7 +325,8 @@ fn key_command_nonzero_exit_is_loud_and_never_leaks_stdout_or_stderr() {
     );
 }
 
-#[cfg(unix)]
+// Not gated `#[cfg(unix)]` like its neighbors: the empty-argv guard returns before
+// `Command` is ever touched, so it needs no shell stub and runs on every platform.
 #[test]
 fn key_command_empty_argv_is_a_loud_error_not_a_panic() {
     let err = resolve_key_from_cmd(&[], Duration::from_secs(5), &[]).unwrap_err();

--- a/tests/credentials.rs
+++ b/tests/credentials.rs
@@ -174,3 +174,207 @@ fn provider_paths_match_amys_dotfiles() {
     );
     assert_eq!(ProviderKind::Openai.key_file(home), home.join(".openai-key"));
 }
+
+// --- api_key_cmd: the operator-declared command source -----------------------
+//
+// The exec core (`resolve_key_from_cmd`) is exercised with `#!/bin/sh` stubs,
+// invoked by ABSOLUTE PATH (no PATH dependence, no child-env rebuild) in temp
+// dirs. Unix-only: a stub needs a shell at the executable.
+//
+// The blank-env discipline: the child inherits the test process env, but nothing
+// below depends on what that env contains — a stub reads only what it is given
+// (its own argv, `extra_env`). `extra_env` is the seam a unit test uses instead
+// of mutating the process environment.
+
+use kaibo::credentials::resolve_key_from_cmd;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+static STUB_SEQ: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(unix)]
+fn stub_script(dir: &Path, body: &str, exit: i32) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let seq = STUB_SEQ.fetch_add(1, Ordering::Relaxed);
+    let p = dir.join(format!("stub-{seq}"));
+    fs::write(&p, format!("#!/bin/sh\n{body}\nexit {exit}\n")).unwrap();
+    fs::set_permissions(&p, fs::Permissions::from_mode(0o755)).unwrap();
+    p
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_stdout_trimmed_is_the_key() {
+    let dir = tempdir().unwrap();
+    let p = stub_script(dir.path(), "printf 'sk-test\\n\\n'", 0);
+    let args = vec![p.to_string_lossy().into_owned()];
+    let key = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap();
+    assert_eq!(key, "sk-test", "stdout is trimmed like a key file's contents");
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_inherits_env_and_receives_argv() {
+    // `extra_env` is the test seam for what a real child sees inherited (HOME,
+    // OP_SERVICE_ACCOUNT_TOKEN); later argv elements pass through verbatim.
+    // Note: this proves the INJECTION seam, not raw process-env inheritance —
+    // `Command::new` inherits by default and nothing on this path calls
+    // `env_clear`, but asserting the ambient env would need a process-env
+    // mutation, which the blank-env discipline forbids (see stability.rs).
+    let dir = tempdir().unwrap();
+    let p = stub_script(dir.path(), "echo \"$KAIBO_STUB_VAR $1\"", 0);
+    let args = vec![p.to_string_lossy().into_owned(), "op://Vault/Item".into()];
+    let key = resolve_key_from_cmd(&args, Duration::from_secs(5), &[("KAIBO_STUB_VAR", "inherited")])
+        .unwrap();
+    assert_eq!(key, "inherited op://Vault/Item");
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_empty_stdout_is_loud() {
+    let dir = tempdir().unwrap();
+    let p = stub_script(dir.path(), ":", 0); // prints nothing, exits 0
+    let args = vec![p.to_string_lossy().into_owned()];
+    let err = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap_err();
+    assert!(
+        err.to_string().contains("printed nothing"),
+        "an empty stdout is a broken command, not a keyless backend: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_non_utf8_stdout_is_loud() {
+    let dir = tempdir().unwrap();
+    let p = stub_script(dir.path(), "printf '\\377'", 0); // invalid UTF-8
+    let args = vec![p.to_string_lossy().into_owned()];
+    let err = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap_err();
+    assert!(
+        err.to_string().contains("non-UTF-8"),
+        "binary output must be surfaced, not mangled into a key: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_oversized_stdout_is_refused_not_trimmed() {
+    let dir = tempdir().unwrap();
+    // 70 KiB of output: past the 64 KiB cap, and past the pipe buffer, so this
+    // also proves the reader drains a verbose child instead of wedging it.
+    let p = stub_script(dir.path(), "head -c 70000 /dev/zero", 0);
+    let args = vec![p.to_string_lossy().into_owned()];
+    let err = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap_err();
+    assert!(
+        err.to_string().contains("more than 65536 bytes"),
+        "refuse, not trim: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_nonzero_exit_is_loud_and_never_leaks_stdout() {
+    let dir = tempdir().unwrap();
+    // The child says something secret on stdout and its diagnosis on stderr: the
+    // error carries the stderr tail (the operator can act on "Vault is locked")
+    // and NEVER the stdout (a broken command may print anything there).
+    let p = stub_script(
+        dir.path(),
+        "printf 'TOP-SECRET-KEY-MATERIAL\\n'; echo 'Vault is locked' >&2",
+        3,
+    );
+    let args = vec![p.to_string_lossy().into_owned()];
+    let err = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("exited"), "must name the failure: {msg}");
+    assert!(
+        msg.contains("Vault is locked"),
+        "stderr tail reaches the failure error: {msg}"
+    );
+    assert!(
+        !msg.contains("TOP-SECRET-KEY-MATERIAL"),
+        "stdout must never appear in an error: {msg}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_missing_binary_is_loud() {
+    let args = vec!["/nonexistent-kaibo-test/op".to_string()];
+    let err = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap_err();
+    assert!(
+        err.to_string().contains("spawning key command"),
+        "a typo'd binary name fails at resolve, not silently: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_timeout_kills_a_hung_child() {
+    let dir = tempdir().unwrap();
+    let p = stub_script(dir.path(), "sleep 60", 0); // would hang forever
+    let args = vec![p.to_string_lossy().into_owned()];
+    let err = resolve_key_from_cmd(&args, Duration::from_millis(200), &[]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("did not exit within") && msg.contains("killed"),
+        "a hung command is killed and named, not left to wedge resolution: {msg}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_stdin_is_nulled() {
+    // The child's read sees immediate EOF (stdin is closed, not inherited) AND
+    // its fd 0 is the null device — the two checks cover each other's blind
+    // spots: on a runner whose own stdin is /dev/null the EOF check alone would
+    // pass even if the pin were removed, and a char-device check alone would
+    // pass on a TTY-backed runner. The MCP-stream property itself (the child
+    // must never read kaibo's protocol stdin) is structurally pinned by
+    // `Stdio::null()` in `resolve_key_from_cmd`.
+    let dir = tempdir().unwrap();
+    let p = stub_script(
+        dir.path(),
+        "if [ -c /dev/stdin ] && ! read -r x; then echo null-stdin; else \
+         echo got-stdin; fi",
+        0,
+    );
+    let args = vec![p.to_string_lossy().into_owned()];
+    let key = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap();
+    assert_eq!(key, "null-stdin", "stdin must be closed, not inherited");
+}
+
+/// The concurrency property the async design leans on, codified: key resolution
+/// on a multi-thread tokio runtime must not stall a sibling task — kaibo runs
+/// `#[tokio::main]` and its whole client-construction chain is sync, so a bounded
+/// (≤30s) blocking resolve occupies one worker while others keep serving. A
+/// sleeping key command (350 ms) plus a ticker that must fire mid-sleep proves it;
+/// this test turns red the day the runtime flavor changes to single-threaded or
+/// the resolution path stops being safely blockable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_blocking_key_resolve_does_not_stall_a_sibling_task() {
+    let dir = tempdir().unwrap();
+    let p = stub_script(dir.path(), "sleep 1", 0);
+    let args = vec![p.to_string_lossy().into_owned()];
+
+    let ticker = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_millis(50));
+        let mut ticks = 0u32;
+        for _ in 0..12 {
+            interval.tick().await;
+            ticks += 1;
+        }
+        ticks
+    });
+    let key = resolve_key_from_cmd(&args, Duration::from_millis(300), &[]).unwrap_err();
+    assert!(
+        key.to_string().contains("did not exit within"),
+        "the resolve must time out on the sleeping stub: {key}"
+    );
+    let ticks = ticker.await.expect("ticker task completes");
+    assert!(
+        ticks >= 2,
+        "a sibling task must keep progressing while the key command blocks \
+         (got {ticks} ticks in ~300ms)"
+    );
+}

--- a/tests/credentials.rs
+++ b/tests/credentials.rs
@@ -63,7 +63,9 @@ fn empty_file_is_an_error_not_an_empty_key() {
 fn openai_parses_from_friendly_aliases() {
     // Canonical "openai", plus the names people reach for when it points at the
     // local keyless default (Gemma served by Lemonade).
-    for s in ["openai", "OpenAI", "local", "lemonade", "  GEMMA ", "gemma4"] {
+    for s in [
+        "openai", "OpenAI", "local", "lemonade", "  GEMMA ", "gemma4",
+    ] {
         assert_eq!(
             ProviderKind::from_str(s).unwrap(),
             ProviderKind::Openai,
@@ -166,13 +168,22 @@ fn provider_paths_match_amys_dotfiles() {
         ProviderKind::Anthropic.key_file(home),
         home.join(".anthropic-key.txt")
     );
-    assert_eq!(ProviderKind::DeepSeek.key_file(home), home.join(".deepseek-key"));
-    assert_eq!(ProviderKind::Gemini.key_file(home), home.join(".gemini-api-key"));
+    assert_eq!(
+        ProviderKind::DeepSeek.key_file(home),
+        home.join(".deepseek-key")
+    );
+    assert_eq!(
+        ProviderKind::Gemini.key_file(home),
+        home.join(".gemini-api-key")
+    );
     assert_eq!(
         ProviderKind::OpenRouter.key_file(home),
         home.join(".openrouter-key")
     );
-    assert_eq!(ProviderKind::Openai.key_file(home), home.join(".openai-key"));
+    assert_eq!(
+        ProviderKind::Openai.key_file(home),
+        home.join(".openai-key")
+    );
 }
 
 // --- api_key_cmd: the operator-declared command source -----------------------
@@ -210,7 +221,10 @@ fn key_command_stdout_trimmed_is_the_key() {
     let p = stub_script(dir.path(), "printf 'sk-test\\n\\n'", 0);
     let args = vec![p.to_string_lossy().into_owned()];
     let key = resolve_key_from_cmd(&args, Duration::from_secs(5), &[]).unwrap();
-    assert_eq!(key, "sk-test", "stdout is trimmed like a key file's contents");
+    assert_eq!(
+        key, "sk-test",
+        "stdout is trimmed like a key file's contents"
+    );
 }
 
 #[cfg(unix)]
@@ -225,8 +239,12 @@ fn key_command_inherits_env_and_receives_argv() {
     let dir = tempdir().unwrap();
     let p = stub_script(dir.path(), "echo \"$KAIBO_STUB_VAR $1\"", 0);
     let args = vec![p.to_string_lossy().into_owned(), "op://Vault/Item".into()];
-    let key = resolve_key_from_cmd(&args, Duration::from_secs(5), &[("KAIBO_STUB_VAR", "inherited")])
-        .unwrap();
+    let key = resolve_key_from_cmd(
+        &args,
+        Duration::from_secs(5),
+        &[("KAIBO_STUB_VAR", "inherited")],
+    )
+    .unwrap();
     assert_eq!(key, "inherited op://Vault/Item");
 }
 
@@ -273,11 +291,13 @@ fn key_command_oversized_stdout_is_refused_not_trimmed() {
 
 #[cfg(unix)]
 #[test]
-fn key_command_nonzero_exit_is_loud_and_never_leaks_stdout() {
+fn key_command_nonzero_exit_is_loud_and_never_leaks_stdout_or_stderr() {
     let dir = tempdir().unwrap();
-    // The child says something secret on stdout and its diagnosis on stderr: the
-    // error carries the stderr tail (the operator can act on "Vault is locked")
-    // and NEVER the stdout (a broken command may print anything there).
+    // The child says something secret on stdout, and something that COULD be a
+    // secret on stderr too (a wrapper traced with `set -x` prints exactly this
+    // shape): the error names the exit status and a stderr byte count, and NEVER
+    // quotes either stream's content — stdout because a broken command may print
+    // anything there, stderr because it can carry the secret as easily as stdout.
     let p = stub_script(
         dir.path(),
         "printf 'TOP-SECRET-KEY-MATERIAL\\n'; echo 'Vault is locked' >&2",
@@ -288,12 +308,30 @@ fn key_command_nonzero_exit_is_loud_and_never_leaks_stdout() {
     let msg = err.to_string();
     assert!(msg.contains("exited"), "must name the failure: {msg}");
     assert!(
-        msg.contains("Vault is locked"),
-        "stderr tail reaches the failure error: {msg}"
+        msg.contains("suppressed"),
+        "must say stderr was suppressed rather than shown: {msg}"
+    );
+    assert!(
+        msg.contains("bytes on stderr"),
+        "a bounded, safe summary (a byte count) stands in for stderr's content: {msg}"
+    );
+    assert!(
+        !msg.contains("Vault is locked"),
+        "stderr's content must never reach the error — it can carry the secret itself: {msg}"
     );
     assert!(
         !msg.contains("TOP-SECRET-KEY-MATERIAL"),
         "stdout must never appear in an error: {msg}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn key_command_empty_argv_is_a_loud_error_not_a_panic() {
+    let err = resolve_key_from_cmd(&[], Duration::from_secs(5), &[]).unwrap_err();
+    assert!(
+        err.to_string().contains("api_key_cmd") && err.to_string().contains("executable"),
+        "an empty argv is a config error naming the field and the fix, not a panic: {err}"
     );
 }
 

--- a/tests/mcp_stdio.rs
+++ b/tests/mcp_stdio.rs
@@ -130,7 +130,9 @@ impl Server {
             tokio::process::Command::new(env!("CARGO_BIN_EXE_kaibo")).configure(|cmd| {
                 // Clear first: the developer's provider keys and `KAIBO_*` overrides would
                 // otherwise decide which tools get advertised. kaibo runs no external
-                // command, so it needs nothing else from the environment.
+                // command except a config-declared `api_key_cmd`, which these tests name
+                // by absolute path (PATH is not rebuilt here), so nothing else from the
+                // environment is needed.
                 cmd.env_clear()
                     .env("HOME", &home)
                     .env("XDG_CONFIG_HOME", &config_home)


### PR DESCRIPTION
## Summary

- **`api_key_cmd`** — a backend's key can come from a command whose trimmed stdout is the key (`["op", "read", "op://Vault/Item/Field"]`): raw argv, no shell, stdin closed (a child must never read the MCP stdio stream), 64 KiB refuse-not-trim, strict UTF-8, stderr shown only on failure, 30s timeout-kill, output never logged.
- **Key sources are declared, never seeded** (Amy's ruling this session) — the built-ins no longer read `ANTHROPIC_API_KEY` / `~/.anthropic-key.txt` out of the box; an operator names `api_key_env` / `api_key_file` / `api_key_cmd` once in config.toml, and file + cmd together is a load error naming both.
- **Invariant carve-out** — AGENTS.md's "cannot run external commands" sentence now names the one config-declared operator-side key fetch; the model-facing sandbox levers are untouched and the exec path is unreachable from it.
- Setup guidance, `config.example.toml`, `config.md`, README (incl. the Docker stanza), and CHANGELOG rewritten for declared-only; the resident instructions stay under the 2048-char budget.

## Test plan

- ~22 new tests, sabotage-checked: exec contract (trim, empty/non-UTF-8/64KiB/nonzero/missing/timeout-kill), stdin-null, sentinel oracle (env wins without running the command), post-merge XOR + empty-argv load errors, `$VAR` non-expansion, `key_status` Present-without-run, Arm-path, binary-level stream isolation (a marker key never reaches kaibo's own stdout), and a codified concurrency test for sync resolution on the multi-thread runtime.
- Full `cargo test` green (an earlier draft of this body excused two `tests/attach.rs` failures; on the rebased tree all 10 attach tests pass, so the excuse is retired). Clippy `--all-targets` clean.

## Reviews

- **GLM 5.2 (zai/GLM-5.2 via Crusoe)** did both cross-family reviews: the rev-1 design review (its findings shaped the plan — seed-collision root fix, timeout test seam, stdio-isolation, post-overlay XOR, sentinel oracle) and the rev-2 implementation review over the full diff (found one garbled doc sentence and a dead `setup_section` arm — both fixed — plus three test-strength upgrades, all in).
- **Trial run**: this PR is being driven end-to-end by **ds4 flash (DeepSeek V4 Flash)** as the working agent — first full PR under that model; flag anything that smells different from the usual arc.


💘 Generated with Crush
