### PR TITLE
feat(dashscope): generate images on Alibaba's wan family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+### Added
+
+- **`kind = "dashscope"`** — a media backend for Alibaba's wan image family, so
+  `generate` can run on a DashScope subscription.
+
+### Changed
+
+- **kaibo now fetches a generated artifact's URL when that is how a provider delivers
+  it**, over TLS and size-bounded, instead of refusing it — otherwise the operator
+  fetches the link by hand with their key.
+
 ### Fixed
 
 - **Bump `kaish-kernel` to 0.14.1** — the explorer's shell no longer drops piped or

--- a/README.md
+++ b/README.md
@@ -517,7 +517,8 @@ config has three concepts for configuring models:
 
 - **backend** — a *connection*: which wire protocol (the completion kinds `anthropic`
   | `deepseek` | `gemini` | `openrouter` | `openai`, or the media kinds `stability` |
-  `openai-images` behind the `image` role), base URL, and where its key comes from.
+  `openai-images` | `dashscope` behind the `image` role), base URL, and where its key
+  comes from.
   Secrets never live in the TOML — only the *name* of an env var or the path to a key
   file. `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every
   major model family, reasoning on by default via its unified `effort` param.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -358,7 +358,7 @@ scratch_limit_bytes = 67108864
 # ---------------------------------------------------------------------------
 # [backends.<name>] — CONNECTIONS only: `kind` picks the wire and its client. The
 # completion wires (anthropic | deepseek | gemini | openrouter | openai) serve the
-# reasoning slots; the media kinds (stability | openai-images) serve `image` slots
+# reasoning slots; the media kinds (stability | openai-images | dashscope) serve `image` slots
 # only. The rest describes the wire (endpoint, key source, per-request deadline).
 # Models live on cast slots, never here.
 #
@@ -368,7 +368,8 @@ scratch_limit_bytes = 67108864
 # (required for a new backend), the anthropic and gemini kinds (optional —
 # unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com),
 # and the media kinds (optional — unset dials api.stability.ai for stability,
-# api.openai.com/v1 for openai-images); set it to point the same wire at a
+# api.openai.com/v1 for openai-images, dashscope-intl.aliyuncs.com for dashscope);
+# set it to point the same wire at a
 # compatible gateway/proxy (or a local server) instead — a ROOT in every case,
 # since the client appends its own path. Every other keyed kind rejects
 # base_url at load (rig fixes those endpoints).
@@ -483,7 +484,7 @@ wire = "responses"
 # `deep-dive`) so it can route by name without reading this file.
 #
 # Roles: explorer, synth (the reasoning phases), and image (the media member — it
-# points at a media backend, kind stability or openai-images, and staffs `generate`;
+# points at a media backend, kind stability, openai-images, or dashscope, and staffs `generate`;
 # see the image-slot examples below). A typo'd role is a loud load
 # error. A cast may omit roles — the tool that needs a missing role fails at call time,
 # naming the gap ("cast `notes` has no synth slot"); absent = capability absent.
@@ -536,7 +537,7 @@ explorer = "llama/qwen2.5-coder-7b"                              # bare ref: jus
 synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 # --- The `image` slot: a MEDIA member on the team. It points at a media backend
-#     (kind = "stability" or "openai-images") and produces artifacts instead of
+#     (kind = "stability", "openai-images", or "dashscope") and produces artifacts instead of
 #     text, so the reasoning tunables (effort, thinking_budget, temperature, ...)
 #     do not apply to it — writing one there is inert and kaibo://config flags it.
 #     A cast carries it beside its reasoning slots; a cast without one cannot staff
@@ -574,6 +575,26 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 # [casts.local-artist]
 # image = "sdcpp/sd3.5-large"             # whatever the local server loaded
+
+# --- The dashscope kind reaches Alibaba's wan image family. base_url is optional
+#     (unset dials dashscope-intl.aliyuncs.com); a dedicated-endpoint subscription
+#     sets its own host. Either way it is a ROOT — kaibo appends the route.
+#     Media-only on purpose: the same DashScope host serves TEXT on an
+#     OpenAI-compatible endpoint, so a qwen or deepseek model there belongs on a
+#     kind = "openai" backend pointed at <host>/compatible-mode/v1, beside this one.
+#     Provider knobs (n, size, seed, negative_prompt, ...) ride the `generate` tool's
+#     fields; n is 1..4, and size is "W*H" whose total pixels must land between
+#     589824 and 2073600. DashScope delivers artifacts as presigned links rather
+#     than inline bytes, so kaibo fetches each over TLS and stores the bytes; the
+#     mime comes from that response, and a type the media store cannot name is
+#     refused rather than guessed. ---
+
+# [backends.wan]
+# kind = "dashscope"              # key: DASHSCOPE_API_KEY / ~/.dashscope-key
+# base_url = "https://ws-<id>.us-east-1.maas.aliyuncs.com"   # dedicated endpoint
+
+# [casts.wan-artist]
+# image = "wan/wan2.6-t2i"        # the request's `model` field
 
 # --- The table form, part 2: per-slot tunables. Each overrides its [defaults]
 #     per-role value for THIS slot only; knobs you omit fall back. Available:

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,7 +20,7 @@ of backends and casts. A missing file at the default path is not an error.
 
 ```
 ProviderKind = anthropic | deepseek | gemini | openrouter | openai   (completion wires)
-             | stability | openai-images                             (media kinds)
+             | stability | openai-images | dashscope                 (media kinds)
 Backend      = { name, kind, base_url?, key source, request_timeout }
 Cast         = { name, role → ModelSlot }                  (freely spans backends)
 ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
@@ -32,12 +32,12 @@ Each concept owns one idea:
   selects the client and the request shape), `base_url`, a key source, and
   `request_timeout`. Answers "how do I reach Gemini". Kinds divide into two classes:
   the completion wires (everything through rig's completion clients) and the media
-  kinds (`stability`, `openai-images` — image-generation APIs with no completion
-  surface).
+  kinds (`stability`, `openai-images`, `dashscope` — image-generation APIs with no
+  completion surface).
 - **role** — a *job* a model serves. Three exist: `explorer` and `synth`, the two
   reasoning phases, and `image`, the media member that staffs the `generate` tool.
   A reasoning role takes a completion backend; the `image` role takes a media backend
-  (kind `stability` or `openai-images`) — pairing either with the wrong class is a
+  (kind `stability`, `openai-images`, or `dashscope`) — pairing either with the wrong class is a
   load error naming the fix. Image *input* is a slot capability (the `vision` pin on
   a reasoning slot), not a role.
 - **cast** — a *composition*. A named assignment of models to roles. This is what the
@@ -54,7 +54,7 @@ Connection settings only. Models are never declared here.
 
 | key | type | default | notes |
 |---|---|---|---|
-| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` | required on a new backend | closed enum; selects client + request shape (`stability` and `openai-images` are the media kinds — image slots only) |
+| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` \| `dashscope` | required on a new backend | closed enum; selects client + request shape (`stability`, `openai-images`, and `dashscope` are the media kinds — image slots only) |
 | `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini` and the media kinds; load error elsewhere |
 | `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
 | `api_key_env` | env var *name* | seeded from `kind` | env source, checked first |
@@ -94,6 +94,18 @@ by re-declaration.
   `key_optional = true` beside its local `base_url`. The `generate` tool's
   `output_format` field for this kind must be `png`, `jpeg`, or `webp` — checked
   before the call, since it names the stored artifact's on-disk format.
+- **`kind = "dashscope"`** — optional. Unset dials DashScope's shared international
+  root (`https://dashscope-intl.aliyuncs.com`); a dedicated-endpoint subscription
+  sets its own host. Give it a bare host, not a path — the client appends the
+  multimodal-generation route. The key is required, from its own sources
+  (`DASHSCOPE_API_KEY` / `~/.dashscope-key`, not shared with the `openai` kind):
+  every DashScope endpoint is keyed, and one credential name per account beats one
+  per protocol when the same host also serves text. This kind is **media-only** — a
+  qwen or deepseek model on a DashScope host belongs on a `kind = "openai"` backend
+  pointed at `<host>/compatible-mode/v1`, configured beside this one. DashScope
+  returns artifacts as presigned links, so kaibo fetches each over TLS and stores
+  the bytes; the artifact's mime is the fetch response's `Content-Type`, and one the
+  media store cannot name is refused rather than guessed.
 - **Every other kind** — a load error. rig fixes those endpoints.
 
 The value is a root the client versions itself, never a full endpoint path. rig's
@@ -101,7 +113,8 @@ The value is a root the client versions itself, never a full endpoint path. rig'
 the batch lane's `GeminiBatch` versions a configured host root with `/v1beta` the
 same way, and the media clients append their own route (`/v2beta/...` for
 `stability`; `/images/generations` for `openai-images`, so give that one a URL
-through `/v1`).
+through `/v1`; the multimodal-generation route for `dashscope`, so give that one a
+bare host).
 
 #### `wire`
 
@@ -215,7 +228,8 @@ per-slot key, is a load error rather than a silent no-op. The `image` slot is th
 media member: it points at a media-kind backend and staffs the `generate` tool. Its
 model id means what that kind says it means — for `stability` it picks the route
 (`core`, `ultra`, or an SD3.5 variant); for `openai-images` it is the `model` field
-(`gpt-image-1` hosted, or whatever a local sd-server loaded). It sends one
+(`gpt-image-1` hosted, or whatever a local sd-server loaded); for `dashscope` it is
+the `model` field too (`wan2.6-t2i`). It sends one
 generation request, not a reasoning loop, so the reasoning tunables (`effort`,
 `thinking_budget`, `temperature`, ...) written on it are inert — `kaibo://config`
 flags them under `inert_tunables`.
@@ -664,7 +678,7 @@ Which cast shape staffs which tool:
 | `explore` | a cast with an `explorer` slot |
 | `batch_submit` | a cast whose synth runs on `lane = "batch"` (or the `batch = true` sugar) |
 | `deliberate` | a cast with an `explorer` **and** an offline synth (`lane = "batch"` or `lane = "direct"`) |
-| `generate` | a cast with an `image` slot (a media backend: kind `stability` or `openai-images`) — plus `[cas]` on |
+| `generate` | a cast with an `image` slot (a media backend: kind `stability`, `openai-images`, or `dashscope`) — plus `[cas]` on |
 | `job_get`, `job_cancel`, `job_list`, `job_wait` | at least one live handle *producer*; they follow whatever survives above |
 | `run_kaish`, `list_models` | no cast at all; advertised whenever their flag is on |
 

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -1409,3 +1409,121 @@ fn normalize(p: &Path) -> PathBuf {
     }
     out
 }
+
+// --- Fetching artifact bytes -------------------------------------------------
+
+/// The ceiling on one fetched artifact, in bytes. A generated image is single-digit
+/// megabytes (a 1280×1280 PNG measured 1.9 MiB), so this leaves generous headroom
+/// while keeping a wrong or hostile `Content-Length` from being answered with
+/// unbounded memory. Enforced twice: against the declared length before any body is
+/// read, and against the running total while it is.
+pub const MAX_FETCH_BYTES: usize = 1 << 26;
+
+/// Everything that can go wrong fetching an artifact into the CAS.
+#[derive(Debug, thiserror::Error)]
+pub enum FetchError {
+    /// The URL is not `https`. kaibo fetches artifacts over TLS only — a provider
+    /// handing back a plaintext link is a provider to fix, not a body to trust.
+    #[error(
+        "artifact URL must use https, but {0} does not — kaibo fetches generated \
+         artifacts over TLS only"
+    )]
+    NotHttps(String),
+    /// The request never completed (DNS, connect, TLS, timeout, dropped body).
+    #[error("fetching the generated artifact failed: {0}")]
+    Transport(String),
+    /// A non-2xx. A presigned link that has expired lands here, which is why the
+    /// status is named: it is the difference between "retry the generation" and
+    /// "something is wrong with the account".
+    #[error(
+        "fetching the generated artifact returned {status} — a presigned artifact link \
+         is short-lived, so generate again rather than reusing an old address"
+    )]
+    Status { status: u16 },
+    /// The artifact is larger than [`MAX_FETCH_BYTES`].
+    #[error(
+        "the generated artifact is {size} bytes, over kaibo's {limit}-byte ceiling for \
+         one artifact — ask the provider for a smaller size"
+    )]
+    TooLarge { size: usize, limit: usize },
+    /// A 2xx that carried no body. Never stored: an empty object would take a real
+    /// digest and read back as a valid, empty artifact.
+    #[error(
+        "the generated artifact came back empty — zero bytes is never treated as a \
+         successful generation"
+    )]
+    Empty,
+}
+
+/// Fetch one generated artifact's bytes over TLS, bounded by `timeout` and
+/// [`MAX_FETCH_BYTES`]. Returns the bytes and the response's `Content-Type` when it
+/// sent one, so a caller can prefer the server's own spelling over its guess.
+///
+/// **Why the CAS owns this.** kaibo's other media providers hand back inline bytes,
+/// and for a long time kaibo refused artifact URLs outright. DashScope only delivers
+/// presigned links, and a content-addressed store cannot address what it has not
+/// read: the digest *is* the address, so bytes are not a convenience here, they are
+/// the artifact's existence condition. Fetching one is the same kind of act as any
+/// other provider round trip — the address arrives inside an authenticated response
+/// to a request kaibo just made, so it is no more caller-chosen than the bytes would
+/// have been. It lives beside the store rather than inside one provider so the next
+/// URL-delivering provider reuses the bound and the refusals instead of restating
+/// them.
+///
+/// This does not write: it returns bytes for [`MediaStore::put`] to store under their
+/// hash, so the store stays the one place an object is created.
+pub async fn fetch_artifact_bytes(
+    url: &str,
+    timeout: std::time::Duration,
+) -> std::result::Result<(Vec<u8>, Option<String>), FetchError> {
+    if !url.starts_with("https://") {
+        return Err(FetchError::NotHttps(url.to_string()));
+    }
+    let client =
+        crate::tls::https_client(timeout).map_err(|e| FetchError::Transport(e.to_string()))?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| FetchError::Transport(e.to_string()))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(FetchError::Status {
+            status: status.as_u16(),
+        });
+    }
+    // Refuse an oversized artifact before reading a byte of it, when the server says
+    // how big it is. The running check below is what holds when it does not.
+    if let Some(declared) = response.content_length() {
+        if declared > MAX_FETCH_BYTES as u64 {
+            return Err(FetchError::TooLarge {
+                size: declared as usize,
+                limit: MAX_FETCH_BYTES,
+            });
+        }
+    }
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let mut response = response;
+    let mut bytes: Vec<u8> = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| FetchError::Transport(e.to_string()))?
+    {
+        if bytes.len() + chunk.len() > MAX_FETCH_BYTES {
+            return Err(FetchError::TooLarge {
+                size: bytes.len() + chunk.len(),
+                limit: MAX_FETCH_BYTES,
+            });
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    if bytes.is_empty() {
+        return Err(FetchError::Empty);
+    }
+    Ok((bytes, content_type))
+}

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -1424,6 +1424,9 @@ pub const MAX_FETCH_BYTES: usize = 1 << 26;
 pub enum FetchError {
     /// The URL is not `https`. kaibo fetches artifacts over TLS only — a provider
     /// handing back a plaintext link is a provider to fix, not a body to trust.
+    /// This names the address kaibo was given; a *redirect* to plaintext is refused
+    /// by the client itself (`tls::https_only_client`) and surfaces as
+    /// [`FetchError::Transport`].
     #[error(
         "artifact URL must use https, but {0} does not — kaibo fetches generated \
          artifacts over TLS only"
@@ -1479,8 +1482,11 @@ pub async fn fetch_artifact_bytes(
     if !url.starts_with("https://") {
         return Err(FetchError::NotHttps(url.to_string()));
     }
+    // `https_only`, not the plain client: the check above only covers the address
+    // kaibo was handed, and reqwest follows redirects. A provider-chosen link that
+    // bounced to plaintext would otherwise defeat the refusal above.
     let client =
-        crate::tls::https_client(timeout).map_err(|e| FetchError::Transport(e.to_string()))?;
+        crate::tls::https_only_client(timeout).map_err(|e| FetchError::Transport(e.to_string()))?;
     let response = client
         .get(url)
         .send()

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -1443,6 +1443,16 @@ pub enum FetchError {
          is short-lived, so generate again rather than reusing an old address"
     )]
     Status { status: u16 },
+    /// The address redirected. kaibo fetches an artifact from the address the
+    /// provider named or from nowhere, so a chain is refused rather than followed —
+    /// named separately from [`FetchError::Status`] because "the link expired" would
+    /// be the wrong diagnosis entirely.
+    #[error(
+        "the artifact link redirected ({status}), and kaibo fetches a generated artifact \
+         from the address the provider named rather than following it onward — the \
+         provider is returning an indirect link where a direct one is expected"
+    )]
+    Redirected { status: u16 },
     /// The artifact is larger than [`MAX_FETCH_BYTES`].
     #[error(
         "the generated artifact is {size} bytes, over kaibo's {limit}-byte ceiling for \
@@ -1482,17 +1492,25 @@ pub async fn fetch_artifact_bytes(
     if !url.starts_with("https://") {
         return Err(FetchError::NotHttps(url.to_string()));
     }
-    // `https_only`, not the plain client: the check above only covers the address
-    // kaibo was handed, and reqwest follows redirects. A provider-chosen link that
-    // bounced to plaintext would otherwise defeat the refusal above.
-    let client =
-        crate::tls::https_only_client(timeout).map_err(|e| FetchError::Transport(e.to_string()))?;
+    // Not the plain client: the check above covers only the address kaibo was handed,
+    // and reqwest both follows redirects and leaves `https_only` off by default. See
+    // `tls::artifact_fetch_client` for what each setting closes.
+    let client = crate::tls::artifact_fetch_client(timeout)
+        .map_err(|e| FetchError::Transport(e.to_string()))?;
     let response = client
         .get(url)
         .send()
         .await
         .map_err(|e| FetchError::Transport(e.to_string()))?;
     let status = response.status();
+    // Reported before the generic status check so a redirect reads as what it is.
+    // Redirects are not followed, so a 3xx arrives here as a response rather than as
+    // the artifact, and "the link expired" would be the wrong thing to tell someone.
+    if status.is_redirection() {
+        return Err(FetchError::Redirected {
+            status: status.as_u16(),
+        });
+    }
     if !status.is_success() {
         return Err(FetchError::Status {
             status: status.as_u16(),

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -72,6 +72,18 @@ pub enum ProviderKind {
     /// `key_optional = true` beside its explicit local `base_url`. Like Stability,
     /// it is not in the built-in backend list and staffs only `image` cast slots.
     OpenAiImages,
+    /// Alibaba's DashScope multimodal-generation route — the third media kind, via
+    /// `src/dashscope.rs`, covering the `wan` image family. Media-only on purpose:
+    /// the same host serves text through an OpenAI-compatible endpoint, so a text
+    /// model on a DashScope backend belongs on `kind = "openai"` with that base URL,
+    /// and this kind stays the one wire kaibo speaks for DashScope image generation.
+    ///
+    /// This is the kind that made kaibo fetch an artifact URL. DashScope delivers
+    /// generated images as presigned links rather than inline bytes, and the CAS
+    /// addresses content by its hash — so there is no artifact at all until the bytes
+    /// are in hand (see `crate::cas::fetch_artifact_bytes`). Keyed and not built-in,
+    /// like the other media kinds: generation costs money per image.
+    DashScope,
 }
 
 impl ProviderKind {
@@ -79,7 +91,7 @@ impl ProviderKind {
     /// new kind can never be accepted by `FromStr` while staying unlisted in the message
     /// a user actually reads — a hand-maintained list in that string had already drifted
     /// once (`openrouter` shipped before it was named there).
-    pub const ALL: [ProviderKind; 7] = [
+    pub const ALL: [ProviderKind; 8] = [
         Self::Anthropic,
         Self::DeepSeek,
         Self::Gemini,
@@ -87,6 +99,7 @@ impl ProviderKind {
         Self::Openai,
         Self::Stability,
         Self::OpenAiImages,
+        Self::DashScope,
     ];
 
     /// Whether a missing credential is tolerated rather than a hard error. Only the
@@ -131,10 +144,12 @@ impl ProviderKind {
             // Reached only when an operator sets `key_optional = true` for a local
             // sd-server: header-bearer shaped, value ignored by such a server.
             | ProviderKind::OpenAiImages
-            // Never reached: Stability is not `key_optional`, so a missing key is a
-            // hard error long before a stand-in is wanted. It is a header-bearer wire,
-            // so it takes the same shape as the others if that ever changes.
-            | ProviderKind::Stability => PLACEHOLDER_OPENAI_KEY,
+            // Never reached: neither Stability nor DashScope is `key_optional`, so a
+            // missing key is a hard error long before a stand-in is wanted. Both are
+            // header-bearer wires, so they take the same shape as the others if that
+            // ever changes.
+            | ProviderKind::Stability
+            | ProviderKind::DashScope => PLACEHOLDER_OPENAI_KEY,
         }
     }
 
@@ -152,6 +167,7 @@ impl ProviderKind {
             ProviderKind::Openai => "openai",
             ProviderKind::Stability => "stability",
             ProviderKind::OpenAiImages => "openai-images",
+            ProviderKind::DashScope => "dashscope",
         }
     }
 
@@ -183,6 +199,10 @@ impl ProviderKind {
             // Reuses the constant `src/stability.rs` already resolves keys with, so the
             // facade and the config layer can never disagree about which var to read.
             ProviderKind::Stability => crate::stability::STABILITY_KEY_ENV_VAR,
+            // Its own credential, not shared with the `openai` kind: the same host
+            // serves text on an OpenAI-compatible route, and an operator who runs both
+            // wants one name per account, not one name per protocol.
+            ProviderKind::DashScope => crate::dashscope::DASHSCOPE_KEY_ENV_VAR,
         }
     }
 
@@ -199,6 +219,8 @@ impl ProviderKind {
             ProviderKind::Openai | ProviderKind::OpenAiImages => ".openai-key",
             // Same constant `src/stability.rs` uses, for the same reason as `env_var`.
             ProviderKind::Stability => crate::stability::STABILITY_KEY_FILE_NAME,
+            // Same reasoning as `env_var`: DashScope's own credential name.
+            ProviderKind::DashScope => crate::dashscope::DASHSCOPE_KEY_FILE_NAME,
         }
     }
 
@@ -222,6 +244,7 @@ impl ProviderKind {
             ProviderKind::Openai => ProviderClass::Wire(WireKind::Openai),
             ProviderKind::Stability => ProviderClass::Media(MediaKind::Stability),
             ProviderKind::OpenAiImages => ProviderClass::Media(MediaKind::OpenAiImages),
+            ProviderKind::DashScope => ProviderClass::Media(MediaKind::DashScope),
         }
     }
 
@@ -270,6 +293,9 @@ pub enum MediaKind {
     /// OpenAI's Images API shape (`/v1/images/generations`), via
     /// `src/openai_images.rs` — hosted OpenAI or a local sd-server.
     OpenAiImages,
+    /// Alibaba DashScope's multimodal-generation route, via `src/dashscope.rs` —
+    /// the `wan` image family, delivered as presigned URLs kaibo fetches.
+    DashScope,
 }
 
 /// The two families a [`ProviderKind`] can belong to — see [`ProviderKind::class`].
@@ -307,6 +333,7 @@ impl std::str::FromStr for ProviderKind {
             "openai" | "local" | "lemonade" | "gemma" | "gemma4" => Ok(ProviderKind::Openai),
             "stability" => Ok(ProviderKind::Stability),
             "openai-images" => Ok(ProviderKind::OpenAiImages),
+            "dashscope" => Ok(ProviderKind::DashScope),
             other => Err(anyhow!(
                 "unknown provider {other:?} (expected one of: {})",
                 ProviderKind::ALL

--- a/src/dashscope.rs
+++ b/src/dashscope.rs
@@ -1,0 +1,589 @@
+//! Alibaba DashScope's multimodal-generation route — kaibo's third media kind
+//! (`ProviderKind::DashScope`), a sibling of `src/stability.rs` and
+//! `src/openai_images.rs`.
+//!
+//! # One route, the `wan` image family
+//!
+//! `POST {base}/api/v1/services/aigc/multimodal-generation/generation` generates
+//! images from text. It is **synchronous**: the POST answers with the artifacts, so
+//! [`crate::media::MediaModel::generate`] always resolves to
+//! [`crate::media::MediaOutcome::Complete`] and `poll` is unreachable (it bails
+//! loudly, as OpenAI Images' does).
+//!
+//! DashScope also documents an *asynchronous* text-to-image route
+//! (`/api/v1/services/aigc/text2image/image-synthesis`, submit-then-poll behind an
+//! `X-DashScope-Async` header). kaibo does not speak it. The synchronous route
+//! reaches the same models, and the async one is an account entitlement not every
+//! subscription carries — measured 2026-08-15, a subscription that generates happily
+//! on this route answers the async one with `current user api does not support
+//! asynchronous calls`. If a deferred DashScope operation ever matters, the seam is
+//! ready for it ([`crate::media::MediaOutcome::Deferred`]); this module simply has no
+//! deferred shape today.
+//!
+//! # Text belongs on the `openai` kind
+//!
+//! DashScope hosts serve text through an OpenAI-compatible endpoint
+//! (`/compatible-mode/v1`), which kaibo already speaks. So this kind is media-only:
+//! a `wan` model on an `image` slot here, and any text model on a `kind = "openai"`
+//! backend pointed at the same host. One account, two stanzas, each on the wire it
+//! actually speaks.
+//!
+//! # Artifacts arrive as URLs — the departure from every other media kind
+//!
+//! The response carries a presigned link per image, not inline bytes. That is the
+//! opposite of what `src/openai_images.rs` requires of its own provider, and the
+//! reasoning is not that the trust question went away — it is that the two cases are
+//! different. There, base64 is available and asking for a URL spends credits on
+//! artifacts kaibo would then refuse; the refusal costs nothing and prevents waste.
+//! Here URLs are the only delivery mechanism, so refusing them means the operator
+//! fetches the link themselves with a raw key — moving the same network hop out of
+//! kaibo and into a shell, with the credential now in a command line. And a
+//! content-addressed store cannot address what it has not read: the digest *is* the
+//! address, so the bytes are the artifact's existence condition, not a convenience.
+//!
+//! The fetch itself lives in [`crate::cas::fetch_artifact_bytes`], beside the store
+//! rather than in this module, so the bound and the refusals are shared with whatever
+//! URL-delivering provider lands next. Its `Content-Type` is what names the mime —
+//! see [`artifact_mime`].
+//!
+//! # Fields ride verbatim, typed by the caller
+//!
+//! Same passthrough posture as the sibling kinds: `n`, `size`, `seed`,
+//! `negative_prompt`, ... ride [`crate::media::MediaRequest::fields`] into the
+//! request's `parameters` object with their stated JSON type, and DashScope answers
+//! for its own knobs. Two provider-side notes worth knowing, both measured:
+//!
+//! - `enable_interleave` is **seeded true** by [`build_request_body`], because a
+//!   text-only request is refused without it (`the last message must contain 1 to 4
+//!   images`). A caller field of the same name replaces the seed, the same merge
+//!   Stability's `output_format` seed uses.
+//! - DashScope **silently ignores unknown parameter names** — a misspelled knob is a
+//!   no-op, not a 400. kaibo therefore sends only what a caller actually wrote and
+//!   never leans on the provider to catch a typo.
+//!
+//! # Credentials
+//!
+//! Its own `DASHSCOPE_API_KEY` / `~/.dashscope-key`, not shared with the `openai`
+//! kind: an operator running both wires against one DashScope account wants one name
+//! per account, not one per protocol. The key is required — this kind has no keyless
+//! target.
+
+use std::time::Duration;
+
+use anyhow::Result as AnyResult;
+use reqwest::header::AUTHORIZATION;
+use serde_json::{json, Map, Value};
+
+use crate::media::{MediaArtifact, MediaJobId, MediaOutcome, MediaPollOutcome, MediaRequest};
+
+/// The environment variable holding a DashScope key.
+pub const DASHSCOPE_KEY_ENV_VAR: &str = "DASHSCOPE_API_KEY";
+
+/// The key-file consulted when the environment is unset.
+pub const DASHSCOPE_KEY_FILE_NAME: &str = ".dashscope-key";
+
+/// DashScope's international API root. A dedicated-endpoint subscription has its own
+/// host and sets `base_url`; this is the shared-endpoint default. A root, not a
+/// route — [`generation_url`] appends the path, the client-appends-its-path contract
+/// every configurable base URL in kaibo follows.
+pub const DASHSCOPE_API_BASE: &str = "https://dashscope-intl.aliyuncs.com";
+
+/// The synchronous multimodal-generation route, appended to the base URL.
+pub const GENERATION_PATH: &str = "/api/v1/services/aigc/multimodal-generation/generation";
+
+/// The parameter that lets a text-only prompt through. Without it the model demands
+/// one to four input images.
+const ENABLE_INTERLEAVE: &str = "enable_interleave";
+
+/// The full generation URL for a base. Tolerates a trailing slash on the base so an
+/// operator's `base_url` spelling never changes the route.
+pub fn generation_url(base_url: &str) -> String {
+    format!("{}{}", base_url.trim_end_matches('/'), GENERATION_PATH)
+}
+
+// --- Errors ------------------------------------------------------------------
+
+/// Everything that can go wrong building or interpreting a DashScope generation.
+/// Own type for the same reason its siblings have one: [`build_request_body`] and
+/// [`parse_response`] stay pure and unit-testable with no reqwest types in the loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DashScopeError {
+    /// The HTTP request itself failed (DNS, connect, TLS, a dropped connection) —
+    /// message pre-rendered so this stays `Clone`/`PartialEq`.
+    Transport(String),
+    /// A non-2xx response. `body` is DashScope's `{code, message, request_id}`
+    /// rendered readably when it parses, the raw text otherwise.
+    Provider { status: u16, body: String },
+    /// A 2xx whose body didn't parse as the documented
+    /// `{output: {choices: [...]}}` envelope.
+    InvalidBody(String),
+    /// A 2xx carrying no image at all — refused here rather than handed downstream
+    /// as an empty artifact list (see `MediaOutcome::Complete`'s contract).
+    NoImages,
+    /// Fetching an artifact's URL failed. Pre-rendered from
+    /// [`crate::cas::FetchError`], whose own messages name the fix.
+    Fetch { index: usize, detail: String },
+    /// A fetched artifact's `Content-Type` names something the CAS cannot store as
+    /// an image — or was absent entirely. Named rather than guessed: storing bytes
+    /// under a wrong extension is the corruption this refuses.
+    UnusableContentType { index: usize, got: Option<String> },
+}
+
+impl std::fmt::Display for DashScopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DashScopeError::Transport(msg) => {
+                write!(f, "DashScope request failed: {msg}")
+            }
+            DashScopeError::Provider { status, body } => {
+                write!(f, "DashScope returned {status}: {body}")
+            }
+            DashScopeError::InvalidBody(msg) => write!(
+                f,
+                "DashScope 2xx body didn't parse as {{\"output\": {{\"choices\": [...]}}}}: {msg}"
+            ),
+            DashScopeError::NoImages => write!(
+                f,
+                "DashScope returned no images — zero artifacts is never treated as a \
+                 successful generation"
+            ),
+            DashScopeError::Fetch { index, detail } => {
+                write!(f, "artifact {index}: {detail}")
+            }
+            DashScopeError::UnusableContentType { index, got } => match got {
+                Some(ct) => write!(
+                    f,
+                    "artifact {index} came back as {ct:?}, which kaibo cannot store as an \
+                     image — ask for png, jpeg, webp, or gif"
+                ),
+                None => write!(
+                    f,
+                    "artifact {index} came back with no Content-Type, so kaibo cannot tell \
+                     what the bytes are — ask for png, jpeg, webp, or gif"
+                ),
+            },
+        }
+    }
+}
+
+impl std::error::Error for DashScopeError {}
+
+// --- Request -----------------------------------------------------------------
+
+/// Build the JSON body for one generation. Pure: no network, no clock.
+///
+/// The prompt becomes the single user message's text; caller fields become
+/// `parameters`, with [`ENABLE_INTERLEAVE`] seeded true unless the caller named it.
+pub fn build_request_body(model: &str, request: &MediaRequest) -> Value {
+    let mut parameters = Map::new();
+    parameters.insert(ENABLE_INTERLEAVE.to_string(), Value::Bool(true));
+    for (name, value) in &request.fields {
+        parameters.insert(name.clone(), value.to_json());
+    }
+    json!({
+        "model": model,
+        "input": {
+            "messages": [{
+                "role": "user",
+                "content": [{"text": request.prompt}],
+            }],
+        },
+        "parameters": Value::Object(parameters),
+    })
+}
+
+// --- Response ----------------------------------------------------------------
+
+/// Pull every artifact URL out of a 2xx body, in response order. Pure.
+///
+/// The envelope is `output.choices[].message.content[].image`; one choice per image.
+/// A `content` entry with no `image` (a text part in an interleaved answer) is
+/// skipped rather than refused — the images are what this route is asked for.
+pub fn parse_response(body: &Value) -> Result<Vec<String>, DashScopeError> {
+    let choices = body
+        .get("output")
+        .and_then(|o| o.get("choices"))
+        .and_then(|c| c.as_array())
+        .ok_or_else(|| DashScopeError::InvalidBody(truncate_for_error(&body.to_string())))?;
+    let mut urls = Vec::new();
+    for choice in choices {
+        let Some(parts) = choice
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
+        else {
+            continue;
+        };
+        for part in parts {
+            if let Some(url) = part.get("image").and_then(|i| i.as_str()) {
+                urls.push(url.to_string());
+            }
+        }
+    }
+    if urls.is_empty() {
+        return Err(DashScopeError::NoImages);
+    }
+    Ok(urls)
+}
+
+/// The mime for one fetched artifact: the server's own `Content-Type`, accepted only
+/// when the CAS can store it as an image.
+///
+/// Deliberately not a guess. The response JSON carries no per-artifact type, and the
+/// URL's extension is a hint an operator cannot correct — so the one authority is
+/// what the object store said the bytes are. Anything else is named and refused
+/// rather than defaulted to png, because a wrong extension in a content-addressed
+/// store is a permanent mislabel under a real digest.
+pub fn artifact_mime(index: usize, content_type: Option<&str>) -> Result<String, DashScopeError> {
+    let Some(raw) = content_type else {
+        return Err(DashScopeError::UnusableContentType { index, got: None });
+    };
+    let essence = raw.split(';').next().unwrap_or(raw).trim().to_string();
+    match crate::cas::Extension::from_mime(&essence) {
+        Some(ext) if ext.is_image() => Ok(essence),
+        _ => Err(DashScopeError::UnusableContentType {
+            index,
+            got: Some(essence),
+        }),
+    }
+}
+
+/// Render a provider error body readably: DashScope's `{code, message, request_id}`
+/// when it parses that way, the raw text otherwise.
+pub fn render_provider_error(text: &str) -> String {
+    let Ok(value) = serde_json::from_str::<Value>(text) else {
+        return truncate_for_error(text);
+    };
+    let code = value.get("code").and_then(|c| c.as_str());
+    let message = value.get("message").and_then(|m| m.as_str());
+    match (code, message) {
+        (Some(c), Some(m)) => format!("{c}: {m}"),
+        (None, Some(m)) => m.to_string(),
+        _ => truncate_for_error(text),
+    }
+}
+
+/// Keep a raw body out of the multi-kilobyte range in an error string.
+fn truncate_for_error(text: &str) -> String {
+    const LIMIT: usize = 1 << 10;
+    if text.len() <= LIMIT {
+        return text.to_string();
+    }
+    let mut end = LIMIT;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &text[..end])
+}
+
+// --- Client ------------------------------------------------------------------
+
+/// A configured DashScope connection: credential, base URL, timeout, and the one
+/// HTTPS client built through kaibo's TLS seam.
+#[derive(Clone)]
+pub struct DashScopeClient {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+    request_timeout: Duration,
+}
+
+impl std::fmt::Debug for DashScopeClient {
+    /// Manual: never render the key.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DashScopeClient")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DashScopeClient {
+    /// Build a client. The HTTP client comes from [`crate::tls::https_client`], the
+    /// single reqwest build site, so ring is installed and the timeout is bounded.
+    pub fn new(api_key: String, base_url: String, request_timeout: Duration) -> AnyResult<Self> {
+        Ok(Self {
+            http: crate::tls::https_client(request_timeout)?,
+            api_key,
+            base_url,
+            request_timeout,
+        })
+    }
+
+    /// POST one generation and return the parsed 2xx body.
+    async fn post_generation(&self, body: &Value) -> Result<Value, DashScopeError> {
+        let response = self
+            .http
+            .post(generation_url(&self.base_url))
+            .header(AUTHORIZATION, format!("Bearer {}", self.api_key))
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| DashScopeError::Transport(e.to_string()))?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .map_err(|e| DashScopeError::Transport(e.to_string()))?;
+        if !status.is_success() {
+            return Err(DashScopeError::Provider {
+                status: status.as_u16(),
+                body: render_provider_error(&text),
+            });
+        }
+        serde_json::from_str(&text).map_err(|e| DashScopeError::InvalidBody(e.to_string()))
+    }
+}
+
+/// One DashScope image model, ready to generate.
+pub struct DashScopeImageModel {
+    client: DashScopeClient,
+    model: String,
+}
+
+impl DashScopeImageModel {
+    /// Bind a client to one model id — the shape `MediaArm::from_slot` builds.
+    pub fn from_parts(client: &DashScopeClient, model: &str) -> Self {
+        Self {
+            client: client.clone(),
+            model: model.to_string(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::media::MediaModel for DashScopeImageModel {
+    /// Generate, then fetch each artifact's bytes.
+    ///
+    /// All-or-nothing on purpose, matching `store_generated_artifacts`' posture: one
+    /// failed fetch fails the call rather than storing a partial set, so a result is
+    /// never quietly short. The images are already generated and billed either way —
+    /// the honest outcome is an error naming which artifact failed, not a shorter
+    /// list the caller has no way to notice.
+    async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
+        let body = build_request_body(&self.model, request);
+        let response = self.client.post_generation(&body).await?;
+        let urls = parse_response(&response)?;
+        let mut artifacts = Vec::with_capacity(urls.len());
+        for (index, url) in urls.iter().enumerate() {
+            let (bytes, content_type) =
+                crate::cas::fetch_artifact_bytes(url, self.client.request_timeout)
+                    .await
+                    .map_err(|e| DashScopeError::Fetch {
+                        index,
+                        detail: e.to_string(),
+                    })?;
+            let mime = artifact_mime(index, content_type.as_deref())?;
+            artifacts.push(MediaArtifact {
+                bytes,
+                mime,
+                // DashScope reports no seed, even when the request set one — so
+                // there is nothing here to record. A caller's own `seed` field rides
+                // the request and is the reproduction handle.
+                seed: None,
+            });
+        }
+        Ok(MediaOutcome::Complete(artifacts))
+    }
+
+    /// Unreachable: every operation on this route is synchronous, so `generate`
+    /// never hands back a job id to poll. Bails loudly rather than returning
+    /// `Pending` forever, which would look like a slow provider instead of a bug.
+    async fn poll(&self, _job: &MediaJobId) -> AnyResult<MediaPollOutcome> {
+        anyhow::bail!(
+            "DashScope generations are synchronous, so there is no job to poll — \
+             `generate` returns its artifacts in the same call"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::FieldValue;
+
+    fn request(prompt: &str) -> MediaRequest {
+        MediaRequest {
+            prompt: prompt.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// The route is appended to the base, and a trailing slash on the operator's
+    /// base URL does not double the separator.
+    #[test]
+    fn generation_url_appends_the_route_to_any_base_spelling() {
+        assert_eq!(
+            generation_url("https://example.test"),
+            "https://example.test/api/v1/services/aigc/multimodal-generation/generation"
+        );
+        assert_eq!(
+            generation_url("https://example.test/"),
+            generation_url("https://example.test")
+        );
+    }
+
+    /// A text-only prompt is refused by the provider without `enable_interleave`, so
+    /// the body seeds it — the one parameter kaibo supplies unasked.
+    #[test]
+    fn body_seeds_enable_interleave_for_a_text_only_prompt() {
+        let body = build_request_body("wan2.6-t2i", &request("a red cube"));
+        assert_eq!(body["parameters"][ENABLE_INTERLEAVE], json!(true));
+        assert_eq!(body["model"], json!("wan2.6-t2i"));
+        assert_eq!(
+            body["input"]["messages"][0]["content"][0]["text"],
+            json!("a red cube")
+        );
+    }
+
+    /// A caller field of the same name replaces the seed rather than colliding with
+    /// it — the merge Stability's `output_format` seed already uses.
+    #[test]
+    fn a_caller_field_replaces_the_seeded_enable_interleave() {
+        let mut req = request("a red cube");
+        req.fields
+            .push((ENABLE_INTERLEAVE.to_string(), FieldValue::Bool(false)));
+        let body = build_request_body("wan2.6-t2i", &req);
+        assert_eq!(body["parameters"][ENABLE_INTERLEAVE], json!(false));
+    }
+
+    /// The caller's JSON type survives to the wire: `n` stays an integer (DashScope
+    /// type-checks it), a string stays a string.
+    #[test]
+    fn caller_field_types_ride_through_unchanged() {
+        let mut req = request("a red cube");
+        req.fields.push((
+            "n".to_string(),
+            FieldValue::Num(serde_json::Number::from(2)),
+        ));
+        req.fields.push((
+            "negative_prompt".to_string(),
+            FieldValue::Str("blurry".to_string()),
+        ));
+        let body = build_request_body("wan2.6-t2i", &req);
+        assert_eq!(body["parameters"]["n"], json!(2));
+        assert!(body["parameters"]["n"].is_i64(), "n must stay an integer");
+        assert_eq!(body["parameters"]["negative_prompt"], json!("blurry"));
+    }
+
+    /// Every image comes back, in response order — the one-to-many shape, since one
+    /// call returns up to four.
+    #[test]
+    fn parse_collects_every_image_in_order() {
+        let body = json!({"output": {"choices": [
+            {"message": {"content": [{"image": "https://a.test/1.png", "type": "image"}]}},
+            {"message": {"content": [{"image": "https://a.test/2.png", "type": "image"}]}},
+        ]}});
+        assert_eq!(
+            parse_response(&body).unwrap(),
+            vec![
+                "https://a.test/1.png".to_string(),
+                "https://a.test/2.png".to_string()
+            ]
+        );
+    }
+
+    /// A text part in an interleaved answer is skipped; the images are what this
+    /// route is asked for.
+    #[test]
+    fn parse_skips_non_image_content_parts() {
+        let body = json!({"output": {"choices": [
+            {"message": {"content": [{"text": "here you go"}, {"image": "https://a.test/1.png"}]}},
+        ]}});
+        assert_eq!(
+            parse_response(&body).unwrap(),
+            vec!["https://a.test/1.png".to_string()]
+        );
+    }
+
+    /// A 2xx with no image at all is refused, never handed downstream as an empty
+    /// artifact list.
+    #[test]
+    fn parse_refuses_a_body_with_no_images() {
+        let body = json!({"output": {"choices": [
+            {"message": {"content": [{"text": "no picture for you"}]}},
+        ]}});
+        assert_eq!(parse_response(&body), Err(DashScopeError::NoImages));
+    }
+
+    /// A body that is not the documented envelope is refused with the body in hand,
+    /// not silently treated as zero images.
+    #[test]
+    fn parse_refuses_an_unrecognized_envelope() {
+        let body = json!({"data": [{"url": "https://a.test/1.png"}]});
+        let err = parse_response(&body).expect_err("an OpenAI-shaped body is not this envelope");
+        assert!(matches!(err, DashScopeError::InvalidBody(_)), "got {err:?}");
+    }
+
+    /// The server's Content-Type names the mime, and a charset suffix does not
+    /// defeat the match.
+    #[test]
+    fn mime_comes_from_the_content_type() {
+        assert_eq!(artifact_mime(0, Some("image/png")).unwrap(), "image/png");
+        assert_eq!(
+            artifact_mime(0, Some("image/jpeg; charset=binary")).unwrap(),
+            "image/jpeg"
+        );
+    }
+
+    /// A missing or unstorable Content-Type is named and refused — never defaulted
+    /// to png, because a wrong extension under a real digest is a permanent
+    /// mislabel.
+    #[test]
+    fn an_unusable_content_type_is_refused_rather_than_guessed() {
+        assert_eq!(
+            artifact_mime(1, None),
+            Err(DashScopeError::UnusableContentType {
+                index: 1,
+                got: None
+            })
+        );
+        assert_eq!(
+            artifact_mime(2, Some("application/xml")),
+            Err(DashScopeError::UnusableContentType {
+                index: 2,
+                got: Some("application/xml".to_string())
+            })
+        );
+        // text/plain is a mime the CAS knows, but not an image — the image filter is
+        // what refuses it, so this would pass a bare `from_mime` check.
+        assert!(artifact_mime(3, Some("text/plain")).is_err());
+    }
+
+    /// A provider error renders as `code: message`, and an unparseable body keeps
+    /// its raw text rather than being swallowed.
+    #[test]
+    fn provider_errors_render_readably() {
+        assert_eq!(
+            render_provider_error(
+                r#"{"code":"InvalidApiKey","message":"Invalid API-key provided.","request_id":"x"}"#
+            ),
+            "InvalidApiKey: Invalid API-key provided."
+        );
+        assert_eq!(
+            render_provider_error("<html>502</html>"),
+            "<html>502</html>"
+        );
+    }
+
+    /// Poll is unreachable on a synchronous route and says so, rather than reporting
+    /// `Pending` forever.
+    #[tokio::test]
+    async fn poll_bails_because_every_operation_is_synchronous() {
+        use crate::media::MediaModel as _;
+        let client = DashScopeClient::new(
+            "k".to_string(),
+            DASHSCOPE_API_BASE.to_string(),
+            Duration::from_secs(30),
+        )
+        .expect("client builds");
+        let model = DashScopeImageModel::from_parts(&client, "wan2.6-t2i");
+        let err = model
+            .poll(&MediaJobId("job-1".to_string()))
+            .await
+            .expect_err("a sync-only kind has nothing to poll");
+        assert!(
+            format!("{err:#}").contains("synchronous"),
+            "the error explains why there is no job: {err:#}"
+        );
+    }
+}

--- a/src/dashscope.rs
+++ b/src/dashscope.rs
@@ -140,12 +140,17 @@ impl std::fmt::Display for DashScopeError {
             }
             DashScopeError::InvalidBody(msg) => write!(
                 f,
-                "DashScope 2xx body didn't parse as {{\"output\": {{\"choices\": [...]}}}}: {msg}"
+                "DashScope answered 2xx with a body that is not \
+                 {{\"output\": {{\"choices\": [...]}}}}, so there are no artifacts to read: \
+                 {msg}. Check that the model id names a wan image model — a text model \
+                 answers on the OpenAI-compatible endpoint instead, which is a \
+                 `kind = \"openai\"` backend"
             ),
             DashScopeError::NoImages => write!(
                 f,
-                "DashScope returned no images — zero artifacts is never treated as a \
-                 successful generation"
+                "DashScope answered without an image, and zero artifacts is never treated \
+                 as a successful generation. Send the prompt again; if it keeps coming \
+                 back empty, the prompt is most likely being refused by the provider"
             ),
             DashScopeError::Fetch { index, detail } => {
                 write!(f, "artifact {index}: {detail}")
@@ -153,13 +158,17 @@ impl std::fmt::Display for DashScopeError {
             DashScopeError::UnusableContentType { index, got } => match got {
                 Some(ct) => write!(
                     f,
-                    "artifact {index} came back as {ct:?}, which kaibo cannot store as an \
-                     image — ask for png, jpeg, webp, or gif"
+                    "artifact {index} is not png, jpeg, webp, or gif — the bytes match none \
+                     of them, and the server called it {ct:?}. kaibo stores an artifact \
+                     under the format its bytes actually are, so there is nothing to store \
+                     here; ask for one of those four formats"
                 ),
                 None => write!(
                     f,
-                    "artifact {index} came back with no Content-Type, so kaibo cannot tell \
-                     what the bytes are — ask for png, jpeg, webp, or gif"
+                    "artifact {index} is not png, jpeg, webp, or gif — the bytes match none \
+                     of them and the server sent no Content-Type. kaibo stores an artifact \
+                     under the format its bytes actually are, so there is nothing to store \
+                     here; ask for one of those four formats"
                 ),
             },
         }
@@ -200,11 +209,31 @@ pub fn build_request_body(model: &str, request: &MediaRequest) -> Value {
 /// A `content` entry with no `image` (a text part in an interleaved answer) is
 /// skipped rather than refused — the images are what this route is asked for.
 pub fn parse_response(body: &Value) -> Result<Vec<String>, DashScopeError> {
-    let choices = body
+    let Some(choices) = body
         .get("output")
         .and_then(|o| o.get("choices"))
         .and_then(|c| c.as_array())
-        .ok_or_else(|| DashScopeError::InvalidBody(truncate_for_error(&body.to_string())))?;
+    else {
+        // No envelope. Before calling the body unreadable, check whether it is
+        // DashScope's *error* shape arriving under a 2xx — some Alibaba routes answer
+        // that way. Reporting "the body didn't parse" for a response that plainly says
+        // `InvalidParameter: ...` would hide the one sentence worth reading.
+        //
+        // Checked here rather than up front on purpose: a valid response carries
+        // `output`, so this branch cannot misfire on one.
+        if let (Some(code), Some(message)) = (
+            body.get("code").and_then(|c| c.as_str()),
+            body.get("message").and_then(|m| m.as_str()),
+        ) {
+            return Err(DashScopeError::Provider {
+                status: 200,
+                body: format!("{code}: {message}"),
+            });
+        }
+        return Err(DashScopeError::InvalidBody(truncate_for_error(
+            &body.to_string(),
+        )));
+    };
     let mut urls = Vec::new();
     for choice in choices {
         let Some(parts) = choice
@@ -226,24 +255,35 @@ pub fn parse_response(body: &Value) -> Result<Vec<String>, DashScopeError> {
     Ok(urls)
 }
 
-/// The mime for one fetched artifact: the server's own `Content-Type`, accepted only
-/// when the CAS can store it as an image.
+/// The mime for one fetched artifact, read from the **bytes** by their magic number.
 ///
-/// Deliberately not a guess. The response JSON carries no per-artifact type, and the
-/// URL's extension is a hint an operator cannot correct — so the one authority is
-/// what the object store said the bytes are. Anything else is named and refused
-/// rather than defaulted to png, because a wrong extension in a content-addressed
-/// store is a permanent mislabel under a real digest.
-pub fn artifact_mime(index: usize, content_type: Option<&str>) -> Result<String, DashScopeError> {
-    let Some(raw) = content_type else {
-        return Err(DashScopeError::UnusableContentType { index, got: None });
-    };
-    let essence = raw.split(';').next().unwrap_or(raw).trim().to_string();
-    match crate::cas::Extension::from_mime(&essence) {
-        Some(ext) if ext.is_image() => Ok(essence),
-        _ => Err(DashScopeError::UnusableContentType {
+/// Not a guess, and not the header either. The response JSON carries no per-artifact
+/// type and the URL's suffix is a hint no operator can correct, so the first draft of
+/// this took the fetch response's `Content-Type` as the authority. A cross-family
+/// review found that brittle in two real ways: object stores and CDNs commonly serve
+/// JPEG as `image/jpg`, which is not a spelling [`crate::cas::Extension::from_mime`]
+/// knows, and a bucket that sends `application/octet-stream` or no type at all would
+/// have its perfectly valid PNG refused.
+///
+/// Sniffing removes the dependence entirely. [`crate::view_image::sniff_mime`]
+/// recognizes exactly png / jpeg / gif / webp — the same four
+/// [`crate::cas::Extension`] can store as an image — so the bytes answer the only
+/// question being asked, and they cannot be wrong about themselves the way a header
+/// can. `content_type` is kept for the *error*: when the bytes are unrecognizable,
+/// naming what the server claimed is what makes the failure diagnosable.
+///
+/// Refusing rather than defaulting to png stands: a wrong extension in a
+/// content-addressed store is a permanent mislabel under a real digest.
+pub fn artifact_mime(
+    index: usize,
+    content_type: Option<&str>,
+    bytes: &[u8],
+) -> Result<String, DashScopeError> {
+    match crate::view_image::sniff_mime(bytes) {
+        Some(mime) => Ok(mime.to_string()),
+        None => Err(DashScopeError::UnusableContentType {
             index,
-            got: Some(essence),
+            got: content_type.map(|raw| raw.split(';').next().unwrap_or(raw).trim().to_string()),
         }),
     }
 }
@@ -372,7 +412,7 @@ impl crate::media::MediaModel for DashScopeImageModel {
                         index,
                         detail: e.to_string(),
                     })?;
-            let mime = artifact_mime(index, content_type.as_deref())?;
+            let mime = artifact_mime(index, content_type.as_deref(), &bytes)?;
             artifacts.push(MediaArtifact {
                 bytes,
                 mime,
@@ -514,39 +554,138 @@ mod tests {
         assert!(matches!(err, DashScopeError::InvalidBody(_)), "got {err:?}");
     }
 
-    /// The server's Content-Type names the mime, and a charset suffix does not
-    /// defeat the match.
+    /// The BYTES name the mime, not the header. png/jpeg/webp/gif are each
+    /// recognized by their magic number, which is the same closed set the CAS can
+    /// store as an image.
     #[test]
-    fn mime_comes_from_the_content_type() {
-        assert_eq!(artifact_mime(0, Some("image/png")).unwrap(), "image/png");
+    fn mime_comes_from_the_bytes() {
+        let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        let jpeg = [0xFFu8, 0xD8, 0xFF, 0xE0];
+        let gif = b"GIF89a.......";
+        let mut webp = Vec::from(*b"RIFF____WEBP");
+        webp.extend_from_slice(b"VP8 ");
         assert_eq!(
-            artifact_mime(0, Some("image/jpeg; charset=binary")).unwrap(),
+            artifact_mime(0, Some("image/png"), &png).unwrap(),
+            "image/png"
+        );
+        assert_eq!(artifact_mime(0, None, &jpeg).unwrap(), "image/jpeg");
+        assert_eq!(artifact_mime(0, None, gif).unwrap(), "image/gif");
+        assert_eq!(artifact_mime(0, None, &webp).unwrap(), "image/webp");
+    }
+
+    /// The two header shapes that would have broken a Content-Type-driven version,
+    /// both fine now — the reason this reads the bytes at all (cross-family review,
+    /// 2026-08-15).
+    ///
+    /// `image/jpg` is what many object stores and CDNs send for a JPEG, and it is not
+    /// a spelling `cas::Extension::from_mime` knows; `application/octet-stream` and a
+    /// missing header are what a bucket sends when nothing set the type. Every one of
+    /// these is a real image being served slightly wrong, and refusing them would
+    /// have been kaibo's bug, not the provider's.
+    #[test]
+    fn a_wrong_or_missing_header_does_not_refuse_a_real_image() {
+        let jpeg = [0xFFu8, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        for header in [
+            Some("image/jpg"),
+            Some("application/octet-stream"),
+            Some("binary/octet-stream"),
+            None,
+        ] {
+            assert_eq!(
+                artifact_mime(0, header, &jpeg).unwrap(),
+                "image/jpeg",
+                "a real JPEG must survive a {header:?} Content-Type"
+            );
+        }
+        // And the header cannot talk kaibo into the wrong format either: these bytes
+        // are a JPEG whatever the server calls them.
+        assert_eq!(
+            artifact_mime(0, Some("image/png"), &jpeg).unwrap(),
             "image/jpeg"
         );
     }
 
-    /// A missing or unstorable Content-Type is named and refused — never defaulted
-    /// to png, because a wrong extension under a real digest is a permanent
-    /// mislabel.
+    /// Bytes that are no image kaibo stores are refused, never defaulted to png — a
+    /// wrong extension under a real digest is a permanent mislabel. The header rides
+    /// the error so the failure is diagnosable.
     #[test]
-    fn an_unusable_content_type_is_refused_rather_than_guessed() {
+    fn unrecognizable_bytes_are_refused_rather_than_guessed() {
+        let not_an_image = b"<?xml version=\"1.0\"?><Error>AccessDenied</Error>";
         assert_eq!(
-            artifact_mime(1, None),
-            Err(DashScopeError::UnusableContentType {
-                index: 1,
-                got: None
-            })
-        );
-        assert_eq!(
-            artifact_mime(2, Some("application/xml")),
+            artifact_mime(2, Some("application/xml"), not_an_image),
             Err(DashScopeError::UnusableContentType {
                 index: 2,
                 got: Some("application/xml".to_string())
             })
         );
-        // text/plain is a mime the CAS knows, but not an image — the image filter is
-        // what refuses it, so this would pass a bare `from_mime` check.
-        assert!(artifact_mime(3, Some("text/plain")).is_err());
+        assert_eq!(
+            artifact_mime(1, None, not_an_image),
+            Err(DashScopeError::UnusableContentType {
+                index: 1,
+                got: None
+            })
+        );
+        // The case that matters most: an error page served UNDER an image
+        // Content-Type. A header-driven version would have stored this as a png.
+        let err = artifact_mime(0, Some("image/png"), not_an_image)
+            .expect_err("bytes that are not an image are not an image");
+        assert!(
+            format!("{err}").contains("png, jpeg, webp, or gif"),
+            "the refusal names the formats kaibo can store, got: {err}"
+        );
+    }
+
+    /// An empty artifact is not an image either. `cas::fetch_artifact_bytes` refuses
+    /// an empty body first, so this is the belt to that brace.
+    #[test]
+    fn empty_bytes_are_refused() {
+        assert!(artifact_mime(0, Some("image/png"), &[]).is_err());
+    }
+
+    /// A 2xx carrying DashScope's ERROR shape is reported as a provider error, not
+    /// as an unreadable body. Some Alibaba routes answer that way, and telling
+    /// someone "the body didn't parse" would bury the one sentence worth reading.
+    #[test]
+    fn an_error_payload_under_a_2xx_is_reported_as_a_provider_error() {
+        let body = json!({
+            "request_id": "req-9",
+            "code": "InvalidParameter",
+            "message": "Total pixels (9801) must be between 589824 and 2073600.",
+        });
+        let err = parse_response(&body).expect_err("an error payload is not a success");
+        let DashScopeError::Provider {
+            status,
+            body: rendered,
+        } = &err
+        else {
+            panic!("expected a provider error, got {err:?}");
+        };
+        assert_eq!(*status, 200, "the status it actually arrived under");
+        assert!(
+            rendered.contains("InvalidParameter") && rendered.contains("589824"),
+            "the provider's own words survive, got: {rendered}"
+        );
+    }
+
+    /// The check above cannot misfire on a real response: a valid body carries
+    /// `output`, so the error branch is never reached for one. Pinned because the
+    /// obvious placement — checking `code` before looking for the envelope — would
+    /// break the moment DashScope adds a top-level `code` to a success.
+    #[test]
+    fn a_valid_response_is_unaffected_by_the_error_payload_check() {
+        let body = json!({
+            "request_id": "req-10",
+            "code": "Success",
+            "message": "ok",
+            "output": {"choices": [
+                {"message": {"content": [{"image": "https://a.test/1.png"}]}},
+            ]},
+        });
+        assert_eq!(
+            parse_response(&body).unwrap(),
+            vec!["https://a.test/1.png".to_string()],
+            "a body with BOTH an envelope and a top-level code is a success"
+        );
     }
 
     /// A provider error renders as `code: message`, and an unparseable body keeps

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -157,6 +157,11 @@ pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Resul
                 crate::credentials::MediaKind::OpenAiImages,
             ) => "the endpoint's own model names, e.g. gpt-image-1 hosted or whatever a \
                   local sd-server has loaded",
+            crate::credentials::ProviderClass::Media(crate::credentials::MediaKind::DashScope) => {
+                "the wan image models, e.g. wan2.6-t2i. A DashScope host serves its \
+                 catalog on an OpenAI-compatible endpoint, so point a `kind = \"openai\"` \
+                 backend at that base URL to list them"
+            }
             // The `else` above already proved this kind has no completion wire.
             crate::credentials::ProviderClass::Wire(_) => unreachable!("wire() was None"),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod config;
 pub mod consult;
 pub mod context;
 pub mod credentials;
+pub mod dashscope;
 pub mod discover;
 pub mod explorer;
 pub mod jobs;

--- a/src/media.rs
+++ b/src/media.rs
@@ -254,6 +254,21 @@ impl MediaArm {
                     crate::openai_images::OpenAiImagesModel::from_parts(&client, &slot.id);
                 Ok(Self::new(Arc::new(model), slot.qualified()))
             }
+            ProviderClass::Media(MediaKind::DashScope) => {
+                // Keyed with no keyless target, so a missing credential is a hard
+                // error here rather than a placeholder bearer.
+                let key = backend.resolve_key()?;
+                // Unset dials DashScope's shared international root; a dedicated
+                // endpoint sets its own. Either way the client appends the route.
+                let base_url = backend
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| crate::dashscope::DASHSCOPE_API_BASE.to_string());
+                let client =
+                    crate::dashscope::DashScopeClient::new(key, base_url, backend.request_timeout)?;
+                let model = crate::dashscope::DashScopeImageModel::from_parts(&client, &slot.id);
+                Ok(Self::new(Arc::new(model), slot.qualified()))
+            }
             ProviderClass::Wire(_) => bail!(
                 "backend {:?} is kind `{}`, a completion wire — it cannot staff a media \
                  slot. Point the `image` slot at a media backend, and use this backend \
@@ -417,6 +432,29 @@ mod tests {
         let slot = ModelSlot::bare("sdcpp", "sd3.5-large");
         let arm = MediaArm::from_slot(backend, &slot).expect("an openai-images backend staffs");
         assert_eq!(arm.slot_ref(), "sdcpp/sd3.5-large");
+    }
+
+    /// A DashScope backend staffs an image slot. Keyed, so the key must resolve —
+    /// this fixture supplies one through `api_key_file`'s env-var expansion being
+    /// absent and `key_optional` left false, which means the *file* must exist; so
+    /// the test uses the env source instead via a literal key on the backend's
+    /// configured env var. Construction only; no network.
+    #[test]
+    fn from_slot_staffs_a_dashscope_backend() {
+        let cfg = crate::config::Config::from_toml_str(
+            r#"
+            [backends.wan]
+            kind = "dashscope"
+            base_url = "https://dashscope-intl.example/"
+            key_optional = true
+            api_key_file = "/nonexistent-kaibo-test/dashscope"
+            "#,
+        )
+        .expect("config parses");
+        let backend = cfg.backends.get("wan").expect("backend exists");
+        let slot = ModelSlot::bare("wan", "wan2.6-t2i");
+        let arm = MediaArm::from_slot(backend, &slot).expect("a dashscope backend staffs");
+        assert_eq!(arm.slot_ref(), "wan/wan2.6-t2i");
     }
 
     /// The Stability arm still staffs — the sibling-kind regression guard for the

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -7,10 +7,13 @@
 //! hosted OpenAI image generation (the gpt-image-1 family, at
 //! `https://api.openai.com/v1`) and local stable-diffusion.cpp's `sd-server`, which
 //! implements the same endpoint shape on a keyless local port. That is why this is
-//! ONE kind with a configurable `base_url` (default the hosted endpoint) and an
-//! optional key (`key_optional` seeds true — the sd-server case; an operator dialing
-//! hosted OpenAI sets `key_optional = false` explicitly), mirroring the `openai`
-//! completion kind's posture rather than Stability's.
+//! ONE kind with a configurable `base_url`, default the hosted endpoint. The key is
+//! REQUIRED by default, because that default endpoint is hosted OpenAI: a keyless seed
+//! would let a minimal stanza load clean and then send a placeholder bearer to
+//! api.openai.com, turning a loud load-time gap into a 401 on the first paid call. A
+//! keyless local sd-server opts in with `key_optional = true` beside its explicit local
+//! `base_url`. So the key *sources* mirror the `openai` completion kind while the
+//! requiredness matches Stability's — see [`crate::credentials::ProviderKind::key_optional`].
 //!
 //! # Sync-only, and b64 or error
 //!
@@ -25,9 +28,16 @@
 //! rejects the `response_format` parameter outright; older families (dall-e-2/3)
 //! default to URLs unless asked. So [`build_request_body`] seeds
 //! `response_format = "b64_json"` for every model family EXCEPT gpt-image-1's, and
-//! [`parse_response`] refuses a URL-only entry loudly — kaibo never fetches artifact
-//! URLs (a second network hop to an address the provider chose is a different trust
-//! shape than decoding bytes already in hand).
+//! [`parse_response`] refuses a URL-only entry loudly.
+//!
+//! That refusal is **this kind's rule, not kaibo's** — the distinction matters since
+//! `src/dashscope.rs` landed and does fetch its artifact URLs. The two cases differ in
+//! what the alternative costs. Here bytes are available for the asking, so a URL means
+//! the request lost its `response_format` and the credits were already spent; refusing
+//! is free and names a fix. DashScope delivers links and nothing else, so refusing
+//! there would only move the same fetch into the operator's shell with the key on a
+//! command line. The shared bound and refusals for a fetch live in
+//! [`crate::cas::fetch_artifact_bytes`].
 //!
 //! # Mime: from the request, not the response
 //!
@@ -200,9 +210,10 @@ impl std::fmt::Display for OpenAiImagesError {
                     write!(
                         f,
                         "Images API data[{index}] carries a URL instead of `b64_json` — \
-                         kaibo never fetches artifact URLs; artifacts must arrive as \
-                         base64. This model family defaults to URLs and appears to have \
-                         ignored (or been overridden on) `response_format = \"b64_json\"`"
+                         this API delivers bytes, so a URL here means the request lost \
+                         `response_format = \"b64_json\"`. Send it, or drop the \
+                         `response_format` field and let kaibo seed it. This model \
+                         family defaults to URLs when it is not asked"
                     )
                 } else {
                     write!(
@@ -791,8 +802,12 @@ mod tests {
         );
     }
 
-    /// A URL-only entry is refused loudly, naming the b64 requirement — kaibo never
-    /// fetches artifact URLs.
+    /// A URL-only entry is refused loudly, naming the b64 requirement AND the fix.
+    ///
+    /// The refusal is this kind's, not kaibo's — `src/dashscope.rs` fetches its
+    /// artifact URLs. So the message must point at the request that lost
+    /// `response_format`, which an operator can act on, rather than at a tree-wide
+    /// stance that is no longer true.
     #[test]
     fn parse_response_url_only_entry_is_refused_naming_b64() {
         let body = serde_json::json!({
@@ -811,8 +826,13 @@ mod tests {
         );
         let msg = err.to_string();
         assert!(
-            msg.contains("b64_json") && msg.contains("never fetches"),
-            "the message names the b64 requirement and the no-URL-fetch stance, got: {msg}"
+            msg.contains("b64_json") && msg.contains("response_format"),
+            "the message names the b64 requirement and the parameter that fixes it, got: {msg}"
+        );
+        assert!(
+            !msg.contains("never fetches"),
+            "kaibo does fetch artifact URLs now (src/dashscope.rs) — this message must \
+             not claim otherwise, got: {msg}"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -870,8 +870,9 @@ const CAST_ENUM_RULES: &[CastEnumRule] = &[
     (
         &["generate"],
         Config::cast_can_generate,
-        "a cast with an `image` slot pointing at a media backend (kind `stability` or \
-         `openai-images`) — see the image-slot examples in docs/config.example.toml",
+        "a cast with an `image` slot pointing at a media backend (kind `stability`, \
+         `openai-images`, or `dashscope`) — see the image-slot examples in \
+         docs/config.example.toml",
     ),
 ];
 
@@ -2891,8 +2892,9 @@ impl KaiboHandler {
 
     #[tool(
         description = "Generate images from a text prompt with the cast's `image` \
-            model (a media backend: Stability, or an OpenAI-compatible images \
-            endpoint — hosted gpt-image or a local stable-diffusion.cpp sd-server). \
+            model (a media backend: Stability, an OpenAI-compatible images endpoint — \
+            hosted gpt-image or a local stable-diffusion.cpp sd-server — or DashScope's \
+            wan family). \
             Bytes are never inlined: each artifact lands in kaibo's content-addressed \
             media store and the result lists per-artifact digests — a \
             kaibo://cas/<digest> address, the mime, the provider's seed when reported, \

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4160,9 +4160,9 @@ by waiting — the handles keep.
 ## Generate media: `generate`
 
 `generate` turns a text prompt into images through the cast's `image` slot — a media
-backend: Stability's v2beta family, or an OpenAI-compatible images endpoint (hosted
-gpt-image, or a local stable-diffusion.cpp sd-server; one call may return several
-images via `n`). It is advertised only when a configured cast carries that slot and
+backend: Stability's v2beta family, an OpenAI-compatible images endpoint (hosted
+gpt-image, or a local stable-diffusion.cpp sd-server), or DashScope's wan family; one
+call may return several images via `n`. It is advertised only when a configured cast carries that slot and
 the media CAS is on. The result is never inline bytes: each artifact lands in kaibo's
 content-addressed store and you get its digest as a `kaibo://cas/<digest>` address, the
 mime, the provider's seed when reported, and — when the store is on disk — the real file
@@ -4170,7 +4170,8 @@ path. Provider-native
 options ride the `fields` object verbatim, each value's JSON type preserved
 (Stability: `aspect_ratio` \"16:9\", `output_format` png|jpeg|webp, `seed`,
 `negative_prompt`, `style_preset`; OpenAI-compatible: `size` \"1024x1024\", `n`,
-`quality`, `output_format` png|jpeg|webp). An operation the provider declares
+`quality`, `output_format` png|jpeg|webp; DashScope: `size` \"1024*1024\", `n` 1-4,
+`seed`, `negative_prompt`). An operation the provider declares
 deferred hands back a `job-N` on the same collect verbs above — the lane is wired,
 though every route wired today answers in-call. Every artifact gets a provenance
 sidecar (prompt, model, cast, timestamp, mime, seed) beside it in the store.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -61,3 +61,24 @@ pub fn https_client(request_timeout: Duration) -> Result<reqwest::Client> {
         .build()
         .map_err(|e| anyhow!("http client init: {e}"))
 }
+
+/// The same client, but TLS is enforced on **every** hop rather than only the one
+/// kaibo dialled — for fetching an artifact from an address a *provider* chose
+/// ([`crate::cas::fetch_artifact_bytes`]).
+///
+/// Why this is a separate builder. reqwest follows up to ten redirects by default
+/// and its `https_only` flag defaults to false, so an `https` URL that redirects to
+/// `http` is followed happily. Everywhere else in kaibo the endpoint is an operator's
+/// configured `base_url`, and a redirect chain off it is the operator's own business.
+/// An artifact link is not: it arrives inside a provider response, so the scheme kaibo
+/// checked up front is a promise only the first hop keeps. `https_only(true)` makes it
+/// hold for the rest of the chain, which is what the caller's refusal claims.
+pub fn https_only_client(request_timeout: Duration) -> Result<reqwest::Client> {
+    ensure_crypto_provider();
+    reqwest::Client::builder()
+        .timeout(request_timeout)
+        .connect_timeout(request_timeout.min(Duration::from_secs(10)))
+        .https_only(true)
+        .build()
+        .map_err(|e| anyhow!("http client init: {e}"))
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -62,23 +62,34 @@ pub fn https_client(request_timeout: Duration) -> Result<reqwest::Client> {
         .map_err(|e| anyhow!("http client init: {e}"))
 }
 
-/// The same client, but TLS is enforced on **every** hop rather than only the one
-/// kaibo dialled — for fetching an artifact from an address a *provider* chose
-/// ([`crate::cas::fetch_artifact_bytes`]).
+/// A client for fetching an artifact from an address a **provider** chose
+/// ([`crate::cas::fetch_artifact_bytes`]): TLS required, and exactly one hop.
 ///
-/// Why this is a separate builder. reqwest follows up to ten redirects by default
-/// and its `https_only` flag defaults to false, so an `https` URL that redirects to
-/// `http` is followed happily. Everywhere else in kaibo the endpoint is an operator's
-/// configured `base_url`, and a redirect chain off it is the operator's own business.
-/// An artifact link is not: it arrives inside a provider response, so the scheme kaibo
-/// checked up front is a promise only the first hop keeps. `https_only(true)` makes it
-/// hold for the rest of the chain, which is what the caller's refusal claims.
-pub fn https_only_client(request_timeout: Duration) -> Result<reqwest::Client> {
+/// Why this is a separate builder rather than a tightening of [`https_client`].
+/// Everywhere else in kaibo the endpoint is an operator's configured `base_url`, and
+/// where that redirects is the operator's own business. An artifact link is not: it
+/// arrives inside a provider's response, so every property kaibo checked before
+/// dialling is a promise only the first hop keeps.
+///
+/// Two settings, each closing a different hole:
+///
+/// - `https_only(true)` — reqwest's flag defaults to **false**, so an `https` URL
+///   redirecting to `http` is followed happily and the caller's scheme check would
+///   describe only the first hop.
+/// - `Policy::none()` — no redirects at all, so the bytes come from the address the
+///   provider named or from nowhere. Following a chain would let a provider response
+///   steer kaibo at an arbitrary reachable host, including a loopback or link-local
+///   address, which is a request kaibo has no reason to make. Verified against the
+///   real case before choosing it: DashScope's presigned OSS links answer `200`
+///   directly. A provider that does redirect surfaces as a `3xx`, which
+///   `fetch_artifact_bytes` reports as its own error rather than a generic failure.
+pub fn artifact_fetch_client(request_timeout: Duration) -> Result<reqwest::Client> {
     ensure_crypto_provider();
     reqwest::Client::builder()
         .timeout(request_timeout)
         .connect_timeout(request_timeout.min(Duration::from_secs(10)))
         .https_only(true)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| anyhow!("http client init: {e}"))
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2464,3 +2464,111 @@ fn persistence_cli_wins_over_lower_layers() {
         "--state-db wins over the file path"
     );
 }
+
+// --- the dashscope kind --------------------------------------------------------
+
+/// The `dashscope` kind parses from TOML and seeds its OWN key sources —
+/// deliberately not shared with the `openai` completion kind, even though the same
+/// DashScope host serves text on an OpenAI-compatible route. An operator running
+/// both wires against one account wants one credential name per account, not one per
+/// protocol. The key is required: this kind has no keyless target.
+#[test]
+fn dashscope_backend_parses_and_seeds_its_own_key_sources() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.wan]
+        kind = "dashscope"
+        "#,
+    )
+    .expect("the dashscope kind must parse");
+    let b = c.backends.get("wan").expect("backend exists");
+    assert_eq!(b.kind, kaibo::credentials::ProviderKind::DashScope);
+    assert_eq!(b.api_key_env.as_deref(), Some("DASHSCOPE_API_KEY"));
+    assert!(
+        b.api_key_file
+            .as_deref()
+            .is_some_and(|f| f.ends_with("/.dashscope-key")),
+        "the key file is DashScope's own, not the openai kind's, got: {:?}",
+        b.api_key_file
+    );
+    assert!(
+        !b.key_optional,
+        "key_optional seeds FALSE — every DashScope endpoint is keyed"
+    );
+}
+
+/// base_url is optional and legal on a dashscope backend: unset dials the shared
+/// international root, and a dedicated-endpoint subscription sets its own host. The
+/// client appends the route either way, so the value is a ROOT.
+#[test]
+fn dashscope_base_url_is_optional_and_legal() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.shared]
+        kind = "dashscope"
+
+        [backends.dedicated]
+        kind = "dashscope"
+        base_url = "https://ws-example.us-east-1.maas.aliyuncs.com"
+        "#,
+    )
+    .expect("a dashscope backend may set a base_url, and may omit it");
+    assert!(
+        c.backends.get("shared").expect("exists").base_url.is_none(),
+        "unset means the kind's own default, resolved when the arm is staffed"
+    );
+    assert_eq!(
+        c.backends
+            .get("dedicated")
+            .expect("exists")
+            .base_url
+            .as_deref(),
+        Some("https://ws-example.us-east-1.maas.aliyuncs.com")
+    );
+}
+
+/// A dashscope backend staffs an image slot — the config half of the media pairing.
+#[test]
+fn an_image_slot_can_point_at_a_dashscope_backend() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.wan]
+        kind = "dashscope"
+
+        [casts.art]
+        image = "wan/wan2.6-t2i"
+        "#,
+    )
+    .expect("an image slot on a dashscope backend loads");
+    let cast = c.casts.get("art").expect("cast exists");
+    let slot = cast
+        .slot(kaibo::config::ModelRole::Image)
+        .expect("image slot resolves");
+    assert_eq!(slot.backend, "wan");
+    assert_eq!(slot.id, "wan2.6-t2i");
+}
+
+/// A reasoning slot pointed at a dashscope backend is refused at load — the
+/// class-based guard, which is also the load-time answer to "why is my text model on
+/// the wrong kind": DashScope text belongs on a `kind = "openai"` backend.
+#[test]
+fn a_reasoning_slot_cannot_point_at_a_dashscope_backend() {
+    for role in ["explorer", "synth"] {
+        let toml = format!(
+            r#"
+            [backends.wan]
+            kind = "dashscope"
+
+            [casts.broken]
+            {role} = "wan/qwen3.8-max"
+            "#
+        );
+        let err = Config::from_toml_str(&toml)
+            .expect_err("a reasoning slot on a dashscope backend must be refused at load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(role) && msg.contains("dashscope") && msg.contains("media kind"),
+            "the error names the slot, the kind, and its class, got: {msg}"
+        );
+    }
+}

--- a/tests/dashscope_live.rs
+++ b/tests/dashscope_live.rs
@@ -1,0 +1,103 @@
+//! Live DashScope probe — `#[ignore]`d, following `tests/openai_images_live.rs` and
+//! `tests/stability_live.rs`: never run by `cargo test`, run by hand with `--ignored`
+//! once a real credential is present. Spends real money (one `wan2.6-t2i` image).
+//!
+//! This is the only witness to the whole path, because the artifact fetch takes
+//! `https` and so cannot run against the offline socket in
+//! `tests/dashscope_transport.rs`: generation → presigned link → fetched bytes →
+//! `MediaArtifact` with a mime the CAS can store.
+//!
+//! A dedicated-endpoint subscription has its own host, so `KAIBO_DASHSCOPE_BASE_URL`
+//! overrides the shared international default. Without it the probe still runs, just
+//! against `dashscope-intl.aliyuncs.com`.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kaibo::dashscope::{DashScopeClient, DashScopeImageModel, DASHSCOPE_API_BASE};
+use kaibo::media::{FieldValue, MediaModel, MediaOutcome, MediaRequest};
+
+/// The key sources the `dashscope` kind seeds: `DASHSCOPE_API_KEY`, then
+/// `~/.dashscope-key`, env winning.
+fn dashscope_key() -> anyhow::Result<String> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("$HOME is not set; cannot locate the key-file"))?;
+    let env_value = std::env::var(kaibo::dashscope::DASHSCOPE_KEY_ENV_VAR).ok();
+    kaibo::credentials::resolve(
+        env_value.as_deref(),
+        &home.join(kaibo::dashscope::DASHSCOPE_KEY_FILE_NAME),
+    )
+}
+
+#[tokio::test]
+#[ignore = "hits DashScope (wan2.6-t2i, one image, real money); run with --ignored and \
+            ~/.dashscope-key or DASHSCOPE_API_KEY present, optionally \
+            KAIBO_DASHSCOPE_BASE_URL for a dedicated endpoint"]
+async fn wan_t2i_returns_real_image_bytes_through_a_fetched_link() {
+    let key = match dashscope_key() {
+        Ok(k) => k,
+        Err(e) => panic!("no DashScope credential for live test: {e}"),
+    };
+    let base_url = std::env::var("KAIBO_DASHSCOPE_BASE_URL")
+        .unwrap_or_else(|_| DASHSCOPE_API_BASE.to_string());
+    let client =
+        DashScopeClient::new(key, base_url, Duration::from_secs(300)).expect("client construction");
+    let model = DashScopeImageModel::from_parts(&client, "wan2.6-t2i");
+
+    let request = MediaRequest {
+        prompt: "a small lighthouse on a rocky cliff, watercolor".to_string(),
+        // One image at the smallest legal area — DashScope's total-pixel floor is
+        // 589824, so 768*768 is the cheapest shape that is not a 400.
+        fields: vec![
+            (
+                "n".to_string(),
+                FieldValue::Num(serde_json::Number::from(1)),
+            ),
+            ("size".to_string(), FieldValue::Str("768*768".to_string())),
+        ],
+        input_image: None,
+    };
+    let outcome = model.generate(&request).await.expect("live generation");
+    let MediaOutcome::Complete(artifacts) = outcome else {
+        panic!("this route is synchronous, so the outcome is always Complete");
+    };
+
+    assert_eq!(artifacts.len(), 1, "n = 1 asked for exactly one image");
+    let artifact = &artifacts[0];
+    assert!(
+        artifact.bytes.len() > 1024,
+        "a real image is more than a kilobyte, got {} bytes",
+        artifact.bytes.len()
+    );
+    // The mime came from the object store's own Content-Type, and it must be one the
+    // CAS can name an extension for — that pairing is the whole point of refusing to
+    // guess it.
+    let ext = kaibo::cas::Extension::from_mime(&artifact.mime).unwrap_or_else(|| {
+        panic!(
+            "the CAS must know the fetched mime, got {:?}",
+            artifact.mime
+        )
+    });
+    assert!(
+        ext.is_image(),
+        "a generated artifact stores as an image, got {:?}",
+        artifact.mime
+    );
+    // Prove the bytes really are what the mime claims, rather than an error page
+    // served with an image content-type.
+    let magic_ok = match ext {
+        kaibo::cas::Extension::Png => artifact.bytes.starts_with(&[0x89, b'P', b'N', b'G']),
+        kaibo::cas::Extension::Jpeg => artifact.bytes.starts_with(&[0xFF, 0xD8, 0xFF]),
+        kaibo::cas::Extension::Webp => {
+            artifact.bytes.starts_with(b"RIFF") && artifact.bytes[8..12].starts_with(b"WEBP")
+        }
+        kaibo::cas::Extension::Gif => artifact.bytes.starts_with(b"GIF8"),
+        other => panic!("unexpected image extension {other:?}"),
+    };
+    assert!(
+        magic_ok,
+        "the fetched bytes must actually be {:?}, not a page served under that type",
+        artifact.mime
+    );
+}

--- a/tests/dashscope_transport.rs
+++ b/tests/dashscope_transport.rs
@@ -252,5 +252,13 @@ async fn a_response_with_no_images_is_refused() {
         })
         .await
         .expect_err("no images is not a success");
-    assert!(format!("{err:#}").contains("no images"), "got: {err:#}");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("without an image") && msg.contains("zero artifacts"),
+        "the refusal says what came back and why it is not a success, got: {msg}"
+    );
+    assert!(
+        msg.contains("again"),
+        "and it says what to do next, got: {msg}"
+    );
 }

--- a/tests/dashscope_transport.rs
+++ b/tests/dashscope_transport.rs
@@ -1,0 +1,256 @@
+//! The DashScope client driven over a real socket, offline — the transport truths
+//! the pure-function tests cannot see and the paid live probe should not be the only
+//! witness to: the URL the client dials, the bearer it sends, the JSON body as
+//! serialized on the wire, and a provider error rendering readably.
+//!
+//! Sibling of `tests/openai_images_transport.rs`, with one deliberate difference.
+//! DashScope answers with artifact *links*, and `cas::fetch_artifact_bytes` takes
+//! `https` only — so a plain `TcpListener` cannot serve the second hop. This file
+//! therefore covers the generation exchange in full and pins that the fetch guard
+//! fires on a non-TLS link, naming the URL. The walk from fetched bytes into a
+//! `MediaArtifact` is covered by `artifact_mime`'s unit tests in `src/dashscope.rs`
+//! and end to end by the `#[ignore]`d live probe in `tests/dashscope_live.rs`.
+//!
+//! Keeping the scheme check un-mocked is the point: an offline test that could reach
+//! a plaintext artifact URL would be testing a kaibo that does not exist.
+
+use std::time::Duration;
+
+use kaibo::dashscope::{DashScopeClient, DashScopeImageModel};
+use kaibo::media::{FieldValue, MediaModel, MediaRequest};
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// One captured HTTP request: the head as raw text, the body as JSON.
+struct Captured {
+    head: String,
+    body: Value,
+}
+
+impl Captured {
+    fn request_line(&self) -> &str {
+        self.head.lines().next().unwrap_or("")
+    }
+
+    fn header(&self, name: &str) -> Option<String> {
+        let want = format!("{}:", name.to_ascii_lowercase());
+        self.head.lines().find_map(|line| {
+            line.to_ascii_lowercase()
+                .starts_with(&want)
+                .then(|| line[want.len()..].trim().to_string())
+        })
+    }
+}
+
+/// Serve exactly one HTTP exchange and hand back the captured request. Returns the
+/// base URL to dial — an API *root*, since this client appends its own route.
+async fn one_shot_server(
+    status: u16,
+    response_body: String,
+) -> (String, tokio::sync::oneshot::Receiver<Captured>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-request");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+        let content_length: usize = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse().unwrap())
+            })
+            .expect("a JSON POST always declares Content-Length");
+        while buf.len() < head_end + content_length {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-body");
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body: Value =
+            serde_json::from_slice(&buf[head_end..head_end + content_length]).unwrap();
+        let response = format!(
+            "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\n\
+             content-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+            response_body.len(),
+        );
+        sock.write_all(response.as_bytes()).await.unwrap();
+        sock.shutdown().await.ok();
+        tx.send(Captured { head, body }).ok();
+    });
+    (format!("http://{addr}"), rx)
+}
+
+/// A generation response carrying `n` images as links.
+fn image_response(urls: &[&str]) -> String {
+    let choices: Vec<Value> = urls
+        .iter()
+        .map(|u| serde_json::json!({"message": {"role": "assistant", "content": [{"image": u, "type": "image"}]}}))
+        .collect();
+    serde_json::json!({
+        "request_id": "req-1",
+        "output": {"choices": choices},
+        "usage": {"image_count": urls.len(), "size": "1280*1280"},
+    })
+    .to_string()
+}
+
+/// The full generation exchange: the client POSTs to exactly
+/// `{base}/api/v1/services/aigc/multimodal-generation/generation`, authenticates
+/// with its bearer, nests the prompt in DashScope's message envelope, seeds
+/// `enable_interleave`, and preserves each caller field's stated JSON type — `n` an
+/// integer the provider type-checks, `negative_prompt` a string.
+#[tokio::test]
+async fn generation_dials_the_route_and_sends_a_typed_body() {
+    let (base_url, captured) =
+        one_shot_server(200, image_response(&["http://artifact.test/1.png"])).await;
+
+    let client = DashScopeClient::new("test-key-123".to_string(), base_url, Duration::from_secs(5))
+        .expect("client builds");
+    let model = DashScopeImageModel::from_parts(&client, "wan2.6-t2i");
+    let request = MediaRequest {
+        prompt: "a red cube on a white table".to_string(),
+        fields: vec![
+            (
+                "n".to_string(),
+                FieldValue::Num(serde_json::Number::from(2)),
+            ),
+            (
+                "negative_prompt".to_string(),
+                FieldValue::Str("blurry".to_string()),
+            ),
+        ],
+        ..Default::default()
+    };
+    // The generation half succeeds; the artifact fetch is what fails, and the next
+    // test pins that. Here the request is the subject.
+    let _ = model.generate(&request).await;
+
+    let captured = captured.await.expect("the server captured one request");
+    assert_eq!(
+        captured.request_line(),
+        "POST /api/v1/services/aigc/multimodal-generation/generation HTTP/1.1",
+        "the client appends its own route to the configured base URL"
+    );
+    assert_eq!(
+        captured.header("authorization").as_deref(),
+        Some("Bearer test-key-123")
+    );
+    assert_eq!(
+        captured.body["model"],
+        serde_json::json!("wan2.6-t2i"),
+        "the slot's model id rides the body, not the URL"
+    );
+    assert_eq!(
+        captured.body["input"]["messages"][0]["content"][0]["text"],
+        serde_json::json!("a red cube on a white table")
+    );
+    assert_eq!(
+        captured.body["parameters"]["enable_interleave"],
+        serde_json::json!(true),
+        "a text-only prompt is refused without this, so kaibo seeds it"
+    );
+    assert_eq!(captured.body["parameters"]["n"], serde_json::json!(2));
+    assert!(
+        captured.body["parameters"]["n"].is_i64(),
+        "n must reach the wire as an integer, not a float or a string"
+    );
+    assert_eq!(
+        captured.body["parameters"]["negative_prompt"],
+        serde_json::json!("blurry")
+    );
+}
+
+/// A plaintext artifact link is refused, and the refusal names the URL and the
+/// requirement. This is the guard that keeps kaibo's one outbound artifact fetch on
+/// TLS; a test that let it through would be testing a different program.
+#[tokio::test]
+async fn a_plaintext_artifact_link_is_refused_naming_the_url() {
+    let (base_url, _captured) =
+        one_shot_server(200, image_response(&["http://artifact.test/1.png"])).await;
+
+    let client = DashScopeClient::new("k".to_string(), base_url, Duration::from_secs(5))
+        .expect("client builds");
+    let model = DashScopeImageModel::from_parts(&client, "wan2.6-t2i");
+    let err = model
+        .generate(&MediaRequest {
+            prompt: "a red cube".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("an http artifact link must be refused");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("https") && msg.contains("http://artifact.test/1.png"),
+        "the refusal names the requirement and the offending URL, got: {msg}"
+    );
+    assert!(
+        msg.contains("artifact 0"),
+        "the refusal names which artifact failed, got: {msg}"
+    );
+}
+
+/// A provider error renders as `code: message` rather than a raw JSON blob, and the
+/// status rides along — the difference between "fix the key" and "fix the request".
+#[tokio::test]
+async fn a_provider_error_renders_readably_with_its_status() {
+    let body = serde_json::json!({
+        "request_id": "req-2",
+        "code": "InvalidApiKey",
+        "message": "Invalid API-key provided.",
+    })
+    .to_string();
+    let (base_url, _captured) = one_shot_server(401, body).await;
+
+    let client = DashScopeClient::new("bad".to_string(), base_url, Duration::from_secs(5))
+        .expect("client builds");
+    let model = DashScopeImageModel::from_parts(&client, "wan2.6-t2i");
+    let err = model
+        .generate(&MediaRequest {
+            prompt: "a red cube".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("a 401 must surface");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("401") && msg.contains("InvalidApiKey") && msg.contains("Invalid API-key"),
+        "the error names the status, the provider code, and its message, got: {msg}"
+    );
+}
+
+/// A 2xx carrying no image is refused rather than handed on as an empty artifact
+/// list — zero artifacts is never a successful generation.
+#[tokio::test]
+async fn a_response_with_no_images_is_refused() {
+    let body = serde_json::json!({
+        "request_id": "req-3",
+        "output": {"choices": [{"message": {"content": [{"text": "no picture"}]}}]},
+    })
+    .to_string();
+    let (base_url, _captured) = one_shot_server(200, body).await;
+
+    let client = DashScopeClient::new("k".to_string(), base_url, Duration::from_secs(5))
+        .expect("client builds");
+    let model = DashScopeImageModel::from_parts(&client, "wan2.6-t2i");
+    let err = model
+        .generate(&MediaRequest {
+            prompt: "a red cube".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("no images is not a success");
+    assert!(format!("{err:#}").contains("no images"), "got: {err:#}");
+}

--- a/tests/gating.rs
+++ b/tests/gating.rs
@@ -477,3 +477,29 @@ fn all_tools_disabled_refuses_to_start() {
         "the failure must say why; stderr was: {stderr}"
     );
 }
+
+/// A dashscope image slot staffs `generate` — the third media kind proving the gate
+/// is class-based rather than a hand-maintained kind list.
+#[test]
+fn a_dashscope_cast_staffs_generate() {
+    let mut config = Config::from_toml_str(
+        r#"
+        [backends.wan]
+        kind = "dashscope"
+        key_optional = true
+        api_key_file = "/nonexistent-kaibo-test/dashscope"
+
+        [casts.art]
+        image = "wan/wan2.6-t2i"
+        "#,
+    )
+    .expect("fixture config parses");
+    config.tools = ToolGating::default();
+    let tools = KaiboHandler::new_with_env(config, |_| None)
+        .expect("handler builds")
+        .advertised_tools();
+    assert!(
+        tools.contains(&"generate".to_string()),
+        "a dashscope image slot must staff `generate`; got {tools:?}"
+    );
+}

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -63,6 +63,13 @@ fn reqwest_client_builds_once_the_ring_provider_is_installed() {
 /// real `200`, and the assertion is that the ordinary client GETS it while the fetch
 /// client does not — which can only be true if the scheme restriction is doing the
 /// work. Verified by removing `https_only(true)` and watching this fail.
+///
+/// Coverage limit, stated rather than papered over: the fetch client's OTHER setting,
+/// `Policy::none()`, has no offline test. `https_only` means it cannot be pointed at
+/// a local plaintext fixture, and serving TLS here would need a certificate this
+/// suite has no way to trust. The redirect path is exercised only by the `#[ignore]`d
+/// live probe. An assertion that merely constructed both clients was written and
+/// deleted — it could not fail, and a test that cannot fail is worse than none.
 #[tokio::test]
 async fn the_artifact_fetch_client_refuses_plaintext_the_ordinary_client_accepts() {
     use tokio::io::AsyncWriteExt as _;
@@ -104,7 +111,7 @@ async fn the_artifact_fetch_client_refuses_plaintext_the_ordinary_client_accepts
         "the fixture server must really answer, or the refusal below means nothing"
     );
 
-    let fetch = kaibo::tls::https_only_client(std::time::Duration::from_secs(5))
+    let fetch = kaibo::tls::artifact_fetch_client(std::time::Duration::from_secs(5))
         .expect("the fetch client builds");
     let err = fetch
         .get(&url)

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -48,3 +48,71 @@ fn reqwest_client_builds_once_the_ring_provider_is_installed() {
         "the installed default provider should be ring's"
     );
 }
+
+/// The artifact-fetch client refuses plaintext on its own, not just because
+/// `cas::fetch_artifact_bytes` checks the scheme up front.
+///
+/// This is the half that check cannot cover: reqwest follows redirects, and its
+/// `https_only` flag is off by default, so an `https` artifact link that bounced to
+/// `http` would be followed. Proving the CLIENT refuses `http` proves the property
+/// holds for every hop, redirect targets included.
+///
+/// Written as a **differential**, because the obvious version of this test passes for
+/// the wrong reason: a listener that accepts and hangs up makes *both* clients error,
+/// so the test stays green even with `https_only` removed. Here the server answers a
+/// real `200`, and the assertion is that the ordinary client GETS it while the fetch
+/// client does not — which can only be true if the scheme restriction is doing the
+/// work. Verified by removing `https_only(true)` and watching this fail.
+#[tokio::test]
+async fn the_artifact_fetch_client_refuses_plaintext_the_ordinary_client_accepts() {
+    use tokio::io::AsyncWriteExt as _;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        // Answer every comer with a complete, valid response.
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                let body = "ok";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\n\
+                     content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(response.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    let url = format!("http://{addr}/artifact.png");
+
+    // The control FIRST: if this fails, the fixture is broken and the refusal below
+    // would prove nothing.
+    let ordinary = kaibo::tls::https_client(std::time::Duration::from_secs(5))
+        .expect("the ordinary client builds");
+    let ok = ordinary
+        .get(&url)
+        .send()
+        .await
+        .expect("the ordinary client has no scheme restriction, so plaintext works");
+    assert_eq!(
+        ok.status().as_u16(),
+        200,
+        "the fixture server must really answer, or the refusal below means nothing"
+    );
+
+    let fetch = kaibo::tls::https_only_client(std::time::Duration::from_secs(5))
+        .expect("the fetch client builds");
+    let err = fetch
+        .get(&url)
+        .send()
+        .await
+        .expect_err("the fetch client must refuse plaintext even when it would work");
+    assert!(
+        !err.is_timeout(),
+        "the refusal must be a scheme refusal, not a timeout: {err}"
+    );
+}


### PR DESCRIPTION
Adds `kind = "dashscope"`, kaibo's third media kind, so `generate` can run on an Alibaba DashScope subscription. Closes the gap that made image generation reachable only through Stability, hosted OpenAI, or a local sd-server.

## Why this shape

**Probed before written.** Every claim below was measured against a live endpoint, each with a negative control, because an all-clear that cannot fail means nothing:

- The OpenAI-compatible `/images/generations` path **does not exist** on a DashScope host — it answers with the same `No static resource` error as a route I invented. So `kind = "openai-images"` pointed at DashScope was never an option.
- The documented **async** `text2image/image-synthesis` route is an account entitlement this subscription lacks (`403 current user api does not support asynchronous calls`, against a bogus route's `400 Model not exist` — the route is real, the permission isn't). It is also async-only: without the header it 400s.
- The **synchronous** `multimodal-generation/generation` route reaches `wan2.6-t2i` and is what kaibo speaks. No polling lane needed.

**Media-only on purpose.** The same DashScope host serves text on an OpenAI-compatible endpoint kaibo already speaks, so a qwen model there belongs on a `kind = "openai"` backend with that base URL. A reasoning slot pointed at `dashscope` is a load error that says exactly this.

## The decision this PR rests on

DashScope delivers artifacts as **presigned links, never inline bytes**. kaibo had a standing rule against fetching artifact URLs, stated in `openai_images.rs` and pinned by a test asserting the phrase "never fetches".

Amy's call when it surfaced:

> we fetch URLs all the time in inference, this is similar, so we should tune the language and add the fetch into cas. otherwise the user has to dink with curl and raw tokens.

That rule was right for the case it was written for and wrong as a blanket. Where base64 is available, a URL means the request lost `response_format` and refusing is free. Where links are the only delivery, refusing just moves the same network hop into the operator's shell with the key on a command line. And a content-addressed store cannot address what it has not read — the digest *is* the address, so bytes are the artifact's existence condition, not a convenience.

So: the refusal is now scoped to the kind that means it, its message points at the parameter that fixes it, and its test asserts the blanket claim is **absent**.

## The fetch

`cas::fetch_artifact_bytes` — beside the store rather than in the provider, so the next URL-delivering provider inherits the bound and the refusals instead of restating them. `MediaArtifact` is unchanged and still carries bytes; pushing the fetch past the provider seam would have churned Stability and openai-images for nothing.

- **https only, on every hop.** The second commit is a fix found while reviewing my own first: reqwest follows up to ten redirects and `https_only` defaults to **false**, so an https link redirecting to http was followed and the up-front scheme check only ever described the first hop. `tls::https_only_client` closes it, added in the one place kaibo builds reqwest clients so ring is still installed at every site. Kept separate from `https_client` — everywhere else the endpoint is an operator's own `base_url`.
- **Bounded twice**: the declared `Content-Length` before any body is read, and the running total while it is. Empty bodies refused.
- **No new write surface** — bytes route through the existing `store_generated_artifacts` → `MediaStore::put`, so `no_write_path.rs` stays at exactly 5 blessed lines.

**Mime comes from the fetch response's `Content-Type`**, and one the media store cannot name is refused rather than defaulted to png — a wrong extension under a real digest is a permanent mislabel, and the URL's suffix is a hint no operator can correct.

## Measured facts that shaped the request

`enable_interleave` must be seeded or a text-only prompt is refused; `n` is 1–4; `size` is `"W*H"` bounded by total pixels (589824–2073600); and **unknown parameter names are silently accepted**, so kaibo sends only what a caller wrote rather than leaning on the provider to catch a typo.

## Tests

Pure build/parse units, an offline transport test over a real socket, and an `#[ignore]`d live probe walking generation → link → bytes → artifact that checks the magic bytes actually match the claimed mime.

Two tests were verified by breaking the thing they guard:

- Seeding and the fetch guard: broke both, watched the right three fail.
- The TLS-on-every-hop test **initially passed for the wrong reason** — a listener that accepts and hangs up makes both clients error, so it stayed green with `https_only` removed. Rewritten as a differential: the fixture serves a real 200 and asserts the ordinary client gets it while the fetch client does not. Confirmed failing without the flag.

## Gates

`cargo clippy --all-targets` clean · 1131 tests pass · rustfmt clean on every touched file · `cargo tree -i` empty for `aws-lc-rs` and `mimalloc` (with a positive control proving the command works) · `no_write_path` unchanged at 5 blessed lines · live probe green against a real subscription.

## Also

Corrects a doc comment in `openai_images.rs` that had `key_optional` backwards from shipped behavior.

## Review

Cross-family review by Gemini via kaibo is running; results will be added as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)