### PR TITLE
feat(tls): identify kaibo on every outbound request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ record. Each later release appends a new section at the top.
 - **kaibo now fetches a generated artifact's URL when that is how a provider delivers
   it**, over TLS and size-bounded, instead of refusing it — otherwise the operator
   fetches the link by hand with their key.
+- **Every outbound request now identifies itself as `kaibo/<version>`** — kaibo's
+  traffic previously carried no `User-Agent` at all.
 
 ### Fixed
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -39,6 +39,26 @@ pub fn ensure_crypto_provider() {
     });
 }
 
+/// What kaibo calls itself on every outbound request: `kaibo/<version>`.
+///
+/// reqwest sends no `User-Agent` unless one is set, so before this existed kaibo's
+/// traffic arrived anonymous — `accept: */*` and a `host:` header, nothing else. Being
+/// named is ordinary good manners toward a provider, and it has two practical edges:
+/// an unnamed client draws the pessimistic rate-limit bucket, and a bot filter in front
+/// of an object store is far likelier to refuse one. That second case became real when
+/// [`artifact_fetch_client`] started dialling a CDN directly, where a refusal would
+/// surface as an opaque 403 on a request the operator does not know kaibo makes.
+///
+/// Nothing is disclosed by this that the request did not already carry — these are
+/// keyed endpoints, so the credential identifies the account before the header does.
+/// Short by choice (no URL, no OS or arch): enough for a provider to attribute traffic,
+/// no more.
+///
+/// The one request that does not carry it is the OTLP span export, whose client the
+/// OpenTelemetry SDK builds itself (see `telemetry.rs`) — and that one goes to the
+/// operator's own collector, where identifying kaibo to itself buys nothing.
+pub const USER_AGENT: &str = concat!("kaibo/", env!("CARGO_PKG_VERSION"));
+
 /// Build a reqwest HTTPS client carrying a per-request deadline — the **one**
 /// construction site for every provider client (rig completions and provider batches
 /// alike), so the `rustls-no-provider` + ring contract lives in exactly one place
@@ -56,6 +76,7 @@ pub fn ensure_crypto_provider() {
 pub fn https_client(request_timeout: Duration) -> Result<reqwest::Client> {
     ensure_crypto_provider();
     reqwest::Client::builder()
+        .user_agent(USER_AGENT)
         .timeout(request_timeout)
         .connect_timeout(request_timeout.min(Duration::from_secs(10)))
         .build()
@@ -86,6 +107,7 @@ pub fn https_client(request_timeout: Duration) -> Result<reqwest::Client> {
 pub fn artifact_fetch_client(request_timeout: Duration) -> Result<reqwest::Client> {
     ensure_crypto_provider();
     reqwest::Client::builder()
+        .user_agent(USER_AGENT)
         .timeout(request_timeout)
         .connect_timeout(request_timeout.min(Duration::from_secs(10)))
         .https_only(true)

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -123,3 +123,61 @@ async fn the_artifact_fetch_client_refuses_plaintext_the_ordinary_client_accepts
         "the refusal must be a scheme refusal, not a timeout: {err}"
     );
 }
+
+/// kaibo names itself on the wire. Observed on a real socket rather than asserted
+/// against the builder, because the question is what a provider actually receives.
+///
+/// This started as a gap, not a regression: reqwest sends no `User-Agent` unless one
+/// is set, so kaibo's traffic arrived carrying only `accept` and `host`. The
+/// assertions below are deliberately about the header's PRESENCE and shape, not its
+/// exact version — pinning the version would turn every release into a test edit.
+#[tokio::test]
+async fn outbound_requests_name_kaibo_and_its_version() {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    /// Serve one request and hand back its head.
+    async fn capture(port_tx: tokio::sync::oneshot::Sender<String>) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        port_tx
+            .send(listener.local_addr().unwrap().to_string())
+            .unwrap();
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 8192];
+        let n = sock.read(&mut buf).await.unwrap();
+        let _ = sock
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\nok")
+            .await;
+        String::from_utf8_lossy(&buf[..n]).to_string()
+    }
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(capture(tx));
+    let addr = rx.await.unwrap();
+    let client = kaibo::tls::https_client(std::time::Duration::from_secs(5)).unwrap();
+    let _ = client.get(format!("http://{addr}/probe")).send().await;
+    let head = server.await.unwrap();
+
+    let ua = head
+        .lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("user-agent:"))
+        .map(|l| l["user-agent:".len()..].trim().to_string())
+        .unwrap_or_else(|| panic!("no User-Agent reached the server; head was:\n{head}"));
+    assert_eq!(
+        ua,
+        kaibo::tls::USER_AGENT,
+        "the wire value must be exactly the constant, not a reqwest default"
+    );
+    assert!(
+        ua.starts_with("kaibo/"),
+        "a provider reading its logs should see kaibo by name, got {ua:?}"
+    );
+    assert!(
+        ua.len() > "kaibo/".len(),
+        "the version must actually be interpolated, got {ua:?}"
+    );
+    // Short form, decided deliberately: no URL, no OS, no arch.
+    assert!(
+        !ua.contains("http") && !ua.contains(' '),
+        "the short form carries a name and a version and nothing else, got {ua:?}"
+    );
+}


### PR DESCRIPTION
**Stacked on #158** (`feat/dashscope-wan`) — both touch `tls.rs`, so this resolves their overlap once rather than racing to `main`. Merge #158 first.

kaibo's outbound traffic was anonymous. reqwest sets no `User-Agent` unless asked, and nothing in the tree ever asked. Confirmed on a socket rather than inferred from the builder — a real request went out as:

```
GET /probe HTTP/1.1
accept: */*
host: 127.0.0.1:33161
```

That covered everything: every rig provider client, both batch lanes, `/models` discovery, Stability, OpenAI Images, and the artifact fetch #158 adds.

## Why it was worth fixing

The intent already existed in exactly one place and had never generalized — the OpenRouter arm builds `.with_app_identity("kaibo", "https://github.com/tobert/kaibo")` (`consult/engine.rs:440`) so kaibo shows up in their dashboard. We identified ourselves to one provider, by accident of that provider having a bespoke mechanism.

Beyond ordinary manners toward a provider, two practical edges:

- **An unnamed client draws the pessimistic rate-limit bucket.** Providers shape traffic by client, and nobody can contact us when we misbehave.
- **The artifact fetch made it load-bearing.** #158 dials an object store's CDN directly, and a bot filter is markedly likelier to refuse an unnamed client. That refusal would surface as an opaque 403 on a request the operator doesn't know kaibo makes.

There's no privacy trade here: these are keyed endpoints, so the credential identifies the account long before a header does.

## Shape

`kaibo/<version>` — short form, no URL, no OS, no arch. Set in `tls.rs` on both builders, which is where the ring contract already lives and the only place kaibo constructs a reqwest client, so it can't drift per call site. Every rig provider client inherits it through the `.http_client()` injection that was already there.

**Not covered:** the OTLP span export, whose client the OpenTelemetry SDK builds itself (`telemetry.rs`). That one goes to the operator's own collector, where identifying kaibo to itself buys nothing. Stated in the constant's doc rather than left as a silent gap.

## Testing

The test reads the header off a real socket, because the question is what a provider actually receives — not what the builder was told. It pins presence and shape but deliberately **not** the version, since pinning that would turn every release into a test edit.

Verified by removing `.user_agent(...)` from both builders and watching it fail with `no User-Agent reached the server`.

Live-checked end to end on both paths the change touches: a DashScope image generation plus artifact fetch, and a full `consult` inference round trip through rig. Neither regressed.

Gates: clippy clean · 1136 tests · rustfmt clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)