### PR TITLE
feat(telemetry): honour the OTEL_* environment, and redact content by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ record. Each later release appends a new section at the top.
 
 - **`kind = "dashscope"`** — a media backend for Alibaba's wan image family, so
   `generate` can run on a DashScope subscription.
+- **kaibo honours the standard `OTEL_*` environment**, and exports to
+  `OTEL_EXPORTER_OTLP_ENDPOINT` without further configuration.
+- **`[telemetry] capture_content`** — prompts, completions, and tool payloads are
+  redacted from exported spans unless you opt in.
+- **`[telemetry] capture`** — admit individual attributes by semantic-convention name.
 
 ### Changed
 
@@ -27,6 +32,9 @@ record. Each later release appends a new section at the top.
   fetches the link by hand with their key.
 - **Every outbound request now identifies itself as `kaibo/<version>`** — kaibo's
   traffic previously carried no `User-Agent` at all.
+- **Telemetry enables itself when an OTLP endpoint is in the environment**, which is
+  safe because content is redacted by default. An explicit `enabled = false` still wins,
+  and `OTEL_SDK_DISABLED` beats everything.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,10 @@ record. Each later release appends a new section at the top.
 
 - **`kind = "dashscope"`** — a media backend for Alibaba's wan image family, so
   `generate` can run on a DashScope subscription.
-- **kaibo honours the standard `OTEL_*` environment**, and exports to
-  `OTEL_EXPORTER_OTLP_ENDPOINT` without further configuration.
-- **`[telemetry] capture_content`** — prompts, completions, and tool payloads are
-  redacted from exported spans unless you opt in.
-- **`[telemetry] capture`** — admit individual attributes by semantic-convention name.
+- **kaibo reads the standard `OTEL_*` environment**, including `OTEL_SDK_DISABLED`.
+- **`[telemetry] capture_content`** — off by default, so exported spans carry no prompts,
+  completions, or tool payloads.
+- **`[telemetry] capture`** — export one named attribute without exporting all of them.
 
 ### Changed
 
@@ -32,9 +31,10 @@ record. Each later release appends a new section at the top.
   fetches the link by hand with their key.
 - **Every outbound request now identifies itself as `kaibo/<version>`** — kaibo's
   traffic previously carried no `User-Agent` at all.
-- **Telemetry enables itself when an OTLP endpoint is in the environment**, which is
-  safe because content is redacted by default. An explicit `enabled = false` still wins,
-  and `OTEL_SDK_DISABLED` beats everything.
+- **Telemetry turns on when `OTEL_EXPORTER_OTLP_ENDPOINT` is set** — safe now that
+  content is redacted by default.
+- **An explicit `[telemetry] enabled = false` beats the environment**, and
+  `OTEL_SDK_DISABLED` beats every source.
 
 ### Fixed
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -259,20 +259,44 @@ scratch_limit_bytes = 67108864
                                 # POSIX-unrestricted. A typo here is a load error.
 
 # ---------------------------------------------------------------------------
-# [telemetry] — OpenTelemetry export: traces and logs. OFF BY DEFAULT, and that
-# default is load-bearing: kaibo reads private source, and the spans rig emits carry
-# prompts, completions, and source snippets. A default run ships NOTHING. Enabling
-# opens an OUTBOUND OTLP/HTTP connection to `endpoint` — allowed under stdio-only
-# (kaibo never *binds* a socket), but a real boundary, so it's opt-in. rig already
-# emits the GenAI span tree (a tool call → each phase → each model turn, with token
-# usage); this just exports it. `logs` adds kaibo's own tracing events, which the
-# span tree does not carry. Transport is OTLP/HTTP + protobuf, reusing kaibo's
-# reqwest — no gRPC. Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,LOGS,LOGS_ENDPOINT,
-# TIMEOUT_SECS,SERVICE_NAME}. `headers` is file-only (a value can be a secret).
+# [telemetry] — OpenTelemetry export: traces and logs.
+#
+# Two separate questions, and kaibo answers them separately:
+#
+#   1. Do spans leave at all?     `enabled`
+#   2. Do they carry CONTENT?     `capture_content`  (default false)
+#
+# Content is off by default and that default is load-bearing: kaibo reads private
+# source, and the spans rig emits carry prompts, completions, and source snippets.
+# With it off, a trace carries model ids, token counts, durations, finish reasons,
+# and exit codes — enough to answer "what did this cost and where did the time go"
+# and nothing you would mind a collector holding. Enforced by an ALLOWLIST applied
+# on export, so an attribute nobody blessed is dropped even if a future dependency
+# starts emitting it.
+#
+# `enabled` turns ON BY ITSELF when the standard OTLP environment is present — if
+# OTEL_EXPORTER_OTLP_ENDPOINT (or ..._TRACES_ENDPOINT) is set, kaibo exports there.
+# That is safe precisely because content is redacted. Set `enabled = false` here to
+# refuse regardless of the environment; an explicit false always wins. OTEL_SDK_DISABLED
+# turns everything off and beats every other source.
+#
+# Standard environment kaibo honours: OTEL_EXPORTER_OTLP_ENDPOINT (a ROOT — the signal
+# path is appended), OTEL_EXPORTER_OTLP_{TRACES,LOGS}_ENDPOINT (FULL urls), OTEL_SERVICE_NAME,
+# OTEL_SDK_DISABLED, and OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT — the GenAI
+# semantic conventions' own name for the content opt-in.
+#
+# Precedence: KAIBO_TELEMETRY_* / CLI  >  this file  >  OTEL_*  >  off. OTEL_* sits
+# lowest on purpose: it is ambient, set by a platform for its own collector, so it may
+# supply what you left blank but never override what you wrote.
+#
+# Enabling opens an OUTBOUND OTLP/HTTP connection — allowed under stdio-only (kaibo
+# never *binds* a socket). Transport is OTLP/HTTP + protobuf, reusing kaibo's reqwest
+# — no gRPC. Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,LOGS,LOGS_ENDPOINT,TIMEOUT_SECS,
+# SERVICE_NAME,CAPTURE_CONTENT}. `headers` and `capture` are file-only.
 # ---------------------------------------------------------------------------
 
 # [telemetry]
-# enabled      = true                                # default false — opt in here
+# enabled      = true                                # default: on if OTEL_* names an endpoint
 # endpoint     = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
 # logs         = true                                # default true when enabled
 # Where log records go. Omit it and kaibo derives the sibling of `endpoint` when that
@@ -284,6 +308,15 @@ scratch_limit_bytes = 67108864
 # VALUES are secrets — they never appear in the kaibo://config render (only the
 # header names do).
 # headers = { authorization = "Bearer <token>" }
+# Export prompts, completions, and tool payloads on the spans. Default false. The
+# GenAI semantic conventions say instrumentations SHOULD NOT capture these by
+# default; kaibo also honours their env spelling,
+# OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT.
+# capture_content = false
+# Admit individual attributes beyond the safe set, by semantic-convention name —
+# the finer knob when you want one field rather than all of them. Unknown names are
+# simply never exported, so a typo costs you a field, never a leak.
+# capture = ["gen_ai.output.messages"]
 
 # ---------------------------------------------------------------------------
 # [cas] — the media content-addressed store: where an artifact-producing tool writes

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -261,38 +261,29 @@ scratch_limit_bytes = 67108864
 # ---------------------------------------------------------------------------
 # [telemetry] — OpenTelemetry export: traces and logs.
 #
-# Two separate questions, and kaibo answers them separately:
+# Two knobs, two questions. `enabled` decides whether spans leave at all.
+# `capture_content` decides whether they carry prompts, completions, and tool
+# payloads — default FALSE, so a span carries model ids, token counts, durations,
+# finish reasons, and exit codes, and no source.
 #
-#   1. Do spans leave at all?     `enabled`
-#   2. Do they carry CONTENT?     `capture_content`  (default false)
+# `enabled` defaults ON when OTEL_EXPORTER_OTLP_ENDPOINT or
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set — kaibo exports to the collector the
+# environment already names. Set `enabled = false` here to refuse whatever the
+# environment says; an explicit false always wins. OTEL_SDK_DISABLED turns every
+# signal off and beats every other source.
 #
-# Content is off by default and that default is load-bearing: kaibo reads private
-# source, and the spans rig emits carry prompts, completions, and source snippets.
-# With it off, a trace carries model ids, token counts, durations, finish reasons,
-# and exit codes — enough to answer "what did this cost and where did the time go"
-# and nothing you would mind a collector holding. Enforced by an ALLOWLIST applied
-# on export, so an attribute nobody blessed is dropped even if a future dependency
-# starts emitting it.
+# Precedence: KAIBO_TELEMETRY_* / CLI > this file > OTEL_* > off. OTEL_* ranks last
+# because it is ambient — a platform sets it for its own collector, so it fills in
+# what you left blank and never overrides what you wrote.
 #
-# `enabled` turns ON BY ITSELF when the standard OTLP environment is present — if
-# OTEL_EXPORTER_OTLP_ENDPOINT (or ..._TRACES_ENDPOINT) is set, kaibo exports there.
-# That is safe precisely because content is redacted. Set `enabled = false` here to
-# refuse regardless of the environment; an explicit false always wins. OTEL_SDK_DISABLED
-# turns everything off and beats every other source.
+# Enabling opens an OUTBOUND OTLP/HTTP connection — allowed under stdio-only, because
+# kaibo never *binds* a socket. Transport is OTLP/HTTP with protobuf, reusing kaibo's
+# reqwest — no gRPC.
 #
-# Standard environment kaibo honours: OTEL_EXPORTER_OTLP_ENDPOINT (a ROOT — the signal
-# path is appended), OTEL_EXPORTER_OTLP_{TRACES,LOGS}_ENDPOINT (FULL urls), OTEL_SERVICE_NAME,
-# OTEL_SDK_DISABLED, and OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT — the GenAI
-# semantic conventions' own name for the content opt-in.
-#
-# Precedence: KAIBO_TELEMETRY_* / CLI  >  this file  >  OTEL_*  >  off. OTEL_* sits
-# lowest on purpose: it is ambient, set by a platform for its own collector, so it may
-# supply what you left blank but never override what you wrote.
-#
-# Enabling opens an OUTBOUND OTLP/HTTP connection — allowed under stdio-only (kaibo
-# never *binds* a socket). Transport is OTLP/HTTP + protobuf, reusing kaibo's reqwest
-# — no gRPC. Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,LOGS,LOGS_ENDPOINT,TIMEOUT_SECS,
-# SERVICE_NAME,CAPTURE_CONTENT}. `headers` and `capture` are file-only.
+# Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,LOGS,LOGS_ENDPOINT,TIMEOUT_SECS,SERVICE_NAME,
+# CAPTURE_CONTENT}, plus the standard OTEL_* set. `headers` and `capture` are
+# file-only. Which attributes survive redaction, and why the guard is an allowlist:
+# kaibo://config/guide, "Telemetry".
 # ---------------------------------------------------------------------------
 
 # [telemetry]
@@ -308,14 +299,14 @@ scratch_limit_bytes = 67108864
 # VALUES are secrets — they never appear in the kaibo://config render (only the
 # header names do).
 # headers = { authorization = "Bearer <token>" }
-# Export prompts, completions, and tool payloads on the spans. Default false. The
-# GenAI semantic conventions say instrumentations SHOULD NOT capture these by
-# default; kaibo also honours their env spelling,
+# Export prompts, completions, and tool payloads on the spans. Default false — the
+# GenAI semantic conventions say an instrumentation must not capture these unless
+# asked. kaibo reads their env spelling too,
 # OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT.
 # capture_content = false
-# Admit individual attributes beyond the safe set, by semantic-convention name —
-# the finer knob when you want one field rather than all of them. Unknown names are
-# simply never exported, so a typo costs you a field, never a leak.
+# Export named attributes beyond the default set, in semantic-convention spelling —
+# use this when you want one field rather than all of them. A name kaibo does not
+# know is never exported, so a typo costs a field and never leaks one.
 # capture = ["gen_ai.output.messages"]
 
 # ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -777,12 +777,12 @@ headers = { authorization = "Bearer <token>" }        # file-only; values are se
 
 | Variable | Effect |
 |---|---|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | A **root**; kaibo appends `/v1/traces` and `/v1/logs`. Setting it enables telemetry. |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | A **full URL**, used verbatim. Beats the root. |
-| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | A full URL for records. |
-| `OTEL_SERVICE_NAME` | `service.name` on both Resources. |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | The GenAI conventions' own content opt-in, honoured verbatim. |
-| `OTEL_SDK_DISABLED` | Turns everything off, and beats every other source. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | kaibo appends `/v1/traces` and `/v1/logs` to this value — it is a root, not a full URL. Setting it turns telemetry on. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | kaibo posts spans to this value unchanged, and ignores the root above for spans. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | kaibo posts records to this value unchanged. |
+| `OTEL_SERVICE_NAME` | kaibo sets `service.name` to this value on both Resources. |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | kaibo exports content when this is set — it is the GenAI conventions' own name for the opt-in, read here unchanged. |
+| `OTEL_SDK_DISABLED` | kaibo exports nothing, whatever any other source says. |
 
 **Precedence: `KAIBO_TELEMETRY_*` / CLI > `config.toml` > `OTEL_*` > off.** This one
 family inverts kaibo's usual env-beats-file rule, deliberately. `OTEL_*` is *ambient* —
@@ -793,29 +793,36 @@ everything, because a kill switch something else can override is not a kill swit
 
 ### What is redacted, and how
 
-Content is dropped by an **allowlist** applied on export (`src/otel_filter.rs`), not by
-declining to record it. kaibo has no choice about that: the attributes carrying content
-— `gen_ai.prompt`, `gen_ai.input.messages`, `gen_ai.tool.call.arguments`,
-`gen_ai.tool.call.result` and their siblings — are emitted inside `rig`, not by kaibo.
-The last place kaibo owns is the exporter.
+kaibo drops content at the export step, rather than by declining to record it — the
+attributes that carry content (`gen_ai.prompt`, `gen_ai.input.messages`,
+`gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`, and their siblings) are written
+by `rig`, so kaibo cannot decline to set them and can only decline to send them.
 
-An allowlist rather than a denylist because the failure directions are not symmetric: a
-denylist fails **open** the day a dependency emits a new content attribute, while an
-allowlist fails **closed** — an unblessed name is simply never exported, and the cost of
-being wrong is a missing field rather than leaked source.
+The rule is an **allowlist**: kaibo exports the attributes it names and drops every
+other. A denylist would name the attributes to drop instead, and it would start leaking
+the day a dependency adds a content attribute nobody has listed yet. An allowlist gets
+that case wrong in the safe direction — a new attribute is missing from a dashboard until
+someone adds it, rather than being sent.
 
-Three surfaces are filtered, not one: span attributes, **event** attributes (kaibo's own
-log lines name paths — `running kaish: cat -n src/auth.rs`), and the **error status
-description**, where a provider's response body lands. The conventions draw that last
-line the same way: `error.type` is safe and kept, `exception.message` is sensitive and
-dropped. Span names are left alone — they are `{operation} {model}` identifiers.
+kaibo filters three parts of a span, not one:
 
-`capture` is the finer knob: name individual attributes in semantic-convention spelling
-to admit them without turning the whole content set on. An unknown name is never
-exported, so a typo costs a field rather than causing a leak.
+- **Span attributes** — the obvious one.
+- **Event attributes** — kaibo's own log lines are span events, and they name paths, as
+  in `running kaish: cat -n src/auth.rs`. An event keeps its name and timestamp, so a
+  reader still sees that something happened.
+- **The error status description** — a provider puts its response body there. kaibo keeps
+  `error.type`, which is a short enum, and drops the description, which is free text. The
+  GenAI conventions draw the same line: `error.type` is safe, `exception.message` is not.
 
-`kaibo://config` reports `capture_content` and a one-line `content_policy` describing
-what is leaving, and the startup log prints the same sentence beside the endpoint.
+Span names are exported unchanged, because a span name is an identifier of the form
+`{operation} {model}` and carries no content.
+
+Use `capture` to export one attribute without exporting all of them. kaibo never exports
+a name it does not know, so a misspelled entry costs you that attribute and cannot leak
+another one.
+
+`kaibo://config` reports `capture_content` and a one-line `content_policy` naming what
+leaves, and the startup log prints the same line beside the endpoint.
 
 **What you get.** The GenAI trace tree rig produces — a tool call → `run_phase` per
 phase → `invoke_agent` → a `chat` span per model turn, carrying `gen_ai.request.model`

--- a/docs/config.md
+++ b/docs/config.md
@@ -743,20 +743,79 @@ implemented.
 
 ## Telemetry (OpenTelemetry traces and logs)
 
-**Off by default.** kaibo reads a private codebase, and the spans `rig-core` emits carry
-prompts, completions, and source snippets. A default run ships nothing off-box, so
-`[telemetry]` is opt-in.
+kaibo splits two questions that are usually conflated:
+
+1. **Do spans leave at all?** — `enabled`
+2. **Do they carry content?** — `capture_content`, default **false**
+
+That split is what lets telemetry be useful and safe at the same time. kaibo reads a
+private codebase, and the spans `rig-core` emits carry prompts, completions, and source
+snippets — so those are redacted unless you ask for them. What remains is model ids,
+token counts, durations, finish reasons, and exit codes: enough to answer *what did this
+cost and where did the time go*, with nothing a collector should not hold.
+
+**`enabled` turns on by itself when the standard OTLP environment is present.** If
+`OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is set, kaibo
+exports there without any kaibo-specific configuration. That is only defensible because
+content is redacted; if you opt content in, you are choosing to send it to whatever that
+variable points at.
 
 ```toml
 [telemetry]
-enabled       = true                                # default false
-endpoint      = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
-logs          = true                                # default true when enabled
-logs_endpoint = "http://localhost:4318/v1/logs"     # omit to derive from endpoint
-timeout_secs  = 10                                  # per-export deadline; must be > 0
-service_name  = "kaibo"                             # service.name on both Resources
-headers = { authorization = "Bearer <token>" }      # file-only; values are secrets
+enabled         = true                                # default: on if OTEL_* names an endpoint
+endpoint        = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
+logs            = true                                # default true when enabled
+logs_endpoint   = "http://localhost:4318/v1/logs"     # omit to derive from endpoint
+timeout_secs    = 10                                  # per-export deadline; must be > 0
+service_name    = "kaibo"                             # service.name on both Resources
+capture_content = false                               # prompts/completions/tool payloads
+capture         = ["gen_ai.output.messages"]          # admit individual attributes
+headers = { authorization = "Bearer <token>" }        # file-only; values are secrets
 ```
+
+### The standard environment
+
+| Variable | Effect |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | A **root**; kaibo appends `/v1/traces` and `/v1/logs`. Setting it enables telemetry. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | A **full URL**, used verbatim. Beats the root. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | A full URL for records. |
+| `OTEL_SERVICE_NAME` | `service.name` on both Resources. |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | The GenAI conventions' own content opt-in, honoured verbatim. |
+| `OTEL_SDK_DISABLED` | Turns everything off, and beats every other source. |
+
+**Precedence: `KAIBO_TELEMETRY_*` / CLI > `config.toml` > `OTEL_*` > off.** This one
+family inverts kaibo's usual env-beats-file rule, deliberately. `OTEL_*` is *ambient* —
+a platform sets it for its own collector, not necessarily aiming it at kaibo — so it may
+supply what you left blank and never override what you wrote. An explicit
+`enabled = false` is absolute. `OTEL_SDK_DISABLED` is the one exception that beats
+everything, because a kill switch something else can override is not a kill switch.
+
+### What is redacted, and how
+
+Content is dropped by an **allowlist** applied on export (`src/otel_filter.rs`), not by
+declining to record it. kaibo has no choice about that: the attributes carrying content
+— `gen_ai.prompt`, `gen_ai.input.messages`, `gen_ai.tool.call.arguments`,
+`gen_ai.tool.call.result` and their siblings — are emitted inside `rig`, not by kaibo.
+The last place kaibo owns is the exporter.
+
+An allowlist rather than a denylist because the failure directions are not symmetric: a
+denylist fails **open** the day a dependency emits a new content attribute, while an
+allowlist fails **closed** — an unblessed name is simply never exported, and the cost of
+being wrong is a missing field rather than leaked source.
+
+Three surfaces are filtered, not one: span attributes, **event** attributes (kaibo's own
+log lines name paths — `running kaish: cat -n src/auth.rs`), and the **error status
+description**, where a provider's response body lands. The conventions draw that last
+line the same way: `error.type` is safe and kept, `exception.message` is sensitive and
+dropped. Span names are left alone — they are `{operation} {model}` identifiers.
+
+`capture` is the finer knob: name individual attributes in semantic-convention spelling
+to admit them without turning the whole content set on. An unknown name is never
+exported, so a typo costs a field rather than causing a leak.
+
+`kaibo://config` reports `capture_content` and a one-line `content_policy` describing
+what is leaving, and the startup log prints the same sentence beside the endpoint.
 
 **What you get.** The GenAI trace tree rig produces — a tool call → `run_phase` per
 phase → `invoke_agent` → a `chat` span per model turn, carrying `gen_ai.request.model`

--- a/src/config.rs
+++ b/src/config.rs
@@ -952,7 +952,7 @@ pub struct TelemetryConfig {
     /// rule — "instrumentations SHOULD NOT capture them by default, but SHOULD
     /// provide an option for users to opt in" — and name
     /// `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` as the opt-in, which
-    /// kaibo honours. Enforced by [`crate::otel_filter`], an allowlist applied on
+    /// kaibo honors. Enforced by [`crate::otel_filter`], an allowlist applied on
     /// the way out; see that module for why it is a filter and not a call-site rule.
     pub capture_content: bool,
     /// Extra attribute names to export, beyond the safe set — semantic-convention
@@ -3303,8 +3303,8 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
             telemetry.service_name = Some(v);
         }
     }
-    // The conventions' own name for the content opt-in. kaibo honours it verbatim so
-    // an operator who has set it for other instrumentations gets the same behaviour
+    // The conventions' own name for the content opt-in. kaibo reads it unchanged so
+    // an operator who has set it for other instrumentations gets the same behavior
     // here without learning a kaibo-specific spelling.
     if let Some(v) = get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT") {
         if telemetry.capture_content.is_none() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -944,16 +944,36 @@ pub struct TelemetryConfig {
     pub timeout: Duration,
     /// `service.name` on the OTLP Resource — how this process shows up in traces.
     pub service_name: String,
+    /// Whether exported spans carry prompts, completions, and tool payloads.
+    ///
+    /// **Off by default**, which is what makes telemetry safe to enable
+    /// optimistically: a redacted trace carries model ids, token counts, durations,
+    /// and exit codes, and no source. The GenAI semantic conventions state the same
+    /// rule — "instrumentations SHOULD NOT capture them by default, but SHOULD
+    /// provide an option for users to opt in" — and name
+    /// `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` as the opt-in, which
+    /// kaibo honours. Enforced by [`crate::otel_filter`], an allowlist applied on
+    /// the way out; see that module for why it is a filter and not a call-site rule.
+    pub capture_content: bool,
+    /// Extra attribute names to export, beyond the safe set — semantic-convention
+    /// spellings, e.g. `gen_ai.output.messages`. The finer knob beside
+    /// [`capture_content`](Self::capture_content): admit one field without admitting
+    /// all of them. File-only; a list has no clean single-env-var form.
+    pub capture: Vec<String>,
 }
 
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
+            // Off unless something says otherwise — but "something" now includes a
+            // standard OTLP endpoint in the environment, resolved in `load_with`.
             enabled: false,
             // The session's `otlp-mcp` collector and most local collectors listen
             // here; flipping `enabled` alone targets localhost, never a remote.
             endpoint: "http://localhost:4318/v1/traces".to_string(),
             logs: true,
+            capture_content: false,
+            capture: Vec::new(),
             logs_endpoint: None,
             headers: BTreeMap::new(),
             timeout: Duration::from_secs(10),
@@ -2418,6 +2438,8 @@ struct RawTelemetry {
     headers: Option<BTreeMap<String, String>>,
     timeout_secs: Option<u64>,
     service_name: Option<String>,
+    capture_content: Option<bool>,
+    capture: Option<Vec<String>>,
 }
 
 /// The `[persistence]` stanza — durable sessions + batch handles. `enabled` defaults on;
@@ -2899,6 +2921,8 @@ fn merge_telemetry(raw: RawTelemetry) -> Result<TelemetryConfig> {
         headers: raw.headers.unwrap_or(d.headers),
         timeout,
         service_name: raw.service_name.unwrap_or(d.service_name),
+        capture_content: raw.capture_content.unwrap_or(d.capture_content),
+        capture: raw.capture.unwrap_or(d.capture),
     })
 }
 
@@ -3227,6 +3251,67 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     // disable_builtins is a list — file-only, no env form.
 
     let telemetry = raw.telemetry.get_or_insert_with(Default::default);
+
+    // --- The standard OTEL_* environment ---------------------------------------
+    //
+    // Applied BEFORE the KAIBO_* block below, and only into fields the config file
+    // left unset, so the precedence reads: KAIBO_* / CLI > config.toml > OTEL_* >
+    // off. That deliberately inverts kaibo's usual env-beats-file rule for this one
+    // family, and the reason is that OTEL_* is AMBIENT: a platform sets it for its
+    // own collector, not necessarily aiming it at kaibo. An operator who wrote
+    // `enabled = false` means it, and nothing in the environment may override that.
+    //
+    // The payoff is that a host already exporting telemetry gets kaibo's spans with
+    // no kaibo-specific configuration at all — safe to do only because content is
+    // redacted unless separately opted into (see `capture_content`).
+    let otel_bool = |v: &str| {
+        let v = v.trim().to_ascii_lowercase();
+        !v.is_empty() && v != "0" && v != "false" && v != "no"
+    };
+    // Per-signal endpoints are FULL URLs; the base is a ROOT the signal path is
+    // appended to. That is the OTLP spec's own rule, and getting it backwards would
+    // post spans to the wrong path and 404 against a real collector.
+    let otel_base = get("OTEL_EXPORTER_OTLP_ENDPOINT");
+    let otel_traces = get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").or_else(|| {
+        otel_base
+            .as_ref()
+            .map(|b| format!("{}/v1/traces", b.trim_end_matches('/')))
+    });
+    let otel_logs = get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT").or_else(|| {
+        otel_base
+            .as_ref()
+            .map(|b| format!("{}/v1/logs", b.trim_end_matches('/')))
+    });
+    if let Some(endpoint) = otel_traces {
+        if telemetry.endpoint.is_none() {
+            telemetry.endpoint = Some(endpoint);
+        }
+        // An endpoint in the environment is the opt-in signal: it means someone runs
+        // a collector and expects processes to speak to it. Only when the file is
+        // silent — an explicit `enabled = false` stays false.
+        if telemetry.enabled.is_none() {
+            telemetry.enabled = Some(true);
+        }
+    }
+    if let Some(endpoint) = otel_logs {
+        if telemetry.logs_endpoint.is_none() {
+            telemetry.logs_endpoint = Some(endpoint);
+        }
+    }
+    if let Some(v) = get("OTEL_SERVICE_NAME") {
+        if telemetry.service_name.is_none() {
+            telemetry.service_name = Some(v);
+        }
+    }
+    // The conventions' own name for the content opt-in. kaibo honours it verbatim so
+    // an operator who has set it for other instrumentations gets the same behaviour
+    // here without learning a kaibo-specific spelling.
+    if let Some(v) = get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT") {
+        if telemetry.capture_content.is_none() {
+            telemetry.capture_content = Some(otel_bool(&v));
+        }
+    }
+
     if let Some(v) = get("KAIBO_TELEMETRY_ENABLED") {
         // Same on/off grammar as the KAIBO_NO_* flags, but here it can flip a
         // file-enabled exporter *off* too — so set the parsed bool either way.
@@ -3256,6 +3341,23 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if let Some(v) = get("KAIBO_TELEMETRY_SERVICE_NAME") {
         telemetry.service_name = Some(v);
+    }
+    if let Some(v) = get("KAIBO_TELEMETRY_CAPTURE_CONTENT") {
+        // Same on/off grammar as the other KAIBO_* toggles, and set either way so it
+        // can turn a file-enabled capture back off.
+        let on = {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no"
+        };
+        telemetry.capture_content = Some(on);
+    }
+    // The SDK's standard kill switch, applied LAST so it beats every other source
+    // including KAIBO_*. An operator reaching for it wants everything off, and a
+    // switch something else can override is not a kill switch.
+    if let Some(v) = get("OTEL_SDK_DISABLED") {
+        if otel_bool(&v) {
+            telemetry.enabled = Some(false);
+        }
     }
     // headers is a map — file-only, no env form (same call as disable_builtins).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod mcp_log;
 pub mod media;
 pub mod openai_images;
 pub mod orientation;
+pub mod otel_filter;
 pub mod progress;
 pub mod sandbox;
 pub mod server;

--- a/src/otel_filter.rs
+++ b/src/otel_filter.rs
@@ -1,0 +1,378 @@
+//! The span-attribute allowlist: what kaibo is willing to put on the wire.
+//!
+//! # Why a filter and not a call-site rule
+//!
+//! Everywhere else kaibo controls what it records, the rule is "never build the
+//! thing you must not send". That is not available here. The attributes carrying
+//! prompts, completions, and tool payloads are emitted by **rig**, not by kaibo —
+//! `gen_ai.prompt`, `gen_ai.completion`, `gen_ai.input.messages`,
+//! `gen_ai.output.messages`, `gen_ai.system_instructions`,
+//! `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` all come from inside the
+//! dependency. kaibo cannot decline to set them; it can only decline to export them.
+//!
+//! So the guard sits at the last place kaibo owns: a transparent wrapper around the
+//! `SpanExporter`, the same shape `completion_watch::Watched` and
+//! `wire_repair::Repaired` take around their traits. Everything the SDK produces
+//! passes through [`Filtered::export`] on its way out.
+//!
+//! # An allowlist, because the failure directions are not symmetric
+//!
+//! A denylist fails **open** on a dependency bump: rig adds one new content
+//! attribute, kaibo has never heard of it, and the next `cargo update` starts
+//! shipping source code to a collector with nothing in the diff to notice. An
+//! allowlist fails **closed**: the new attribute is simply not exported until
+//! someone blesses it by name, and the cost of being wrong is a missing field on a
+//! dashboard. That is the same reasoning `tests/no_write_path.rs` uses when it pins
+//! an exact blessed count rather than enumerating what is forbidden.
+//!
+//! The list is built from the OpenTelemetry GenAI semantic conventions, whose own
+//! rule is the one kaibo follows: *"OpenTelemetry instrumentations SHOULD NOT
+//! capture them by default, but SHOULD provide an option for users to opt in"*
+//! (`gen-ai-spans.md`, and its pattern 1 — "[Default] Don't record instructions,
+//! inputs, or outputs").
+//!
+//! # Three surfaces, not one
+//!
+//! A span carries content in three places, and an allowlist that covered only the
+//! first would leak through the other two:
+//!
+//! 1. **Span attributes** — the obvious one.
+//! 2. **Event attributes.** `tracing` events inside a span become span events, and
+//!    kaibo's own log lines are events: `running kaish: cat -n src/auth.rs` names a
+//!    real path and a real intent. Event attributes go through the same allowlist;
+//!    an event whose attributes all drop keeps its name and timestamp, so the
+//!    skeleton of what happened survives without the flesh.
+//! 3. **The error status description.** A failed provider call puts the response
+//!    body there, and a failed tool call can put a source snippet there. The
+//!    semantic conventions draw exactly this line — `error.type` is a safe,
+//!    low-cardinality enum and is on the allowlist, while `exception.message`
+//!    carries a sensitivity warning — so kaibo keeps the type and drops the prose.
+//!
+//! Span **names** are left alone deliberately: the conventions define them as
+//! `{operation} {model}` / `execute_tool {tool_name}` shapes, which are identifiers
+//! rather than payloads. `tests/otel_filter.rs`'s canary asserts that stays true by
+//! searching names along with everything else.
+
+use std::collections::BTreeSet;
+
+use opentelemetry::trace::Status;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::{SpanData, SpanExporter};
+
+/// Attributes kaibo exports by default: identifiers, counts, timings, and outcomes.
+///
+/// Every entry is here because it describes *shape* rather than content — a model
+/// id, a token count, an exit code. Sorted by origin so a reader can tell which are
+/// the conventions' and which are kaibo's own.
+pub const SAFE_ATTRIBUTES: &[&str] = &[
+    // --- GenAI conventions: the operation ---
+    "gen_ai.operation.name",
+    "gen_ai.provider.name",
+    "gen_ai.system",
+    "gen_ai.conversation.id",
+    "gen_ai.output.type",
+    "gen_ai.agent.name",
+    "gen_ai.agent.id",
+    "gen_ai.agent.description",
+    "gen_ai.workflow.name",
+    // --- GenAI conventions: the request knobs (no payload) ---
+    "gen_ai.request.model",
+    "gen_ai.request.max_tokens",
+    "gen_ai.request.temperature",
+    "gen_ai.request.top_p",
+    "gen_ai.request.top_k",
+    "gen_ai.request.seed",
+    "gen_ai.request.stream",
+    "gen_ai.request.choice.count",
+    "gen_ai.request.frequency_penalty",
+    "gen_ai.request.presence_penalty",
+    "gen_ai.request.reasoning.level",
+    "gen_ai.request.previous_response.id",
+    // --- GenAI conventions: the response shape ---
+    "gen_ai.response.id",
+    "gen_ai.response.model",
+    "gen_ai.response.finish_reasons",
+    "gen_ai.response.time_to_first_chunk",
+    // --- GenAI conventions: usage ---
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.output_tokens",
+    "gen_ai.usage.reasoning_tokens",
+    "gen_ai.usage.reasoning.output_tokens",
+    "gen_ai.usage.cache_read.input_tokens",
+    "gen_ai.usage.cache_creation.input_tokens",
+    "gen_ai.usage.tool_use_prompt_tokens",
+    "gen_ai.token.type",
+    // --- GenAI conventions: tools, identity only ---
+    "gen_ai.tool.name",
+    "gen_ai.tool.type",
+    "gen_ai.tool.call.id",
+    // `gen_ai.tool.description` carries a sensitivity warning in the conventions but
+    // is `Recommended`, not `Opt-In` — a real inconsistency for a general
+    // instrumentation. It is safe HERE for a reason specific to kaibo: our tool
+    // descriptions are published product text, written to be read by a calling
+    // model. Blessed deliberately, not by oversight.
+    "gen_ai.tool.description",
+    // --- Errors: the type, never the prose ---
+    "error.type",
+    // --- Server identity ---
+    "server.address",
+    "server.port",
+    // --- kaibo's own span fields ---
+    // From `tool_span.rs`: the shell's outcome and the SIZE of what it printed,
+    // never what it printed. `gen_ai.tool.arguments` is deliberately absent — it is
+    // kaibo's summary of the kaish script, which names paths.
+    "kaish.exit_code",
+    "kaish.output_bytes",
+    "outcome",
+    // The team that answered. A cast name is operator vocabulary from config, and a
+    // slot ref is `backend/model-id` — both identifiers.
+    "cast",
+    "model",
+    "slot",
+    "phase",
+    "role",
+    // Loop shape: how many turns, how many delegations. The numbers that answer
+    // "did the driver actually delegate", with no payload.
+    "turns",
+    "turn",
+    "max_turns",
+    "finish_reason",
+];
+
+/// Attributes that carry content, exported only when the operator opts in.
+///
+/// Split out rather than merged into one big list so the diff that adds content to
+/// the wire is legible, and so [`AttributePolicy::describe`] can say what changed.
+/// The conventions mark most of these `Opt-In`; the two `gen_ai.prompt` /
+/// `gen_ai.completion` entries are rig's older spelling of the same thing, and are
+/// listed because rig still emits both.
+pub const CONTENT_ATTRIBUTES: &[&str] = &[
+    "gen_ai.prompt",
+    "gen_ai.completion",
+    "gen_ai.input.messages",
+    "gen_ai.output.messages",
+    "gen_ai.system_instructions",
+    "gen_ai.tool.definitions",
+    "gen_ai.tool.call.arguments",
+    "gen_ai.tool.call.result",
+    // kaibo's own: a summary of the kaish script the model ran.
+    "gen_ai.tool.arguments",
+    // `tracing`'s event body — kaibo's own log lines, which name paths and commands.
+    "message",
+];
+
+/// What this process will put on the wire.
+#[derive(Debug, Clone)]
+pub struct AttributePolicy {
+    allow: BTreeSet<String>,
+    content: bool,
+}
+
+impl AttributePolicy {
+    /// The default policy: the safe set, plus any extra names the operator listed.
+    ///
+    /// `capture_content` folds in [`CONTENT_ATTRIBUTES`] wholesale — the spec-named
+    /// master switch. `extra` is the finer knob: individual semantic-convention
+    /// names, so an operator who wants completions but not prompts can say so
+    /// without turning everything on.
+    pub fn new(capture_content: bool, extra: &[String]) -> Self {
+        let mut allow: BTreeSet<String> = SAFE_ATTRIBUTES.iter().map(|s| s.to_string()).collect();
+        if capture_content {
+            allow.extend(CONTENT_ATTRIBUTES.iter().map(|s| s.to_string()));
+        }
+        allow.extend(extra.iter().cloned());
+        Self {
+            allow,
+            content: capture_content,
+        }
+    }
+
+    /// Is this attribute exported?
+    pub fn allows(&self, key: &str) -> bool {
+        self.allow.contains(key)
+    }
+
+    /// Whether the error status description survives. Tied to content capture: a
+    /// provider's error body and a failed tool's output both land there.
+    pub fn allows_status_description(&self) -> bool {
+        self.content
+    }
+
+    /// One line for the startup log, so an operator can see what is leaving without
+    /// reading config back.
+    pub fn describe(&self) -> String {
+        if self.content {
+            format!(
+                "prompts and responses INCLUDED ({} attributes allowed)",
+                self.allow.len()
+            )
+        } else {
+            format!(
+                "content redacted — metadata only ({} attributes allowed)",
+                self.allow.len()
+            )
+        }
+    }
+
+    /// Strip everything this policy does not allow, in place.
+    pub fn scrub(&self, span: &mut SpanData) {
+        span.attributes.retain(|kv| self.allows(kv.key.as_str()));
+        for event in &mut span.events.events {
+            event.attributes.retain(|kv| self.allows(kv.key.as_str()));
+        }
+        if !self.allows_status_description() {
+            if let Status::Error { .. } = span.status {
+                // Keep the fact of the error — `error.type` carries the kind — and
+                // drop the prose, which is where a provider body or a source
+                // snippet would be.
+                span.status = Status::Error {
+                    description: "".into(),
+                };
+            }
+        }
+    }
+}
+
+/// A [`SpanExporter`] that scrubs every batch before handing it on.
+///
+/// Transparent by design: it owns no transport and makes no export decisions, so
+/// swapping the inner exporter for an in-memory one in a test exercises the real
+/// filter rather than a stand-in.
+#[derive(Debug)]
+pub struct Filtered<E> {
+    inner: E,
+    policy: AttributePolicy,
+}
+
+impl<E> Filtered<E> {
+    /// Wrap an exporter in a policy.
+    pub fn new(inner: E, policy: AttributePolicy) -> Self {
+        Self { inner, policy }
+    }
+}
+
+impl<E: SpanExporter> SpanExporter for Filtered<E> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
+        for span in &mut batch {
+            self.policy.scrub(span);
+        }
+        self.inner.export(batch).await
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        self.inner.shutdown()
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.inner.set_resource(resource);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two lists must not overlap: a name in both would be exported by default
+    /// while reading as gated, which is the one way this design fails quietly.
+    #[test]
+    fn the_safe_and_content_lists_are_disjoint() {
+        let safe: BTreeSet<_> = SAFE_ATTRIBUTES.iter().collect();
+        let content: BTreeSet<_> = CONTENT_ATTRIBUTES.iter().collect();
+        let both: Vec<_> = safe.intersection(&content).collect();
+        assert!(
+            both.is_empty(),
+            "an attribute cannot be both safe and gated: {both:?}"
+        );
+    }
+
+    /// Every attribute rig is known to emit for content is gated. This is the list
+    /// that rots on a rig bump, so it is pinned explicitly rather than inferred.
+    #[test]
+    fn every_content_attribute_rig_emits_is_gated() {
+        for name in [
+            "gen_ai.prompt",
+            "gen_ai.completion",
+            "gen_ai.input.messages",
+            "gen_ai.output.messages",
+            "gen_ai.system_instructions",
+            "gen_ai.tool.call.arguments",
+            "gen_ai.tool.call.result",
+        ] {
+            assert!(
+                CONTENT_ATTRIBUTES.contains(&name),
+                "{name} is emitted by rig and carries content — it must be gated"
+            );
+            assert!(
+                !AttributePolicy::new(false, &[]).allows(name),
+                "{name} must not be exported by default"
+            );
+        }
+    }
+
+    /// The default policy keeps the numbers an operator actually watches.
+    #[test]
+    fn the_default_policy_keeps_metadata() {
+        let p = AttributePolicy::new(false, &[]);
+        for name in [
+            "gen_ai.request.model",
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.output_tokens",
+            "gen_ai.response.finish_reasons",
+            "gen_ai.tool.name",
+            "kaish.exit_code",
+            "kaish.output_bytes",
+            "error.type",
+            "cast",
+        ] {
+            assert!(p.allows(name), "{name} is metadata and should survive");
+        }
+    }
+
+    /// An unknown attribute is dropped — the fail-closed property, which is the
+    /// whole reason this is an allowlist. A rig bump that adds
+    /// `gen_ai.something.new` must not reach the wire.
+    #[test]
+    fn an_unknown_attribute_is_dropped() {
+        let p = AttributePolicy::new(false, &[]);
+        assert!(!p.allows("gen_ai.something.new"));
+        assert!(!p.allows("rig.internal.prompt_text"));
+    }
+
+    /// Opting in adds the content set and nothing else — it is not a bypass.
+    #[test]
+    fn opting_in_adds_content_but_stays_an_allowlist() {
+        let p = AttributePolicy::new(true, &[]);
+        assert!(p.allows("gen_ai.input.messages"));
+        assert!(
+            !p.allows("gen_ai.something.new"),
+            "capture_content is not a wildcard"
+        );
+    }
+
+    /// A named extra is admitted without turning the whole content set on — the
+    /// finer knob, for an operator who wants one field.
+    #[test]
+    fn an_extra_name_is_admitted_alone() {
+        let p = AttributePolicy::new(false, &["gen_ai.output.messages".to_string()]);
+        assert!(p.allows("gen_ai.output.messages"));
+        assert!(
+            !p.allows("gen_ai.input.messages"),
+            "naming one attribute must not admit its siblings"
+        );
+    }
+
+    /// The startup line says which mode is live, in words an operator can act on.
+    #[test]
+    fn describe_names_the_mode() {
+        assert!(AttributePolicy::new(false, &[])
+            .describe()
+            .contains("redacted"));
+        assert!(AttributePolicy::new(true, &[])
+            .describe()
+            .contains("INCLUDED"));
+    }
+}

--- a/src/otel_filter.rs
+++ b/src/otel_filter.rs
@@ -1,4 +1,5 @@
-//! The span-attribute allowlist: what kaibo is willing to put on the wire.
+//! The span-attribute allowlist: kaibo exports the attributes named here and drops
+//! every other one.
 //!
 //! # Why a filter and not a call-site rule
 //!
@@ -10,10 +11,10 @@
 //! `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` all come from inside the
 //! dependency. kaibo cannot decline to set them; it can only decline to export them.
 //!
-//! So the guard sits at the last place kaibo owns: a transparent wrapper around the
-//! `SpanExporter`, the same shape `completion_watch::Watched` and
-//! `wire_repair::Repaired` take around their traits. Everything the SDK produces
-//! passes through [`Filtered::export`] on its way out.
+//! So the guard goes at the export step, which kaibo does own: a transparent wrapper
+//! around the `SpanExporter`, the same shape `completion_watch::Watched` and
+//! `wire_repair::Repaired` take around their traits. Every span the SDK produces
+//! passes through [`Filtered::export`] before it leaves.
 //!
 //! # An allowlist, because the failure directions are not symmetric
 //!
@@ -39,9 +40,9 @@
 //! 1. **Span attributes** — the obvious one.
 //! 2. **Event attributes.** `tracing` events inside a span become span events, and
 //!    kaibo's own log lines are events: `running kaish: cat -n src/auth.rs` names a
-//!    real path and a real intent. Event attributes go through the same allowlist;
-//!    an event whose attributes all drop keeps its name and timestamp, so the
-//!    skeleton of what happened survives without the flesh.
+//!    real path and a real command. Event attributes go through the same allowlist.
+//!    An event whose attributes all drop keeps its name and timestamp — the record
+//!    that something happened is not content, so it stays.
 //! 3. **The error status description.** A failed provider call puts the response
 //!    body there, and a failed tool call can put a source snippet there. The
 //!    semantic conventions draw exactly this line — `error.type` is a safe,
@@ -161,7 +162,7 @@ pub const CONTENT_ATTRIBUTES: &[&str] = &[
     "message",
 ];
 
-/// What this process will put on the wire.
+/// The attributes this process exports. Everything else is dropped.
 #[derive(Debug, Clone)]
 pub struct AttributePolicy {
     allow: BTreeSet<String>,
@@ -198,23 +199,26 @@ impl AttributePolicy {
         self.content
     }
 
-    /// One line for the startup log, so an operator can see what is leaving without
-    /// reading config back.
+    /// One line naming what leaves this process, for the startup log and
+    /// `kaibo://config` — an operator can read the state without reading config back.
+    ///
+    /// Both spellings state the count, because the number is the part an operator can
+    /// check against a change they just made.
     pub fn describe(&self) -> String {
         if self.content {
             format!(
-                "prompts and responses INCLUDED ({} attributes allowed)",
+                "content exported — {} attributes, including prompts and responses",
                 self.allow.len()
             )
         } else {
             format!(
-                "content redacted — metadata only ({} attributes allowed)",
+                "content redacted — {} attributes, no prompts or responses",
                 self.allow.len()
             )
         }
     }
 
-    /// Strip everything this policy does not allow, in place.
+    /// Drop every attribute this policy does not allow, in place.
     pub fn scrub(&self, span: &mut SpanData) {
         span.attributes.retain(|kv| self.allows(kv.key.as_str()));
         for event in &mut span.events.events {
@@ -289,8 +293,8 @@ mod tests {
         );
     }
 
-    /// Every attribute rig is known to emit for content is gated. This is the list
-    /// that rots on a rig bump, so it is pinned explicitly rather than inferred.
+    /// Every attribute rig is known to emit for content is gated. A rig bump can add
+    /// to this list, so it is pinned by name rather than inferred.
     #[test]
     fn every_content_attribute_rig_emits_is_gated() {
         for name in [
@@ -365,14 +369,27 @@ mod tests {
         );
     }
 
-    /// The startup line says which mode is live, in words an operator can act on.
+    /// The startup line says which mode is live, in words an operator can act on, and
+    /// states the count either way — the number is what someone checks against a
+    /// change they just made.
     #[test]
-    fn describe_names_the_mode() {
-        assert!(AttributePolicy::new(false, &[])
-            .describe()
-            .contains("redacted"));
-        assert!(AttributePolicy::new(true, &[])
-            .describe()
-            .contains("INCLUDED"));
+    fn describe_names_the_mode_and_the_count() {
+        let off = AttributePolicy::new(false, &[]).describe();
+        assert!(off.contains("redacted"), "got: {off}");
+        assert!(
+            off.contains("no prompts or responses"),
+            "the redacted line must say what is absent, not only that it is redacted: {off}"
+        );
+        let on = AttributePolicy::new(true, &[]).describe();
+        assert!(
+            on.contains("including prompts and responses"),
+            "the opted-in line must name what is now leaving: {on}"
+        );
+        for line in [&off, &on] {
+            assert!(
+                line.chars().any(|c| c.is_ascii_digit()),
+                "both spellings state the attribute count: {line}"
+            );
+        }
     }
 }

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -222,6 +222,16 @@ pub(crate) fn render_config_resource(
         service_name: String,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         header_names: Vec<String>,
+        /// Whether exported spans carry prompts, completions, and tool payloads.
+        /// The single most consequential telemetry fact for an operator, so it is
+        /// reported even when false.
+        capture_content: bool,
+        /// One line naming what that means in practice — the same sentence the
+        /// startup log prints, so the two can never disagree.
+        content_policy: String,
+        /// Attribute names admitted beyond the safe set, if any.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        capture: Vec<String>,
     }
 
     /// Persistence as resolved. `path` is the state db kaibo would open (absent only
@@ -590,6 +600,8 @@ pub(crate) fn render_config_resource(
         headers: telemetry_headers,
         timeout: telemetry_timeout,
         service_name: telemetry_service_name,
+        capture_content: telemetry_capture_content,
+        capture: telemetry_capture,
     } = &config.telemetry;
     let doc = ConfigDoc {
         allowed_paths: allowed_set
@@ -670,6 +682,13 @@ pub(crate) fn render_config_resource(
             timeout_secs: telemetry_timeout.as_secs(),
             service_name: telemetry_service_name.clone(),
             header_names: telemetry_headers.keys().cloned().collect(),
+            capture_content: *telemetry_capture_content,
+            content_policy: crate::otel_filter::AttributePolicy::new(
+                *telemetry_capture_content,
+                telemetry_capture,
+            )
+            .describe(),
+            capture: telemetry_capture.clone(),
         },
         persistence: PersistenceDoc {
             enabled: config.persistence.enabled,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -185,6 +185,21 @@ where
         .build()
         .context("building the OTLP/HTTP span exporter")?;
 
+    // Every span leaves through the allowlist. Wrapping the exporter — rather than
+    // filtering at the call sites — is the only option available: the attributes
+    // carrying prompts and tool payloads are emitted inside rig, not by kaibo. See
+    // `crate::otel_filter`.
+    let policy = crate::otel_filter::AttributePolicy::new(cfg.capture_content, &cfg.capture);
+    // Say what is leaving, at the moment it starts leaving. An operator who enabled
+    // this through an ambient OTEL_* endpoint may not have thought about kaibo at
+    // all, so the line names the destination and the content policy together.
+    tracing::info!(
+        endpoint = %cfg.endpoint,
+        policy = %policy.describe(),
+        "telemetry enabled — exporting spans"
+    );
+    let exporter = crate::otel_filter::Filtered::new(exporter, policy);
+
     let resource = Resource::builder()
         .with_service_name(cfg.service_name.clone())
         .build();

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2572,3 +2572,128 @@ fn a_reasoning_slot_cannot_point_at_a_dashscope_backend() {
         );
     }
 }
+
+// --- standard OTEL_* environment ------------------------------------------------
+
+/// Helper: load with no config file and a fixed env map.
+fn load_env(pairs: &[(&str, &str)]) -> Config {
+    let owned: Vec<(String, String)> = pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    Config::load_with(
+        None,
+        Some("/nonexistent/kaibo/config.toml".into()),
+        move |k| {
+            owned
+                .iter()
+                .find(|(name, _)| name == k)
+                .map(|(_, v)| v.clone())
+        },
+    )
+    .expect("config loads")
+}
+
+/// A collector in the environment turns telemetry ON by itself — the optimistic
+/// enable. Safe only because content is redacted, which the same assertion pins.
+#[test]
+fn an_otlp_endpoint_in_the_environment_enables_redacted_telemetry() {
+    let c = load_env(&[("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")]);
+    assert!(c.telemetry.enabled, "an OTLP endpoint is the opt-in signal");
+    assert_eq!(
+        c.telemetry.endpoint, "http://collector:4318/v1/traces",
+        "the BASE var is a root; the signal path is appended"
+    );
+    assert!(
+        !c.telemetry.capture_content,
+        "turning on by ambient environment must never also turn on content"
+    );
+}
+
+/// The per-signal var is a FULL url and is not suffixed — the other half of the
+/// OTLP rule, and the half that would silently 404 if we got it backwards.
+#[test]
+fn the_per_signal_endpoint_is_used_verbatim_and_beats_the_base() {
+    let c = load_env(&[
+        ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://base:4318"),
+        (
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "http://traces:4318/custom/path",
+        ),
+    ]);
+    assert_eq!(c.telemetry.endpoint, "http://traces:4318/custom/path");
+}
+
+/// A trailing slash on the base does not produce a doubled separator.
+#[test]
+fn a_trailing_slash_on_the_base_endpoint_is_tolerated() {
+    let c = load_env(&[("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318/")]);
+    assert_eq!(c.telemetry.endpoint, "http://collector:4318/v1/traces");
+}
+
+/// The conventions' own content opt-in is honoured verbatim, so an operator who
+/// already sets it for other instrumentations gets the same behaviour here.
+#[test]
+fn the_semconv_content_env_var_opts_in() {
+    let c = load_env(&[
+        ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318"),
+        ("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true"),
+    ]);
+    assert!(c.telemetry.capture_content);
+}
+
+/// `OTEL_SDK_DISABLED` is a kill switch: it beats the endpoint that would have
+/// enabled telemetry, and it beats KAIBO_TELEMETRY_ENABLED asking for it. A switch
+/// something else can override is not a kill switch.
+#[test]
+fn otel_sdk_disabled_beats_everything() {
+    let c = load_env(&[
+        ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318"),
+        ("KAIBO_TELEMETRY_ENABLED", "true"),
+        ("OTEL_SDK_DISABLED", "true"),
+    ]);
+    assert!(
+        !c.telemetry.enabled,
+        "the standard kill switch has the last word"
+    );
+}
+
+/// KAIBO_* beats OTEL_*: the kaibo-specific setting is the deliberate one, where
+/// OTEL_* may have been set by a platform for its own purposes.
+#[test]
+fn kaibo_env_beats_the_ambient_otel_env() {
+    let c = load_env(&[
+        ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://ambient:4318"),
+        (
+            "KAIBO_TELEMETRY_ENDPOINT",
+            "http://deliberate:4318/v1/traces",
+        ),
+    ]);
+    assert_eq!(c.telemetry.endpoint, "http://deliberate:4318/v1/traces");
+}
+
+/// An explicit `enabled = false` in the file is absolute — ambient environment may
+/// supply what you left blank, never override what you wrote.
+#[test]
+fn an_explicit_file_disable_survives_an_ambient_endpoint() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[telemetry]\nenabled = false\n").expect("write");
+    let c = Config::load_with(Some(path), None, |k| {
+        (k == "OTEL_EXPORTER_OTLP_ENDPOINT").then(|| "http://collector:4318".to_string())
+    })
+    .expect("config loads");
+    assert!(
+        !c.telemetry.enabled,
+        "a stated refusal must beat the ambient environment"
+    );
+}
+
+/// With nothing in the environment, telemetry stays off — the optimistic enable is
+/// triggered by a real endpoint, not by the feature existing.
+#[test]
+fn no_otel_environment_leaves_telemetry_off() {
+    let c = load_env(&[]);
+    assert!(!c.telemetry.enabled);
+    assert!(!c.telemetry.capture_content);
+}

--- a/tests/otel_filter.rs
+++ b/tests/otel_filter.rs
@@ -1,0 +1,175 @@
+//! The canary: a distinctive string planted everywhere a span can carry content,
+//! run through the real SDK export path, and asserted absent.
+//!
+//! This is the test the whole filter exists to pass. The unit tests in
+//! `src/otel_filter.rs` check the policy's *decisions*; this one checks that those
+//! decisions are actually applied to a span the SDK produced, on every surface a
+//! span has — attributes, event attributes, and the error status description.
+//!
+//! **Written as a differential.** Asserting only "the marker is absent" would pass
+//! just as well if the test were looking in the wrong place, or if no span were
+//! exported at all. So every case runs twice: once redacted, where the marker must
+//! be gone, and once with `capture_content = true`, where it must be *present*. The
+//! second half is what proves the first half was looking somewhere real.
+//!
+//! It drives the OpenTelemetry SDK directly rather than through the `tracing`
+//! bridge, deliberately. A `tracing` subscriber installed in one test poisons
+//! callsite interest for others in the same binary, and that flake would make a
+//! security test intermittently green for the wrong reason. The bridge is covered
+//! by construction instead: `tracing_opentelemetry` maps a field *name* to an
+//! attribute *key* unchanged, so a `gen_ai.prompt` field arrives as a
+//! `gen_ai.prompt` attribute and meets the same allowlist. What this file proves is
+//! that the allowlist is enforced on the way out, which is the half that could
+//! silently stop working.
+
+use opentelemetry::trace::{Span, Status, Tracer, TracerProvider as _};
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+
+use kaibo::otel_filter::{AttributePolicy, Filtered};
+
+/// A string that appears nowhere else in the codebase, so finding it anywhere in an
+/// exported span means it came from the payload we planted.
+const MARKER: &str = "CANARY-7f3a91-SECRET-SOURCE-LINE";
+
+/// Emit one span carrying `MARKER` on every content-bearing surface, and return
+/// what the exporter actually received.
+fn export_a_span_full_of_content(capture_content: bool) -> Vec<SpanData> {
+    let sink = InMemorySpanExporter::default();
+    let policy = AttributePolicy::new(capture_content, &[]);
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(Filtered::new(sink.clone(), policy))
+        .build();
+    let tracer = provider.tracer("canary");
+
+    let mut span = tracer
+        .span_builder("chat gpt-5.6")
+        .with_attributes([
+            // Content, in rig's two spellings plus the current conventions.
+            KeyValue::new("gen_ai.prompt", MARKER),
+            KeyValue::new("gen_ai.completion", MARKER),
+            KeyValue::new("gen_ai.input.messages", MARKER),
+            KeyValue::new("gen_ai.output.messages", MARKER),
+            KeyValue::new("gen_ai.system_instructions", MARKER),
+            KeyValue::new("gen_ai.tool.call.arguments", MARKER),
+            KeyValue::new("gen_ai.tool.call.result", MARKER),
+            KeyValue::new("gen_ai.tool.arguments", MARKER),
+            // An attribute nobody has blessed — the shape of a future rig bump.
+            KeyValue::new("rig.some.new.payload", MARKER),
+            // Metadata, which must survive either way.
+            KeyValue::new("gen_ai.request.model", "gpt-5.6-terra"),
+            KeyValue::new("gen_ai.usage.input_tokens", 1234_i64),
+            KeyValue::new("kaish.exit_code", 0_i64),
+        ])
+        .start(&tracer);
+
+    // Surface 2: an event, the way one of kaibo's own log lines arrives.
+    span.add_event(
+        "log",
+        vec![
+            KeyValue::new("message", format!("running kaish: cat -n {MARKER}")),
+            KeyValue::new("kaish.output_bytes", 4096_i64),
+        ],
+    );
+
+    // Surface 3: the error status description, where a provider body lands.
+    span.set_status(Status::error(format!("provider said: {MARKER}")));
+    span.end();
+
+    provider.force_flush().expect("flush");
+    sink.get_finished_spans().expect("spans were exported")
+}
+
+/// Every place the marker could hide in an exported span, rendered as text.
+fn everything_in(spans: &[SpanData]) -> String {
+    let mut out = String::new();
+    for s in spans {
+        out.push_str(&s.name);
+        out.push('\n');
+        for kv in &s.attributes {
+            out.push_str(kv.key.as_str());
+            out.push('=');
+            out.push_str(&kv.value.as_str());
+            out.push('\n');
+        }
+        for e in s.events.iter() {
+            out.push_str(&e.name);
+            out.push('\n');
+            for kv in &e.attributes {
+                out.push_str(kv.key.as_str());
+                out.push('=');
+                out.push_str(&kv.value.as_str());
+                out.push('\n');
+            }
+        }
+        if let Status::Error { description } = &s.status {
+            out.push_str(description);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// The canary. With content redacted, the marker reaches the exporter nowhere —
+/// not on an attribute, not on an event, not in the error description.
+#[test]
+fn no_content_reaches_the_exporter_when_redacted() {
+    let spans = export_a_span_full_of_content(false);
+    assert_eq!(spans.len(), 1, "exactly one span was exported");
+    let haystack = everything_in(&spans);
+    assert!(
+        !haystack.contains(MARKER),
+        "content leaked past the filter. Exported span was:\n{haystack}"
+    );
+}
+
+/// The other half of the differential: with the opt-in on, the marker IS there.
+/// Without this, the test above would pass on an empty span or a broken search.
+#[test]
+fn the_same_content_does_reach_the_exporter_when_opted_in() {
+    let spans = export_a_span_full_of_content(true);
+    let haystack = everything_in(&spans);
+    assert!(
+        haystack.contains(MARKER),
+        "opting in must actually export content — otherwise the redaction test \
+         proves nothing. Exported span was:\n{haystack}"
+    );
+}
+
+/// Redaction is not a blanket: the numbers an operator watches survive it. A filter
+/// that dropped everything would pass the canary and be useless.
+#[test]
+fn metadata_survives_redaction() {
+    let spans = export_a_span_full_of_content(false);
+    let haystack = everything_in(&spans);
+    for expected in [
+        "gen_ai.request.model=gpt-5.6-terra",
+        "gen_ai.usage.input_tokens=1234",
+        "kaish.exit_code=0",
+        "kaish.output_bytes=4096",
+    ] {
+        assert!(
+            haystack.contains(expected),
+            "{expected} is metadata and must survive redaction; got:\n{haystack}"
+        );
+    }
+    // The span name and the fact of the error both survive — the skeleton stays.
+    assert!(haystack.contains("chat gpt-5.6"), "the span name survives");
+    assert!(
+        matches!(spans[0].status, Status::Error { .. }),
+        "the error is still an error; only its prose is dropped"
+    );
+}
+
+/// An attribute nobody blessed is dropped even though it is not on the content
+/// list — the fail-closed property, stated as an end-to-end fact rather than a
+/// policy unit test. This is what protects us on a rig bump.
+#[test]
+fn an_unblessed_attribute_never_reaches_the_wire() {
+    let spans = export_a_span_full_of_content(false);
+    let haystack = everything_in(&spans);
+    assert!(
+        !haystack.contains("rig.some.new.payload"),
+        "an attribute absent from the allowlist must not be exported; got:\n{haystack}"
+    );
+}


### PR DESCRIPTION
First of two. This one makes traces **safe**; the follow-up adds the metrics signal, which is what makes traces *optional*.

## The split

kaibo now answers two questions separately instead of conflating them:

| | knob | default |
|---|---|---|
| Do spans leave at all? | `enabled` | on when `OTEL_*` names an endpoint |
| Do they carry content? | `capture_content` | **false** |

Before this, telemetry was all-or-nothing and therefore off — kaibo reads private source and rig's spans carry prompts, completions, and source snippets, so anyone who wanted latency and token numbers had to ship their code to a collector to get them. With content redacted a trace carries model ids, token counts, durations, finish reasons, and exit codes. That's safe enough that telemetry can turn itself on when the environment already names a collector.

## Following the spec rather than inventing a scheme

Pulled the GenAI semantic conventions (they moved to their own repo) and implemented their rule: *"instrumentations SHOULD NOT capture them by default, but SHOULD provide an option for users to opt in."* Their env spelling `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is honoured verbatim, so an operator who already sets it elsewhere gets the same behaviour here.

| Variable | Effect |
|---|---|
| `OTEL_EXPORTER_OTLP_ENDPOINT` | A **root** — signal path appended. Setting it enables telemetry. |
| `OTEL_EXPORTER_OTLP_{TRACES,LOGS}_ENDPOINT` | **Full URLs**, used verbatim. |
| `OTEL_SERVICE_NAME` | `service.name` |
| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | content opt-in |
| `OTEL_SDK_DISABLED` | off, beating everything |

Root-vs-full-URL is the spec's own rule and would 404 against a real collector if inverted, so both directions are tested.

**Precedence: `KAIBO_*` / CLI > `config.toml` > `OTEL_*` > off.** This inverts kaibo's usual env-beats-file rule for one family, deliberately: `OTEL_*` is *ambient*, set by a platform for its own collector rather than aimed at kaibo, so it may supply what you left blank and never override what you wrote. An explicit `enabled = false` is absolute. `OTEL_SDK_DISABLED` is the one exception that beats everything — a kill switch something else can override is not a kill switch.

## Why a filter, and why an allowlist

The redaction is applied on export, not at the call sites, and that's **forced rather than chosen**: `gen_ai.prompt`, `gen_ai.input.messages`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` and their siblings are emitted inside **rig**. kaibo cannot decline to set them, only decline to export them. So `otel_filter` wraps the exporter — the same transparent-wrapper shape `completion_watch::Watched` and `wire_repair::Repaired` take.

**Allowlist, not denylist**, because the failure directions aren't symmetric. A denylist fails **open** the day a dependency emits a new content attribute — `cargo update` starts shipping source with nothing in the diff to notice. An allowlist fails **closed**: an unblessed name is never exported and being wrong costs a missing dashboard field. Same reasoning `no_write_path.rs` uses in pinning an exact blessed count rather than enumerating what's forbidden.

**Three surfaces, not one** — an allowlist covering only the first would leak through the others:

1. Span attributes.
2. **Event attributes** — kaibo's own log lines name paths (`running kaish: cat -n src/auth.rs`).
3. **The error status description** — where a provider's response body lands. The conventions draw this line the same way: `error.type` safe and kept, `exception.message` sensitive and dropped.

Two spec gotchas are encoded rather than left to be rediscovered: `gen_ai.tool.description` carries a sensitivity warning but is `Recommended`, not `Opt-In` (it's on the safe list here for a kaibo-specific reason — our tool descriptions are published product text — and the comment says so); and `gen_ai.retrieval.documents` is `Opt-In` with *no* warning, gated for volume rather than privacy, so the two axes aren't conflated.

## Verification

Not just unit tests. A **real consult** exported to a capturing collector through `OTEL_EXPORTER_OTLP_ENDPOINT` alone. The raw OTLP protobuf:

```
MUST NOT APPEAR                SHOULD APPEAR
✓ absent  MAX_FETCH_BYTES      ✓ present 12  gen_ai.usage
✓ absent  pub const            ✓ present  2  gen_ai.request.model
✓ absent  cat -n               ✓ present  5  qwen3.8-max
✓ absent  In one sentence      ✓ present  2  gen_ai.tool.name
✓ absent  You are the          ✓ present  2  service.name
```

The same run with content opted in **does** put the answer text on the wire — the differential proving the search was looking somewhere real.

`tests/otel_filter.rs` is the canary for the surfaces rig doesn't populate on that path: a marker planted in all three, asserted absent redacted and present opted-in. Each of the three scrubs was sabotage-checked independently (disable one → the right test fails). The env precedence tests were checked the same way.

`kaibo://config` reports `capture_content` and a one-line `content_policy`; the startup log prints the same sentence beside the endpoint, so someone who enabled this through an ambient variable can see what's leaving.

Gates: clippy clean · 1155 tests · rustfmt introduces no new debt (the pre-existing count in `config.rs`/`tests/config.rs` is unchanged).

## Next

Metrics — `gen_ai.client.token.usage`, `gen_ai.invoke_agent.{duration,inference_calls,tool_calls}`, `gen_ai.execute_tool.duration`. Content-free by construction (confirmed: no metric in the spec references any content attribute), so opting out of tracing entirely still leaves cost, latency, and delegation counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)