### PR TITLE
docs: the probe battery follows the sandbox, not the release calendar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,11 @@ project and cannot run external commands.
   shipped boundary now and then (write/external/read-escape/env/path batteries via
   `run_kaish`, plus an optional model-driven pass). It's framed as **defensive** work
   — auditing our own claims — and routes adversarial framing to a **local** cast so a
-  remote classifier never sees it. Re-run it before a release; stamp the "Last run" line.
+  remote classifier never sees it. Re-run it when the sandbox rules or the VFS change — a
+  `kaish-kernel` or `kaish-vfs` bump counts, and the 2026-07-18 run is the model — and
+  stamp the "Last run" line. A release by itself is not the trigger: the `cargo test`
+  suites guard every commit, so a release that touched neither the rules nor the VFS
+  gives the battery nothing new to find.
 - **Model loops are tested offline.** A scripted `CompletionClient` in
   `src/test_support.rs` (`#[cfg(test)]`) drives the *real* consult loop with no
   network — delegation→report aggregation, session replay, turn-cap recovery. It's
@@ -438,9 +442,11 @@ even for a one-line doc fix.
 - **Cutting a release.** Bump `version` in `Cargo.toml`, retitle the unreleased
   section to `## [X.Y.Z] — <date>` and open a fresh empty unreleased section above it,
   then tag `vX.Y.Z` — `.github/workflows/release.yml` builds the platform matrix on a
-  `v*` tag. Before tagging: confirm the `kaish-kernel` and `turso` pins are current, re-run
-  `docs/sandbox-probes.md` and stamp its "Last run" line, and verify `cargo tree -i` is
-  empty for `aws-lc-rs` and `mimalloc` and the musl binary is `not a dynamic executable`.
+  `v*` tag. Before tagging: confirm the `kaish-kernel` and `turso` pins are current, and
+  verify `cargo tree -i` is empty for `aws-lc-rs` and `mimalloc` and the musl binary is
+  `not a dynamic executable`. Re-run `docs/sandbox-probes.md` when this release changed
+  the sandbox rules or the VFS — a `kaish-kernel` bump is the common case, so check the
+  pin first.
   After the release publishes: run the README "Verify a download" commands against a
   fresh asset (`gh attestation verify`, `cosign verify-blob` with the new tag's
   identity) — the tag-gated publish job signs releases, and signing an operator can't


### PR DESCRIPTION
`AGENTS.md` told us to re-run `docs/sandbox-probes.md` before every release and stamp its "Last run" line. Amy's call, 2026-08-16: *"I don't think we need to do the probes every release, mainly when we meddle with the rules or VFS."*

The reasoning is that the battery and the test suites answer different questions. `cargo test` guards the boundary on every commit; the live battery exists to check that the *shipped* binary still behaves the way the suites claim, which only becomes a new question when the rules or the VFS underneath them move. A release that touched neither gives the battery nothing to find — and a ritual that runs anyway teaches us to run it without reading the result.

So the trigger is now the change, not the tag:

- The runbook bullet names the trigger (sandbox rules or VFS changed, a `kaish-kernel`/`kaish-vfs` bump counts) and points at the 2026-07-18 run as the model, since that run happened for exactly this reason.
- The release checklist keeps its probe line, scoped, with a pointer to check the pin first — a kernel bump is the common way a release does trip it.

Doc-only; no code, no tests touched.

**Note for v0.4.0:** this does not excuse the next release. We expect to fold in kaish 0.15.0, which trips the new trigger on its own, and Amy has already said she wants a probe run before 0.4.0 regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)