### PR TITLE
feat(telemetry): the GenAI metrics signal, safe by construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **`[telemetry]` exports the GenAI metrics signal** — token usage, call and phase
+  durations, turns per phase, and tool calls per phase, as the conventions name them.
+- **`gen_ai.invoke_agent.tool_calls` answers whether a consult driver delegated**,
+  split by `synth` / `explorer`, without reading a single trace.
+- **`[telemetry] traces` and `[telemetry] metrics`** — per-signal switches, so
+  `traces = false, metrics = true` exports kaibo's spend and latency and nothing else.
+  No metric can carry prompts, so that posture is safe by construction.
+- **`[telemetry] metrics_endpoint`** — omit it and kaibo derives the sibling of
+  `endpoint`, the same rule `logs_endpoint` follows.
+- **`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` turns telemetry on by itself**, for a
+  platform that collects metrics and not traces.
 - **`kind = "dashscope"`** — a media backend for Alibaba's wan image family, so
   `generate` can run on a DashScope subscription.
 - **kaibo reads the standard `OTEL_*` environment**, including `OTEL_SDK_DISABLED`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,13 +155,18 @@ opentelemetry = "0.32"
 # `logs` is a default feature today and the logs signal would stop compiling without
 # it; named explicitly so a minor bump that re-sorts the defaults fails at resolve
 # time rather than by dropping a signal we ship.
-opentelemetry_sdk = { version = "0.32", features = ["logs"] }
+# `metrics` joins them for the GenAI metrics signal (src/metrics.rs), which needs the
+# SDK's meter provider and its periodic reader.
+opentelemetry_sdk = { version = "0.32", features = ["logs", "metrics"] }
 # No `reqwest-rustls` here: that feature pulls `reqwest/default-tls` → `reqwest/rustls`
 # → aws-lc-rs, re-introducing the C provider we just dropped. The blocking exporter
 # builds a plain reqwest client and uses whatever TLS the (feature-unified) reqwest
 # was compiled with — i.e. our rustls-no-provider + ring. So we keep only the
 # transport features and let TLS come from the shared reqwest above.
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "logs", "http-proto", "reqwest-blocking-client"] }
+# `metrics` rides the same http-proto/blocking transport as the other two signals, so
+# it adds an exporter, not a second TLS stack — the aws-lc reasoning above is unchanged
+# by it (verified with `cargo tree -i aws-lc-rs`).
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "logs", "metrics", "http-proto", "reqwest-blocking-client"] }
 tracing-opentelemetry = "0.33"
 # The LOGS signal's half of the bridge: `tracing` events → OTel log records. Traces
 # carry rig's spans (prompts, completions, token counts); this carries kaibo's own

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -259,12 +259,17 @@ scratch_limit_bytes = 67108864
                                 # POSIX-unrestricted. A typo here is a load error.
 
 # ---------------------------------------------------------------------------
-# [telemetry] — OpenTelemetry export: traces and logs.
+# [telemetry] — OpenTelemetry export: traces, logs, and metrics.
 #
-# Two knobs, two questions. `enabled` decides whether spans leave at all.
-# `capture_content` decides whether they carry prompts, completions, and tool
+# Two knobs, two questions. `enabled` decides whether anything leaves at all.
+# `capture_content` decides whether spans carry prompts, completions, and tool
 # payloads — default FALSE, so a span carries model ids, token counts, durations,
 # finish reasons, and exit codes, and no source.
+#
+# Each signal then has its own on/off key, all defaulting on under `enabled`. Only
+# traces can ever carry content, so `traces = false, metrics = true` exports kaibo's
+# spend, latency, and delegation with no prompt able to leave by that road — no
+# metric in the GenAI conventions has a content-bearing attribute.
 #
 # `enabled` defaults ON when OTEL_EXPORTER_OTLP_ENDPOINT or
 # OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set — kaibo exports to the collector the
@@ -280,8 +285,9 @@ scratch_limit_bytes = 67108864
 # kaibo never *binds* a socket. Transport is OTLP/HTTP with protobuf, reusing kaibo's
 # reqwest — no gRPC.
 #
-# Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,LOGS,LOGS_ENDPOINT,TIMEOUT_SECS,SERVICE_NAME,
-# CAPTURE_CONTENT}, plus the standard OTEL_* set. `headers` and `capture` are
+# Env: KAIBO_TELEMETRY_{ENABLED,ENDPOINT,TRACES,LOGS,LOGS_ENDPOINT,METRICS,
+# METRICS_ENDPOINT,TIMEOUT_SECS,SERVICE_NAME,CAPTURE_CONTENT}, plus the standard
+# OTEL_* set. `headers` and `capture` are
 # file-only. Which attributes survive redaction, and why the guard is an allowlist:
 # kaibo://config/guide, "Telemetry".
 # ---------------------------------------------------------------------------
@@ -289,10 +295,17 @@ scratch_limit_bytes = 67108864
 # [telemetry]
 # enabled      = true                                # default: on if OTEL_* names an endpoint
 # endpoint     = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
+# traces       = true                                # default true when enabled
 # logs         = true                                # default true when enabled
+# metrics      = true                                # default true when enabled
 # Where log records go. Omit it and kaibo derives the sibling of `endpoint` when that
 # ends in /v1/traces; any other shape is a load error rather than a guess.
 # logs_endpoint = "http://localhost:4318/v1/logs"
+# Same derivation for metrics. The one difference: with a non-standard `endpoint` and
+# no `metrics_endpoint`, a metrics you never wrote warns and stays off, while a
+# metrics you wrote as true is a load error — an upgrade must not break a config that
+# worked, but an asked-for signal kaibo cannot route must say so.
+# metrics_endpoint = "http://localhost:4318/v1/metrics"
 # timeout_secs = 10                                  # per-export deadline; must be > 0
 # service_name = "kaibo"                             # service.name on both Resources
 # Extra export headers (auth for a remote collector), sent on both signals. The

--- a/docs/config.md
+++ b/docs/config.md
@@ -612,8 +612,11 @@ Everything else follows one naming rule:
 | ignore scope | `kaish.ignore.scope` *(`"enforced"` \| `"advisory"`; default `"enforced"`)* | — | — |
 | telemetry on/off | `telemetry.enabled` *(default false)* | `KAIBO_TELEMETRY_ENABLED` | — |
 | OTLP traces endpoint | `telemetry.endpoint` | `KAIBO_TELEMETRY_ENDPOINT` | — |
+| traces signal on/off | `telemetry.traces` *(default true when enabled)* | `KAIBO_TELEMETRY_TRACES` | — |
 | logs signal on/off | `telemetry.logs` *(default true when enabled)* | `KAIBO_TELEMETRY_LOGS` | — |
 | OTLP logs endpoint | `telemetry.logs_endpoint` *(derived from `endpoint` when omitted)* | `KAIBO_TELEMETRY_LOGS_ENDPOINT` | — |
+| metrics signal on/off | `telemetry.metrics` *(default true when enabled)* | `KAIBO_TELEMETRY_METRICS` | — |
+| OTLP metrics endpoint | `telemetry.metrics_endpoint` *(derived from `endpoint` when omitted)* | `KAIBO_TELEMETRY_METRICS_ENDPOINT` | — |
 | export timeout (s) | `telemetry.timeout_secs` *(must be > 0)* | `KAIBO_TELEMETRY_TIMEOUT_SECS` | — |
 | trace service name | `telemetry.service_name` | `KAIBO_TELEMETRY_SERVICE_NAME` | — |
 | export headers | `telemetry.headers` *(map; file-only — values are secrets)* | — | — |
@@ -741,12 +744,13 @@ unusable backend surfaces only when a call to it fails. Project-local layering (
 repo-root `.kaibo.toml` merged over the user config) is a plausible later addition, not
 implemented.
 
-## Telemetry (OpenTelemetry traces and logs)
+## Telemetry (OpenTelemetry traces, logs, and metrics)
 
-kaibo splits two questions that are usually conflated:
+kaibo splits three questions that are usually conflated:
 
-1. **Do spans leave at all?** — `enabled`
-2. **Do they carry content?** — `capture_content`, default **false**
+1. **Does anything leave at all?** — `enabled`
+2. **Which signals leave?** — `traces`, `logs`, `metrics`, each default **true** under `enabled`
+3. **Do spans carry content?** — `capture_content`, default **false**
 
 That split is what lets telemetry be useful and safe at the same time. kaibo reads a
 private codebase, and the spans `rig-core` emits carry prompts, completions, and source
@@ -764,8 +768,11 @@ variable points at.
 [telemetry]
 enabled         = true                                # default: on if OTEL_* names an endpoint
 endpoint        = "http://localhost:4318/v1/traces"   # OTLP/HTTP traces receiver
+traces          = true                                # default true when enabled
 logs            = true                                # default true when enabled
 logs_endpoint   = "http://localhost:4318/v1/logs"     # omit to derive from endpoint
+metrics         = true                                # default true when enabled
+metrics_endpoint = "http://localhost:4318/v1/metrics" # omit to derive from endpoint
 timeout_secs    = 10                                  # per-export deadline; must be > 0
 service_name    = "kaibo"                             # service.name on both Resources
 capture_content = false                               # prompts/completions/tool payloads
@@ -777,9 +784,10 @@ headers = { authorization = "Bearer <token>" }        # file-only; values are se
 
 | Variable | Effect |
 |---|---|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | kaibo appends `/v1/traces` and `/v1/logs` to this value — it is a root, not a full URL. Setting it turns telemetry on. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | kaibo appends `/v1/traces`, `/v1/logs`, and `/v1/metrics` to this value — it is a root, not a full URL. Setting it turns telemetry on. |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | kaibo posts spans to this value unchanged, and ignores the root above for spans. |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | kaibo posts records to this value unchanged. |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | kaibo posts measurements to this value unchanged. Setting it alone also turns telemetry on, for a platform that collects metrics and not traces. |
 | `OTEL_SERVICE_NAME` | kaibo sets `service.name` to this value on both Resources. |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | kaibo exports content when this is set — it is the GenAI conventions' own name for the opt-in, read here unchanged. |
 | `OTEL_SDK_DISABLED` | kaibo exports nothing, whatever any other source says. |
@@ -853,6 +861,43 @@ Set `logs = false` for a collector that accepts spans but not records. Set
 the logs URL from `endpoint` only when that ends in `/v1/traces`, and **fails at startup
 naming the key** for any other shape rather than guessing a destination. A guess would
 surface only as records that never arrive.
+
+### The metrics signal
+
+Traces answer "what happened in this one call". Metrics answer "what is happening across
+every call", and they answer it without carrying anything a collector should not hold —
+**no metric in the GenAI semantic conventions has a content-bearing attribute.** Traces
+are made safe by a filter that must stay correct as `rig-core` changes; metrics need no
+filter at all. That is why `traces = false, metrics = true` is a supported posture and
+not a compromise: you keep spend, latency, and delegation, and no prompt can leave by
+that road even if the filter were wrong.
+
+kaibo emits six instruments, all histograms, all named by the conventions:
+
+| Metric | What it answers |
+|---|---|
+| `gen_ai.client.token.usage` | Spend, split by `gen_ai.token.type` (`input` / `output`) and by model |
+| `gen_ai.client.operation.duration` | How long one provider call took, including calls that failed |
+| `gen_ai.invoke_agent.duration` | How long a whole phase took, end to end |
+| `gen_ai.invoke_agent.inference_calls` | How many turns a phase used — a phase pinned at its turn cap shows as pile-up |
+| `gen_ai.invoke_agent.tool_calls` | **Did the consult driver delegate**, or read everything itself |
+| `gen_ai.execute_tool.duration` | How long one `run_kaish` / `explore′` / `view_image` took |
+
+The agent metrics carry `gen_ai.agent.name` — `synth` or `explorer` — and that label is
+what makes them worth reading. A delegated sweep is its own invocation, so its twenty
+turns are counted against `explorer`, and the driver's `tool_calls` counts only the
+delegation it made. Reading `gen_ai.invoke_agent.tool_calls` for `synth` therefore
+answers the delegation question directly, where before it took trace archaeology.
+
+Histogram bucket boundaries are the conventions' published advisory values, so kaibo's
+histograms are comparable with any other GenAI instrumentation's.
+
+**One asymmetry worth knowing.** `metrics` defaults on, and its endpoint derives from
+`endpoint` the same way `logs_endpoint` does. If your `endpoint` is non-standard and you
+have not set `metrics_endpoint`, kaibo warns and skips metrics rather than refusing to
+start — a config that worked before this signal existed must keep working. Write
+`metrics = true` explicitly and the same case becomes a startup error naming the key,
+because then you have asked for a signal kaibo cannot route.
 
 **Boundary.** Enabling opens an **outbound** OTLP connection to `endpoint`. This is
 allowed under kaibo's stdio-only invariant: kaibo can read a filesystem, so it must never

--- a/src/completion_watch.rs
+++ b/src/completion_watch.rs
@@ -33,6 +33,7 @@
 //! reasoning), so holding it would grow with the transcript for a payload nothing
 //! reads. The extraction is the point; the haystack is not worth keeping.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig_core::completion::message::AssistantContent;
@@ -220,7 +221,18 @@ fn completion_error_type(error: &CompletionError) -> &'static str {
 /// nothing to do with the kaish kernel — the log holds plain data, crosses `.await`
 /// freely, and never touches the `!Send` kernel behind `KaishWorker`.
 #[derive(Clone, Default, Debug)]
-pub struct CompletionLog(Arc<Mutex<Vec<TurnRecord>>>);
+pub struct CompletionLog {
+    turns: Arc<Mutex<Vec<TurnRecord>>>,
+    /// How many completions were *attempted*, which is not how many were recorded.
+    ///
+    /// A `TurnRecord` describes a provider *response*, so a call that failed produces
+    /// none — deliberate, and pinned by `a_provider_error_passes_through_untouched`.
+    /// That makes `turns` the wrong number for "how many inference calls did this
+    /// phase make", which the GenAI conventions say must include the failures. So the
+    /// attempt is counted separately, at the same seam, and the two answer different
+    /// questions: `turns` is what the provider said, `attempts` is what kaibo asked.
+    attempts: Arc<AtomicU64>,
+}
 
 impl CompletionLog {
     /// An empty log for one phase call.
@@ -228,14 +240,26 @@ impl CompletionLog {
         Self::default()
     }
 
-    /// Every completion recorded so far, oldest first — tool-loop turns included.
+    /// How many completions this phase attempted — every turn of the tool loop, the
+    /// forced final turn, each retry of a malformed generation, and every call that
+    /// failed. This is `gen_ai.invoke_agent.inference_calls`.
+    pub fn attempts(&self) -> u64 {
+        self.attempts.load(Ordering::Relaxed)
+    }
+
+    fn record_attempt(&self) {
+        self.attempts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Every completion *response* recorded so far, oldest first — tool-loop turns
+    /// included. A failed call is absent; see [`attempts`](Self::attempts).
     pub fn turns(&self) -> Vec<TurnRecord> {
-        self.0.lock().expect("completion log poisoned").clone()
+        self.turns.lock().expect("completion log poisoned").clone()
     }
 
     /// The most recent completion — the turn that produced the answer (or failed to).
     pub fn last(&self) -> Option<TurnRecord> {
-        self.0
+        self.turns
             .lock()
             .expect("completion log poisoned")
             .last()
@@ -248,10 +272,10 @@ impl CompletionLog {
         self.last().and_then(|turn| turn.finish_reason)
     }
 
-    /// How many completions this phase has made — every turn of the tool loop, plus
-    /// any forced final turn.
+    /// How many completion *responses* this phase recorded. Not the inference-call
+    /// count — a failed call is missing from it; use [`attempts`](Self::attempts).
     pub fn len(&self) -> usize {
-        self.0.lock().expect("completion log poisoned").len()
+        self.turns.lock().expect("completion log poisoned").len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -259,7 +283,10 @@ impl CompletionLog {
     }
 
     fn push(&self, turn: TurnRecord) {
-        self.0.lock().expect("completion log poisoned").push(turn);
+        self.turns
+            .lock()
+            .expect("completion log poisoned")
+            .push(turn);
     }
 }
 
@@ -346,6 +373,10 @@ impl<M: CompletionModel> CompletionModel for Watched<M> {
         let started = std::time::Instant::now();
         let result = self.inner.completion(request).await;
         let elapsed = started.elapsed();
+        // Counted before the outcome is inspected, so a failed call is an inference
+        // call — which is what the conventions require and what a phase that died at
+        // turn 90 has to report to be read honestly.
+        self.log.record_attempt();
 
         if let Some(ident) = &self.ident {
             let call = crate::metrics::CallIdent {
@@ -625,6 +656,12 @@ mod tests {
             "the provider's error reaches the caller unchanged"
         );
         assert!(log.is_empty(), "a failed call records no turn");
+        assert_eq!(
+            log.attempts(),
+            1,
+            "but it IS an inference call — the conventions count failures, and a phase \
+             that died at turn 90 must report 90, not 89"
+        );
     }
 
     /// A tool-call turn is recorded too — no text, one call, and whatever the

--- a/src/completion_watch.rs
+++ b/src/completion_watch.rs
@@ -186,6 +186,30 @@ impl TurnRecord {
     }
 }
 
+/// The conventions' `error.type` for a failed completion — the failure's *class*, from
+/// rig's own error enum.
+///
+/// The variant name, never the message. A metric attribute mints a time series per
+/// distinct value, and every one of these variants carries a formatted string holding
+/// a URL, a provider's error body, or a serde path — unbounded cardinality, and content
+/// on the signal built to carry none. Seven variants is the right resolution for "what
+/// kind of thing went wrong", and the message is still in the error the caller gets.
+fn completion_error_type(error: &CompletionError) -> &'static str {
+    match error {
+        CompletionError::HttpError(_) => "http_error",
+        CompletionError::JsonError(_) => "json_error",
+        CompletionError::UrlError(_) => "url_error",
+        CompletionError::RequestError(_) => "request_error",
+        CompletionError::ResponseError(_) => "response_error",
+        CompletionError::ProviderError(_) => "provider_error",
+        CompletionError::ProviderResponse(_) => "provider_response_error",
+        // rig's enum is `#[non_exhaustive]`. A variant added upstream lands here
+        // rather than failing our build, and "other" is the honest label for a class
+        // we have not named yet — the metric keeps working across a rig bump.
+        _ => "other",
+    }
+}
+
 /// The per-call slot [`Watched`] records into: every completion of one phase, in
 /// order. Cheaply cloneable and `Send + Sync`, because the model is cloned into each
 /// agent rig builds (once per loop iteration, again for the forced final turn) and
@@ -250,19 +274,49 @@ impl CompletionLog {
 pub struct Watched<M> {
     inner: M,
     log: CompletionLog,
+    /// Who this arm calls, for the GenAI client metrics. `None` for an arm with no
+    /// provider behind it — the offline scripted client — which records nothing; see
+    /// [`crate::metrics::PhaseIdentity`].
+    ident: Option<MetricIdent>,
+}
+
+/// The owned half of [`crate::metrics::CallIdent`]. Owned because this wrapper is
+/// cloned into every agent rig builds and must outlive the call site that named it.
+#[derive(Clone, Debug)]
+struct MetricIdent {
+    provider: crate::credentials::ProviderKind,
+    model: String,
 }
 
 impl<M> Watched<M> {
-    /// Wrap `model` so its completions record into `log`.
-    pub fn new(model: M, log: CompletionLog) -> Self {
-        Self { inner: model, log }
+    /// Wrap `model` so its completions record into `log`, and — when the arm names a
+    /// provider — into the client metrics.
+    pub fn new(
+        model: M,
+        log: CompletionLog,
+        ident: Option<crate::metrics::PhaseIdentity>,
+        model_name: &str,
+    ) -> Self {
+        Self {
+            inner: model,
+            log,
+            ident: ident.map(|i| MetricIdent {
+                provider: i.provider,
+                model: model_name.to_string(),
+            }),
+        }
     }
 }
 
 /// Wrap a completion model so every turn records into `log` — the drop-in at an
 /// agent-builder call site, mirroring [`traced`](crate::tool_span::traced) for tools.
-pub fn watched<M: CompletionModel>(model: M, log: CompletionLog) -> Watched<M> {
-    Watched::new(model, log)
+pub fn watched<M: CompletionModel>(
+    model: M,
+    log: CompletionLog,
+    ident: Option<crate::metrics::PhaseIdentity>,
+    model_name: &str,
+) -> Watched<M> {
+    Watched::new(model, log, ident, model_name)
 }
 
 impl<M: CompletionModel> CompletionModel for Watched<M> {
@@ -276,14 +330,46 @@ impl<M: CompletionModel> CompletionModel for Watched<M> {
     /// one here would have to invent a log nobody holds, silently discarding every
     /// observation; a panic names the correct constructor instead.
     fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
-        unreachable!("Watched is built by `watched(model, log)`, never by CompletionModel::make")
+        unreachable!(
+            "Watched is built by `watched(model, log, ..)`, never by CompletionModel::make"
+        )
     }
 
+    /// Still a pure passthrough: the response and every error are returned untouched.
+    /// What it now also does is *time* the call, because this is the one place kaibo
+    /// sees a single provider request begin and end — rig's agent hook fires per turn
+    /// of the outer loop, which is a different bracket once a turn retries.
     async fn completion(
         &self,
         request: CompletionRequest,
     ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
-        let response = self.inner.completion(request).await?;
+        let started = std::time::Instant::now();
+        let result = self.inner.completion(request).await;
+        let elapsed = started.elapsed();
+
+        if let Some(ident) = &self.ident {
+            let call = crate::metrics::CallIdent {
+                provider: ident.provider,
+                model: &ident.model,
+            };
+            match &result {
+                // A failed call has no usage to report, but its duration is the
+                // number an operator most wants when a provider is degrading.
+                Err(error) => {
+                    crate::metrics::record_completion(
+                        call,
+                        elapsed,
+                        None,
+                        Some(completion_error_type(error)),
+                    );
+                }
+                Ok(response) => {
+                    crate::metrics::record_completion(call, elapsed, Some(&response.usage), None);
+                }
+            }
+        }
+
+        let response = result?;
         self.log.push(TurnRecord::observe(&response));
         Ok(response)
     }
@@ -490,7 +576,7 @@ mod tests {
 
         let bare = model.completion(req()).await.expect("bare completion");
         let log = CompletionLog::new();
-        let wrapped = watched(model.clone(), log.clone())
+        let wrapped = watched(model.clone(), log.clone(), None, "scripted")
             .completion(req())
             .await
             .expect("wrapped completion");
@@ -529,7 +615,9 @@ mod tests {
         let log = CompletionLog::new();
 
         let bare = model.completion(req()).await;
-        let wrapped = watched(model.clone(), log.clone()).completion(req()).await;
+        let wrapped = watched(model.clone(), log.clone(), None, "scripted")
+            .completion(req())
+            .await;
 
         assert_eq!(
             format!("{:?}", wrapped.unwrap_err()),
@@ -551,7 +639,7 @@ mod tests {
             ))
         });
         let log = CompletionLog::new();
-        watched(model, log.clone())
+        watched(model, log.clone(), None, "scripted")
             .completion(req())
             .await
             .expect("completion");

--- a/src/config.rs
+++ b/src/config.rs
@@ -925,9 +925,48 @@ pub enum CastUsability {
 #[derive(Debug, Clone)]
 pub struct TelemetryConfig {
     /// Whether to stand up the OTLP exporter at all. `false` → zero overhead.
+    ///
+    /// The master switch over all three signals. Each signal has its own boolean
+    /// below, so an operator can take some and decline others.
     pub enabled: bool,
     /// OTLP/HTTP (protobuf) traces endpoint, e.g. `http://localhost:4318/v1/traces`.
+    ///
+    /// Also the root the other signals' endpoints are derived from, which is why it
+    /// keeps its meaning with [`traces`](Self::traces) off.
     pub endpoint: String,
+    /// Whether to export the **traces** signal. On whenever `enabled` is.
+    ///
+    /// Separable from `enabled` because traces are the content-adjacent signal: they
+    /// carry rig's span tree, which is where prompts and source snippets ride when
+    /// [`capture_content`](Self::capture_content) is on. An operator who wants
+    /// kaibo's spend and latency without that surface at all sets `traces = false,
+    /// metrics = true` — the metrics signal cannot carry content in the first place
+    /// (see `src/metrics.rs`).
+    pub traces: bool,
+    /// Whether to export the **metrics** signal. On whenever `enabled` is.
+    ///
+    /// Defaults on for the same reason [`logs`](Self::logs) does, only more so: no
+    /// metric in the GenAI conventions carries a content-bearing attribute, so this
+    /// signal is safe by construction rather than by the trace path's filter. Turn it
+    /// off for a collector that takes spans but not metrics.
+    pub metrics: bool,
+    /// OTLP/HTTP metrics endpoint. `None` derives it from
+    /// [`endpoint`](Self::endpoint) when that ends in the standard `/v1/traces`; any
+    /// other shape is a loud load error rather than a guess — the same rule
+    /// [`logs_endpoint`](Self::logs_endpoint) follows, for the same reason.
+    pub metrics_endpoint: Option<String>,
+    /// Whether the operator *wrote* `metrics`, rather than inheriting the default.
+    ///
+    /// Provenance, not a knob — it decides what an underivable metrics endpoint
+    /// means. Someone who wrote `metrics = true` against a non-standard `endpoint`
+    /// gets the same loud refusal `logs` gives, because they asked for a signal kaibo
+    /// cannot route. Someone who never mentioned metrics gets a warning and their
+    /// other signals, because the alternative is that a config working on 0.3.0
+    /// refuses to start after an upgrade over a signal they never asked for.
+    ///
+    /// This asymmetry with `logs` is deliberate: `logs` shipped with its rule, so no
+    /// working config ever broke on it.
+    pub metrics_explicit: bool,
     /// Whether to export the **logs** signal alongside traces. On whenever
     /// `enabled` is — the two ride one opt-in, because kaibo's own `tracing` events
     /// are strictly less sensitive than the prompts and completions the traces
@@ -971,10 +1010,16 @@ impl Default for TelemetryConfig {
             // The session's `otlp-mcp` collector and most local collectors listen
             // here; flipping `enabled` alone targets localhost, never a remote.
             endpoint: "http://localhost:4318/v1/traces".to_string(),
+            // Every signal rides the one opt-in. Declining a signal is a separate,
+            // deliberate act — an operator who turned telemetry on wants to see kaibo.
+            traces: true,
             logs: true,
+            metrics: true,
             capture_content: false,
             capture: Vec::new(),
             logs_endpoint: None,
+            metrics_endpoint: None,
+            metrics_explicit: false,
             headers: BTreeMap::new(),
             timeout: Duration::from_secs(10),
             service_name: "kaibo".to_string(),
@@ -2433,8 +2478,11 @@ struct RawConfig {
 struct RawTelemetry {
     enabled: Option<bool>,
     endpoint: Option<String>,
+    traces: Option<bool>,
     logs: Option<bool>,
     logs_endpoint: Option<String>,
+    metrics: Option<bool>,
+    metrics_endpoint: Option<String>,
     headers: Option<BTreeMap<String, String>>,
     timeout_secs: Option<u64>,
     service_name: Option<String>,
@@ -2916,8 +2964,12 @@ fn merge_telemetry(raw: RawTelemetry) -> Result<TelemetryConfig> {
     Ok(TelemetryConfig {
         enabled: raw.enabled.unwrap_or(d.enabled),
         endpoint: raw.endpoint.unwrap_or(d.endpoint),
+        traces: raw.traces.unwrap_or(d.traces),
         logs: raw.logs.unwrap_or(d.logs),
         logs_endpoint: raw.logs_endpoint.or(d.logs_endpoint),
+        metrics_explicit: raw.metrics.is_some(),
+        metrics: raw.metrics.unwrap_or(d.metrics),
+        metrics_endpoint: raw.metrics_endpoint.or(d.metrics_endpoint),
         headers: raw.headers.unwrap_or(d.headers),
         timeout,
         service_name: raw.service_name.unwrap_or(d.service_name),
@@ -3282,6 +3334,11 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
             .as_ref()
             .map(|b| format!("{}/v1/logs", b.trim_end_matches('/')))
     });
+    let otel_metrics = get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT").or_else(|| {
+        otel_base
+            .as_ref()
+            .map(|b| format!("{}/v1/metrics", b.trim_end_matches('/')))
+    });
     if let Some(endpoint) = otel_traces {
         if telemetry.endpoint.is_none() {
             telemetry.endpoint = Some(endpoint);
@@ -3297,6 +3354,18 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
         if telemetry.logs_endpoint.is_none() {
             telemetry.logs_endpoint = Some(endpoint);
         }
+    }
+    if let Some(endpoint) = otel_metrics {
+        if telemetry.metrics_endpoint.is_none() {
+            telemetry.metrics_endpoint = Some(endpoint);
+        }
+    }
+    // A metrics-only collector in the environment turns telemetry on the same way a
+    // traces one does. Without this, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` alone —
+    // the exact shape of a platform that collects metrics and not traces — would set
+    // an endpoint kaibo never exports to.
+    if telemetry.enabled.is_none() && telemetry.metrics_endpoint.is_some() {
+        telemetry.enabled = Some(true);
     }
     if let Some(v) = get("OTEL_SERVICE_NAME") {
         if telemetry.service_name.is_none() {
@@ -3335,6 +3404,26 @@ fn apply_raw_env(raw: &mut RawConfig, get: &impl Fn(&str) -> Option<String>) -> 
     }
     if let Some(v) = get("KAIBO_TELEMETRY_LOGS_ENDPOINT") {
         telemetry.logs_endpoint = Some(v);
+    }
+    if let Some(v) = get("KAIBO_TELEMETRY_TRACES") {
+        // Same on/off grammar as the other signal toggles, and set either way so it
+        // can turn the file-enabled traces signal back off — which is the whole point
+        // of separating it from `enabled`.
+        let on = {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no"
+        };
+        telemetry.traces = Some(on);
+    }
+    if let Some(v) = get("KAIBO_TELEMETRY_METRICS") {
+        let on = {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false" && v != "no"
+        };
+        telemetry.metrics = Some(on);
+    }
+    if let Some(v) = get("KAIBO_TELEMETRY_METRICS_ENDPOINT") {
+        telemetry.metrics_endpoint = Some(v);
     }
     if let Some(v) = get("KAIBO_TELEMETRY_TIMEOUT_SECS") {
         telemetry.timeout_secs = Some(parse_env_int("KAIBO_TELEMETRY_TIMEOUT_SECS", &v)?);
@@ -4855,8 +4944,16 @@ mod tests {
             .into_iter()
             .map(|d| d.cast)
             .filter(|c| {
-                ["plain", "off", "newer", "lifted", "dropped", "batch-off", "local-thinks"]
-                    .contains(&c.as_str())
+                [
+                    "plain",
+                    "off",
+                    "newer",
+                    "lifted",
+                    "dropped",
+                    "batch-off",
+                    "local-thinks",
+                ]
+                .contains(&c.as_str())
             })
             .collect();
         assert_eq!(

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -82,6 +82,7 @@ trait PhaseRunner: Send + Sync {
         progress: &'a dyn ProgressSink,
         make_tools: ToolFactory<'a>,
         break_on_tool_images: bool,
+        identity: Option<crate::metrics::PhaseIdentity>,
     ) -> PhaseFuture<'a>;
 
     /// One completion, straight to the provider — no agent, no tool loop. The
@@ -95,6 +96,7 @@ trait PhaseRunner: Send + Sync {
         temperature: Option<f64>,
         prompt: Message,
         params: Option<&'a Value>,
+        identity: Option<crate::metrics::PhaseIdentity>,
     ) -> PhaseFuture<'a>;
 }
 
@@ -125,6 +127,7 @@ where
         progress: &'a dyn ProgressSink,
         make_tools: ToolFactory<'a>,
         break_on_tool_images: bool,
+        identity: Option<crate::metrics::PhaseIdentity>,
     ) -> PhaseFuture<'a> {
         Box::pin(run_phase(
             &self.model,
@@ -138,6 +141,7 @@ where
             progress,
             make_tools,
             break_on_tool_images,
+            identity,
         ))
     }
 
@@ -148,6 +152,7 @@ where
         temperature: Option<f64>,
         prompt: Message,
         params: Option<&'a Value>,
+        identity: Option<crate::metrics::PhaseIdentity>,
     ) -> PhaseFuture<'a> {
         Box::pin(async move {
             run_completion(
@@ -159,6 +164,7 @@ where
                 temperature,
                 prompt,
                 params,
+                identity,
             )
             .await
         })
@@ -192,6 +198,11 @@ pub struct Arm {
     /// vision arm gets `view_image` when vision-in lands; a blind one never sees
     /// the tool).
     pub caps: ModelCaps,
+    /// Who this arm is, for the GenAI metrics: its provider and the cast role it
+    /// fills. `None` for an arm built through [`Arm::new`] — the offline injection
+    /// seam, where no provider is called and a recorded latency would be a fiction.
+    /// [`Arm::from_slot`] is the single live construction point and always sets it.
+    pub(crate) identity: Option<crate::metrics::PhaseIdentity>,
 }
 
 impl std::fmt::Debug for Arm {
@@ -268,6 +279,8 @@ impl Arm {
             temperature,
             params,
             caps,
+            // Set by `from_slot`, which is the only path that knows a backend.
+            identity: None,
         }
     }
 
@@ -277,7 +290,26 @@ impl Arm {
     /// falling back to the per-role `[defaults]`). This is the single place the
     /// four concrete client types live; a cast whose phases straddle any
     /// capability line — different kinds, even — is fit per-arm by construction.
+    /// Stamps the metrics identity onto whatever the wire-specific construction
+    /// below returns. Done here, once, rather than in each `WireKind` arm: this is
+    /// the only function that knows both the backend and the role, and threading two
+    /// more arguments through six construction arms would give six chances to forget
+    /// one.
     pub fn from_slot(
+        backend: &Backend,
+        slot: &ModelSlot,
+        role: ModelRole,
+        defaults: &Defaults,
+    ) -> Result<Self> {
+        let mut arm = Self::from_slot_unidentified(backend, slot, role, defaults)?;
+        arm.identity = Some(crate::metrics::PhaseIdentity {
+            provider: backend.kind,
+            agent: role.key(),
+        });
+        Ok(arm)
+    }
+
+    fn from_slot_unidentified(
         backend: &Backend,
         slot: &ModelSlot,
         role: ModelRole,
@@ -447,7 +479,13 @@ impl Arm {
                     .build()
                     .map_err(|e| anyhow!("openrouter client init: {e}"))?;
                 let model = Self::openrouter_completion_model(&client, &slot.id);
-                Ok(Self::from_model(model, &slot.id, t.max_tokens, params, caps))
+                Ok(Self::from_model(
+                    model,
+                    &slot.id,
+                    t.max_tokens,
+                    params,
+                    caps,
+                ))
             }
             WireKind::Openai => {
                 // Any OpenAI-compatible endpoint, addressed by the backend's base
@@ -542,6 +580,7 @@ impl Arm {
                 progress,
                 make_tools,
                 self.rewrites_tool_images(),
+                self.identity,
             )
             .await
     }
@@ -563,6 +602,7 @@ impl Arm {
                 self.temperature,
                 prompt,
                 self.params.as_ref(),
+                self.identity,
             )
             .await
     }
@@ -1101,6 +1141,7 @@ pub(crate) async fn run_phase<M, F>(
     progress: &dyn ProgressSink,
     make_tools: F,
     break_on_tool_images: bool,
+    identity: Option<crate::metrics::PhaseIdentity>,
 ) -> Result<(String, Usage)>
 where
     M: CompletionModel + 'static,
@@ -1119,6 +1160,7 @@ where
         progress,
         make_tools,
         break_on_tool_images,
+        identity,
     )
     .await
 }
@@ -1178,6 +1220,7 @@ pub(crate) async fn run_phase_logged<M, F>(
     progress: &dyn ProgressSink,
     make_tools: F,
     break_on_tool_images: bool,
+    identity: Option<crate::metrics::PhaseIdentity>,
 ) -> Result<(String, Usage)>
 where
     M: CompletionModel + 'static,
@@ -1189,6 +1232,10 @@ where
     if let Some(t) = thinking {
         tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
     }
+    // This bracket IS the agent invocation the GenAI conventions name: it opens when
+    // the phase starts and closes when it answers or fails, which is the same span
+    // this function is instrumented with.
+    let started = std::time::Instant::now();
     let result = run_phase_loop(
         // Two wrappers, innermost first: [`retried`] sends a turn the provider could not
         // parse again, then [`watched`] records the response that finally came back. A
@@ -1196,7 +1243,12 @@ where
         // way — the order is about who resolves the failure, and the retry must resolve it
         // below the loop, which loses the transcript on a completion error
         // (`crate::completion_retry`).
-        &watched(retried(model.clone(), model_name), log.clone()),
+        &watched(
+            retried(model.clone(), model_name),
+            log.clone(),
+            identity,
+            model_name,
+        ),
         log,
         model_name,
         preamble,
@@ -1214,6 +1266,26 @@ where
     // phase reports how its last completion ended too.
     if let Some(reason) = log.last_finish_reason() {
         tracing::Span::current().record("gen_ai.response.finish_reason", reason.as_str());
+    }
+    // The agent metrics, on every exit path for the same reason the finish reason is
+    // read here: a phase that died at turn 90 of 100 still made 90 inference calls,
+    // and the conventions say to count them. The counts come straight off the log —
+    // `len` is every completion this phase made, and each turn already recorded how
+    // many tool calls it emitted — so this is a read, not new bookkeeping.
+    //
+    // Sub-agent exclusion falls out of the structure: a delegated `explore′` sweep is
+    // its own `run_phase` with its own explorer identity, so its turns are counted
+    // against it, and the driver sees only the one tool call it made to reach it.
+    if let Some(identity) = identity {
+        let turns = log.turns();
+        crate::metrics::record_agent_invocation(
+            identity.agent,
+            model_name,
+            started.elapsed(),
+            turns.len() as u64,
+            turns.iter().map(|t| t.tool_calls as u64).sum(),
+            result.as_ref().err().map(|_| "phase_failed"),
+        );
     }
     result
 }
@@ -1584,6 +1656,7 @@ pub(crate) async fn run_completion<M>(
     temperature: Option<f64>,
     prompt: Message,
     thinking: Option<&Value>,
+    identity: Option<crate::metrics::PhaseIdentity>,
 ) -> Result<(String, Usage)>
 where
     M: CompletionModel + 'static,
@@ -1591,53 +1664,86 @@ where
     if let Some(t) = thinking {
         tracing::Span::current().record("gen_ai.request.thinking", tracing::field::display(t));
     }
-    // Same two wrappers the loop uses: a single-shot lane declares no tools, so it
-    // cannot fumble a tool call, but a provider that could not shape the response
-    // (`MalformedResponse`) reaches here too and is worth the same retry.
-    let mut builder = watched(retried(model.clone(), model_name), log.clone())
+    // A single-shot lane is still an agent invocation — one with exactly one
+    // inference call and no tools. Recording it keeps `oneshot` and `deliberate`
+    // visible in the same series a consult reports into, rather than leaving a hole
+    // where the cheapest lane should be.
+    let started = std::time::Instant::now();
+    // Every exit below records the invocation, so the body runs inside a block whose
+    // value is the outcome. Three paths reach an end here — a failed call, an empty
+    // answer, and a real answer — and an agent metric that skipped two of them would
+    // undercount exactly the failures the conventions say to include.
+    let outcome = async {
+        // Same two wrappers the loop uses: a single-shot lane declares no tools, so it
+        // cannot fumble a tool call, but a provider that could not shape the response
+        // (`MalformedResponse`) reaches here too and is worth the same retry.
+        let mut builder = watched(
+            retried(model.clone(), model_name),
+            log.clone(),
+            identity,
+            model_name,
+        )
         .completion_request(prompt)
         .preamble(preamble.to_string())
         .max_tokens(max_tokens);
-    if let Some(t) = temperature {
-        builder = builder.temperature(t);
-    }
-    if let Some(params) = thinking {
-        builder = builder.additional_params(params.clone());
-    }
-    // `send()` is `model.completion(builder.build())` — the one provider call.
-    let response = builder.send().await;
-    if let Some(reason) = log.last_finish_reason() {
-        tracing::Span::current().record("gen_ai.response.finish_reason", reason.as_str());
-    }
-    // "model call failed" keeps this on the provider side of `classify_failure`
-    // (`server/render.rs`), where a loop failure lands via "model loop failed" — an
-    // overload or rate limit here is still worth a caller retry.
-    let response = response.map_err(|e| anyhow!("model call failed: {e}"))?;
-    let answer = response
-        .choice
-        .iter()
-        .filter_map(|content| match content {
-            AssistantContent::Text(text) => Some(text.text.as_str()),
-            _ => None,
-        })
-        .collect::<String>();
-    // The single-shot lanes are toolless by definition, so an empty answer here can
-    // never satisfy the evidence gate the loop's recovery runs on — there is nothing
-    // gathered to write up, and no re-ask that wouldn't invite an ungrounded answer.
-    // Fail with the same diagnostics vocabulary as the loop, finish reason included
-    // (this path reads it off its own log).
-    if answer.trim().is_empty() {
-        return Err(empty_answer_error(
-            model_name,
-            1,
-            1,
-            &response.usage,
-            log.last_finish_reason().as_deref(),
-            "the single toolless completion returned no answer text, and a lane with \
+        if let Some(t) = temperature {
+            builder = builder.temperature(t);
+        }
+        if let Some(params) = thinking {
+            builder = builder.additional_params(params.clone());
+        }
+        // `send()` is `model.completion(builder.build())` — the one provider call.
+        let response = builder.send().await;
+        if let Some(reason) = log.last_finish_reason() {
+            tracing::Span::current().record("gen_ai.response.finish_reason", reason.as_str());
+        }
+        // "model call failed" keeps this on the provider side of `classify_failure`
+        // (`server/render.rs`), where a loop failure lands via "model loop failed" — an
+        // overload or rate limit here is still worth a caller retry.
+        let response = response.map_err(|e| anyhow!("model call failed: {e}"))?;
+        let answer = response
+            .choice
+            .iter()
+            .filter_map(|content| match content {
+                AssistantContent::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            })
+            .collect::<String>();
+        // The single-shot lanes are toolless by definition, so an empty answer here can
+        // never satisfy the evidence gate the loop's recovery runs on — there is nothing
+        // gathered to write up, and no re-ask that wouldn't invite an ungrounded answer.
+        // Fail with the same diagnostics vocabulary as the loop, finish reason included
+        // (this path reads it off its own log).
+        if answer.trim().is_empty() {
+            return Err(empty_answer_error(
+                model_name,
+                1,
+                1,
+                &response.usage,
+                log.last_finish_reason().as_deref(),
+                "the single toolless completion returned no answer text, and a lane with \
              no tools has no gathered evidence to write up, so kaibo does not re-ask",
-        ));
+            ));
+        }
+        Ok((answer, response.usage))
     }
-    Ok((answer, response.usage))
+    .await;
+    // One inference call by definition — or two, when `retried` resent a generation
+    // the provider malformed — so the count comes off the log rather than a literal.
+    // No tools: a single-shot lane declares none, and a zero here is the honest
+    // reading that makes `oneshot` distinguishable from a consult that never
+    // delegated.
+    if let Some(identity) = identity {
+        crate::metrics::record_agent_invocation(
+            identity.agent,
+            model_name,
+            started.elapsed(),
+            log.len() as u64,
+            0,
+            outcome.as_ref().err().map(|_| "phase_failed"),
+        );
+    }
+    outcome
 }
 
 /// Run the explorer phase once and return its cited report. The explorer [`Arm`]
@@ -1892,10 +1998,7 @@ impl Tool for RunExplore {
         // Fold this sweep's tokens into the shared consult total before returning the
         // report to the driver — the synth's own `PromptResponse` will never see them.
         // Lock poisoning means another delegation panicked — surface it, don't mask.
-        *self
-            .usage_sink
-            .lock()
-            .expect("explore usage sink poisoned") += usage;
+        *self.usage_sink.lock().expect("explore usage sink poisoned") += usage;
         // A sweep that reported nothing is a *failed* sweep, not an empty one. Handing the
         // driver a blank tool result is the same silent-empty class one level down, and
         // worse in one way: the driver cannot tell a blank sweep from a sweep that found
@@ -2084,8 +2187,10 @@ fn consult_tools(
     // Resolved exactly as `attach_one` resolves an explorer's path — canonicalized, not
     // merely joined. A plain join misses the dedupe for any caller path carrying a `./`,
     // a `..`, or a symlink, and the reader then receives the same bytes twice.
-    let already_delivered: HashSet<PathBuf> =
-        crate::sweep_attach::delivered_seed(root, cfg.attachments.iter().map(|a| Path::new(a.path())));
+    let already_delivered: HashSet<PathBuf> = crate::sweep_attach::delivered_seed(
+        root,
+        cfg.attachments.iter().map(|a| Path::new(a.path())),
+    );
     let explore = RunExplore::new(
         explorer.clone(),
         cfg.explore.explorer_max_turns,
@@ -3045,6 +3150,8 @@ mod tests {
                 )?))])
             },
             false,
+            // Offline scripted arm: no provider is called, so nothing to attribute.
+            None,
         )
         .await
         .expect("the scripted loop answers");
@@ -3133,6 +3240,8 @@ mod tests {
                 )?))])
             },
             false,
+            // Offline scripted arm: no provider is called, so nothing to attribute.
+            None,
         )
         .await
         .expect("one malformed tool call must not fail the phase");
@@ -3225,6 +3334,8 @@ mod tests {
                 )?))])
             },
             false,
+            // Offline scripted arm: no provider is called, so nothing to attribute.
+            None,
         )
         .await
         .expect("a tool call naming a tool that does not exist must not fail the phase");
@@ -3341,6 +3452,8 @@ mod tests {
                 )?))])
             },
             false,
+            // Offline scripted arm: no provider is called, so nothing to attribute.
+            None,
         );
         let (answer, _usage) = tokio::time::timeout(Duration::from_secs(30), run)
             .await
@@ -3355,7 +3468,9 @@ mod tests {
             asked.len()
         );
         assert!(
-            asked.iter().any(|r| r.tool_choice == Some(ToolChoice::None)),
+            asked
+                .iter()
+                .any(|r| r.tool_choice == Some(ToolChoice::None)),
             "exhausting the budget must reach the forced write-up turn"
         );
     }
@@ -3524,8 +3639,14 @@ mod tests {
         // Expected = per-call usage × how many completions each model actually made.
         let ns = client.requests_for(SYNTH).len() as u64;
         let ne = client.requests_for(EXPLORER).len() as u64;
-        assert!(ns >= 2, "driver should delegate then answer (≥2 turns), got {ns}");
-        assert!(ne >= 1, "explorer should have been delegated at least one sweep");
+        assert!(
+            ns >= 2,
+            "driver should delegate then answer (≥2 turns), got {ns}"
+        );
+        assert!(
+            ne >= 1,
+            "explorer should have been delegated at least one sweep"
+        );
 
         assert_eq!(
             out.usage.input_tokens,
@@ -3653,9 +3774,15 @@ mod tests {
         let dir = project_with_marker();
         let cfg = ConsultConfig::default();
 
-        consult_with("q", dir.path(), &arm(&client, EXPLORER), &arm(&client, SYNTH), &cfg)
-            .await
-            .expect("scripted consult should succeed");
+        consult_with(
+            "q",
+            dir.path(),
+            &arm(&client, EXPLORER),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect("scripted consult should succeed");
     }
 
     /// The load-bearing wiring test: a sweep that calls `attach` must land its
@@ -3706,8 +3833,10 @@ mod tests {
 
         let synth_reqs = client.requests_for(SYNTH);
         assert!(
-            synth_reqs.iter().any(|r| r.transcript.contains("<file path=\"src/foo.rs\">")
-                && r.transcript.contains("fn target_marker")),
+            synth_reqs
+                .iter()
+                .any(|r| r.transcript.contains("<file path=\"src/foo.rs\">")
+                    && r.transcript.contains("fn target_marker")),
             "the driver's transcript must carry the attached file's numbered body: {:?}",
             synth_reqs.iter().map(|r| &r.transcript).collect::<Vec<_>>()
         );
@@ -3787,15 +3916,23 @@ mod tests {
                     Ok(text_response("ANSWER"))
                 }
             })
-            .on_model(EXPLORER, |_req| Ok(text_response("PLAIN REPORT: src/foo.rs:1")))
+            .on_model(EXPLORER, |_req| {
+                Ok(text_response("PLAIN REPORT: src/foo.rs:1"))
+            })
             .build();
 
         let dir = project_with_marker();
         let cfg = ConsultConfig::default();
 
-        consult_with("q", dir.path(), &arm(&client, EXPLORER), &arm(&client, SYNTH), &cfg)
-            .await
-            .expect("scripted consult should succeed");
+        consult_with(
+            "q",
+            dir.path(),
+            &arm(&client, EXPLORER),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect("scripted consult should succeed");
 
         let synth_reqs = client.requests_for(SYNTH);
         assert!(
@@ -3940,9 +4077,15 @@ mod tests {
             ..ConsultConfig::default()
         };
 
-        consult_with("q", dir.path(), &arm(&client, EXPLORER), &arm(&client, SYNTH), &cfg)
-            .await
-            .expect("scripted consult should succeed");
+        consult_with(
+            "q",
+            dir.path(),
+            &arm(&client, EXPLORER),
+            &arm(&client, SYNTH),
+            &cfg,
+        )
+        .await
+        .expect("scripted consult should succeed");
     }
 
     /// A sweep's `attach` call surfaces as `PhaseEvent::Attached` on the shared
@@ -4148,7 +4291,10 @@ mod tests {
                 .iter()
                 .any(|r| user_image_messages(&r.chat_history) > 0),
             "the OpenAI-shaped driver must receive the image on its own user turn: {:?}",
-            synth_reqs.iter().map(|r| r.chat_history.len()).collect::<Vec<_>>()
+            synth_reqs
+                .iter()
+                .map(|r| r.chat_history.len())
+                .collect::<Vec<_>>()
         );
         assert!(
             synth_reqs
@@ -4466,7 +4612,9 @@ mod tests {
                         json!({ "paths": ["src/foo.rs"] }),
                     ))
                 } else {
-                    Ok(text_response("DOSSIER REPORT: src/foo.rs is the relevant module"))
+                    Ok(text_response(
+                        "DOSSIER REPORT: src/foo.rs is the relevant module",
+                    ))
                 }
             })
             .build();
@@ -4658,7 +4806,8 @@ mod tests {
         .await
         .expect("deliberate_direct did not honor its deadline — it hung past 5s (no backstop)");
 
-        let err = outcome.expect_err("a wedged local synth must abort the deliberation, not answer");
+        let err =
+            outcome.expect_err("a wedged local synth must abort the deliberation, not answer");
         assert!(
             format!("{err:#}").contains("deadline"),
             "the abort must name the wall-clock deadline, got: {err:#}"
@@ -5092,7 +5241,9 @@ mod tests {
             finalizes[0].transcript
         );
         assert!(
-            !finalizes[0].transcript.contains("reached your research limit"),
+            !finalizes[0]
+                .transcript
+                .contains("reached your research limit"),
             "the forced turn must NOT claim a turn cap that was never hit: {:?}",
             finalizes[0].transcript
         );
@@ -5339,7 +5490,10 @@ mod tests {
         .expect_err("an explorer that reported nothing must fail, not return an empty report");
         // No tool results in its transcript, so no blind re-ask — the same gate.
         assert!(
-            !client.requests_for(EXPLORER).iter().any(is_finalize_request),
+            !client
+                .requests_for(EXPLORER)
+                .iter()
+                .any(is_finalize_request),
             "an explorer with no evidence must not be asked to report anyway"
         );
         let msg = format!("{err:#}").to_lowercase();
@@ -5547,7 +5701,11 @@ mod tests {
                     if transcript_text(req).contains("REPORT") {
                         Ok(text_response("ANSWER"))
                     } else {
-                        Ok(tool_call_response("s1", "explore", json!({ "question": "q" })))
+                        Ok(tool_call_response(
+                            "s1",
+                            "explore",
+                            json!({ "question": "q" }),
+                        ))
                     }
                 })
                 .on_model(EXPLORER, |_req| Ok(text_response("REPORT: src/foo.rs:1")))
@@ -5588,7 +5746,8 @@ mod tests {
             "both the driver and its sweep must emit a run_phase span, got {seen:?}"
         );
         assert!(
-            seen.iter().all(|v| v.as_deref() == Some(expected_str.as_str())),
+            seen.iter()
+                .all(|v| v.as_deref() == Some(expected_str.as_str())),
             "every run_phase span must record the exact thinking blob, got {seen:?}"
         );
 
@@ -5666,8 +5825,9 @@ mod tests {
         .await
         .unwrap();
 
-        let params =
-            |r: &crate::test_support::RecordedRequest| r.additional_params.as_ref().unwrap().clone();
+        let params = |r: &crate::test_support::RecordedRequest| {
+            r.additional_params.as_ref().unwrap().clone()
+        };
         // The adaptive synth: top-level adaptive thinking + effort, no Gemini nesting.
         for r in client.requests_for(SYNTH) {
             let p = params(&r);
@@ -6008,7 +6168,9 @@ mod tests {
         let arm = Arm::from_slot(&backend, &slot, ModelRole::Synth, &defaults)
             .expect("a responses-wire gateway arm builds offline with a placeholder key");
         assert_eq!(arm.model, "gpt-5.6-sol");
-        let params = arm.params.expect("responses-wire gateway sends Responses params");
+        let params = arm
+            .params
+            .expect("responses-wire gateway sends Responses params");
         assert_eq!(
             params["reasoning"]["effort"], "high",
             "reasoning effort reaches the gateway the same way it reaches Platform"
@@ -6272,7 +6434,10 @@ mod tests {
     /// short of the body would stay green through that.
     #[tokio::test]
     async fn openrouter_arm_enables_prompt_caching() {
-        async fn system_block(model: openrouter::CompletionModel<CaptureHttp>, http: &CaptureHttp) -> Value {
+        async fn system_block(
+            model: openrouter::CompletionModel<CaptureHttp>,
+            http: &CaptureHttp,
+        ) -> Value {
             let request = CompletionRequest {
                 model: None,
                 preamble: Some("ground every claim".into()),
@@ -6794,8 +6959,15 @@ mod tests {
         );
 
         let seeing_synth = vision_arm(&client, "synth-model");
-        let seeing = consult_tools(&explorer, dir.path(), &cfg, reports, usage_sink, &seeing_synth)
-            .expect("vision toolset builds");
+        let seeing = consult_tools(
+            &explorer,
+            dir.path(),
+            &cfg,
+            reports,
+            usage_sink,
+            &seeing_synth,
+        )
+        .expect("vision toolset builds");
         let seeing_names: Vec<String> = seeing.iter().map(|t| t.name().to_string()).collect();
         assert!(
             seeing_names.iter().any(|n| n == "view_image"),

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -1277,13 +1277,14 @@ where
     // its own `run_phase` with its own explorer identity, so its turns are counted
     // against it, and the driver sees only the one tool call it made to reach it.
     if let Some(identity) = identity {
-        let turns = log.turns();
         crate::metrics::record_agent_invocation(
             identity.agent,
             model_name,
             started.elapsed(),
-            turns.len() as u64,
-            turns.iter().map(|t| t.tool_calls as u64).sum(),
+            // Attempts, not recorded turns: a call that failed produces no
+            // `TurnRecord`, and the conventions count it as an inference call anyway.
+            log.attempts(),
+            log.turns().iter().map(|t| t.tool_calls as u64).sum(),
             result.as_ref().err().map(|_| "phase_failed"),
         );
     }
@@ -1728,17 +1729,17 @@ where
         Ok((answer, response.usage))
     }
     .await;
-    // One inference call by definition — or two, when `retried` resent a generation
-    // the provider malformed — so the count comes off the log rather than a literal.
-    // No tools: a single-shot lane declares none, and a zero here is the honest
-    // reading that makes `oneshot` distinguishable from a consult that never
-    // delegated.
+    // One inference call by definition — or more, when `retried` resent a generation
+    // the provider malformed — so the count comes off the log's attempts rather than a
+    // literal, and a lane whose single call failed still reports the call it made. No
+    // tools: a single-shot lane declares none, and a zero here is the honest reading
+    // that makes `oneshot` distinguishable from a consult that never delegated.
     if let Some(identity) = identity {
         crate::metrics::record_agent_invocation(
             identity.agent,
             model_name,
             started.elapsed(),
-            log.len() as u64,
+            log.attempts(),
             0,
             outcome.as_ref().err().map(|_| "phase_failed"),
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod jobs;
 pub mod kaish_syntax;
 pub mod mcp_log;
 pub mod media;
+pub mod metrics;
 pub mod openai_images;
 pub mod orientation;
 pub mod otel_filter;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,686 @@
+//! GenAI metrics — the signal that carries no content.
+//!
+//! The second half of the telemetry split. [`crate::otel_filter`] made *traces* safe
+//! by filtering attributes on the way out; metrics are safe by **construction**, and
+//! the difference matters. A filter is a policy: it holds because an allowlist is
+//! correct and stays correct as rig's attributes drift. This signal needs no
+//! allowlist, because no metric in the GenAI semantic conventions carries a
+//! content-bearing attribute at all — every one of them is a model id, a provider
+//! name, a token type, an error type, an agent name, or a tool name. That was
+//! confirmed by reading `model/gen-ai/metrics.yaml` and the attribute groups it
+//! references, not assumed from the metric names.
+//!
+//! So an operator can run `traces = false, metrics = true` and export kaibo's
+//! behavior — spend, latency, delegation, tool use — while no prompt, completion, or
+//! source line can leave the process by this road even in principle.
+//!
+//! ## What kaibo measures, and where it already knew it
+//!
+//! Nothing here is new bookkeeping; each instrument reads a number kaibo already had.
+//!
+//! | Metric | Recorded at | The number was already in |
+//! |---|---|---|
+//! | `gen_ai.client.token.usage` | [`record_completion`] | the provider's `Usage` on every turn |
+//! | `gen_ai.client.operation.duration` | [`record_completion`] | — (timed around the call) |
+//! | `gen_ai.invoke_agent.duration` | [`record_agent_invocation`] | — (timed around the phase) |
+//! | `gen_ai.invoke_agent.inference_calls` | [`record_agent_invocation`] | `CompletionLog::len` |
+//! | `gen_ai.invoke_agent.tool_calls` | [`record_agent_invocation`] | `TurnRecord::tool_calls`, summed |
+//! | `gen_ai.execute_tool.duration` | [`record_tool_execution`] | — (timed around the tool) |
+//!
+//! `inference_calls` and `tool_calls` fall out of [`crate::completion_watch`] for
+//! free, which is why they cost one addition each rather than a counter threaded
+//! through the loop. `tool_calls` is the one Amy asked for by name: it answers "did
+//! the consult driver actually delegate a sweep, or did it read all 203 turns
+//! itself" — the question a $4 OpenRouter consult raised, and which until now needed
+//! OTLP span archaeology to answer.
+//!
+//! ## Counting rules that are easy to get wrong
+//!
+//! Straight from `metrics.yaml:188-225`, because two of them are counterintuitive:
+//!
+//! - Both agent call-count metrics are scoped to **one invocation**, and both
+//!   **include failed calls**. A phase that died at turn 90 still reports 90.
+//! - Both **exclude calls made by sub-agents**. kaibo's delegated `explore′` sweep is
+//!   a sub-agent invocation: it records its own `inference_calls` against its own
+//!   name, and the driver counts the delegation as **one tool call**. That is what
+//!   makes each call counted exactly once across the tree, and it is why the driver's
+//!   `tool_calls` is the delegation answer rather than a mixed total.
+//! - `tool_calls` counts **client-side** tool calls only — tools kaibo executes.
+//!   A provider-side built-in (web search, code execution) is not ours to count.
+//!
+//! ## Off costs nothing
+//!
+//! The instruments hang off the **global** meter provider. With metrics disabled
+//! kaibo installs none, so `global::meter` yields the SDK's no-op provider and every
+//! `record` here is a virtual call that returns — no allocation, no attribute set
+//! built, nothing buffered. That is the same shape the traces layer gets from having
+//! no subscriber attached, and it keeps the default run free of a telemetry tax.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use opentelemetry::metrics::Histogram;
+use opentelemetry::{global, KeyValue};
+
+use crate::credentials::ProviderKind;
+
+/// Advisory bucket boundaries, taken from the rendered conventions
+/// (`docs/gen-ai/gen-ai-metrics.md`) rather than invented.
+///
+/// They are **not** in `metrics.yaml` — the YAML defines the instrument, the rendered
+/// doc carries the `ExplicitBucketBoundaries` line — so anyone re-deriving these from
+/// the model files alone will not find them. Using the published ones is what lets a
+/// backend compare kaibo's histograms against every other GenAI instrumentation's.
+mod buckets {
+    /// Tokens: powers of four to 64M, so a 16k prompt and a 4M cache read land in
+    /// different buckets.
+    pub const TOKEN_USAGE: &[f64] = &[
+        1.0, 4.0, 16.0, 64.0, 256.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0,
+        4194304.0, 16777216.0, 67108864.0,
+    ];
+    /// One provider call, in seconds — doubling from 10ms to ~82s.
+    pub const CLIENT_OPERATION: &[f64] = &[
+        0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+    ];
+    /// A whole agent invocation, in seconds — doubling from 100ms to ~410s. Wider
+    /// than a single call because a consult is many calls plus tool time; the 21-minute
+    /// OpenRouter consult lands in the top bucket, which is the right shape for a
+    /// runaway.
+    pub const AGENT_DURATION: &[f64] = &[
+        0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2, 102.4, 204.8, 409.6,
+    ];
+    /// Calls per invocation — powers of two to 128. kaibo's turn caps sit inside this
+    /// range, so a phase pinned at its cap is visible as pile-up in one bucket.
+    pub const CALL_COUNT: &[f64] = &[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0];
+    /// One tool execution, in seconds. Same ladder as a client call: a `run_kaish`
+    /// grep and a delegated sweep differ by orders of magnitude, and both fit.
+    pub const TOOL_DURATION: &[f64] = &[
+        0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+    ];
+}
+
+/// The conventions' name for a provider, which is not always kaibo's.
+///
+/// `gen_ai.provider.name` is an **open** enum: the spec fixes a spelling for the
+/// providers it knows and lets instrumentation name the rest. Two of kaibo's kinds
+/// need the translation, and getting it wrong would file kaibo's numbers under a name
+/// no other instrumentation uses — the whole value of a shared convention.
+///
+/// - Gemini is `gcp.gemini` in the spec, never `gemini`.
+/// - OpenRouter has no spelling in the spec at all (it is a gateway, not a model
+///   vendor), so kaibo's own `openrouter` stands. A reader sees the gateway, which is
+///   the honest answer: the upstream model behind one OpenRouter slug varies per call
+///   and kaibo is not told which one served it.
+///
+/// The media kinds never reach here — they generate images through kaibo's own
+/// facades, not a rig completion model, so no client metric is recorded for them.
+fn provider_name(kind: ProviderKind) -> &'static str {
+    match kind {
+        ProviderKind::Gemini => "gcp.gemini",
+        other => other.canonical_name(),
+    }
+}
+
+/// The six instruments, built once. Cached in a `OnceLock` rather than rebuilt per
+/// call because instrument creation walks the provider's registry — cheap, but not
+/// free, and these are recorded on every turn of every phase.
+///
+/// **Bound at first use.** An OTel `Meter` captures the global provider as it stands
+/// when the meter is made, so these instruments answer to whatever was installed the
+/// first time anything recorded. In the binary that is unambiguous — `main` runs
+/// `telemetry::init` before it serves a single request — but it means installing a
+/// provider *after* a record is a no-op, which is why the tests below build their own
+/// `Instruments` from a test meter instead of racing the global.
+struct Instruments {
+    token_usage: Histogram<u64>,
+    operation_duration: Histogram<f64>,
+    agent_duration: Histogram<f64>,
+    inference_calls: Histogram<u64>,
+    tool_calls: Histogram<u64>,
+    tool_duration: Histogram<f64>,
+}
+
+static INSTRUMENTS: OnceLock<Instruments> = OnceLock::new();
+
+/// Build the instruments against whatever meter provider is installed *now*.
+///
+/// Called lazily on first record, which is after `main` has installed the provider (or
+/// decided not to). With metrics off that is the no-op provider and these become no-op
+/// instruments — built once, then free forever.
+fn instruments() -> &'static Instruments {
+    INSTRUMENTS.get_or_init(|| Instruments::new(&global::meter("kaibo")))
+}
+
+impl Instruments {
+    /// Build the six against a given meter. Split from the global cache so a test can
+    /// hold its own set and read what was recorded, and so the boundaries live in
+    /// exactly one place for both.
+    fn new(meter: &opentelemetry::metrics::Meter) -> Self {
+        Instruments {
+            token_usage: meter
+                .u64_histogram("gen_ai.client.token.usage")
+                .with_description("Number of input and output tokens used.")
+                .with_unit("{token}")
+                .with_boundaries(buckets::TOKEN_USAGE.to_vec())
+                .build(),
+            operation_duration: meter
+                .f64_histogram("gen_ai.client.operation.duration")
+                .with_description("GenAI operation duration.")
+                .with_unit("s")
+                .with_boundaries(buckets::CLIENT_OPERATION.to_vec())
+                .build(),
+            agent_duration: meter
+                .f64_histogram("gen_ai.invoke_agent.duration")
+                .with_description("The end-to-end duration of a single agent invocation.")
+                .with_unit("s")
+                .with_boundaries(buckets::AGENT_DURATION.to_vec())
+                .build(),
+            inference_calls: meter
+                .u64_histogram("gen_ai.invoke_agent.inference_calls")
+                .with_description(
+                    "The number of inference calls an agent makes during a single invocation.",
+                )
+                .with_unit("{inference_call}")
+                .with_boundaries(buckets::CALL_COUNT.to_vec())
+                .build(),
+            tool_calls: meter
+                .u64_histogram("gen_ai.invoke_agent.tool_calls")
+                .with_description(
+                    "The number of tool calls an agent makes during a single invocation.",
+                )
+                .with_unit("{tool_call}")
+                .with_boundaries(buckets::CALL_COUNT.to_vec())
+                .build(),
+            tool_duration: meter
+                .f64_histogram("gen_ai.execute_tool.duration")
+                .with_description("The duration of a single tool execution.")
+                .with_unit("s")
+                .with_boundaries(buckets::TOOL_DURATION.to_vec())
+                .build(),
+        }
+    }
+}
+
+/// Who is running a phase — the identity its metrics are attributed to.
+///
+/// Carried rather than looked up because the one place that knows both facts is cast
+/// resolution (`Arm::from_slot`), and the places that measure are the phase loop and
+/// the completion wrapper several layers below it.
+///
+/// `Option<PhaseIdentity>` on an arm, and absent means **no provider call is
+/// happening**: the offline scripted client the test harness injects through
+/// `Arm::new` runs the real loop against an in-process responder. Recording a
+/// microsecond "provider call" for that would poison every latency histogram it
+/// touched, so an arm without an identity records nothing. Live arms always have one —
+/// `Arm::from_slot` is the single live construction point and sets it there.
+#[derive(Debug, Clone, Copy)]
+pub struct PhaseIdentity {
+    /// The provider kind behind this arm — translated to the conventions' spelling by
+    /// [`provider_name`].
+    pub provider: ProviderKind,
+    /// This phase's agent name: the cast role it fills, `"synth"` or `"explorer"`.
+    ///
+    /// That is the distinction the agent metrics exist to draw. A consult driver is
+    /// the synth; a delegated `explore′` sweep is an explorer running its own
+    /// invocation. Reading `gen_ai.invoke_agent.tool_calls` split by this name is how
+    /// "did the driver delegate, or did it read everything itself" gets answered
+    /// without opening a single trace.
+    pub agent: &'static str,
+}
+
+/// Who made one provider call — [`PhaseIdentity`] plus the model that served it.
+#[derive(Debug, Clone, Copy)]
+pub struct CallIdent<'a> {
+    /// The provider kind behind this arm.
+    pub provider: ProviderKind,
+    /// The model id as configured, e.g. `deepseek-v4-pro`. Reported as
+    /// `gen_ai.request.model`: kaibo asks for a specific id and gets it, and rig's
+    /// normalized response does not carry the served id separately.
+    pub model: &'a str,
+}
+
+/// Record one provider call: its duration, and the tokens it reported.
+///
+/// `usage` is rig's normalized report for this single completion. A provider that
+/// reported nothing yields a zero-valued `Usage`, and zero-valued token counts are
+/// **not** recorded — the conventions say to report usage only when the count is
+/// readily available, and a recorded zero would drag every average down while
+/// claiming a call genuinely used no tokens.
+///
+/// `error` is the `error.type` for a failed call (the conventions' own attribute), and
+/// `None` for a call that returned normally. A failed call still records its duration:
+/// a provider that takes 30 seconds to fail is exactly what an operator needs to see.
+pub fn record_completion(
+    ident: CallIdent<'_>,
+    duration: Duration,
+    usage: Option<&rig_core::completion::Usage>,
+    error: Option<&str>,
+) {
+    record_completion_on(instruments(), ident, duration, usage, error);
+}
+
+fn record_completion_on(
+    inst: &Instruments,
+    ident: CallIdent<'_>,
+    duration: Duration,
+    usage: Option<&rig_core::completion::Usage>,
+    error: Option<&str>,
+) {
+    let provider = provider_name(ident.provider);
+
+    let mut attrs = vec![
+        KeyValue::new("gen_ai.provider.name", provider),
+        KeyValue::new("gen_ai.request.model", ident.model.to_string()),
+        KeyValue::new("gen_ai.operation.name", "chat"),
+    ];
+    if let Some(kind) = error {
+        attrs.push(KeyValue::new("error.type", kind.to_string()));
+    }
+    inst.operation_duration
+        .record(duration.as_secs_f64(), &attrs);
+
+    let Some(usage) = usage else { return };
+    // Token type is a REQUIRED attribute on this metric, so the two directions are
+    // two records against one instrument, never one record of a total.
+    let token_attrs = |token_type: &'static str| {
+        vec![
+            KeyValue::new("gen_ai.provider.name", provider),
+            KeyValue::new("gen_ai.request.model", ident.model.to_string()),
+            KeyValue::new("gen_ai.operation.name", "chat"),
+            KeyValue::new("gen_ai.token.type", token_type),
+        ]
+    };
+    if usage.input_tokens > 0 {
+        inst.token_usage
+            .record(usage.input_tokens, &token_attrs("input"));
+    }
+    if usage.output_tokens > 0 {
+        inst.token_usage
+            .record(usage.output_tokens, &token_attrs("output"));
+    }
+}
+
+/// Record one agent invocation — a whole phase, from its first turn to its answer.
+///
+/// `inference_calls` and `tool_calls` follow the conventions' counting rules quoted in
+/// the module docs: this invocation's own calls, failed ones included, sub-agent calls
+/// excluded. kaibo satisfies the sub-agent rule by construction rather than by
+/// filtering — a delegated `explore′` sweep runs its own [`record_agent_invocation`]
+/// under its own agent name, and the driver sees the delegation only as the one tool
+/// call it made.
+pub fn record_agent_invocation(
+    agent: &str,
+    model: &str,
+    duration: Duration,
+    inference_calls: u64,
+    tool_calls: u64,
+    error: Option<&str>,
+) {
+    record_agent_invocation_on(
+        instruments(),
+        agent,
+        model,
+        duration,
+        inference_calls,
+        tool_calls,
+        error,
+    );
+}
+
+#[allow(clippy::too_many_arguments)] // one argument per recorded attribute or value
+fn record_agent_invocation_on(
+    inst: &Instruments,
+    agent: &str,
+    model: &str,
+    duration: Duration,
+    inference_calls: u64,
+    tool_calls: u64,
+    error: Option<&str>,
+) {
+    let mut attrs = vec![
+        KeyValue::new("gen_ai.agent.name", agent.to_string()),
+        KeyValue::new("gen_ai.request.model", model.to_string()),
+    ];
+    if let Some(kind) = error {
+        attrs.push(KeyValue::new("error.type", kind.to_string()));
+    }
+    inst.agent_duration.record(duration.as_secs_f64(), &attrs);
+
+    // The call counts take the agent name alone, which is what the conventions list
+    // for them. Keeping the model off these two is deliberate: "how many turns does a
+    // consult driver take" is a question about the phase, and mixing models into the
+    // series would split it per cast for no gain the duration metric doesn't already
+    // give.
+    let count_attrs = [KeyValue::new("gen_ai.agent.name", agent.to_string())];
+    inst.inference_calls.record(inference_calls, &count_attrs);
+    inst.tool_calls.record(tool_calls, &count_attrs);
+}
+
+/// Record one tool execution — a `run_kaish` shell call, a delegated `explore′` sweep,
+/// a `view_image` read.
+///
+/// The delegated sweep shows up here *and* as its own agent invocation, which is not
+/// double counting: they measure different things. This says how long the driver
+/// waited; the sweep's own invocation says what it did while the driver waited.
+pub fn record_tool_execution(tool: &str, duration: Duration, error: Option<&str>) {
+    record_tool_execution_on(instruments(), tool, duration, error);
+}
+
+fn record_tool_execution_on(
+    inst: &Instruments,
+    tool: &str,
+    duration: Duration,
+    error: Option<&str>,
+) {
+    let mut attrs = vec![KeyValue::new("gen_ai.tool.name", tool.to_string())];
+    if let Some(kind) = error {
+        attrs.push(KeyValue::new("error.type", kind.to_string()));
+    }
+    inst.tool_duration.record(duration.as_secs_f64(), &attrs);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gemini_is_reported_under_the_conventions_spelling() {
+        // The one translation that would silently file kaibo's numbers under a name no
+        // other instrumentation uses. `gemini` is kaibo's name; `gcp.gemini` is the
+        // spec's, and the spec wins on the wire.
+        assert_eq!(provider_name(ProviderKind::Gemini), "gcp.gemini");
+    }
+
+    #[test]
+    fn a_provider_the_spec_does_not_name_keeps_kaibos_own() {
+        // OpenRouter is a gateway, absent from the spec's enum — which is open, so our
+        // canonical name is the honest answer rather than a forced fit into someone
+        // else's.
+        assert_eq!(provider_name(ProviderKind::OpenRouter), "openrouter");
+        assert_eq!(provider_name(ProviderKind::Anthropic), "anthropic");
+        assert_eq!(provider_name(ProviderKind::DeepSeek), "deepseek");
+        assert_eq!(provider_name(ProviderKind::Openai), "openai");
+    }
+
+    #[test]
+    fn recording_without_a_meter_provider_is_a_no_op_not_a_panic() {
+        // The default run: metrics off, no provider installed, and every record here
+        // must be a cheap return. If this ever panics or blocks, telemetry-off stopped
+        // being free.
+        let ident = CallIdent {
+            provider: ProviderKind::DeepSeek,
+            model: "deepseek-v4-pro",
+        };
+        record_completion(ident, Duration::from_millis(10), None, None);
+        record_agent_invocation(
+            "synth",
+            "deepseek-v4-pro",
+            Duration::from_secs(1),
+            5,
+            2,
+            None,
+        );
+        record_tool_execution("run_kaish", Duration::from_millis(3), Some("timeout"));
+    }
+
+    // --- Recording, against a real reader -----------------------------------------
+    //
+    // These build their own `Instruments` from a test meter rather than installing a
+    // global provider. Two reasons, both structural: the global is process-wide, so a
+    // test that installed one would leak into every other test in this binary; and the
+    // instruments bind to whichever provider was live at first use, so racing for that
+    // slot would make the suite order-dependent. See `Instruments`.
+
+    use opentelemetry::metrics::MeterProvider as _;
+    use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    /// One recorded point: the metric's name, its attributes as (key, value) pairs, and
+    /// the value asserted on — a summed count for the integer histograms, a point count
+    /// for the duration ones (wall-clock cannot be pinned).
+    type Point = (String, Vec<(String, String)>, u64);
+
+    /// A provider whose measurements can be read back, plus the instruments feeding it.
+    fn reader() -> (SdkMeterProvider, InMemoryMetricExporter, Instruments) {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(PeriodicReader::builder(exporter.clone()).build())
+            .build();
+        let instruments = Instruments::new(&provider.meter("kaibo"));
+        (provider, exporter, instruments)
+    }
+
+    /// Every (metric name, attributes, recorded sum) the exporter saw, flattened —
+    /// enough to assert both that a metric was recorded and what it was labelled with.
+    fn collected(
+        provider: &SdkMeterProvider,
+        exporter: &InMemoryMetricExporter,
+    ) -> Vec<Point> {
+        provider.force_flush().expect("flush the test reader");
+        let mut out = Vec::new();
+        for rm in exporter.get_finished_metrics().expect("read metrics") {
+            for sm in rm.scope_metrics() {
+                for m in sm.metrics() {
+                    let name = m.name().to_string();
+                    let points: Vec<_> = match m.data() {
+                        AggregatedMetrics::U64(d) => match d {
+                            opentelemetry_sdk::metrics::data::MetricData::Histogram(h) => h
+                                .data_points()
+                                .map(|p| {
+                                    (
+                                        p.attributes()
+                                            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+                                            .collect::<Vec<_>>(),
+                                        p.sum(),
+                                    )
+                                })
+                                .collect(),
+                            _ => Vec::new(),
+                        },
+                        AggregatedMetrics::F64(d) => match d {
+                            opentelemetry_sdk::metrics::data::MetricData::Histogram(h) => h
+                                .data_points()
+                                // Durations are asserted on presence and labels, not
+                                // value — a wall-clock number cannot be pinned.
+                                .map(|p| {
+                                    (
+                                        p.attributes()
+                                            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+                                            .collect::<Vec<_>>(),
+                                        p.count(),
+                                    )
+                                })
+                                .collect(),
+                            _ => Vec::new(),
+                        },
+                        AggregatedMetrics::I64(_) => Vec::new(),
+                    };
+                    for (attrs, value) in points {
+                        out.push((name.clone(), attrs, value));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn find<'a>(rows: &'a [Point], metric: &str) -> Vec<&'a Point> {
+        rows.iter().filter(|(n, _, _)| n == metric).collect()
+    }
+
+    fn attr(row: &Point, key: &str) -> Option<String> {
+        row.1
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.to_string())
+    }
+
+    #[test]
+    fn token_usage_splits_input_and_output_into_two_records() {
+        // `gen_ai.token.type` is a REQUIRED attribute, so a single record of a total
+        // would be unreadable — a backend could not tell prompt spend from completion
+        // spend, which is the split that makes the metric worth having.
+        let (provider, exporter, inst) = reader();
+        let usage = rig_core::completion::Usage {
+            input_tokens: 1200,
+            output_tokens: 340,
+            ..Default::default()
+        };
+        record_completion_on(
+            &inst,
+            CallIdent {
+                provider: ProviderKind::DeepSeek,
+                model: "deepseek-v4-pro",
+            },
+            Duration::from_millis(900),
+            Some(&usage),
+            None,
+        );
+
+        let rows = collected(&provider, &exporter);
+        let usage_rows = find(&rows, "gen_ai.client.token.usage");
+        assert_eq!(usage_rows.len(), 2, "one record per direction: {rows:?}");
+
+        let input = usage_rows
+            .iter()
+            .find(|r| attr(r, "gen_ai.token.type").as_deref() == Some("input"))
+            .expect("an input-token record");
+        assert_eq!(input.2, 1200, "input tokens recorded verbatim");
+        assert_eq!(
+            attr(input, "gen_ai.provider.name").as_deref(),
+            Some("deepseek"),
+        );
+        assert_eq!(
+            attr(input, "gen_ai.request.model").as_deref(),
+            Some("deepseek-v4-pro"),
+        );
+
+        let output = usage_rows
+            .iter()
+            .find(|r| attr(r, "gen_ai.token.type").as_deref() == Some("output"))
+            .expect("an output-token record");
+        assert_eq!(output.2, 340, "output tokens recorded verbatim");
+    }
+
+    #[test]
+    fn a_provider_that_reported_no_tokens_records_no_token_usage() {
+        // rig hands back a zero-valued `Usage` when the provider reported nothing. The
+        // conventions say to report usage only when the count is readily available, and
+        // a recorded zero is worse than an absent one: it claims a call genuinely used
+        // no tokens and drags every average toward zero.
+        let (provider, exporter, inst) = reader();
+        record_completion_on(
+            &inst,
+            CallIdent {
+                provider: ProviderKind::Anthropic,
+                model: "claude-sonnet-4-6",
+            },
+            Duration::from_millis(50),
+            Some(&rig_core::completion::Usage::default()),
+            None,
+        );
+
+        let rows = collected(&provider, &exporter);
+        assert!(
+            find(&rows, "gen_ai.client.token.usage").is_empty(),
+            "a zero-valued Usage records no tokens: {rows:?}"
+        );
+        assert_eq!(
+            find(&rows, "gen_ai.client.operation.duration").len(),
+            1,
+            "the call still happened, so its duration is still recorded: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn a_failed_call_records_its_duration_and_its_error_class() {
+        // The number an operator most wants when a provider degrades is how long it
+        // took to fail. Dropping failures would hide exactly that.
+        let (provider, exporter, inst) = reader();
+        record_completion_on(
+            &inst,
+            CallIdent {
+                provider: ProviderKind::Openai,
+                model: "gpt-5.6-terra",
+            },
+            Duration::from_secs(30),
+            None,
+            Some("http_error"),
+        );
+
+        let rows = collected(&provider, &exporter);
+        let duration = find(&rows, "gen_ai.client.operation.duration");
+        assert_eq!(duration.len(), 1, "a failed call is still recorded: {rows:?}");
+        assert_eq!(
+            attr(duration[0], "error.type").as_deref(),
+            Some("http_error"),
+            "the failure class rides the record"
+        );
+    }
+
+    #[test]
+    fn the_driver_and_the_sweep_are_separate_series() {
+        // The reason this whole signal was prioritized. A consult driver that delegated
+        // twice and an explorer sweep that ran twenty turns must be readable apart —
+        // `tool_calls` on the synth answers "did it delegate", and it only answers that
+        // if the sweep's own turns are counted against the explorer instead.
+        let (provider, exporter, inst) = reader();
+        record_agent_invocation_on(
+            &inst,
+            "synth",
+            "deepseek-v4-pro",
+            Duration::from_secs(120),
+            8,
+            2,
+            None,
+        );
+        record_agent_invocation_on(
+            &inst,
+            "explorer",
+            "deepseek-v4-flash",
+            Duration::from_secs(40),
+            20,
+            19,
+            None,
+        );
+
+        let rows = collected(&provider, &exporter);
+        let tool_calls = find(&rows, "gen_ai.invoke_agent.tool_calls");
+        let synth = tool_calls
+            .iter()
+            .find(|r| attr(r, "gen_ai.agent.name").as_deref() == Some("synth"))
+            .expect("a synth series");
+        let explorer = tool_calls
+            .iter()
+            .find(|r| attr(r, "gen_ai.agent.name").as_deref() == Some("explorer"))
+            .expect("an explorer series");
+        assert_eq!(synth.2, 2, "the driver's own tool calls — its delegations");
+        assert_eq!(explorer.2, 19, "the sweep's own reads, on its own series");
+
+        let inference = find(&rows, "gen_ai.invoke_agent.inference_calls");
+        let synth_turns = inference
+            .iter()
+            .find(|r| attr(r, "gen_ai.agent.name").as_deref() == Some("synth"))
+            .expect("a synth series");
+        assert_eq!(
+            synth_turns.2, 8,
+            "the driver's turns exclude the sweep's twenty"
+        );
+    }
+
+    #[test]
+    fn a_tool_execution_carries_its_name_and_failure_class() {
+        let (provider, exporter, inst) = reader();
+        record_tool_execution_on(&inst, "run_kaish", Duration::from_millis(12), None);
+        record_tool_execution_on(&inst, "view_image", Duration::from_millis(5), Some("timeout"));
+
+        let rows = collected(&provider, &exporter);
+        let tools = find(&rows, "gen_ai.execute_tool.duration");
+        assert_eq!(tools.len(), 2, "one series per (tool, error) pair: {rows:?}");
+        let failed = tools
+            .iter()
+            .find(|r| attr(r, "gen_ai.tool.name").as_deref() == Some("view_image"))
+            .expect("the failed tool's series");
+        assert_eq!(attr(failed, "error.type").as_deref(), Some("timeout"));
+    }
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -23,7 +23,7 @@
 //! | `gen_ai.client.token.usage` | [`record_completion`] | the provider's `Usage` on every turn |
 //! | `gen_ai.client.operation.duration` | [`record_completion`] | — (timed around the call) |
 //! | `gen_ai.invoke_agent.duration` | [`record_agent_invocation`] | — (timed around the phase) |
-//! | `gen_ai.invoke_agent.inference_calls` | [`record_agent_invocation`] | `CompletionLog::len` |
+//! | `gen_ai.invoke_agent.inference_calls` | [`record_agent_invocation`] | `CompletionLog::attempts` |
 //! | `gen_ai.invoke_agent.tool_calls` | [`record_agent_invocation`] | `TurnRecord::tool_calls`, summed |
 //! | `gen_ai.execute_tool.duration` | [`record_tool_execution`] | — (timed around the tool) |
 //!
@@ -39,7 +39,9 @@
 //! Straight from `metrics.yaml:188-225`, because two of them are counterintuitive:
 //!
 //! - Both agent call-count metrics are scoped to **one invocation**, and both
-//!   **include failed calls**. A phase that died at turn 90 still reports 90.
+//!   **include failed calls**. A phase that died at turn 90 still reports 90 — which
+//!   is why `inference_calls` reads `CompletionLog::attempts` and not its length: a
+//!   failed call produces no `TurnRecord`, so the length would report 89.
 //! - Both **exclude calls made by sub-agents**. kaibo's delegated `explore′` sweep is
 //!   a sub-agent invocation: it records its own `inference_calls` against its own
 //!   name, and the driver counts the delegation as **one tool call**. That is what

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -210,6 +210,10 @@ pub(crate) fn render_config_resource(
     struct TelemetryDoc {
         enabled: bool,
         endpoint: String,
+        /// Whether the span tree exports. Separable from `enabled` because traces are
+        /// the signal that can carry content; `metrics` cannot, so an operator may
+        /// take one and decline the other.
+        traces: bool,
         /// Whether kaibo's own `tracing` events export alongside the span tree.
         logs: bool,
         /// Where those records go, **as resolved** — the explicit `logs_endpoint` or
@@ -218,6 +222,14 @@ pub(crate) fn render_config_resource(
         /// in their head from the file.
         #[serde(skip_serializing_if = "Option::is_none")]
         logs_endpoint: Option<String>,
+        /// Whether the GenAI metrics signal exports. This one carries no content by
+        /// construction — no metric in the conventions has a content-bearing
+        /// attribute — so it is the signal to keep when declining traces.
+        metrics: bool,
+        /// Where the measurements go, **as resolved**. Absent when `metrics` is off.
+        /// Same derivation rule as `logs_endpoint`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metrics_endpoint: Option<String>,
         timeout_secs: u64,
         service_name: String,
         #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -593,10 +605,18 @@ pub(crate) fn render_config_resource(
     let crate::config::TelemetryConfig {
         enabled: telemetry_enabled,
         endpoint: telemetry_endpoint,
+        traces: telemetry_traces,
         logs: telemetry_logs,
         // Read through `resolve_logs_endpoint` below, which is where the derivation
         // lives; the raw override alone would under-report where records go.
         logs_endpoint: _,
+        metrics: telemetry_metrics,
+        // Same as `logs_endpoint`: resolved below, not echoed.
+        metrics_endpoint: _,
+        // Provenance, not a knob: it decides whether an underivable metrics endpoint
+        // is a load error or a warning, which the resolved `metrics_endpoint` below
+        // already reflects by being absent.
+        metrics_explicit: _,
         headers: telemetry_headers,
         timeout: telemetry_timeout,
         service_name: telemetry_service_name,
@@ -672,12 +692,17 @@ pub(crate) fn render_config_resource(
         telemetry: TelemetryDoc {
             enabled: *telemetry_enabled,
             endpoint: telemetry_endpoint.clone(),
+            traces: *telemetry_traces,
             logs: *telemetry_logs,
             // A non-derivable endpoint is a fatal startup error, so a *running*
             // server always resolves here. Reported absent rather than guessed if
             // that ever stops being true.
             logs_endpoint: (*telemetry_logs)
                 .then(|| crate::telemetry::resolve_logs_endpoint(&config.telemetry).ok())
+                .flatten(),
+            metrics: *telemetry_metrics,
+            metrics_endpoint: (*telemetry_metrics)
+                .then(|| crate::telemetry::resolve_metrics_endpoint(&config.telemetry).ok())
                 .flatten(),
             timeout_secs: telemetry_timeout.as_secs(),
             service_name: telemetry_service_name.clone(),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -242,19 +242,24 @@ where
     // because a config that worked before the upgrade must not refuse to start over a
     // signal nobody asked for. The warning names the two keys either fix uses, so the
     // degraded case is still actionable rather than merely survivable.
-    let metrics_endpoint = match (cfg.metrics, resolve_metrics_endpoint(cfg)) {
-        (false, _) => None,
-        (true, Ok(endpoint)) => Some(endpoint),
-        (true, Err(e)) if cfg.metrics_explicit => return Err(e),
-        (true, Err(_)) => {
-            tracing::warn!(
+    let metrics_endpoint = if !cfg.metrics {
+        // Guarded rather than matched on a tuple, so a declined signal does no
+        // derivation work at all — the same shape `logs` above uses.
+        None
+    } else {
+        match resolve_metrics_endpoint(cfg) {
+            Ok(endpoint) => Some(endpoint),
+            Err(e) if cfg.metrics_explicit => return Err(e),
+            Err(_) => {
+                tracing::warn!(
                 endpoint = %cfg.endpoint,
                 "[telemetry] metrics is on by default but its endpoint cannot be derived \
                  from a non-standard endpoint, so metrics are not exported. Set \
                  [telemetry] metrics_endpoint to the collector's OTLP/HTTP metrics URL, \
                  or set metrics = false to stop reading this line."
-            );
-            None
+                );
+                None
+            }
         }
     };
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,4 +1,4 @@
-//! OpenTelemetry export — traces and logs, opt-in, off by default.
+//! OpenTelemetry export — traces, logs, and metrics, opt-in, off by default.
 //!
 //! kaibo barely needs to instrument anything: rig already emits the GenAI span
 //! tree from inside its agent loop — an `invoke_agent` span per phase, a `chat`
@@ -10,7 +10,7 @@
 //! is to *export* it: stand up the OTLP/HTTP exporters and hand `main`'s subscriber
 //! registry the layers that feed them.
 //!
-//! ## Two signals, and why the second one exists
+//! ## Three signals, and why each later one exists
 //!
 //! Traces carry rig's span tree. **Logs carry kaibo's own `tracing` events**, which
 //! nothing exported before — and several things worth counting are only ever events,
@@ -19,6 +19,18 @@
 //! phase returns an empty answer and is forced into a write-up turn. Both classes
 //! were tracked as "incidence unmeasured" precisely because the instrument existed
 //! and had nowhere to report.
+//!
+//! **Metrics carry what neither of those makes cheap to aggregate** — and, more to the
+//! point, what neither of them can do *safely by construction*. Traces are made safe by
+//! a filter ([`crate::otel_filter`]); metrics need none, because no metric in the GenAI
+//! conventions has a content-bearing attribute. That is what makes `traces = false,
+//! metrics = true` a real posture rather than a compromise: an operator gets kaibo's
+//! spend, latency, and delegation with no prompt able to leave by that road. The
+//! instruments and the counting rules live in [`crate::metrics`]; this module only
+//! stands up the exporter. Note the shape difference — traces and logs install
+//! subscriber *layers*, while metrics installs a **global meter provider**, which is
+//! the SDK's own arrangement and why [`init`] can return zero layers and still be
+//! exporting.
 //!
 //! **Which events.** The traces layer admits everything at `info`, because rig's
 //! spans *are* the tree. The logs layer is deliberately narrower — `kaibo=info` —
@@ -34,14 +46,19 @@
 //!   prompts, completions, and source snippets. A default run must ship nothing —
 //!   so [`init`] returns `Ok(None)` unless `[telemetry]` opts in. See
 //!   [`crate::config::TelemetryConfig`].
-//! - **One opt-in covers both signals.** `logs` defaults on *under* `enabled`,
-//!   because kaibo's own diagnostics are strictly less sensitive than the prompts
-//!   the traces already carry — an operator who accepted the first has no new
-//!   disclosure to weigh. `logs = false` is there for a collector that takes spans
-//!   but not records.
-//! - **The logs endpoint is derived only from the standard path shape**, never
-//!   guessed. See [`resolve_logs_endpoint`] — a misroute would be discovered only by
-//!   the records' absence, which is the silent failure this house refuses.
+//! - **One opt-in covers every signal, and each can be declined.** `logs` and
+//!   `metrics` default on *under* `enabled`, because kaibo's own diagnostics are
+//!   strictly less sensitive than the prompts the traces already carry (and the
+//!   metrics carry no content at all) — an operator who accepted the first has no new
+//!   disclosure to weigh. Each has its own `false` for a collector that takes one
+//!   signal and not another, and `traces = false` is the one that makes a
+//!   content-free posture expressible.
+//! - **A sibling endpoint is derived only from the standard path shape**, never
+//!   guessed. See [`derive_sibling_endpoint`] — a misroute would be discovered only by
+//!   the records' absence, which is the silent failure this house refuses. The one
+//!   asymmetry: a *defaulted* metrics signal degrades with a warning instead of
+//!   refusing, so a config that worked before metrics existed still starts. An
+//!   operator who wrote `metrics = true` gets the refusal.
 //! - **stdio-only holds.** The exporters open *outbound* connections to the
 //!   collector; they never *bind* a socket. That's the line the invariant draws.
 //! - **Never the stdout channel.** Errors (a down collector, a flush timeout) go to
@@ -54,8 +71,11 @@ use std::collections::HashMap;
 use anyhow::{bail, Context, Result};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
-use opentelemetry_otlp::{LogExporter, Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_otlp::{
+    LogExporter, MetricExporter, Protocol, SpanExporter, WithExportConfig, WithHttpConfig,
+};
 use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
 use tracing::Subscriber;
@@ -64,10 +84,11 @@ use tracing_subscriber::{filter::EnvFilter, Layer};
 
 use crate::config::TelemetryConfig;
 
-/// The standard OTLP/HTTP path pair. Deriving one from the other is only honest for
-/// exactly this shape; anything else is the operator's to state.
+/// The standard OTLP/HTTP paths. Deriving one from another is only honest for exactly
+/// this shape; anything else is the operator's to state.
 const TRACES_PATH: &str = "/v1/traces";
 const LOGS_PATH: &str = "/v1/logs";
+const METRICS_PATH: &str = "/v1/metrics";
 
 /// What the logs layer admits. Narrower than the traces layer's `info` — see the
 /// module docs' "Which events" note for why the model stack is left out.
@@ -77,9 +98,15 @@ const LOGS_FILTER: &str = "kaibo=info,opentelemetry=off";
 /// processor buffers records off-thread; dropping a provider without a
 /// [`shutdown`](OtelGuard::shutdown) would discard whatever hasn't been exported.
 pub struct OtelGuard {
-    traces: SdkTracerProvider,
+    /// `None` when `[telemetry] traces = false` — the signal was never stood up.
+    traces: Option<SdkTracerProvider>,
     /// `None` when `[telemetry] logs = false` — the signal was never stood up.
     logs: Option<SdkLoggerProvider>,
+    /// `None` when `[telemetry] metrics = false`. Held for the same reason the others
+    /// are, and more urgently: the metrics reader aggregates in memory and exports on
+    /// an interval, so a process that exits without this shutdown loses every
+    /// measurement since the last tick.
+    metrics: Option<SdkMeterProvider>,
 }
 
 impl OtelGuard {
@@ -89,12 +116,19 @@ impl OtelGuard {
     /// shut down even if the first reports an error — one bad collector must not
     /// strand the other signal's buffer.
     pub fn shutdown(self) {
-        if let Err(e) = self.traces.shutdown() {
-            tracing::warn!(error = %e, "OTLP trace exporter shutdown reported an error");
+        if let Some(traces) = self.traces {
+            if let Err(e) = traces.shutdown() {
+                tracing::warn!(error = %e, "OTLP trace exporter shutdown reported an error");
+            }
         }
         if let Some(logs) = self.logs {
             if let Err(e) = logs.shutdown() {
                 tracing::warn!(error = %e, "OTLP log exporter shutdown reported an error");
+            }
+        }
+        if let Some(metrics) = self.metrics {
+            if let Err(e) = metrics.shutdown() {
+                tracing::warn!(error = %e, "OTLP metric exporter shutdown reported an error");
             }
         }
     }
@@ -114,16 +148,43 @@ type OtelLayers<S> = (Vec<Box<dyn Layer<S> + Send + Sync>>, OtelGuard);
 /// — a silent misroute, discovered only by their absence. So it fails at load and
 /// names the key that fixes it.
 pub(crate) fn resolve_logs_endpoint(cfg: &TelemetryConfig) -> Result<String> {
-    if let Some(explicit) = &cfg.logs_endpoint {
-        return Ok(explicit.clone());
+    derive_sibling_endpoint(cfg, cfg.logs_endpoint.as_deref(), LOGS_PATH, "logs")
+}
+
+/// Where the metrics signal exports to — the explicit `metrics_endpoint`, else the
+/// standard sibling. Same rule and same refusal as the logs endpoint above.
+pub(crate) fn resolve_metrics_endpoint(cfg: &TelemetryConfig) -> Result<String> {
+    derive_sibling_endpoint(
+        cfg,
+        cfg.metrics_endpoint.as_deref(),
+        METRICS_PATH,
+        "metrics",
+    )
+}
+
+/// The shared derivation: take the explicit endpoint if the operator wrote one,
+/// otherwise swap the standard traces path for this signal's — and refuse when
+/// `endpoint` is not the standard shape.
+///
+/// One helper rather than one function per signal so a third signal cannot arrive with
+/// a subtly different refusal. The `signal` name is threaded through only to build the
+/// key names in the error, which is the part the reader acts on.
+fn derive_sibling_endpoint(
+    cfg: &TelemetryConfig,
+    explicit: Option<&str>,
+    path: &str,
+    signal: &str,
+) -> Result<String> {
+    if let Some(explicit) = explicit {
+        return Ok(explicit.to_string());
     }
     match cfg.endpoint.strip_suffix(TRACES_PATH) {
-        Some(base) => Ok(format!("{base}{LOGS_PATH}")),
+        Some(base) => Ok(format!("{base}{path}")),
         None => bail!(
-            "[telemetry] endpoint `{}` does not end in `{TRACES_PATH}`, so the logs \
-             endpoint cannot be derived from it. Set [telemetry] logs_endpoint to the \
-             collector's OTLP/HTTP logs URL, or set logs = false to export traces only. \
-             Run `kaibo example-config` for the shape.",
+            "[telemetry] endpoint `{}` does not end in `{TRACES_PATH}`, so the {signal} \
+             endpoint cannot be derived from it. Set [telemetry] {signal}_endpoint to the \
+             collector's OTLP/HTTP {signal} URL, or set {signal} = false to export the \
+             other signals only. Run `kaibo example-config` for the shape.",
             cfg.endpoint
         ),
     }
@@ -154,14 +215,47 @@ where
     if !cfg.enabled {
         return Ok(None);
     }
+    // Enabled with every signal declined exports nothing, which is almost certainly
+    // not what the operator meant — they wrote four keys to arrive where `enabled =
+    // false` already was. Say so and stand up nothing, rather than running an exporter
+    // stack that can never emit.
+    if !cfg.traces && !cfg.logs && !cfg.metrics {
+        tracing::warn!(
+            "[telemetry] enabled = true with traces, logs, and metrics all false — \
+             nothing is exported. Turn on the signal you want, or set enabled = false."
+        );
+        return Ok(None);
+    }
 
-    // Resolve before building anything: a logs endpoint we cannot derive is an
-    // operator mistake, and it should surface as a load error rather than after a
-    // tracer provider is already standing.
+    // Resolve before building anything: an endpoint we cannot derive is an operator
+    // mistake, and it should surface as a load error rather than after a provider is
+    // already standing.
     let logs_endpoint = if cfg.logs {
         Some(resolve_logs_endpoint(cfg)?)
     } else {
         None
+    };
+    // Metrics is the one signal that defaults on *after* kaibo already shipped without
+    // it, so an underivable endpoint means two different things. Written by the
+    // operator: the same refusal `logs` gives, because they asked for a signal kaibo
+    // cannot route. Inherited from the default: a warning and the other signals,
+    // because a config that worked before the upgrade must not refuse to start over a
+    // signal nobody asked for. The warning names the two keys either fix uses, so the
+    // degraded case is still actionable rather than merely survivable.
+    let metrics_endpoint = match (cfg.metrics, resolve_metrics_endpoint(cfg)) {
+        (false, _) => None,
+        (true, Ok(endpoint)) => Some(endpoint),
+        (true, Err(e)) if cfg.metrics_explicit => return Err(e),
+        (true, Err(_)) => {
+            tracing::warn!(
+                endpoint = %cfg.endpoint,
+                "[telemetry] metrics is on by default but its endpoint cannot be derived \
+                 from a non-standard endpoint, so metrics are not exported. Set \
+                 [telemetry] metrics_endpoint to the collector's OTLP/HTTP metrics URL, \
+                 or set metrics = false to stop reading this line."
+            );
+            None
+        }
     };
 
     // opentelemetry-otlp builds its own reqwest (blocking) client when we build the
@@ -173,56 +267,73 @@ where
     // live binary on its first span export.
     crate::tls::ensure_crypto_provider();
 
-    // HTTP/protobuf on the async reqwest client — reuses kaibo's reqwest 0.13 +
-    // rustls (no tonic/gRPC). HttpBinary is the protobuf wire (the `/v1/traces`
-    // endpoint in config points at it).
-    let exporter = SpanExporter::builder()
-        .with_http()
-        .with_protocol(Protocol::HttpBinary)
-        .with_endpoint(cfg.endpoint.clone())
-        .with_timeout(cfg.timeout)
-        .with_headers(cfg.headers.clone().into_iter().collect::<HashMap<_, _>>())
-        .build()
-        .context("building the OTLP/HTTP span exporter")?;
-
-    // Every span leaves through the allowlist. Wrapping the exporter — rather than
-    // filtering at the call sites — is the only option available: the attributes
-    // carrying prompts and tool payloads are emitted inside rig, not by kaibo. See
-    // `crate::otel_filter`.
-    let policy = crate::otel_filter::AttributePolicy::new(cfg.capture_content, &cfg.capture);
-    // Say what is leaving, at the moment it starts leaving. An operator who enabled
-    // this through an ambient OTEL_* endpoint may not have thought about kaibo at
-    // all, so the line names the destination and the content policy together.
-    tracing::info!(
-        endpoint = %cfg.endpoint,
-        policy = %policy.describe(),
-        "telemetry enabled — exporting spans"
-    );
-    let exporter = crate::otel_filter::Filtered::new(exporter, policy);
-
+    let headers = || cfg.headers.clone().into_iter().collect::<HashMap<_, _>>();
     let resource = Resource::builder()
         .with_service_name(cfg.service_name.clone())
         .build();
+    let mut layers: Vec<Box<dyn Layer<S> + Send + Sync>> = Vec::new();
 
-    // Batch processor: spans buffer off the hot path and export in the background.
-    let provider = SdkTracerProvider::builder()
-        .with_batch_exporter(exporter)
-        .with_resource(resource.clone())
-        .build();
+    // The content policy is a TRACES property: it is the span attributes that carry
+    // prompts and completions. Resolved here so the startup line can state it beside
+    // the signals actually leaving, which is what an operator needs in one place.
+    let policy = crate::otel_filter::AttributePolicy::new(cfg.capture_content, &cfg.capture);
+    // Say what is leaving, at the moment it starts leaving. An operator who enabled
+    // this through an ambient OTEL_* endpoint may not have thought about kaibo at
+    // all, so the line names the destination, the signals, and the content policy
+    // together. `metrics` is named without a policy note on purpose — that signal has
+    // no content to have a policy about.
+    tracing::info!(
+        endpoint = %cfg.endpoint,
+        traces = cfg.traces,
+        logs = cfg.logs,
+        metrics = cfg.metrics,
+        policy = %policy.describe(),
+        "telemetry enabled"
+    );
 
-    let tracer = provider.tracer("kaibo");
+    // The traces signal. HTTP/protobuf on the async reqwest client — reuses kaibo's
+    // reqwest 0.13 + rustls (no tonic/gRPC). HttpBinary is the protobuf wire (the
+    // `/v1/traces` endpoint in config points at it).
+    let traces_provider = if cfg.traces {
+        let exporter = SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(cfg.endpoint.clone())
+            .with_timeout(cfg.timeout)
+            .with_headers(headers())
+            .build()
+            .context("building the OTLP/HTTP span exporter")?;
 
-    // The fmt/MCP layers filter to the `kaibo` target — which would drop rig's
-    // spans (targets `rig::agent_chat`, `rig::*`), the whole reason this layer
-    // exists. So the OTel layer carries its OWN filter, admitting everything at
-    // `info` while turning `opentelemetry`'s internal logs OFF: exporting those
-    // could feed back into the exporter and loop.
-    let filter = EnvFilter::new("info,opentelemetry=off");
+        // Every span leaves through the allowlist. Wrapping the exporter — rather than
+        // filtering at the call sites — is the only option available: the attributes
+        // carrying prompts and tool payloads are emitted inside rig, not by kaibo. See
+        // `crate::otel_filter`.
+        let exporter = crate::otel_filter::Filtered::new(exporter, policy);
 
-    let mut layers: Vec<Box<dyn Layer<S> + Send + Sync>> = vec![tracing_opentelemetry::layer()
-        .with_tracer(tracer)
-        .with_filter(filter)
-        .boxed()];
+        // Batch processor: spans buffer off the hot path and export in the background.
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_resource(resource.clone())
+            .build();
+
+        let tracer = provider.tracer("kaibo");
+
+        // The fmt/MCP layers filter to the `kaibo` target — which would drop rig's
+        // spans (targets `rig::agent_chat`, `rig::*`), the whole reason this layer
+        // exists. So the OTel layer carries its OWN filter, admitting everything at
+        // `info` while turning `opentelemetry`'s internal logs OFF: exporting those
+        // could feed back into the exporter and loop.
+        let filter = EnvFilter::new("info,opentelemetry=off");
+        layers.push(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(filter)
+                .boxed(),
+        );
+        Some(provider)
+    } else {
+        None
+    };
 
     // The logs signal, on the same transport and the same Resource, so a backend
     // joins a record to the span tree it happened under.
@@ -233,12 +344,12 @@ where
                 .with_protocol(Protocol::HttpBinary)
                 .with_endpoint(endpoint)
                 .with_timeout(cfg.timeout)
-                .with_headers(cfg.headers.clone().into_iter().collect::<HashMap<_, _>>())
+                .with_headers(headers())
                 .build()
                 .context("building the OTLP/HTTP log exporter")?;
             let logs_provider = SdkLoggerProvider::builder()
                 .with_batch_exporter(exporter)
-                .with_resource(resource)
+                .with_resource(resource.clone())
                 .build();
             layers.push(logs_layer(&logs_provider));
             Some(logs_provider)
@@ -246,11 +357,37 @@ where
         None => None,
     };
 
+    // The metrics signal. Unlike the other two it installs no tracing layer: the
+    // instruments in `crate::metrics` read the GLOBAL meter provider, so this is the
+    // one signal whose wiring is a global install rather than a subscriber layer.
+    // That is the SDK's own shape for metrics, and it is what makes a `record` call
+    // free when this block never runs.
+    let metrics_provider = match metrics_endpoint {
+        Some(endpoint) => {
+            let exporter = MetricExporter::builder()
+                .with_http()
+                .with_protocol(Protocol::HttpBinary)
+                .with_endpoint(endpoint)
+                .with_timeout(cfg.timeout)
+                .with_headers(headers())
+                .build()
+                .context("building the OTLP/HTTP metric exporter")?;
+            let provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(exporter)
+                .with_resource(resource)
+                .build();
+            opentelemetry::global::set_meter_provider(provider.clone());
+            Some(provider)
+        }
+        None => None,
+    };
+
     Ok(Some((
         layers,
         OtelGuard {
-            traces: provider,
+            traces: traces_provider,
             logs: logs_provider,
+            metrics: metrics_provider,
         },
     )))
 }
@@ -289,13 +426,16 @@ mod tests {
         // doesn't require a reachable collector.
         let cfg = enabled();
         assert!(cfg.logs, "guard: logs ride the same opt-in by default");
+        assert!(cfg.metrics, "guard: so do metrics");
         let (layers, guard) = init::<Registry>(&cfg)
             .unwrap()
             .expect("enabled telemetry must yield layers");
+        // Two LAYERS, three signals: metrics installs a global meter provider rather
+        // than a subscriber layer, which is the SDK's own shape for it.
         assert_eq!(
             layers.len(),
             2,
-            "an enabled config exports both signals: traces and logs"
+            "the two subscriber-layer signals: traces and logs"
         );
         guard.shutdown();
     }
@@ -313,6 +453,97 @@ mod tests {
             .expect("traces alone still yield a layer");
         assert_eq!(layers.len(), 1, "declining logs leaves the traces layer");
         guard.shutdown();
+    }
+
+    #[tokio::test]
+    async fn metrics_can_be_taken_without_traces() {
+        // The combination this whole signal exists to make possible, and Amy's framing
+        // for it: traces are information-rich, so an operator should be able to opt out
+        // of them and still get metrics. If this ever stops building, the promise in
+        // `src/metrics.rs` — that no content can leave by the metrics road — becomes
+        // unreachable rather than false, which is just as bad.
+        let cfg = TelemetryConfig {
+            traces: false,
+            logs: false,
+            ..enabled()
+        };
+        let (layers, guard) = init::<Registry>(&cfg)
+            .unwrap()
+            .expect("metrics alone still stands telemetry up");
+        assert!(
+            layers.is_empty(),
+            "metrics installs a meter provider, not a subscriber layer"
+        );
+        guard.shutdown();
+    }
+
+    #[test]
+    fn enabled_with_every_signal_declined_installs_nothing() {
+        // Four keys to arrive where `enabled = false` already was. Standing up an
+        // exporter stack that can never emit would be worse than saying so.
+        let cfg = TelemetryConfig {
+            traces: false,
+            logs: false,
+            metrics: false,
+            ..enabled()
+        };
+        let out = init::<Registry>(&cfg).unwrap();
+        assert!(
+            out.is_none(),
+            "every signal declined installs nothing, whatever `enabled` says"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_default_metrics_signal_degrades_on_a_nonstandard_endpoint() {
+        // The upgrade case. A 0.3.0 config with a vendor endpoint and an explicit
+        // logs_endpoint worked; metrics arriving default-on must not make it refuse to
+        // start over a signal the operator never asked for. It warns and drops metrics.
+        let cfg = TelemetryConfig {
+            endpoint: "http://collector.internal/otlp/ingest".to_string(),
+            logs_endpoint: Some("http://collector.internal/otlp/logs".to_string()),
+            ..enabled()
+        };
+        assert!(cfg.metrics, "guard: metrics is on");
+        assert!(
+            !cfg.metrics_explicit,
+            "guard: and it was inherited, not written"
+        );
+        let (layers, guard) = init::<Registry>(&cfg)
+            .unwrap()
+            .expect("the other signals still stand up");
+        assert_eq!(layers.len(), 2, "traces and logs are unaffected");
+        guard.shutdown();
+    }
+
+    #[test]
+    fn an_explicit_metrics_signal_refuses_a_nonstandard_endpoint() {
+        // The other half of that asymmetry: an operator who WROTE `metrics = true` gets
+        // the same loud refusal `logs` gives, because they asked for a signal kaibo
+        // cannot route and a silent drop would be discovered only by its absence.
+        let cfg = TelemetryConfig {
+            endpoint: "http://collector.internal/otlp/ingest".to_string(),
+            logs: false,
+            metrics_explicit: true,
+            ..enabled()
+        };
+        let err = match init::<Registry>(&cfg) {
+            Ok(_) => panic!("an asked-for signal kaibo cannot route must refuse"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("metrics_endpoint"),
+            "the refusal must name the key that fixes it; got: {err}"
+        );
+    }
+
+    #[test]
+    fn the_standard_endpoint_derives_the_metrics_sibling() {
+        assert_eq!(
+            resolve_metrics_endpoint(&enabled()).unwrap(),
+            "http://127.0.0.1:4318/v1/metrics",
+            "the standard traces path derives the standard metrics path"
+        );
     }
 
     #[test]

--- a/src/tool_span.rs
+++ b/src/tool_span.rs
@@ -107,8 +107,20 @@ pub fn traced<T: Tool + 'static>(tool: T) -> DynamicTool {
                     "kaish.output_bytes" = field::Empty,
                 );
                 async move {
+                    // The metric measures the same bracket the span does, from the
+                    // same place, so a backend reading `gen_ai.execute_tool.duration`
+                    // and one reading the span's duration can never disagree.
+                    let started = std::time::Instant::now();
                     let result = run_traced(tool.as_ref(), context, args).await;
                     Span::current().record("outcome", if result.is_ok() { "ok" } else { "error" });
+                    // A failed tool call is still a tool execution with a duration —
+                    // the conventions say to count failures, and a tool that takes ten
+                    // seconds to fail is exactly what an operator needs to see.
+                    crate::metrics::record_tool_execution(
+                        &name,
+                        started.elapsed(),
+                        result.as_ref().err().map(tool_error_type),
+                    );
                     result
                 }
                 .instrument(span)
@@ -116,6 +128,19 @@ pub fn traced<T: Tool + 'static>(tool: T) -> DynamicTool {
             }) as WasmBoxedFuture<'_, Result<ToolOutput, ToolExecutionError>>
         },
     )
+}
+
+/// The conventions' `error.type` for a failed tool call — the *class* of failure, never
+/// the message.
+///
+/// A metric attribute mints one time series per distinct value, so the message (which
+/// carries paths, model ids, and shell output) would produce an unbounded series set
+/// *and* drag content onto the one signal built to carry none. rig already normalizes
+/// every tool failure into `ToolErrorKind`, whose `as_str` is documented as the stable
+/// machine-readable name — nine values, no payload. That is exactly the shape this
+/// attribute wants, so kaibo takes it rather than inventing a parallel vocabulary.
+fn tool_error_type(error: &ToolExecutionError) -> &'static str {
+    error.kind().as_str()
 }
 
 /// The erased call itself: parse, dispatch, then normalize both halves of the typed


### PR DESCRIPTION
The second half of the telemetry split. #160 made traces *safe* by filtering content out on the way to the exporter; this makes traces **optional**. Amy's framing: *"perhaps tracing is information rich and users can opt out of tracing while getting metrics."*

## Why a second signal rather than more spans

The difference is the kind of guarantee. A filter is a *policy* — it holds because an allowlist is correct today and stays correct as rig's attributes drift. The metrics signal needs no allowlist at all: **no metric in the GenAI conventions has a content-bearing attribute.** That was confirmed by reading `model/gen-ai/metrics.yaml` and every attribute group it references, not assumed from the metric names.

So `traces = false, metrics = true` is a real posture, not a compromise — an operator keeps spend, latency, and delegation, and no prompt can leave by that road even if the filter were wrong.

## What it measures

Six instruments, all histograms, all named by the conventions. None is new bookkeeping — each reads a number kaibo already had, which is why the whole signal costs three call sites (the completion wrapper, the phase loop, the tool wrapper).

| Metric | Answers |
|---|---|
| `gen_ai.client.token.usage` | Spend, split by token type and model |
| `gen_ai.client.operation.duration` | One provider call, failures included |
| `gen_ai.invoke_agent.duration` | A whole phase, end to end |
| `gen_ai.invoke_agent.inference_calls` | Turns per phase |
| `gen_ai.invoke_agent.tool_calls` | **Did the driver delegate** |
| `gen_ai.execute_tool.duration` | One `run_kaish` / `explore′` / `view_image` |

`tool_calls` is the one asked for by name. It answers "did the consult driver delegate a sweep, or read everything itself" — the question the $4 GLM consult raised, which until now took OTLP span archaeology. It only answers it because a delegated sweep is its own invocation under its own agent name, so the driver's count is its delegations and the sweep's turns are counted against the explorer. That is also exactly the conventions' sub-agent exclusion rule, satisfied by structure rather than by filtering.

Bucket boundaries are the conventions' published advisory values. They live in the **rendered docs, not the YAML**, so anyone re-deriving them from the model files will not find them — hence the pointer in the module doc.

## Decisions worth reviewing

- **Per-signal booleans, and `traces` is now separable from `enabled`.** Without a `traces` key the headline posture could not be expressed at all.
- **An upgrade must not break a working config.** Metrics defaults on and derives its endpoint like `logs_endpoint` does, so a 0.3.0 config with a vendor endpoint plus an explicit `logs_endpoint` would have refused to start over a signal nobody asked for. A *defaulted* metrics signal therefore warns and degrades; an explicit `metrics = true` gets the same loud refusal `logs` gives. `metrics_explicit` carries that provenance. The asymmetry with `logs` is deliberate — `logs` shipped with its rule, so no config ever broke on it.
- **Error attributes are classes, never messages.** A metric attribute mints a series per distinct value, so a message carrying a path or a provider's error body would explode cardinality *and* drag content onto the one signal built to carry none. rig already normalizes both error types; kaibo takes its vocabulary rather than inventing a parallel one.

## Review

Dogfooded cross-family (kaibo `consult`, `deepseek` cast) before opening this. It found **one real bug, which is fixed in the second commit**: the module documented "a phase that died at turn 90 still reports 90" and shipped a count that reported 89 — `inference_calls` read the log's length, but a failed call produces no `TurnRecord`. The log now counts attempts alongside responses; the fix is not a synthetic record, because the empty-answer diagnostics read that log. Every claim was verified against the code before being accepted.

Its other three areas came back clean and are recorded as *checked* rather than assumed: no live path reaches an `Arm` with no identity, every metric attribute is bounded and content-free (the tool span's `gen_ai.tool.arguments` is a trace attribute and never reaches a metric), and the `OnceLock` instruments cannot bind to the no-op provider because both entry points run `telemetry::init` before any phase records.

## Verification

- 1168 tests pass across 34 binaries; `cargo clippy --all-targets` clean.
- **Negative controls run on the new tests** — making the zero-usage guard unconditional fails the zero-token test, collapsing the agent-name attribute fails the driver-vs-sweep test, and counting the attempt only on success fails the failed-call test.
- `cargo tree -i` empty for `aws-lc-rs`, `mimalloc`, and `openssl-sys` — the otlp `metrics` feature rides the same http-proto/blocking transport and pulls no second TLS stack.

## Diff note

`src/consult/engine.rs` carries ~136 lines of rustfmt normalization that **predate this change** (measured against `HEAD`), on top of ~190 lines that are the change itself. Unrelated files touched by that same formatting pass were reverted, per the repo's no-repo-wide-fmt rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)