### PR TITLE
feat(media): named, plural input images, resolved by digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ record. Each later release appends a new section at the top.
   `image`+`mask` or `init_image`+`style_image` are reachable.
 - **A media backend with no input-image route refuses a call that carries one**, rather
   than silently generating from the prompt alone and returning an unrelated image.
+- **An unknown or non-image input digest refuses before the provider is called**, so a
+  typo never costs a generation.
 - **`write_cas` stores an image in kaibo's media store and returns its digest** — the
   deposit half of `read_cas`, and how an image reaches kaibo at all.
 - **`write_cas` takes a `path` and reads the file itself**, so an image costs no tokens;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **`generate` takes input images by digest** — `inputs {"image": "<digest>"}` is
+  image-to-image on Stability's `ultra` and `sd3` routes, reusing an image already in
+  the store rather than re-sending it.
+- **`generate` carries several named input parts**, so the operations that take
+  `image`+`mask` or `init_image`+`style_image` are reachable.
+- **A media backend with no input-image route refuses a call that carries one**, rather
+  than silently generating from the prompt alone and returning an unrelated image.
 - **`write_cas` stores an image in kaibo's media store and returns its digest** — the
   deposit half of `read_cas`, and how an image reaches kaibo at all.
 - **`write_cas` takes a `path` and reads the file itself**, so an image costs no tokens;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2059,7 +2059,7 @@ async fn generate_inner(
         fields,
         // Text-to-image only from the CLI today: the edit/upscale operations that take an
         // input image would need a file to read, and the CLI has no such argument yet.
-        input_image: None,
+        inputs: Vec::new(),
     };
     let outcome = match arm.generate(&request).await {
         Ok(o) => o,

--- a/src/dashscope.rs
+++ b/src/dashscope.rs
@@ -400,6 +400,7 @@ impl crate::media::MediaModel for DashScopeImageModel {
     /// the honest outcome is an error naming which artifact failed, not a shorter
     /// list the caller has no way to notice.
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
+        crate::media::refuse_binary_inputs(request, "DashScope")?;
         let body = build_request_body(&self.model, request);
         let response = self.client.post_generation(&body).await?;
         let urls = parse_response(&response)?;

--- a/src/dashscope.rs
+++ b/src/dashscope.rs
@@ -400,7 +400,6 @@ impl crate::media::MediaModel for DashScopeImageModel {
     /// the honest outcome is an error naming which artifact failed, not a shorter
     /// list the caller has no way to notice.
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
-        crate::media::refuse_binary_inputs(request, "DashScope")?;
         let body = build_request_body(&self.model, request);
         let response = self.client.post_generation(&body).await?;
         let urls = parse_response(&response)?;

--- a/src/media.rs
+++ b/src/media.rs
@@ -150,16 +150,22 @@ pub struct MediaInput {
     pub field: String,
     /// The filename to send with the part, extension included (`image.png`).
     pub filename: String,
+    /// The part's own `Content-Type`. Carried for the same reason as the filename: a
+    /// multipart part with no mime defaults to `application/octet-stream`, which asks
+    /// the provider to infer a format it was never told — and the store already knows
+    /// the answer, so leaving the part untyped discards information rather than lacking
+    /// it.
+    pub mime: String,
     pub bytes: Vec<u8>,
 }
 
 impl MediaInput {
-    /// One input part, with the filename built from the field name and the extension the
-    /// store reported for these bytes.
-    pub fn new(field: impl Into<String>, extension: &str, bytes: Vec<u8>) -> Self {
+    /// One input part, named and typed from what the store says these bytes are.
+    pub fn new(field: impl Into<String>, extension: crate::cas::Extension, bytes: Vec<u8>) -> Self {
         let field = field.into();
         Self {
-            filename: format!("{field}.{extension}"),
+            filename: format!("{field}.{}", extension.as_str()),
+            mime: extension.mime().to_string(),
             field,
             bytes,
         }
@@ -213,7 +219,7 @@ pub fn resolve_inputs(
                 extension.mime()
             );
         }
-        out.push(MediaInput::new(field.clone(), extension.as_str(), bytes));
+        out.push(MediaInput::new(field.clone(), extension, bytes));
     }
     Ok(out)
 }
@@ -232,7 +238,7 @@ pub fn refuse_binary_inputs(request: &MediaRequest, provider: &str) -> Result<()
     let named: Vec<&str> = request.inputs.iter().map(|i| i.field.as_str()).collect();
     bail!(
         "this call carries the input image{} `{}`, and the {provider} backend has no \
-         operation that accepts one — nothing was generated. Point the cast's `image` \
+         operation that accepts input images — nothing was generated. Point the cast's `image` \
          slot at a backend whose operations take an input image (Stability), or drop \
          `inputs` to generate from the prompt alone.",
         if named.len() == 1 { "" } else { "s" },
@@ -297,6 +303,19 @@ pub trait MediaModel: Send + Sync {
     /// Collect one deferred job's result. One shot, no retry loop — the caller owns
     /// the cadence.
     async fn poll(&self, job: &MediaJobId) -> Result<MediaPollOutcome>;
+
+    /// Whether this provider has any operation that takes a binary input part.
+    ///
+    /// **Defaults to `false`, and that default is the point.** [`MediaArm::generate`]
+    /// refuses a request carrying inputs unless the model says it can take them, so a
+    /// provider added later that never thinks about `inputs` fails closed — it refuses
+    /// loudly instead of dropping the caller's image and generating from the prompt
+    /// alone. An impl that *can* take inputs opts in by overriding this; forgetting to
+    /// opt in costs a clear refusal, where forgetting a guard would have cost a
+    /// convincing wrong answer.
+    fn accepts_inputs(&self) -> bool {
+        false
+    }
 }
 
 /// A staffed media slot, ready to call: the model behind an `image = "backend/id"`
@@ -397,7 +416,14 @@ impl MediaArm {
     }
 
     /// Run one generation request on this arm.
+    ///
+    /// The single dispatch point for every media call, and therefore where the
+    /// binary-input guard belongs: one check the arm fastens, rather than a convention
+    /// each provider impl has to remember. See [`MediaModel::accepts_inputs`].
     pub async fn generate(&self, request: &MediaRequest) -> Result<MediaOutcome> {
+        if !self.model.accepts_inputs() {
+            refuse_binary_inputs(request, &self.slot_ref)?;
+        }
         self.model.generate(request).await
     }
 

--- a/src/media.rs
+++ b/src/media.rs
@@ -121,10 +121,123 @@ pub struct MediaRequest {
     /// default — that merge is the provider's business, not a contract of this
     /// struct.
     pub fields: Vec<(String, FieldValue)>,
-    /// Bytes of an input image, for the operations that take one (edit / upscale /
-    /// image-to-image). `None` for text-to-image. Carried on the request now so the
-    /// trait does not churn when those operations land.
-    pub input_image: Option<Vec<u8>>,
+    /// The binary parts this operation carries, in the order the caller gave them.
+    /// Empty for text-to-image.
+    ///
+    /// **Named, and plural, because the provider's operations are.** A first cut had a
+    /// single `input_image: Option<Vec<u8>>`, which fits `edit/outpaint` and
+    /// `control/sketch` and fits nothing else: `edit/erase` and `edit/inpaint` take
+    /// `image` *and* `mask`, `control/style-transfer` takes `init_image` *and*
+    /// `style_image`, and `edit/replace-background-and-relight` takes three. The field
+    /// *name* varies too — `image`, `audio`, `subject_image` — so the name is data, not
+    /// a constant a provider impl can assume. This is the text-part `fields` list's
+    /// binary sibling, and it is a `Vec` for the same reason: a provider may care about
+    /// order.
+    pub inputs: Vec<MediaInput>,
+}
+
+/// One binary part of a generation request: which form field it fills, what to call it
+/// on the wire, and the bytes.
+///
+/// The filename is carried rather than derived. A multipart file part without a
+/// `filename=` is rejected or mis-typed by some servers, and guessing one from the bytes
+/// would put a second, weaker format opinion next to the one the media store already
+/// holds — the store is the authority on what an object is (`MediaStore::extension_for`),
+/// so the caller that resolved the bytes passes the name the store gave them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaInput {
+    /// The provider's own form-field name — `image`, `mask`, `init_image`, `audio`.
+    pub field: String,
+    /// The filename to send with the part, extension included (`image.png`).
+    pub filename: String,
+    pub bytes: Vec<u8>,
+}
+
+impl MediaInput {
+    /// One input part, with the filename built from the field name and the extension the
+    /// store reported for these bytes.
+    pub fn new(field: impl Into<String>, extension: &str, bytes: Vec<u8>) -> Self {
+        let field = field.into();
+        Self {
+            filename: format!("{field}.{extension}"),
+            field,
+            bytes,
+        }
+    }
+}
+
+/// Resolve caller-named `{form-field: digest}` pairs into request parts, reading the
+/// bytes out of the media store.
+///
+/// This is the join that makes the media lane compose: `write_cas` (or a previous
+/// `generate`) hands the caller a digest, and the caller feeds that digest straight back
+/// in as the input to an edit. Digests are the operator's currency for exactly this — no
+/// bytes cross the wire twice, and the chain from source image to edited result is
+/// recorded in the store at every hop.
+///
+/// The store, not the caller, says what each object is: the filename's extension comes
+/// from [`crate::cas::MediaStore::extension_for`], so a part can never be labelled
+/// something the object is not.
+///
+/// Every failure is named and nothing is sent: a bad digest, a digest for an object this
+/// store does not hold, or an object that is not an image all refuse before a request is
+/// built.
+pub fn resolve_inputs(
+    store: &crate::cas::MediaStore,
+    asked: &std::collections::BTreeMap<String, String>,
+) -> Result<Vec<MediaInput>> {
+    let mut out = Vec::with_capacity(asked.len());
+    for (field, digest_hex) in asked {
+        let digest = crate::cas::Digest::from_hex(digest_hex).map_err(|_| {
+            anyhow::anyhow!(
+                "`inputs.{field}` is not a digest: {digest_hex:?}. A digest is the 64 \
+                 lowercase hex characters `write_cas` and `generate` hand back — the tail \
+                 of a kaibo://cas/<digest> address."
+            )
+        })?;
+        let (bytes, extension) = store
+            .get(&digest)
+            .map_err(|e| {
+                anyhow::anyhow!("`inputs.{field}`: reading {digest_hex} from the media store: {e}")
+            })?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "`inputs.{field}`: this store holds no object at {digest_hex}. Store \
+                     the image with `write_cas` first and pass the digest it returns."
+                )
+            })?;
+        if !extension.is_image() {
+            bail!(
+                "`inputs.{field}`: the object at {digest_hex} is {}, not an image. An \
+                 input part is an image; pass the digest of one.",
+                extension.mime()
+            );
+        }
+        out.push(MediaInput::new(field.clone(), extension.as_str(), bytes));
+    }
+    Ok(out)
+}
+
+/// Refuse a request carrying binary inputs on a provider that has no route for them.
+///
+/// **Dropping them is the failure this exists to prevent.** A provider impl that ignored
+/// `inputs` would send the prompt alone, get back a plausible image, and store it with a
+/// digest and a provenance sidecar — the caller asked to edit *this* picture and received
+/// an unrelated one that looks like a success. That is silent corruption of the result,
+/// and it is far worse than a refusal naming the two ways forward.
+pub fn refuse_binary_inputs(request: &MediaRequest, provider: &str) -> Result<()> {
+    if request.inputs.is_empty() {
+        return Ok(());
+    }
+    let named: Vec<&str> = request.inputs.iter().map(|i| i.field.as_str()).collect();
+    bail!(
+        "this call carries the input image{} `{}`, and the {provider} backend has no \
+         operation that accepts one — nothing was generated. Point the cast's `image` \
+         slot at a backend whose operations take an input image (Stability), or drop \
+         `inputs` to generate from the prompt alone.",
+        if named.len() == 1 { "" } else { "s" },
+        named.join("`, `"),
+    )
 }
 
 /// One generated artifact, provider-neutral: the bytes, the wire content type in the
@@ -250,8 +363,7 @@ impl MediaArm {
                     base_url,
                     backend.request_timeout,
                 )?;
-                let model =
-                    crate::openai_images::OpenAiImagesModel::from_parts(&client, &slot.id);
+                let model = crate::openai_images::OpenAiImagesModel::from_parts(&client, &slot.id);
                 Ok(Self::new(Arc::new(model), slot.qualified()))
             }
             ProviderClass::Media(MediaKind::DashScope) => {

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -482,7 +482,6 @@ impl crate::media::MediaModel for OpenAiImagesModel {
     /// Always resolves to [`MediaOutcome::Complete`] — the Images API is
     /// synchronous, and `n` makes a multi-artifact list the normal shape.
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
-        crate::media::refuse_binary_inputs(request, "OpenAI Images")?;
         let artifacts = self.client.generate(&self.model, request).await?;
         Ok(MediaOutcome::Complete(artifacts))
     }

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -482,6 +482,7 @@ impl crate::media::MediaModel for OpenAiImagesModel {
     /// Always resolves to [`MediaOutcome::Complete`] — the Images API is
     /// synchronous, and `n` makes a multi-artifact list the normal shape.
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
+        crate::media::refuse_binary_inputs(request, "OpenAI Images")?;
         let artifacts = self.client.generate(&self.model, request).await?;
         Ok(MediaOutcome::Complete(artifacts))
     }
@@ -523,7 +524,7 @@ mod tests {
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.clone()))
                 .collect(),
-            input_image: None,
+            inputs: Vec::new(),
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5567,6 +5567,12 @@ mod tests {
 
     #[async_trait::async_trait]
     impl crate::media::MediaModel for SyncArtifacts {
+        /// Stands in for Stability, the backend `inputs` exists for — so the handler
+        /// tests exercise the accepting path rather than the arm's refusal.
+        fn accepts_inputs(&self) -> bool {
+            true
+        }
+
         async fn generate(
             &self,
             _request: &crate::media::MediaRequest,
@@ -6508,6 +6514,100 @@ enabled = false
             err.message.contains("corrupt"),
             "and it says so rather than reporting a miss: {}",
             err.message
+        );
+    }
+
+    /// Records the request the arm handed the provider, so the handler's wiring is
+    /// observable rather than inferred from a success.
+    #[derive(Default)]
+    struct RecordingProvider(std::sync::Mutex<Option<crate::media::MediaRequest>>);
+
+    #[async_trait::async_trait]
+    impl crate::media::MediaModel for RecordingProvider {
+        fn accepts_inputs(&self) -> bool {
+            true
+        }
+
+        async fn generate(
+            &self,
+            request: &crate::media::MediaRequest,
+        ) -> anyhow::Result<crate::media::MediaOutcome> {
+            *self.0.lock().unwrap() = Some(request.clone());
+            Ok(crate::media::MediaOutcome::Complete(vec![png(b"result")]))
+        }
+
+        async fn poll(
+            &self,
+            _job: &crate::media::MediaJobId,
+        ) -> anyhow::Result<crate::media::MediaPollOutcome> {
+            unreachable!("this test never defers")
+        }
+    }
+
+    /// **The whole `inputs` path, driven through the tool face.**
+    ///
+    /// `resolve_inputs` is unit-tested on its own, but nothing proved the handler
+    /// actually threads a caller's digest into the request the provider receives — the
+    /// wiring is exactly what a later refactor drops silently, because dropping it still
+    /// returns a plausible image. This asserts the provider saw the part, under the
+    /// caller's field name, with the bytes and the format the store recorded.
+    #[tokio::test]
+    async fn generate_threads_caller_digests_into_the_providers_request() {
+        let provider = Arc::new(RecordingProvider::default());
+        let h = media_handler(provider.clone());
+        // Seed the store the way `write_cas` would, then hand `generate` that digest.
+        let digest = h
+            .media_store()
+            .expect("media CAS is on")
+            .put(
+                b"\x89PNG\r\n\x1a\nsource",
+                crate::cas::Extension::Png,
+                &textual_provenance(),
+            )
+            .expect("seeded")
+            .to_hex();
+
+        h.generate(Parameters(GenerateInput {
+            prompt: "erase the sign".to_string(),
+            cast: Some("artist".to_string()),
+            fields: None,
+            inputs: Some([("image".to_string(), digest)].into_iter().collect()),
+        }))
+        .await
+        .expect("a stored digest is a usable input");
+
+        let seen = provider.0.lock().unwrap().clone().expect("provider was called");
+        assert_eq!(seen.inputs.len(), 1, "the part reached the provider");
+        assert_eq!(seen.inputs[0].field, "image", "under the caller's field name");
+        assert_eq!(seen.inputs[0].bytes, b"\x89PNG\r\n\x1a\nsource");
+        assert_eq!(
+            seen.inputs[0].filename, "image.png",
+            "named from the store's record, not the caller's belief"
+        );
+        assert_eq!(seen.inputs[0].mime, "image/png");
+    }
+
+    /// A digest the store does not hold refuses at the tool face, before any provider
+    /// request is made — so a typo never costs a generation.
+    #[tokio::test]
+    async fn generate_refuses_an_unknown_input_digest_without_calling_the_provider() {
+        let provider = Arc::new(RecordingProvider::default());
+        let h = media_handler(provider.clone());
+        let absent = crate::cas::Digest::of_bytes(b"never stored").to_hex();
+
+        let err = h
+            .generate(Parameters(GenerateInput {
+                prompt: "erase the sign".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+                inputs: Some([("image".to_string(), absent)].into_iter().collect()),
+            }))
+            .await
+            .expect_err("an absent digest is refused");
+        assert!(err.message.contains("holds no object"), "{}", err.message);
+        assert!(
+            provider.0.lock().unwrap().is_none(),
+            "the provider must never have been called"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -731,6 +731,15 @@ pub struct GenerateInput {
     /// cast's image slot.
     #[serde(default)]
     pub fields: Option<std::collections::BTreeMap<String, GenerateFieldValue>>,
+
+    /// Input images for the operations that take them, as `{form-field: digest}` —
+    /// e.g. `{"image": "<digest>"}` for image-to-image, `{"image": "...", "mask":
+    /// "..."}` where an operation takes both. Each digest is one `write_cas` or
+    /// `generate` handed back, so an image already in kaibo's store is reused by
+    /// address and never re-sent. The form-field names are the provider's own; the
+    /// store decides each part's format, not you.
+    #[serde(default)]
+    pub inputs: Option<std::collections::BTreeMap<String, String>>,
 }
 
 /// One `generate` field value, as typed JSON: the schema face of
@@ -3049,7 +3058,13 @@ impl KaiboHandler {
             (metadata first, ranges on request; a small image comes back viewable). \
             Provider-native options (aspect_ratio, size, n, output_format, seed, \
             negative_prompt, style_preset, ...) pass through `fields` verbatim, each \
-            value's JSON type (string | number | boolean) preserved to the wire. An \
+            value's JSON type (string | number | boolean) preserved to the wire. \
+            To generate FROM an image rather than from the prompt alone, pass its \
+            digest in `inputs` under the provider's field name — \
+            `inputs {\"image\": \"<digest>\"}` with `fields {\"strength\": 0.6}` is \
+            image-to-image. Digests come from `write_cas` or an earlier `generate`, so \
+            an image already in the store is reused by address and never re-sent. \
+            Stability accepts input images; the other media backends do not and say so. An \
             operation the provider declares deferred returns a `job-N` handle for \
             job_wait/job_get instead (every route wired today answers in-call). \
             Provenance (prompt, model, cast, seed) is recorded beside every artifact."
@@ -3122,10 +3137,17 @@ impl KaiboHandler {
                 ));
             }
         }
+        // Resolved before the arm is called, so a bad digest refuses without spending a
+        // provider request — and the store, not the caller, names each part's format.
+        let inputs = match input.inputs.as_ref() {
+            Some(asked) => crate::media::resolve_inputs(&store, asked)
+                .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?,
+            None => Vec::new(),
+        };
         let request = crate::media::MediaRequest {
             prompt: input.prompt.clone(),
             fields,
-            input_image: None,
+            inputs,
         };
         let span = tracing::info_span!("generate", cast = %cast.name, model = %arm.slot_ref());
         match arm.generate(&request).instrument(span).await {
@@ -5621,6 +5643,7 @@ mod tests {
                 prompt: "a lighthouse at dusk".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect("generate succeeds");
@@ -5667,6 +5690,7 @@ mod tests {
             prompt: "a red door".to_string(),
             cast: Some("artist".to_string()),
             fields: None,
+            inputs: None,
         }))
         .await
         .expect("generate succeeds");
@@ -5702,6 +5726,7 @@ mod tests {
                 prompt: "slow art".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect("submit succeeds");
@@ -5778,6 +5803,7 @@ mod tests {
                     .into_iter()
                     .collect(),
                 ),
+                inputs: None,
             }))
             .await
             .expect_err("a fields.prompt override must be refused");
@@ -5799,6 +5825,7 @@ mod tests {
                     .into_iter()
                     .collect(),
                 ),
+                inputs: None,
             }))
             .await
             .expect_err("a fields.model override must be refused");
@@ -5821,6 +5848,7 @@ mod tests {
                 prompt: "p".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect("a tool-result error, not a protocol error");
@@ -5847,6 +5875,7 @@ mod tests {
                 prompt: "p".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect("a tool-result error, not a protocol error");
@@ -5888,6 +5917,7 @@ mod tests {
                 prompt: "p".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect("a tool-result error, not a protocol error");
@@ -5941,6 +5971,7 @@ mod tests {
                 prompt: "p".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect("submit succeeds"),
@@ -5984,6 +6015,7 @@ mod tests {
                 prompt: "p".to_string(),
                 cast: Some("anthropic".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect_err("no image slot must refuse");
@@ -6052,6 +6084,7 @@ enabled = false
                 prompt: "p".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
+                inputs: None,
             }))
             .await
             .expect("submit succeeds"),
@@ -6287,6 +6320,7 @@ enabled = false
             prompt: "p".to_string(),
             cast: Some("artist".to_string()),
             fields: None,
+            inputs: None,
         }))
         .await
         .expect("generate succeeds");
@@ -6322,6 +6356,7 @@ enabled = false
             prompt: "p".to_string(),
             cast: Some("artist".to_string()),
             fields: None,
+            inputs: None,
         }))
         .await
         .expect("generate succeeds");

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -15,7 +15,7 @@
 //! generate, takes an **input image** alongside its other fields. Building straight to
 //! rig's shape would mean rewriting this module's core type the day any of those
 //! lands. So the primary abstraction here is [`StabilityRequest`]/[`Operation`] —
-//! provider-native, already carrying an optional input image — and
+//! provider-native, already carrying its named binary input parts — and
 //! [`StabilityImageModel`]'s [`rig_core::image_generation::ImageGenerationModel`] impl
 //! is a thin translation at the bottom ([`from_rig_request`]) that only text-to-image
 //! ever needs.
@@ -233,10 +233,11 @@ pub struct StabilityRequest {
     /// (`remove-background`, `erase`) would need this widened to `Option<String>` —
     /// noted rather than solved speculatively.
     pub prompt: String,
-    /// Bytes of an input image, for operations that take one (every edit/control/
-    /// upscale call, and generate's own image-to-image mode — audio and 3D operations
-    /// don't take one). Attached as a multipart file part named `image`, matching the
-    /// field name every one of those operations documents. `None` for text-to-image.
+    /// The binary parts this operation carries, each under the form-field name that
+    /// operation documents — `image`, `mask`, `init_image`, `style_image`,
+    /// `subject_image`, `audio`. Several routes take more than one, so the name is data
+    /// rather than a constant this module can assume. Empty for text-to-image; attached
+    /// as named multipart file parts by [`StabilityClient::call`].
     pub inputs: Vec<crate::media::MediaInput>,
     /// Stability's own `aspect_ratio` enum value (e.g. `"16:9"`), when this operation
     /// takes one. The rig adapter ([`from_rig_request`]) derives it from
@@ -958,7 +959,15 @@ impl StabilityClient {
             form = form.part(
                 input.field.clone(),
                 reqwest::multipart::Part::bytes(input.bytes.clone())
-                    .file_name(input.filename.clone()),
+                    .file_name(input.filename.clone())
+                    .mime_str(&input.mime)
+                    .map_err(|e| {
+                        StabilityError::Transport(format!(
+                            "input part `{}` has mime {:?}, which is not a valid \
+                             content type: {e}",
+                            input.field, input.mime
+                        ))
+                    })?,
             );
         }
 
@@ -1165,6 +1174,13 @@ impl StabilityImageModel {
 /// (see [`StabilityImageModel::image_generation`]'s forced error there).
 #[async_trait::async_trait]
 impl crate::media::MediaModel for StabilityImageModel {
+    /// Stability is the backend the whole `inputs` shape exists for: every `edit`,
+    /// `control` and `upscale` operation takes at least one, and `generate/ultra` and
+    /// `generate/sd3` take one for image-to-image.
+    fn accepts_inputs(&self) -> bool {
+        true
+    }
+
     async fn generate(
         &self,
         request: &crate::media::MediaRequest,

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -225,7 +225,7 @@ pub fn resolve_key() -> AnyResult<String> {
 
 /// One request to a Stability v2beta image operation — provider-native (Stability's
 /// own `aspect_ratio`, not rig's `width`/`height`) and already shaped for growth. See
-/// the module doc for why `input_image` exists even though the only operation wired so
+/// the module doc for why `inputs` exists even though the only operation wired so
 /// far ([`Operation::Generate`]) never sets it.
 #[derive(Debug, Clone, Default)]
 pub struct StabilityRequest {
@@ -237,7 +237,7 @@ pub struct StabilityRequest {
     /// upscale call, and generate's own image-to-image mode — audio and 3D operations
     /// don't take one). Attached as a multipart file part named `image`, matching the
     /// field name every one of those operations documents. `None` for text-to-image.
-    pub input_image: Option<Vec<u8>>,
+    pub inputs: Vec<crate::media::MediaInput>,
     /// Stability's own `aspect_ratio` enum value (e.g. `"16:9"`), when this operation
     /// takes one. The rig adapter ([`from_rig_request`]) derives it from
     /// `ImageGenerationRequest`'s width/height via [`aspect_ratio_for`]; a caller
@@ -383,7 +383,7 @@ pub fn aspect_ratio_for(width: u32, height: u32) -> &'static str {
 /// request carries one), then every `request.fields` entry — a later entry with a name
 /// already present (including `aspect_ratio` itself, letting an explicit override win
 /// over a derived one) replaces it rather than duplicating the field. Pure and
-/// order-preserving; `request.input_image` is attached separately as a file part by
+/// order-preserving; `request.inputs` are attached separately as file parts by
 /// [`StabilityClient::call`], since it isn't a text field.
 pub fn build_form_fields(request: &StabilityRequest) -> Vec<(String, String)> {
     let mut fields: Vec<(String, String)> = vec![("prompt".to_string(), request.prompt.clone())];
@@ -899,7 +899,7 @@ pub fn from_rig_request(
         Operation::Generate(route),
         StabilityRequest {
             prompt: request.prompt.clone(),
-            input_image: None,
+            inputs: Vec::new(),
             aspect_ratio: Some(aspect_ratio_for(request.width, request.height).to_string()),
             fields,
         },
@@ -936,7 +936,7 @@ impl StabilityClient {
     }
 
     /// Run one call: build the multipart body from `request` ([`build_form_fields`] for
-    /// the text fields, plus an `image` file part when `request.input_image` is set),
+    /// the text fields, plus one named file part per `request.inputs` entry),
     /// POST to `op`'s endpoint with `Accept: image/*` (every operation wired so far is
     /// in the image family; a future audio/3D operation needs its own `Accept` value
     /// here, since that's a per-route fact, not a module-wide constant), and hand the
@@ -951,8 +951,15 @@ impl StabilityClient {
         for (name, value) in build_form_fields(request) {
             form = form.text(name, value);
         }
-        if let Some(bytes) = &request.input_image {
-            form = form.part("image", reqwest::multipart::Part::bytes(bytes.clone()));
+        // Each binary part under the provider's own field name, with a filename —
+        // a multipart file part without `filename=` is rejected or mis-typed by some
+        // servers, and every one of these routes is a file upload.
+        for input in &request.inputs {
+            form = form.part(
+                input.field.clone(),
+                reqwest::multipart::Part::bytes(input.bytes.clone())
+                    .file_name(input.filename.clone()),
+            );
         }
 
         let url = format!("{}/v2beta/{}", self.base_url, op.path());
@@ -1139,7 +1146,7 @@ impl StabilityImageModel {
             Operation::Generate(route),
             StabilityRequest {
                 prompt: request.prompt.clone(),
-                input_image: request.input_image.clone(),
+                inputs: request.inputs.clone(),
                 // No derived ratio on this path: the neutral request has no
                 // width/height to bridge, and an `aspect_ratio` field from the caller
                 // rides `fields` verbatim.
@@ -1322,7 +1329,7 @@ mod tests {
                 ("tiling".to_string(), FieldValue::Bool(true)),
                 ("style_preset".to_string(), FieldValue::Str("anime".to_string())),
             ],
-            input_image: None,
+            inputs: Vec::new(),
         });
         for (name, wire) in [("seed", "42"), ("tiling", "true"), ("style_preset", "anime")] {
             assert!(

--- a/tests/dashscope_live.rs
+++ b/tests/dashscope_live.rs
@@ -56,7 +56,7 @@ async fn wan_t2i_returns_real_image_bytes_through_a_fetched_link() {
             ),
             ("size".to_string(), FieldValue::Str("768*768".to_string())),
         ],
-        input_image: None,
+        inputs: Vec::new(),
     };
     let outcome = model.generate(&request).await.expect("live generation");
     let MediaOutcome::Complete(artifacts) = outcome else {

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -1,0 +1,188 @@
+//! Behavioral tests for the media lane's binary-input seam ([`kaibo::media`]).
+//!
+//! What these pin:
+//!
+//! - **Inputs are named and plural.** Stability's operations take `image`+`mask`,
+//!   `init_image`+`style_image`, and in one case three parts — so the field name is
+//!   data, not a constant, and one request carries several.
+//! - **The store names each part's format, not the caller.** A part's filename
+//!   extension comes from `MediaStore::extension_for`, which is what makes it
+//!   impossible to label a part as something the object is not.
+//! - **A provider with no route for binary input refuses instead of dropping it.**
+//!   Dropping is the dangerous direction: the caller asked to edit *this* picture, and a
+//!   dropped input returns an unrelated image that looks exactly like a success — with a
+//!   digest and a provenance sidecar to make it convincing.
+//! - **Every resolution failure happens before a request is built**, so a bad digest
+//!   never costs a provider call.
+//!
+//! Teeth: make `refuse_binary_inputs` return `Ok(())` unconditionally and
+//! `a_provider_without_an_input_route_refuses_rather_than_dropping` fails; have
+//! `resolve_inputs` take the caller's word for the extension and
+//! `the_store_names_the_parts_format_not_the_caller` fails.
+
+use std::collections::BTreeMap;
+
+use kaibo::cas::{Cas, Digest, Extension, MediaStore, Provenance};
+use kaibo::media::{refuse_binary_inputs, resolve_inputs, MediaInput, MediaRequest};
+use tempfile::TempDir;
+
+fn store() -> (MediaStore, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let cas = Cas::open(&dir.path().join("cas"), &[], None).expect("cas opens");
+    (MediaStore::Disk(cas), dir)
+}
+
+fn prov(mime: &str) -> Provenance {
+    Provenance {
+        prompt: String::new(),
+        model: String::new(),
+        cast: String::new(),
+        timestamp: 1_753_000_000,
+        mime: mime.to_string(),
+        seed: None,
+        tool: Some("write_cas".into()),
+        slot: None,
+        label: None,
+        session: None,
+    }
+}
+
+/// Store `bytes` under `ext` and return its digest hex.
+fn put(store: &MediaStore, bytes: &[u8], ext: Extension) -> String {
+    store
+        .put(bytes, ext, &prov(ext.mime()))
+        .expect("put succeeds")
+        .to_hex()
+}
+
+fn asked(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+fn request_with(inputs: Vec<MediaInput>) -> MediaRequest {
+    MediaRequest {
+        prompt: "erase the sign".into(),
+        fields: Vec::new(),
+        inputs,
+    }
+}
+
+/// One operation, several named parts — the shape `edit/inpaint` (`image` + `mask`) and
+/// `control/style-transfer` (`init_image` + `style_image`) actually need, and the whole
+/// reason this is a list rather than one optional blob.
+#[test]
+fn several_named_parts_resolve_together() {
+    let (store, _d) = store();
+    let image = put(&store, b"\x89PNG\r\n\x1a\nphoto", Extension::Png);
+    let mask = put(&store, b"\x89PNG\r\n\x1a\nmask", Extension::Png);
+
+    let resolved = resolve_inputs(&store, &asked(&[("image", &image), ("mask", &mask)]))
+        .expect("both parts resolve");
+
+    assert_eq!(resolved.len(), 2);
+    assert_eq!(resolved[0].field, "image");
+    assert_eq!(resolved[0].filename, "image.png");
+    assert_eq!(resolved[0].bytes, b"\x89PNG\r\n\x1a\nphoto");
+    assert_eq!(resolved[1].field, "mask");
+    assert_eq!(resolved[1].filename, "mask.png");
+}
+
+/// The filename's extension is the *store's* answer for what the object is, never the
+/// caller's belief. The two differ whenever identical content was first stored under
+/// another container, and a part labelled with the wrong one is a lie the provider acts
+/// on.
+#[test]
+fn the_store_names_the_parts_format_not_the_caller() {
+    let (store, _d) = store();
+    let jpeg = put(&store, b"\xff\xd8\xffphoto", Extension::Jpeg);
+
+    let resolved = resolve_inputs(&store, &asked(&[("image", &jpeg)])).expect("resolves");
+    assert_eq!(
+        resolved[0].filename, "image.jpeg",
+        "the extension comes from the store's record, not from the field name"
+    );
+}
+
+#[test]
+fn a_digest_shaped_string_that_is_not_one_is_refused_by_name() {
+    let (store, _d) = store();
+    let err = resolve_inputs(&store, &asked(&[("image", "not-a-digest")]))
+        .expect_err("not 64 hex characters");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("inputs.image"), "names the field: {msg}");
+    assert!(
+        msg.contains("64 lowercase hex"),
+        "says what a digest is: {msg}"
+    );
+}
+
+/// A well-formed digest this store does not hold. The refusal has to say how to get one
+/// in, because the caller's next move is `write_cas`, not a retry.
+#[test]
+fn a_digest_the_store_does_not_hold_is_refused_with_the_way_in() {
+    let (store, _d) = store();
+    let absent = Digest::of_bytes(b"never stored").to_hex();
+    let err = resolve_inputs(&store, &asked(&[("image", &absent)])).expect_err("absent");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("holds no object"), "{msg}");
+    assert!(msg.contains("write_cas"), "names the way in: {msg}");
+}
+
+/// The store also names the text formats `save_artifact` writes. An input part is an
+/// image, and keeping the refusal keyed to that is what stops a widened `Extension` from
+/// quietly widening what the media lane accepts.
+#[test]
+fn a_stored_object_that_is_not_an_image_is_refused_as_an_input() {
+    let (store, _d) = store();
+    let text = put(&store, b"a corpus of shell commands", Extension::Txt);
+    let err = resolve_inputs(&store, &asked(&[("image", &text)])).expect_err("not an image");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("not an image"), "{msg}");
+    assert!(
+        msg.contains("text/plain"),
+        "names what it actually is: {msg}"
+    );
+}
+
+/// **The dangerous direction, pinned.** A provider with no input-image route must refuse.
+/// Dropping the input would send the prompt alone, return a plausible unrelated image,
+/// and store it with a digest and a sidecar — a corrupt result wearing a success's
+/// clothes.
+#[test]
+fn a_provider_without_an_input_route_refuses_rather_than_dropping() {
+    let request = request_with(vec![
+        MediaInput::new("image", "png", b"photo".to_vec()),
+        MediaInput::new("mask", "png", b"mask".to_vec()),
+    ]);
+    let err = refuse_binary_inputs(&request, "DashScope").expect_err("no route for inputs");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("DashScope"), "names the backend: {msg}");
+    assert!(
+        msg.contains("image") && msg.contains("mask"),
+        "names every part it refused: {msg}"
+    );
+    assert!(
+        msg.contains("nothing was generated"),
+        "says no work was done, so the caller knows it was not billed: {msg}"
+    );
+}
+
+/// The same guard must not fire on an ordinary text-to-image call — otherwise it would
+/// break every provider that has no input route and never needed one.
+#[test]
+fn a_request_with_no_binary_parts_passes_the_guard() {
+    assert!(refuse_binary_inputs(&request_with(Vec::new()), "DashScope").is_ok());
+}
+
+/// `MediaInput::new` builds the wire filename from the field name and the store's
+/// extension. A part without a `filename=` is rejected or mis-typed by some multipart
+/// servers, and every route that takes one of these is a file upload.
+#[test]
+fn every_part_carries_a_filename_with_the_stores_extension() {
+    let part = MediaInput::new("subject_image", "webp", b"bytes".to_vec());
+    assert_eq!(part.field, "subject_image");
+    assert_eq!(part.filename, "subject_image.webp");
+}

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -23,7 +23,10 @@
 use std::collections::BTreeMap;
 
 use kaibo::cas::{Cas, Digest, Extension, MediaStore, Provenance};
-use kaibo::media::{refuse_binary_inputs, resolve_inputs, MediaInput, MediaRequest};
+use kaibo::media::{
+    refuse_binary_inputs, resolve_inputs, MediaArm, MediaInput, MediaJobId, MediaModel,
+    MediaOutcome, MediaPollOutcome, MediaRequest,
+};
 use tempfile::TempDir;
 
 fn store() -> (MediaStore, TempDir) {
@@ -154,12 +157,12 @@ fn a_stored_object_that_is_not_an_image_is_refused_as_an_input() {
 #[test]
 fn a_provider_without_an_input_route_refuses_rather_than_dropping() {
     let request = request_with(vec![
-        MediaInput::new("image", "png", b"photo".to_vec()),
-        MediaInput::new("mask", "png", b"mask".to_vec()),
+        MediaInput::new("image", Extension::Png, b"photo".to_vec()),
+        MediaInput::new("mask", Extension::Png, b"mask".to_vec()),
     ]);
-    let err = refuse_binary_inputs(&request, "DashScope").expect_err("no route for inputs");
+    let err = refuse_binary_inputs(&request, "dashscope/wan2.2").expect_err("no route for inputs");
     let msg = format!("{err:#}");
-    assert!(msg.contains("DashScope"), "names the backend: {msg}");
+    assert!(msg.contains("dashscope/wan2.2"), "names the backend: {msg}");
     assert!(
         msg.contains("image") && msg.contains("mask"),
         "names every part it refused: {msg}"
@@ -174,7 +177,7 @@ fn a_provider_without_an_input_route_refuses_rather_than_dropping() {
 /// break every provider that has no input route and never needed one.
 #[test]
 fn a_request_with_no_binary_parts_passes_the_guard() {
-    assert!(refuse_binary_inputs(&request_with(Vec::new()), "DashScope").is_ok());
+    assert!(refuse_binary_inputs(&request_with(Vec::new()), "dashscope/wan2.2").is_ok());
 }
 
 /// `MediaInput::new` builds the wire filename from the field name and the store's
@@ -182,7 +185,82 @@ fn a_request_with_no_binary_parts_passes_the_guard() {
 /// servers, and every route that takes one of these is a file upload.
 #[test]
 fn every_part_carries_a_filename_with_the_stores_extension() {
-    let part = MediaInput::new("subject_image", "webp", b"bytes".to_vec());
+    let part = MediaInput::new("subject_image", Extension::Webp, b"bytes".to_vec());
     assert_eq!(part.field, "subject_image");
     assert_eq!(part.filename, "subject_image.webp");
+    assert_eq!(
+        part.mime, "image/webp",
+        "a part with no mime defaults to application/octet-stream on the wire, asking the \
+         provider to infer what the store already knows"
+    );
+}
+
+/// A provider that never thinks about `inputs` — the shape of a `MediaModel` added
+/// later by someone who has not read this file.
+struct ForgetfulProvider;
+
+#[async_trait::async_trait]
+impl MediaModel for ForgetfulProvider {
+    async fn generate(&self, _request: &MediaRequest) -> anyhow::Result<MediaOutcome> {
+        panic!("the arm must refuse before a forgetful provider is ever called")
+    }
+    async fn poll(&self, _job: &MediaJobId) -> anyhow::Result<MediaPollOutcome> {
+        unreachable!("this test never defers")
+    }
+}
+
+/// A provider that has an input route and says so.
+struct AcceptingProvider;
+
+#[async_trait::async_trait]
+impl MediaModel for AcceptingProvider {
+    fn accepts_inputs(&self) -> bool {
+        true
+    }
+    async fn generate(&self, request: &MediaRequest) -> anyhow::Result<MediaOutcome> {
+        assert_eq!(
+            request.inputs.len(),
+            1,
+            "the parts reach the provider intact"
+        );
+        Ok(MediaOutcome::Complete(Vec::new()))
+    }
+    async fn poll(&self, _job: &MediaJobId) -> anyhow::Result<MediaPollOutcome> {
+        unreachable!("this test never defers")
+    }
+}
+
+/// **The guard is structural, not a convention each provider remembers.**
+///
+/// `accepts_inputs` defaults to `false` and `MediaArm::generate` — the single dispatch
+/// point for every media call — refuses on that default. So a provider added later that
+/// never considers `inputs` fails *closed*: a loud refusal, not a silently dropped image
+/// and a convincing wrong answer. `ForgetfulProvider::generate` panics if it is ever
+/// reached, so this test fails loudly if the arm stops checking.
+#[tokio::test]
+async fn the_arm_refuses_for_a_provider_that_never_opted_in() {
+    let arm = MediaArm::new(std::sync::Arc::new(ForgetfulProvider), "fake/forgetful");
+    let request = request_with(vec![MediaInput::new(
+        "image",
+        Extension::Png,
+        b"photo".to_vec(),
+    )]);
+    let err = arm.generate(&request).await.expect_err("must refuse");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("fake/forgetful"), "names the slot: {msg}");
+    assert!(msg.contains("nothing was generated"), "{msg}");
+}
+
+/// And the guard does not stand in the way of a provider that opted in — otherwise it
+/// would refuse the very calls the whole change exists to enable. Without this, the test
+/// above would still pass if the arm refused unconditionally.
+#[tokio::test]
+async fn the_arm_passes_inputs_through_for_a_provider_that_opted_in() {
+    let arm = MediaArm::new(std::sync::Arc::new(AcceptingProvider), "fake/accepting");
+    let request = request_with(vec![MediaInput::new(
+        "image",
+        Extension::Png,
+        b"photo".to_vec(),
+    )]);
+    arm.generate(&request).await.expect("accepted");
 }

--- a/tests/openai_images_live.rs
+++ b/tests/openai_images_live.rs
@@ -39,7 +39,7 @@ async fn gpt_image_1_returns_real_png_bytes() {
 
     let request = MediaRequest {
         prompt: "a small lighthouse on a rocky cliff, watercolor".to_string(),
-        input_image: None,
+        inputs: Vec::new(),
         // The cheapest hosted shape; output_format png is gpt-image-1's default,
         // stated explicitly so the mime derivation is exercised end to end.
         fields: vec![

--- a/tests/openai_images_transport.rs
+++ b/tests/openai_images_transport.rs
@@ -133,7 +133,7 @@ async fn dall_e_round_trip_sends_typed_body_and_collects_ordered_artifacts() {
                     ("transparent".to_string(), FieldValue::Bool(true)),
                     ("size".to_string(), FieldValue::Str("1024x1024".to_string())),
                 ],
-                input_image: None,
+                inputs: Vec::new(),
             },
         )
         .await

--- a/tests/stability_live.rs
+++ b/tests/stability_live.rs
@@ -24,7 +24,7 @@ async fn generate_core_returns_a_real_png_with_a_seed() {
 
     let request = StabilityRequest {
         prompt: "a small lighthouse on a rocky cliff, watercolor".to_string(),
-        input_image: None,
+        inputs: Vec::new(),
         aspect_ratio: Some("1:1".to_string()),
         fields: vec![("output_format".to_string(), "png".to_string())],
     };


### PR DESCRIPTION
## What

The media seam now carries **several named binary input parts** instead of one anonymous optional image, and a caller supplies them as **CAS digests**. Image-to-image on Stability's `ultra` and `sd3` falls out with no route change.

This is the plumbing the remaining 22 Stability operations need. Stacked conceptually on #163 (merged), which supplied the deposit half.

## Why the shape changed

`MediaRequest.input_image: Option<Vec<u8>>` fit `edit/outpaint` and `control/sketch` and fit nothing else. From the live spec: `edit/erase` and `edit/inpaint` take `image` **and** `mask`, `control/style-transfer` takes `init_image` **and** `style_image`, `edit/replace-background-and-relight` takes three, and audio's field is `audio`. The field name is data, not a constant a provider impl can assume.

So it becomes `inputs: Vec<MediaInput>` — the binary sibling of the existing `fields` text list, and a `Vec` for the same reason (a provider may care about order).

## Decisions

- **Inputs arrive as digests, not bytes.** This is what makes the lane compose: `write_cas` (or an earlier `generate`) hands back a digest, and that digest goes straight back in as the input to an edit. No bytes cross the wire twice, and the chain from source image to result is recorded at every hop. Digests are the operator's currency; this is the join they were for.
- **The store names each part, the caller never does.** Filename *and* mime come from `MediaStore::extension_for`, so a part cannot be labelled something the object is not. `MediaInput::new` takes an `Extension`, not a string, so there is nothing to invent.
- **The guard fails closed.** `MediaModel::accepts_inputs()` defaults to **false** and `MediaArm::generate` — the single dispatch point — enforces it. A provider added later that never thinks about `inputs` refuses loudly rather than dropping the caller's image and generating from the prompt alone. That failure would be the dangerous one: an unrelated image, with a digest and a provenance sidecar, wearing a success's clothes.
- **Every resolution failure happens before a provider request**, so a typo never costs a generation.

## Review

Cross-family pass with kaibo (cast `crusoe`, GLM-5.2). Four findings, all verified against the code before acting, all fixed in the second commit:

1. **The guard was a convention, not a structure** — it lived in each provider's `generate`, so a fourth provider could forget it. This was the review's most valuable catch and drove the `accepts_inputs` design above.
2. **Multipart parts had no `Content-Type`** — reqwest defaults to `application/octet-stream`, asking the provider to infer what the store already knew.
3. **Two stale doc comments** in `stability.rs` still described the old single-image shape, one of them contradicting the design rationale directly beside it.
4. **No end-to-end handler test** — `resolve_inputs` was unit-tested, but nothing proved the handler threads a digest through to the provider. That wiring is what a refactor drops silently, because dropping it still returns a plausible image.

## Testing

12 new tests. The arm-level guard has its own negative control: one test drives a provider that never opted in and **panics if it is ever reached**, the other drives one that did — so a guard that refused unconditionally fails the second.

Earlier tests were verified against a sabotaged build: making `refuse_binary_inputs` return `Ok(())` unconditionally, and taking the caller's word for a part's format instead of the store's, failed exactly those two tests and no others.

**Method note.** One check in this session read `cargo test | grep -c FAILED` as clean while the lib tests were not compiling at all — zero `test result` lines greps as zero failures. That is the same fails-open shape I flagged elsewhere today, and I walked into it. Every gate here asserts on cargo's exit code instead.

Full suite green (1204 passing, exit 0), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)