### PR TITLE
feat(media): twelve Stability operations behind an `op` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,14 @@ record. Each later release appends a new section at the top.
   MCP client.
 - **`generate` reaches Stability's edit, control and upscale routes** through a new `op`
   parameter — twelve operations where three were wired.
-- **Each operation's credit cost is published on the `op` parameter**, so a model sees
-  that `upscale/conservative` costs twenty times `generate/core` before it picks.
+- **Each operation's cost is published on the `op` parameter** in the provider's own
+  unit, unconverted — so a model sees the twenty-fold spread before it picks a route.
 - **An unrecognized `op`, or one on a backend with no operations, is refused** rather
   than run as a text-to-image generation.
-- **`generate` takes input images by digest** — `inputs {"image": "<digest>"}` is
-  image-to-image on Stability's `ultra` and `sd3` routes, reusing an image already in
-  the store rather than re-sending it.
+- **`generate` takes input images by digest** — `inputs [{"field": "image", "digest":
+  "..."}]` is image-to-image on Stability's `ultra` and `sd3` routes, reusing an image
+  already in the store rather than re-sending it. A field name may repeat, for the
+  operations that take several source images under one name.
 - **`generate` carries several named input parts**, so an operation taking
   `init_image`+`style_image`, or an image plus an optional mask, is reachable.
 - **A media backend with no input-image route refuses a call that carries one**, rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ record. Each later release appends a new section at the top.
 - **`kaibo cas write FILE`** stores an image from the command line and prints its
   digest — the CLI half of `write_cas`, so an operator can put an image in without an
   MCP client.
+- **`generate` reaches an OpenAI-compatible images backend's `edits` and `variations`
+  routes** through the same `op` parameter, over multipart where `generations` is JSON.
 - **`generate` reaches Stability's edit, control and upscale routes** through a new `op`
   parameter — twelve operations where three were wired.
 - **Each operation's cost is published on the `op` parameter** in the provider's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ record. Each later release appends a new section at the top.
 - **`kaibo cas write FILE`** stores an image from the command line and prints its
   digest — the CLI half of `write_cas`, so an operator can put an image in without an
   MCP client.
+- **`generate` reaches Stability's edit, control and upscale routes** through a new `op`
+  parameter — twelve operations where three were wired.
+- **Each operation's credit cost is published on the `op` parameter**, so a model sees
+  that `upscale/conservative` costs twenty times `generate/core` before it picks.
+- **An unrecognized `op`, or one on a backend with no operations, is refused** rather
+  than run as a text-to-image generation.
 - **`generate` takes input images by digest** — `inputs {"image": "<digest>"}` is
   image-to-image on Stability's `ultra` and `sd3` routes, reusing an image already in
   the store rather than re-sending it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ record. Each later release appends a new section at the top.
 - **`generate` takes input images by digest** — `inputs {"image": "<digest>"}` is
   image-to-image on Stability's `ultra` and `sd3` routes, reusing an image already in
   the store rather than re-sending it.
-- **`generate` carries several named input parts**, so the operations that take
-  `image`+`mask` or `init_image`+`style_image` are reachable.
+- **`generate` carries several named input parts**, so an operation taking
+  `init_image`+`style_image`, or an image plus an optional mask, is reachable.
 - **A media backend with no input-image route refuses a call that carries one**, rather
   than silently generating from the prompt alone and returning an unrelated image.
 - **An unknown or non-image input digest refuses before the provider is called**, so a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2093,6 +2093,7 @@ async fn generate_inner(
         // Text-to-image only from the CLI today: the edit/upscale operations that take an
         // input image would need a file to read, and the CLI has no such argument yet.
         inputs: Vec::new(),
+        op: None,
     };
     let outcome = match arm.generate(&request).await {
         Ok(o) => o,

--- a/src/media.rs
+++ b/src/media.rs
@@ -134,6 +134,16 @@ pub struct MediaRequest {
     /// binary sibling, and it is a `Vec` for the same reason: a provider may care about
     /// order.
     pub inputs: Vec<MediaInput>,
+
+    /// Which of the provider's operations to run, in that provider's own vocabulary
+    /// (`"edit/inpaint"`, `"control/style-transfer"`). `None` is the provider's default
+    /// — text-to-image everywhere today.
+    ///
+    /// Provider-neutral only in the sense `fields` is: kaibo carries the string and the
+    /// provider answers for its own vocabulary. It is *not* the model slot's job — a
+    /// cast's `image` slot names one model, and Stability alone has twenty-five
+    /// operations behind it, so an operation is a property of the call.
+    pub op: Option<String>,
 }
 
 /// One binary part of a generation request: which form field it fills, what to call it
@@ -222,6 +232,23 @@ pub fn resolve_inputs(
         out.push(MediaInput::new(field.clone(), extension, bytes));
     }
     Ok(out)
+}
+
+/// Refuse a named operation on a provider that has no vocabulary of them.
+///
+/// Same failure being prevented as [`refuse_binary_inputs`]: running the default route
+/// for a caller who named a different one returns a plausible artifact for the wrong
+/// question, stored with a digest and a sidecar that make it look deliberate.
+pub fn refuse_operation(request: &MediaRequest, provider: &str) -> Result<()> {
+    let Some(op) = &request.op else {
+        return Ok(());
+    };
+    bail!(
+        "this call asks for operation `{op}`, and the {provider} backend has no named \
+         operations — it generates from a prompt and nothing else, so nothing was \
+         generated. Point the cast's `image` slot at a backend with an operation \
+         vocabulary (Stability), or drop `op`."
+    )
 }
 
 /// Refuse a request carrying binary inputs on a provider that has no route for them.
@@ -314,6 +341,17 @@ pub trait MediaModel: Send + Sync {
     /// opt in costs a clear refusal, where forgetting a guard would have cost a
     /// convincing wrong answer.
     fn accepts_inputs(&self) -> bool {
+        false
+    }
+
+    /// Whether this provider has a vocabulary of named operations at all.
+    ///
+    /// Defaults to `false` for the same reason as [`accepts_inputs`](Self::accepts_inputs),
+    /// and enforced in the same place: a provider that ignored `op` would run its default
+    /// route and hand back a text-to-image render when the caller asked for an inpaint —
+    /// a wrong answer that looks entirely like a right one. Failing closed costs a
+    /// refusal instead.
+    fn accepts_ops(&self) -> bool {
         false
     }
 }
@@ -423,6 +461,9 @@ impl MediaArm {
     pub async fn generate(&self, request: &MediaRequest) -> Result<MediaOutcome> {
         if !self.model.accepts_inputs() {
             refuse_binary_inputs(request, &self.slot_ref)?;
+        }
+        if !self.model.accepts_ops() {
+            refuse_operation(request, &self.slot_ref)?;
         }
         self.model.generate(request).await
     }

--- a/src/media.rs
+++ b/src/media.rs
@@ -201,7 +201,7 @@ impl MediaInput {
 /// built.
 pub fn resolve_inputs(
     store: &crate::cas::MediaStore,
-    asked: &std::collections::BTreeMap<String, String>,
+    asked: &[(String, String)],
 ) -> Result<Vec<MediaInput>> {
     let mut out = Vec::with_capacity(asked.len());
     for (field, digest_hex) in asked {

--- a/src/media.rs
+++ b/src/media.rs
@@ -13,10 +13,11 @@
 //!
 //! The vocabulary here is deliberately provider-neutral (a [`MediaArtifact`] is bytes,
 //! a mime string, and a seed) — providers translate their native shapes at their own
-//! impl, exactly as rig providers translate into rig's completion types. Two live
+//! impl, exactly as rig providers translate into rig's completion types. Three live
 //! implementations today: Stability's (`src/stability.rs`, multipart form wire, sync
-//! and deferred shapes) and OpenAI Images (`src/openai_images.rs`, JSON body wire,
-//! sync only).
+//! and deferred shapes, and the only one with an operation vocabulary), OpenAI Images
+//! (`src/openai_images.rs`, JSON body wire, sync only), and DashScope
+//! (`src/dashscope.rs`).
 //!
 //! # The construction point
 //!

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -185,6 +185,10 @@ pub enum OpenAiImagesError {
     /// build, before the call — any value, even a redundant `"b64_json"`, so the
     /// contract stays one-sided.
     CallerResponseFormat,
+    /// The caller named an `op` this client does not wire. Refused rather than run as a
+    /// plain generation: an edit request answered with a fresh unrelated image is a wrong
+    /// answer that looks like a right one, and the caller pays for it.
+    UnknownOperation { asked: String },
 }
 
 impl std::fmt::Display for OpenAiImagesError {
@@ -243,6 +247,13 @@ impl std::fmt::Display for OpenAiImagesError {
                  as base64 (`url` would spend credits on artifacts kaibo refuses to \
                  fetch), and kaibo already sends the right value per model family. \
                  Omit the field"
+            ),
+            OpenAiImagesError::UnknownOperation { asked } => write!(
+                f,
+                "`op` {asked:?} is not an operation kaibo wires for the Images API, so \
+                 nothing was generated. Pass one of: {}. Omit `op` entirely to generate \
+                 from the prompt alone.",
+                images_op_names().join(", ")
             ),
         }
     }
@@ -405,6 +416,110 @@ pub fn parse_response(
 /// An Images API connection: the `reqwest::Client` (ring-installed —
 /// [`crate::tls::https_client`] is the one build site in this codebase), the
 /// resolved key, and the base URL (a root through `/v1`; this client appends
+/// Turn the JSON body plus the request's input parts into a multipart form.
+///
+/// The scalars ride as text parts under the same names the JSON body uses — OpenAI
+/// documents the multipart form as the same field set — so one `build_request_body`
+/// serves both wires and the two cannot drift on what a knob is called. `prompt` is
+/// dropped for a route that documents none (`variations`), the same rule Stability's
+/// table drives.
+fn multipart_body(
+    body: &Value,
+    request: &MediaRequest,
+    op: &ImagesOp,
+) -> Result<reqwest::multipart::Form, OpenAiImagesError> {
+    let mut form = reqwest::multipart::Form::new();
+    if let Some(map) = body.as_object() {
+        for (k, v) in map {
+            if k == "prompt" && !op.takes_prompt {
+                continue;
+            }
+            let text = match v {
+                Value::String(s) => s.clone(),
+                Value::Null => continue,
+                other => other.to_string(),
+            };
+            form = form.text(k.clone(), text);
+        }
+    }
+    for input in &request.inputs {
+        form = form.part(
+            input.field.clone(),
+            reqwest::multipart::Part::bytes(input.bytes.clone())
+                .file_name(input.filename.clone())
+                .mime_str(&input.mime)
+                .map_err(|e| {
+                    OpenAiImagesError::Transport(format!(
+                        "input part `{}` has mime {:?}, which is not a valid content \
+                         type: {e}",
+                        input.field, input.mime
+                    ))
+                })?,
+        );
+    }
+    Ok(form)
+}
+
+/// One Images API route this client can address, beyond the default `generations`.
+///
+/// The same shape `stability::OpSpec` carries, for the same reason — one source for the
+/// parser, the refusal and the published cost — and deliberately *not* a shared type.
+/// These two providers agree on the idea of a named operation and on nothing else: the
+/// path is a different URL suffix, one wire is JSON and the other multipart, and the
+/// cost is a different unit. A common struct here would be three fields of coincidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImagesOp {
+    /// What a caller passes as `op`.
+    pub name: &'static str,
+    /// The path appended to the base URL.
+    pub path: &'static str,
+    /// Required binary parts, by form-field name.
+    pub inputs: &'static [&'static str],
+    /// Whether this route documents a `prompt`.
+    pub takes_prompt: bool,
+    /// What it costs, in the provider's own words — see `stability::OpSpec::cost` for
+    /// why kaibo quotes rather than converts. OpenAI publishes no flat per-call figure
+    /// for these; the price depends on the model, the size and the quality, so that is
+    /// what kaibo says rather than inventing a number.
+    pub cost: &'static str,
+}
+
+/// The Images API routes that take an input image, confirmed against
+/// `openai/openai-openapi`'s `openapi.yaml` (2026-08-22).
+///
+/// `generations` is absent on purpose: it is what a call with no `op` already does, and
+/// listing it would offer two spellings for one thing.
+pub const IMAGES_OPS: &[ImagesOp] = &[
+    ImagesOp {
+        name: "edits",
+        path: "/images/edits",
+        inputs: &["image"],
+        takes_prompt: true,
+        cost: "priced per image by model, size and quality",
+    },
+    ImagesOp {
+        name: "variations",
+        path: "/images/variations",
+        inputs: &["image"],
+        // The spec's required list is `image` alone — no `prompt` property at all. The
+        // same prompt-less shape `upscale/fast` has on Stability, which is the first
+        // evidence that flag was worth having rather than a Stability quirk.
+        takes_prompt: false,
+        cost: "priced per image by model and size",
+    },
+];
+
+/// Look up one Images operation by the name a caller passed.
+pub fn images_op_by_name(name: &str) -> Option<&'static ImagesOp> {
+    IMAGES_OPS.iter().find(|o| o.name == name)
+}
+
+/// Every operation name a caller may pass, rendered from the table so a refusal cannot
+/// list something [`images_op_by_name`] rejects.
+pub fn images_op_names() -> Vec<&'static str> {
+    IMAGES_OPS.iter().map(|o| o.name).collect()
+}
+
 /// `/images/generations`).
 #[derive(Clone)]
 pub struct OpenAiImagesClient {
@@ -437,13 +552,32 @@ impl OpenAiImagesClient {
         model: &str,
         request: &MediaRequest,
     ) -> Result<Vec<MediaArtifact>, OpenAiImagesError> {
+        // Two wires on one API, chosen by the route rather than sniffed: `generations`
+        // is JSON, `edits` and `variations` are multipart because they carry files.
+        // Whichever wire it is, `parse_response` sees the same `{data:[{b64_json}]}`.
+        let op = match request.op.as_deref() {
+            None => None,
+            Some(name) => Some(images_op_by_name(name).ok_or_else(|| {
+                OpenAiImagesError::UnknownOperation {
+                    asked: name.to_string(),
+                }
+            })?),
+        };
         let (body, format) = build_request_body(model, request)?;
-        let url = format!("{}/images/generations", self.base_url.trim_end_matches('/'));
-        let resp = self
-            .http
-            .post(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.api_key))
-            .json(&body)
+        let base = self.base_url.trim_end_matches('/');
+        let mut req = self.http.post(match op {
+            Some(o) => format!("{base}{}", o.path),
+            None => format!("{base}/images/generations"),
+        });
+        req = req.header(AUTHORIZATION, format!("Bearer {}", self.api_key));
+        req = match op {
+            // The JSON body's scalars become text parts; the input images become file
+            // parts under the caller's own field names, so an operation taking several
+            // images under one name sends several parts under that name.
+            Some(o) => req.multipart(multipart_body(&body, request, o)?),
+            None => req.json(&body),
+        };
+        let resp = req
             .send()
             .await
             .map_err(|e| OpenAiImagesError::Transport(e.to_string()))?;
@@ -481,6 +615,17 @@ impl OpenAiImagesModel {
 impl crate::media::MediaModel for OpenAiImagesModel {
     /// Always resolves to [`MediaOutcome::Complete`] — the Images API is
     /// synchronous, and `n` makes a multi-artifact list the normal shape.
+    /// The Images API takes an input image on `edits` and `variations`.
+    fn accepts_inputs(&self) -> bool {
+        true
+    }
+
+    /// Three routes behind one model id — `generations` (the default), `edits` and
+    /// `variations`.
+    fn accepts_ops(&self) -> bool {
+        true
+    }
+
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
         let artifacts = self.client.generate(&self.model, request).await?;
         Ok(MediaOutcome::Complete(artifacts))

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -524,6 +524,7 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), v.clone()))
                 .collect(),
             inputs: Vec::new(),
+            op: None,
         }
     }
 

--- a/src/server/containment.rs
+++ b/src/server/containment.rs
@@ -150,10 +150,7 @@ impl super::Resolver {
             )
         })?;
         let meta = std::fs::metadata(&canon).map_err(|e| {
-            McpError::invalid_params(
-                format!("{} could not be read: {e}", canon.display()),
-                None,
-            )
+            McpError::invalid_params(format!("{} could not be read: {e}", canon.display()), None)
         })?;
         if !meta.is_file() {
             return Err(McpError::invalid_params(
@@ -178,23 +175,16 @@ impl super::Resolver {
                 None,
             ));
         }
-        let worker =
-            KaishWorker::spawn_with(&tree, self.config.sandbox.clone()).map_err(|e| {
-                McpError::internal_error(
-                    format!("file reader for {}: {e:#}", tree.display()),
-                    None,
-                )
-            })?;
+        let worker = KaishWorker::spawn_with(&tree, self.config.sandbox.clone()).map_err(|e| {
+            McpError::internal_error(format!("file reader for {}: {e:#}", tree.display()), None)
+        })?;
         // One byte past the cap, so a file raced larger between the stat and this read
         // comes back over-length and is refused below rather than read whole.
         let bytes = worker
             .read_file_capped(canon.clone(), max_bytes + 1)
             .await
             .map_err(|e| {
-                McpError::invalid_params(
-                    format!("reading {}: {e:#}", canon.display()),
-                    None,
-                )
+                McpError::invalid_params(format!("reading {}: {e:#}", canon.display()), None)
             })?;
         if bytes.len() as u64 > max_bytes {
             return Err(McpError::invalid_params(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -742,16 +742,24 @@ pub struct GenerateInput {
     pub inputs: Option<std::collections::BTreeMap<String, String>>,
 
     /// Which operation to run, when the backend has more than one. Omit it to generate
-    /// from the prompt alone. Stability's operations and what each costs in credits (one
-    /// credit is about a US cent, so `upscale/conservative` is twenty times
-    /// `generate/core`): `edit/erase` 5 (image; optional `mask`, or an alpha channel on the image),
-    /// `edit/inpaint` 5 (image; optional `mask`, or an alpha channel on the image),
-    /// `edit/outpaint` 4 (image), `edit/search-and-replace` 5 (image, `search_prompt`),
-    /// `edit/search-and-recolor` 5 (image, `select_prompt`), `edit/remove-background` 5
-    /// (image), `control/sketch` 5 (image), `control/structure` 5 (image),
-    /// `control/style` 5 (image), `control/style-transfer` 8 (init_image+style_image),
-    /// `upscale/fast` 2 (image), `upscale/conservative` 40 (image). The parenthesised
-    /// names are the `inputs` keys that operation needs.
+    /// from the prompt alone.
+    ///
+    /// Stability's operations, with what each costs in credits — one credit is about a
+    /// US cent, so `upscale/conservative` is twenty times `generate/core` — and the
+    /// `inputs` keys it requires:
+    ///
+    /// `edit/erase` 5 (image), `edit/inpaint` 5 (image), `edit/outpaint` 4 (image),
+    /// `edit/search-and-replace` 5 (image), `edit/search-and-recolor` 5 (image),
+    /// `edit/remove-background` 5 (image), `control/sketch` 5 (image),
+    /// `control/structure` 5 (image), `control/style` 5 (image),
+    /// `control/style-transfer` 8 (init_image, style_image), `upscale/fast` 2 (image),
+    /// `upscale/conservative` 40 (image).
+    ///
+    /// `edit/erase` and `edit/inpaint` also take an optional `mask` in `inputs`, or an
+    /// alpha channel on the image instead. Text knobs ride `fields`, not `inputs`:
+    /// `edit/search-and-replace` needs `search_prompt` there, `edit/search-and-recolor`
+    /// needs `select_prompt`. `prompt` is ignored on `edit/remove-background` and
+    /// `upscale/fast`, which document none.
     #[serde(default)]
     pub op: Option<String>,
 }
@@ -2902,12 +2910,7 @@ impl KaiboHandler {
                     .resolver
                     .read_contained_file(path, crate::upload::MAX_UPLOAD_BYTES as u64)
                     .await?;
-                crate::upload::store_bytes(
-                    store,
-                    &bytes,
-                    input.label.as_deref(),
-                    now_epoch_secs(),
-                )
+                crate::upload::store_bytes(store, &bytes, input.label.as_deref(), now_epoch_secs())
             }
             (None, Some(content)) => crate::upload::store_upload(
                 store,
@@ -2937,9 +2940,7 @@ impl KaiboHandler {
         // parameter the caller got wrong — the same split `read_cas` makes between a bad
         // digest and an unreadable object.
         .map_err(|e| match e {
-            crate::upload::UploadError::Store(_) => {
-                McpError::internal_error(e.to_string(), None)
-            }
+            crate::upload::UploadError::Store(_) => McpError::internal_error(e.to_string(), None),
             _ => McpError::invalid_params(e.to_string(), None),
         })?;
 
@@ -3721,7 +3722,9 @@ impl KaiboHandler {
 /// answer). Fulfilling stays the right call: a client that asks for the newest
 /// version wants what that version's other features buy it, and the two fields cost
 /// kaibo nothing to answer truthfully.
-fn sep_2549_cache_fields(context: &RequestContext<RoleServer>) -> (Option<u64>, Option<CacheScope>) {
+fn sep_2549_cache_fields(
+    context: &RequestContext<RoleServer>,
+) -> (Option<u64>, Option<CacheScope>) {
     // ISO `YYYY-MM-DD` versions compare lexically the same as chronologically.
     let required = context
         .protocol_version()
@@ -6609,9 +6612,17 @@ enabled = false
         .await
         .expect("a stored digest is a usable input");
 
-        let seen = provider.0.lock().unwrap().clone().expect("provider was called");
+        let seen = provider
+            .0
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("provider was called");
         assert_eq!(seen.inputs.len(), 1, "the part reached the provider");
-        assert_eq!(seen.inputs[0].field, "image", "under the caller's field name");
+        assert_eq!(
+            seen.inputs[0].field, "image",
+            "under the caller's field name"
+        );
         assert_eq!(seen.inputs[0].bytes, b"\x89PNG\r\n\x1a\nsource");
         assert_eq!(
             seen.inputs[0].filename, "image.png",
@@ -6643,6 +6654,53 @@ enabled = false
             provider.0.lock().unwrap().is_none(),
             "the provider must never have been called"
         );
+    }
+
+    /// **The `op` parameter's prose must agree with the table it describes.**
+    ///
+    /// That doc is hand-written — schemars renders a doc comment, not a table — and this
+    /// change already proved the drift is real rather than theoretical: it listed
+    /// `search_prompt` and `select_prompt` as `inputs` keys when they are text `fields`,
+    /// so a model following it would have put a prompt where a digest goes and been
+    /// refused for a reason that was our fault. It also listed a credit figure per
+    /// operation, which is the sort of number that silently goes stale.
+    ///
+    /// So: every operation in the table appears in the doc, with its own credit figure,
+    /// and no operation appears that the table does not wire.
+    #[test]
+    fn the_op_parameter_doc_agrees_with_the_operation_table() {
+        let schema = schemars::schema_for!(GenerateInput);
+        let json = serde_json::to_string(&schema).expect("the schema serializes");
+        let doc = json
+            .split("\"op\"")
+            .nth(1)
+            .expect("the schema carries the op property")
+            // Backticks are markdown for the reader, noise for a match — the doc writes
+            // "`edit/erase` 5 (image)" and the fact being pinned is "edit/erase 5".
+            .replace('`', "");
+
+        for spec in crate::stability::STABLE_IMAGE_OPS {
+            assert!(
+                doc.contains(spec.name),
+                "the `op` doc must name {}, or a caller cannot discover it",
+                spec.name
+            );
+            assert!(
+                doc.contains(&format!("{} {}", spec.name, spec.credits)),
+                "the `op` doc must carry {}'s cost as {} credits — a stale price is worse \
+                 than none, because it is trusted",
+                spec.name,
+                spec.credits
+            );
+        }
+        // And nothing the table does not wire: a doc naming a route that refuses is a
+        // trap, and it is the shape a half-finished revert leaves behind.
+        for absent in ["upscale/creative", "edit/replace-background-and-relight"] {
+            assert!(
+                !doc.contains(absent),
+                "the `op` doc names {absent}, which `op_by_name` refuses"
+            );
+        }
     }
 
     /// A minimal but real PNG header — enough that `sniff_image` reads a true signature.
@@ -8667,7 +8725,7 @@ enabled = false
         );
         let text = read_text(TOOLS_URI, &[]);
         for needle in [
-            "attach",              // the attachment guidance moved here
+            "attach",                                     // the attachment guidance moved here
             "inlined",             // the consult-vs-oneshot attach distinction
             "whole file",          // the toolless-model whole-files steer
             "verbatim",            // the model-id override semantics

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -680,6 +680,20 @@ pub struct ReadCasInput {
     pub length: Option<usize>,
 }
 
+/// One entry of `generate`'s `inputs`: which form field a stored image fills.
+///
+/// A pair rather than a map entry so a field name may repeat — see `GenerateInput::inputs`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GenerateInputRef {
+    /// The provider's form-field name for this part — `image`, `mask`, `init_image`,
+    /// `style_image`.
+    pub field: String,
+    /// The stored image's digest: 64 lowercase hex, as `write_cas` or `generate` printed
+    /// it (the tail of a `kaibo://cas/<digest>` address).
+    pub digest: String,
+}
+
 /// Arguments for [`KaiboHandler::write_cas`] — where the image is, and an optional label.
 ///
 /// Exactly one of `path` and `content`. There is no destination of any kind (the address
@@ -732,28 +746,35 @@ pub struct GenerateInput {
     #[serde(default)]
     pub fields: Option<std::collections::BTreeMap<String, GenerateFieldValue>>,
 
-    /// Input images for the operations that take them, as `{form-field: digest}` —
-    /// e.g. `{"image": "<digest>"}` for image-to-image, `{"image": "...", "mask":
-    /// "..."}` where an operation takes both. Each digest is one `write_cas` or
-    /// `generate` handed back, so an image already in kaibo's store is reused by
-    /// address and never re-sent. The form-field names are the provider's own; the
-    /// store decides each part's format, not you.
+    /// Input images for the operations that take them, as a list of
+    /// `{"field": "<form-field>", "digest": "<digest>"}` — e.g.
+    /// `[{"field": "image", "digest": "..."}]` for image-to-image, or an `image` and a
+    /// `mask` entry where an operation takes both. Each digest is one `write_cas` or
+    /// `generate` handed back, so an image already in kaibo's store is reused by address
+    /// and never re-sent. The field names are the provider's own; the store decides each
+    /// part's format, not you.
+    ///
+    /// A list rather than a map because a field name can repeat: an operation that takes
+    /// several source images under one name needs two entries called `image`, which a map
+    /// cannot express. Order is preserved, since a provider may care about it.
     #[serde(default)]
-    pub inputs: Option<std::collections::BTreeMap<String, String>>,
+    pub inputs: Option<Vec<GenerateInputRef>>,
 
     /// Which operation to run, when the backend has more than one. Omit it to generate
     /// from the prompt alone.
     ///
-    /// Stability's operations, with what each costs in credits — one credit is about a
-    /// US cent, so `upscale/conservative` is twenty times `generate/core` — and the
-    /// `inputs` keys it requires:
+    /// Stability's operations, each with the cost the provider itself quotes and the
+    /// `inputs` field names it requires. Costs are the provider's own unit, passed
+    /// through unconverted — work out what that means in money yourself if you need to,
+    /// and note the spread: `upscale/conservative` costs twenty times `generate/core`.
     ///
-    /// `edit/erase` 5 (image), `edit/inpaint` 5 (image), `edit/outpaint` 4 (image),
-    /// `edit/search-and-replace` 5 (image), `edit/search-and-recolor` 5 (image),
-    /// `edit/remove-background` 5 (image), `control/sketch` 5 (image),
-    /// `control/structure` 5 (image), `control/style` 5 (image),
-    /// `control/style-transfer` 8 (init_image, style_image), `upscale/fast` 2 (image),
-    /// `upscale/conservative` 40 (image).
+    /// `edit/erase` 5 credits (image), `edit/inpaint` 5 credits (image),
+    /// `edit/outpaint` 4 credits (image), `edit/search-and-replace` 5 credits (image),
+    /// `edit/search-and-recolor` 5 credits (image), `edit/remove-background` 5 credits
+    /// (image), `control/sketch` 5 credits (image), `control/structure` 5 credits
+    /// (image), `control/style` 5 credits (image), `control/style-transfer` 8 credits
+    /// (init_image, style_image), `upscale/fast` 2 credits (image),
+    /// `upscale/conservative` 40 credits (image).
     ///
     /// `edit/erase` and `edit/inpaint` also take an optional `mask` in `inputs`, or an
     /// alpha channel on the image instead. Text knobs ride `fields`, not `inputs`:
@@ -3159,8 +3180,14 @@ impl KaiboHandler {
         // Resolved before the arm is called, so a bad digest refuses without spending a
         // provider request — and the store, not the caller, names each part's format.
         let inputs = match input.inputs.as_ref() {
-            Some(asked) => crate::media::resolve_inputs(&store, asked)
-                .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?,
+            Some(asked) => {
+                let pairs: Vec<(String, String)> = asked
+                    .iter()
+                    .map(|r| (r.field.clone(), r.digest.clone()))
+                    .collect();
+                crate::media::resolve_inputs(&store, &pairs)
+                    .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?
+            }
             None => Vec::new(),
         };
         let request = crate::media::MediaRequest {
@@ -6606,7 +6633,10 @@ enabled = false
             prompt: "erase the sign".to_string(),
             cast: Some("artist".to_string()),
             fields: None,
-            inputs: Some([("image".to_string(), digest)].into_iter().collect()),
+            inputs: Some(vec![GenerateInputRef {
+                field: "image".to_string(),
+                digest,
+            }]),
             op: None,
         }))
         .await
@@ -6644,7 +6674,10 @@ enabled = false
                 prompt: "erase the sign".to_string(),
                 cast: Some("artist".to_string()),
                 fields: None,
-                inputs: Some([("image".to_string(), absent)].into_iter().collect()),
+                inputs: Some(vec![GenerateInputRef {
+                    field: "image".to_string(),
+                    digest: absent,
+                }]),
                 op: None,
             }))
             .await
@@ -6686,11 +6719,11 @@ enabled = false
                 spec.name
             );
             assert!(
-                doc.contains(&format!("{} {}", spec.name, spec.credits)),
-                "the `op` doc must carry {}'s cost as {} credits — a stale price is worse \
-                 than none, because it is trusted",
+                doc.contains(&format!("{} {}", spec.name, spec.cost)),
+                "the `op` doc must carry {}'s cost as {:?} — a stale price is worse than \
+                 none, because it is trusted",
                 spec.name,
-                spec.credits
+                spec.cost
             );
         }
         // And nothing the table does not wire: a doc naming a route that refuses is a

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -768,7 +768,7 @@ pub struct GenerateInput {
     /// through unconverted — work out what that means in money yourself if you need to,
     /// and note the spread: `upscale/conservative` costs twenty times `generate/core`.
     ///
-    /// `edit/erase` 5 credits (image), `edit/inpaint` 5 credits (image),
+    /// **Stability:** `edit/erase` 5 credits (image), `edit/inpaint` 5 credits (image),
     /// `edit/outpaint` 4 credits (image), `edit/search-and-replace` 5 credits (image),
     /// `edit/search-and-recolor` 5 credits (image), `edit/remove-background` 5 credits
     /// (image), `control/sketch` 5 credits (image), `control/structure` 5 credits
@@ -776,11 +776,16 @@ pub struct GenerateInput {
     /// (init_image, style_image), `upscale/fast` 2 credits (image),
     /// `upscale/conservative` 40 credits (image).
     ///
+    /// **An OpenAI-compatible images backend:** `edits` priced per image by model, size
+    /// and quality (image; up to 16 `image` entries), `variations` priced per image by
+    /// model and size (image; takes no prompt).
+    ///
     /// `edit/erase` and `edit/inpaint` also take an optional `mask` in `inputs`, or an
     /// alpha channel on the image instead. Text knobs ride `fields`, not `inputs`:
     /// `edit/search-and-replace` needs `search_prompt` there, `edit/search-and-recolor`
-    /// needs `select_prompt`. `prompt` is ignored on `edit/remove-background` and
-    /// `upscale/fast`, which document none.
+    /// needs `select_prompt`. `prompt` is ignored on any route that documents none —
+    /// Stability's `edit/remove-background` and `upscale/fast`, and the Images API's
+    /// `variations`.
     #[serde(default)]
     pub op: Option<String>,
 }
@@ -6709,21 +6714,39 @@ enabled = false
             .nth(1)
             .expect("the schema carries the op property")
             // Backticks are markdown for the reader, noise for a match — the doc writes
-            // "`edit/erase` 5 (image)" and the fact being pinned is "edit/erase 5".
+            // "`edit/erase` 5 credits" and the fact being pinned is "edit/erase 5
+            // credits". Whitespace is collapsed for the same reason: a doc comment wraps
+            // where the line ends, so "size\nand quality" and "size and quality" are the
+            // same sentence and only one of them is what the author wrote.
             .replace('`', "");
+        // The doc arrives JSON-escaped, so a line break is the two characters `\` and
+        // `n`, which no whitespace routine can see. Unescape first, then collapse.
+        let doc: String = doc
+            .replace("\\n", " ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
 
-        for spec in crate::stability::STABLE_IMAGE_OPS {
+        // Both provider tables: the doc is one parameter and has to describe every
+        // operation a caller may pass, whichever backend staffs the slot.
+        let wired: Vec<(&str, &str)> = crate::stability::STABLE_IMAGE_OPS
+            .iter()
+            .map(|o| (o.name, o.cost))
+            .chain(
+                crate::openai_images::IMAGES_OPS
+                    .iter()
+                    .map(|o| (o.name, o.cost)),
+            )
+            .collect();
+        for (name, cost) in wired {
             assert!(
-                doc.contains(spec.name),
-                "the `op` doc must name {}, or a caller cannot discover it",
-                spec.name
+                doc.contains(name),
+                "the `op` doc must name {name}, or a caller cannot discover it"
             );
             assert!(
-                doc.contains(&format!("{} {}", spec.name, spec.cost)),
-                "the `op` doc must carry {}'s cost as {:?} — a stale price is worse than \
-                 none, because it is trusted",
-                spec.name,
-                spec.cost
+                doc.contains(&format!("{name} {cost}")),
+                "the `op` doc must carry {name}'s cost as {cost:?} — a stale price is \
+                 worse than none, because it is trusted"
             );
         }
         // And nothing the table does not wire: a doc naming a route that refuses is a

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -740,6 +740,19 @@ pub struct GenerateInput {
     /// store decides each part's format, not you.
     #[serde(default)]
     pub inputs: Option<std::collections::BTreeMap<String, String>>,
+
+    /// Which operation to run, when the backend has more than one. Omit it to generate
+    /// from the prompt alone. Stability's operations and what each costs in credits (one
+    /// credit is about a US cent, so `upscale/conservative` is twenty times
+    /// `generate/core`): `edit/erase` 5 (image+mask), `edit/inpaint` 5 (image+mask),
+    /// `edit/outpaint` 4 (image), `edit/search-and-replace` 5 (image, `search_prompt`),
+    /// `edit/search-and-recolor` 5 (image, `select_prompt`), `edit/remove-background` 5
+    /// (image), `control/sketch` 5 (image), `control/structure` 5 (image),
+    /// `control/style` 5 (image), `control/style-transfer` 8 (init_image+style_image),
+    /// `upscale/fast` 2 (image), `upscale/conservative` 40 (image). The parenthesised
+    /// names are the `inputs` keys that operation needs.
+    #[serde(default)]
+    pub op: Option<String>,
 }
 
 /// One `generate` field value, as typed JSON: the schema face of
@@ -3064,7 +3077,11 @@ impl KaiboHandler {
             `inputs {\"image\": \"<digest>\"}` with `fields {\"strength\": 0.6}` is \
             image-to-image. Digests come from `write_cas` or an earlier `generate`, so \
             an image already in the store is reused by address and never re-sent. \
-            Stability accepts input images; the other media backends do not and say so. An \
+            Stability accepts input images; the other media backends do not and say so. \
+            `op` picks an operation when the backend has more than one — Stability's \
+            edit, control and upscale routes, each with its required `inputs` keys and \
+            its credit cost listed on the parameter, so you can see the price before you \
+            pick. Omit `op` to generate from the prompt. An \
             operation the provider declares deferred returns a `job-N` handle for \
             job_wait/job_get instead (every route wired today answers in-call). \
             Provenance (prompt, model, cast, seed) is recorded beside every artifact."
@@ -3148,6 +3165,7 @@ impl KaiboHandler {
             prompt: input.prompt.clone(),
             fields,
             inputs,
+            op: input.op.clone(),
         };
         let span = tracing::info_span!("generate", cast = %cast.name, model = %arm.slot_ref());
         match arm.generate(&request).instrument(span).await {
@@ -5650,6 +5668,7 @@ mod tests {
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect("generate succeeds");
@@ -5697,6 +5716,7 @@ mod tests {
             cast: Some("artist".to_string()),
             fields: None,
             inputs: None,
+            op: None,
         }))
         .await
         .expect("generate succeeds");
@@ -5733,6 +5753,7 @@ mod tests {
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect("submit succeeds");
@@ -5810,6 +5831,7 @@ mod tests {
                     .collect(),
                 ),
                 inputs: None,
+                op: None,
             }))
             .await
             .expect_err("a fields.prompt override must be refused");
@@ -5832,6 +5854,7 @@ mod tests {
                     .collect(),
                 ),
                 inputs: None,
+                op: None,
             }))
             .await
             .expect_err("a fields.model override must be refused");
@@ -5855,6 +5878,7 @@ mod tests {
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect("a tool-result error, not a protocol error");
@@ -5882,6 +5906,7 @@ mod tests {
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect("a tool-result error, not a protocol error");
@@ -5924,6 +5949,7 @@ mod tests {
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect("a tool-result error, not a protocol error");
@@ -5978,6 +6004,7 @@ mod tests {
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect("submit succeeds"),
@@ -6022,6 +6049,7 @@ mod tests {
                 cast: Some("anthropic".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect_err("no image slot must refuse");
@@ -6091,6 +6119,7 @@ enabled = false
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: None,
+                op: None,
             }))
             .await
             .expect("submit succeeds"),
@@ -6327,6 +6356,7 @@ enabled = false
             cast: Some("artist".to_string()),
             fields: None,
             inputs: None,
+            op: None,
         }))
         .await
         .expect("generate succeeds");
@@ -6363,6 +6393,7 @@ enabled = false
             cast: Some("artist".to_string()),
             fields: None,
             inputs: None,
+            op: None,
         }))
         .await
         .expect("generate succeeds");
@@ -6572,6 +6603,7 @@ enabled = false
             cast: Some("artist".to_string()),
             fields: None,
             inputs: Some([("image".to_string(), digest)].into_iter().collect()),
+            op: None,
         }))
         .await
         .expect("a stored digest is a usable input");
@@ -6601,6 +6633,7 @@ enabled = false
                 cast: Some("artist".to_string()),
                 fields: None,
                 inputs: Some([("image".to_string(), absent)].into_iter().collect()),
+                op: None,
             }))
             .await
             .expect_err("an absent digest is refused");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -744,7 +744,8 @@ pub struct GenerateInput {
     /// Which operation to run, when the backend has more than one. Omit it to generate
     /// from the prompt alone. Stability's operations and what each costs in credits (one
     /// credit is about a US cent, so `upscale/conservative` is twenty times
-    /// `generate/core`): `edit/erase` 5 (image+mask), `edit/inpaint` 5 (image+mask),
+    /// `generate/core`): `edit/erase` 5 (image; optional `mask`, or an alpha channel on the image),
+    /// `edit/inpaint` 5 (image; optional `mask`, or an alpha channel on the image),
     /// `edit/outpaint` 4 (image), `edit/search-and-replace` 5 (image, `search_prompt`),
     /// `edit/search-and-recolor` 5 (image, `select_prompt`), `edit/remove-background` 5
     /// (image), `control/sketch` 5 (image), `control/structure` 5 (image),

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -275,14 +275,31 @@ pub struct OpSpec {
     pub path: &'static str,
     /// Stability's flat credit price per successful generation.
     pub credits: u32,
-    /// The binary parts this route requires, by form-field name. Informational: Stability
-    /// validates its own requirements, and kaibo does not second-guess them — this drives
-    /// the tool description so a caller knows what to pass without a round trip.
+    /// The binary parts this route **requires**, by form-field name — the spec's own
+    /// `required` list intersected with its binary fields, nothing looser.
+    ///
+    /// Required, not accepted, and the distinction is not pedantry: `edit/erase` and
+    /// `edit/inpaint` take an optional `mask`, and an earlier version of this table
+    /// listed it here. That told a caller it had to supply one, when the spec offers a
+    /// second route to the same result — the alpha channel of `image` — and a caller
+    /// that believed the table would have gone looking for a mask it never needed.
+    /// Optional parts belong in the prose a caller reads, not in a field named for what
+    /// a route demands.
+    ///
+    /// Informational either way: Stability validates its own requirements and kaibo does
+    /// not second-guess them. This exists so a caller knows what to pass without paying
+    /// for a round trip to find out.
     pub inputs: &'static [&'static str],
 }
 
 /// Every synchronous `stable-image` route outside `generate`, confirmed against the live
-/// `https://api.stability.ai/v2alpha/openapi` spec (2026-08-21).
+/// `https://api.stability.ai/v2alpha/openapi` spec (2026-08-22) — every row checked
+/// mechanically against that spec, not by eye: the path exists, a `2xx` carries an
+/// `image/*` content type (so `Shape::Sync` is a fact rather than an assumption), the
+/// `inputs` list equals the spec's required-and-binary fields, and `credits` matches the
+/// number in the route's own "### Credits" section. That check is worth re-running on any
+/// edit here; it is what caught `mask` being listed as required on the two `edit` routes
+/// where it is optional.
 ///
 /// Deferred routes are deliberately absent: `upscale/creative` and
 /// `edit/replace-background-and-relight` return a job id rather than an artifact, so they
@@ -295,13 +312,13 @@ pub const STABLE_IMAGE_OPS: &[OpSpec] = &[
         name: "edit/erase",
         path: "stable-image/edit/erase",
         credits: 5,
-        inputs: &["image", "mask"],
+        inputs: &["image"],
     },
     OpSpec {
         name: "edit/inpaint",
         path: "stable-image/edit/inpaint",
         credits: 5,
-        inputs: &["image", "mask"],
+        inputs: &["image"],
     },
     OpSpec {
         name: "edit/outpaint",

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -7,8 +7,9 @@
 //! [`rig_core::image_generation::ImageGenerationModel`], and that trait's request shape
 //! (`prompt`/`width`/`height`/`additional_params`) is deliberately thin — it fits a
 //! single text-to-image call and nothing else. Stability's v2beta API is bigger than
-//! that: alongside `stable-image/generate/{core,ultra,sd3}` (the only family wired
-//! here), it also ships upscale (conservative/creative/fast), edit
+//! that: alongside `stable-image/generate/{core,ultra,sd3}` and the synchronous
+//! `edit`/`control`/`upscale` routes wired in [`STABLE_IMAGE_OPS`], it also ships the
+//! deferred half of upscale (creative) and edit (replace-background-and-relight),
 //! (inpaint/outpaint/erase/search-and-replace/remove-background), control
 //! (sketch/structure/style), audio (`stable-audio` text-to-audio/audio-to-audio), and
 //! 3D (`stable-fast-3d`) — and every one of the image-family operations, unlike
@@ -22,8 +23,8 @@
 //!
 //! # Sync vs deferred — declared, not sniffed
 //!
-//! Every operation wired so far ([`Operation::Generate`]) is synchronous: the POST
-//! itself returns the artifact. But `upscale/creative`, `stable-audio`, and
+//! Every operation wired so far — the `generate` family and every row of
+//! [`STABLE_IMAGE_OPS`] — is synchronous: the POST itself returns the artifact. But `upscale/creative`, `stable-audio`, and
 //! `stable-fast-3d` are **deferred** — the POST only returns a job id, and the artifact
 //! comes later from a poll. The tempting shortcut — "202 means deferred, 200 means
 //! sync" — is wrong: confirmed against the live
@@ -225,14 +226,18 @@ pub fn resolve_key() -> AnyResult<String> {
 
 /// One request to a Stability v2beta image operation — provider-native (Stability's
 /// own `aspect_ratio`, not rig's `width`/`height`) and already shaped for growth. See
-/// the module doc for why `inputs` exists even though the only operation wired so
-/// far ([`Operation::Generate`]) never sets it.
+/// the module doc for the shape; every `edit`, `control` and `upscale` route sets
+/// `inputs`, and the `generate` family sets it for image-to-image.
 #[derive(Debug, Clone, Default)]
 pub struct StabilityRequest {
-    /// Mandatory for every operation wired so far. A future prompt-less operation
-    /// (`remove-background`, `erase`) would need this widened to `Option<String>` —
-    /// noted rather than solved speculatively.
-    pub prompt: String,
+    /// The text prompt, when this operation documents one.
+    ///
+    /// `Option` because two wired routes do not: `edit/remove-background` and
+    /// `upscale/fast` declare no `prompt` property, so sending one would be an
+    /// undocumented field on a provider that validates its own knobs. That was recorded
+    /// here as a future widening while only the `generate` family was wired; wiring the
+    /// `edit` and `upscale` families is what made it due.
+    pub prompt: Option<String>,
     /// The binary parts this operation carries, each under the form-field name that
     /// operation documents — `image`, `mask`, `init_image`, `style_image`,
     /// `subject_image`, `audio`. Several routes take more than one, so the name is data
@@ -290,6 +295,16 @@ pub struct OpSpec {
     /// not second-guess them. This exists so a caller knows what to pass without paying
     /// for a round trip to find out.
     pub inputs: &'static [&'static str],
+    /// Whether this route documents a `prompt` field at all.
+    ///
+    /// Two do not — `edit/remove-background` and `upscale/fast` declare no `prompt`
+    /// property — so sending one is an undocumented field on a provider that validates
+    /// its own knobs. `edit/erase` is a third case and a genuine spec contradiction: its
+    /// `required` list names `prompt` while its properties do not contain it. Kept `true`
+    /// there, because the required list is the half that would produce a 400 if the
+    /// server enforces it, and omitting a field the spec calls required is the riskier
+    /// guess.
+    pub takes_prompt: bool,
 }
 
 /// Every synchronous `stable-image` route outside `generate`, confirmed against the live
@@ -313,72 +328,84 @@ pub const STABLE_IMAGE_OPS: &[OpSpec] = &[
         path: "stable-image/edit/erase",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "edit/inpaint",
         path: "stable-image/edit/inpaint",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "edit/outpaint",
         path: "stable-image/edit/outpaint",
         credits: 4,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "edit/search-and-replace",
         path: "stable-image/edit/search-and-replace",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "edit/search-and-recolor",
         path: "stable-image/edit/search-and-recolor",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "edit/remove-background",
         path: "stable-image/edit/remove-background",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: false,
     },
     OpSpec {
         name: "control/sketch",
         path: "stable-image/control/sketch",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "control/structure",
         path: "stable-image/control/structure",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "control/style",
         path: "stable-image/control/style",
         credits: 5,
         inputs: &["image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "control/style-transfer",
         path: "stable-image/control/style-transfer",
         credits: 8,
         inputs: &["init_image", "style_image"],
+        takes_prompt: true,
     },
     OpSpec {
         name: "upscale/fast",
         path: "stable-image/upscale/fast",
         credits: 2,
         inputs: &["image"],
+        takes_prompt: false,
     },
     OpSpec {
         name: "upscale/conservative",
         path: "stable-image/upscale/conservative",
         credits: 40,
         inputs: &["image"],
+        takes_prompt: true,
     },
 ];
 
@@ -532,7 +559,11 @@ pub fn aspect_ratio_for(width: u32, height: u32) -> &'static str {
 /// order-preserving; `request.inputs` are attached separately as file parts by
 /// [`StabilityClient::call`], since it isn't a text field.
 pub fn build_form_fields(request: &StabilityRequest) -> Vec<(String, String)> {
-    let mut fields: Vec<(String, String)> = vec![("prompt".to_string(), request.prompt.clone())];
+    let mut fields: Vec<(String, String)> = Vec::new();
+    // Only when the operation documents one — see `StabilityRequest::prompt`.
+    if let Some(prompt) = &request.prompt {
+        fields.push(("prompt".to_string(), prompt.clone()));
+    }
     if let Some(ar) = &request.aspect_ratio {
         fields.push(("aspect_ratio".to_string(), ar.clone()));
     }
@@ -1056,7 +1087,7 @@ pub fn from_rig_request(
     Ok((
         Operation::Generate(route),
         StabilityRequest {
-            prompt: request.prompt.clone(),
+            prompt: Some(request.prompt.clone()),
             inputs: Vec::new(),
             aspect_ratio: Some(aspect_ratio_for(request.width, request.height).to_string()),
             fields,
@@ -1333,10 +1364,16 @@ impl StabilityImageModel {
                 fields.push((k.clone(), v));
             }
         }
+        // A route that documents no `prompt` does not get one, whatever the caller passed
+        // — stated on the tool's own `prompt` parameter rather than dropped quietly.
+        let prompt = match &operation {
+            Operation::StableImage(spec) if !spec.takes_prompt => None,
+            _ => Some(request.prompt.clone()),
+        };
         Ok((
             operation,
             StabilityRequest {
-                prompt: request.prompt.clone(),
+                prompt,
                 inputs: request.inputs.clone(),
                 // No derived ratio on this path: the neutral request has no
                 // width/height to bridge, and an `aspect_ratio` field from the caller
@@ -1461,7 +1498,7 @@ mod tests {
     #[test]
     fn build_form_fields_prompt_and_aspect_ratio() {
         let req = StabilityRequest {
-            prompt: "a cat wearing a hat".to_string(),
+            prompt: Some("a cat wearing a hat".to_string()),
             aspect_ratio: Some("16:9".to_string()),
             ..Default::default()
         };
@@ -1478,7 +1515,7 @@ mod tests {
     #[test]
     fn build_form_fields_appends_extra_fields_in_order() {
         let req = StabilityRequest {
-            prompt: "p".to_string(),
+            prompt: Some("p".to_string()),
             aspect_ratio: None,
             fields: vec![
                 ("output_format".to_string(), "webp".to_string()),
@@ -1500,7 +1537,7 @@ mod tests {
     #[test]
     fn build_form_fields_explicit_field_overrides_derived_aspect_ratio() {
         let req = StabilityRequest {
-            prompt: "p".to_string(),
+            prompt: Some("p".to_string()),
             aspect_ratio: Some("1:1".to_string()),
             fields: vec![("aspect_ratio".to_string(), "16:9".to_string())],
             ..Default::default()

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -278,8 +278,14 @@ pub struct OpSpec {
     pub name: &'static str,
     /// The path segment after `/v2beta/`.
     pub path: &'static str,
-    /// Stability's flat credit price per successful generation.
-    pub credits: u32,
+    /// What this route costs, **in the provider's own unit, verbatim**.
+    ///
+    /// A string, not a number, and not normalized to anything. kaibo does not track the
+    /// pricing landscape and would go stale silently if it tried: Stability bills flat
+    /// credits, OpenAI Images bills per image by size and quality, Gemini bills per
+    /// image. So kaibo reports what the provider says and the caller does whatever
+    /// arithmetic it wants — a figure kaibo converted is a figure kaibo has to chase.
+    pub cost: &'static str,
     /// The binary parts this route **requires**, by form-field name — the spec's own
     /// `required` list intersected with its binary fields, nothing looser.
     ///
@@ -326,84 +332,84 @@ pub const STABLE_IMAGE_OPS: &[OpSpec] = &[
     OpSpec {
         name: "edit/erase",
         path: "stable-image/edit/erase",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "edit/inpaint",
         path: "stable-image/edit/inpaint",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "edit/outpaint",
         path: "stable-image/edit/outpaint",
-        credits: 4,
+        cost: "4 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "edit/search-and-replace",
         path: "stable-image/edit/search-and-replace",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "edit/search-and-recolor",
         path: "stable-image/edit/search-and-recolor",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "edit/remove-background",
         path: "stable-image/edit/remove-background",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: false,
     },
     OpSpec {
         name: "control/sketch",
         path: "stable-image/control/sketch",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "control/structure",
         path: "stable-image/control/structure",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "control/style",
         path: "stable-image/control/style",
-        credits: 5,
+        cost: "5 credits",
         inputs: &["image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "control/style-transfer",
         path: "stable-image/control/style-transfer",
-        credits: 8,
+        cost: "8 credits",
         inputs: &["init_image", "style_image"],
         takes_prompt: true,
     },
     OpSpec {
         name: "upscale/fast",
         path: "stable-image/upscale/fast",
-        credits: 2,
+        cost: "2 credits",
         inputs: &["image"],
         takes_prompt: false,
     },
     OpSpec {
         name: "upscale/conservative",
         path: "stable-image/upscale/conservative",
-        credits: 40,
+        cost: "40 credits",
         inputs: &["image"],
         takes_prompt: true,
     },

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -254,13 +254,136 @@ pub struct StabilityRequest {
     pub fields: Vec<(String, String)>,
 }
 
-/// One Stability v2beta endpoint this facade can address. Only [`Operation::Generate`]
-/// is wired; `Upscale`/`Edit`/`Control`/`Audio`/`ThreeD` are the natural siblings v2beta
-/// already documents, each one endpoint path (and, for the deferred ones, a [`Shape`]
-/// arm) away — see the module doc.
+/// One synchronous `stable-image` operation outside the `generate` family: its caller-
+/// facing name, its endpoint path, what it costs, and the binary parts it requires.
+///
+/// A table rather than twelve enum variants with twelve `match` arms. These routes differ
+/// only in their path segment and in which fields Stability validates, so a table is the
+/// honest shape — and it means the tool's schema `enum`, the parser, the refusal message
+/// and the cost list all render from one source and cannot drift apart. The same argument
+/// `artifact::FORMATS` and `upload::SIGNATURES` record.
+///
+/// **`credits` is published to the model**, and that is the point of carrying it. One
+/// credit is about a US cent, and `upscale/conservative` costs *twenty times*
+/// `generate/core`. A model that reads the price before it picks a route spends
+/// differently from one that does not, and this is the cheapest place to tell it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpSpec {
+    /// What a caller passes as `op` — the family and route, as Stability spells them.
+    pub name: &'static str,
+    /// The path segment after `/v2beta/`.
+    pub path: &'static str,
+    /// Stability's flat credit price per successful generation.
+    pub credits: u32,
+    /// The binary parts this route requires, by form-field name. Informational: Stability
+    /// validates its own requirements, and kaibo does not second-guess them — this drives
+    /// the tool description so a caller knows what to pass without a round trip.
+    pub inputs: &'static [&'static str],
+}
+
+/// Every synchronous `stable-image` route outside `generate`, confirmed against the live
+/// `https://api.stability.ai/v2alpha/openapi` spec (2026-08-21).
+///
+/// Deferred routes are deliberately absent: `upscale/creative` and
+/// `edit/replace-background-and-relight` return a job id rather than an artifact, so they
+/// need the deferred lane wired to a poll cadence, which is its own change. Audio and 3D
+/// are absent for a different reason — the media CAS cannot name `mp3`, `wav` or `glb` on
+/// disk yet, and storing them under an invented extension is exactly what
+/// `MediaType::to_cas_extension` refuses to do.
+pub const STABLE_IMAGE_OPS: &[OpSpec] = &[
+    OpSpec {
+        name: "edit/erase",
+        path: "stable-image/edit/erase",
+        credits: 5,
+        inputs: &["image", "mask"],
+    },
+    OpSpec {
+        name: "edit/inpaint",
+        path: "stable-image/edit/inpaint",
+        credits: 5,
+        inputs: &["image", "mask"],
+    },
+    OpSpec {
+        name: "edit/outpaint",
+        path: "stable-image/edit/outpaint",
+        credits: 4,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "edit/search-and-replace",
+        path: "stable-image/edit/search-and-replace",
+        credits: 5,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "edit/search-and-recolor",
+        path: "stable-image/edit/search-and-recolor",
+        credits: 5,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "edit/remove-background",
+        path: "stable-image/edit/remove-background",
+        credits: 5,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "control/sketch",
+        path: "stable-image/control/sketch",
+        credits: 5,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "control/structure",
+        path: "stable-image/control/structure",
+        credits: 5,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "control/style",
+        path: "stable-image/control/style",
+        credits: 5,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "control/style-transfer",
+        path: "stable-image/control/style-transfer",
+        credits: 8,
+        inputs: &["init_image", "style_image"],
+    },
+    OpSpec {
+        name: "upscale/fast",
+        path: "stable-image/upscale/fast",
+        credits: 2,
+        inputs: &["image"],
+    },
+    OpSpec {
+        name: "upscale/conservative",
+        path: "stable-image/upscale/conservative",
+        credits: 40,
+        inputs: &["image"],
+    },
+];
+
+/// Look up one operation by the name a caller passed.
+pub fn op_by_name(name: &str) -> Option<&'static OpSpec> {
+    STABLE_IMAGE_OPS.iter().find(|o| o.name == name)
+}
+
+/// Every operation name a caller may pass, in table order — for a schema enum or a
+/// refusal, rendered from the table so it cannot drift from what `op_by_name` accepts.
+pub fn op_names() -> Vec<&'static str> {
+    STABLE_IMAGE_OPS.iter().map(|o| o.name).collect()
+}
+
+/// One Stability v2beta endpoint this facade can address. `Audio`/`ThreeD` and the two
+/// deferred `stable-image` routes are the remaining siblings v2beta documents — each one
+/// table row (and, for the deferred ones, a [`Shape`] arm) away. See the module doc.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Operation {
     Generate(GenerateRoute),
+    /// One row of [`STABLE_IMAGE_OPS`] — every `edit`, `control` and sync `upscale` route.
+    StableImage(&'static OpSpec),
 }
 
 /// Whether an operation's POST returns its artifact directly, or only a job id to poll
@@ -283,6 +406,7 @@ impl Operation {
     fn path(&self) -> String {
         match self {
             Operation::Generate(route) => format!("stable-image/generate/{}", route.path_segment()),
+            Operation::StableImage(spec) => spec.path.to_string(),
         }
     }
 
@@ -291,7 +415,11 @@ impl Operation {
     /// new match arm here, not a rewrite of [`handle_response`]'s dispatch.
     fn shape(&self) -> Shape {
         match self {
-            Operation::Generate(_) => Shape::Sync,
+            // Every route in `STABLE_IMAGE_OPS` is synchronous by construction — the two
+            // deferred `stable-image` routes are deliberately not in that table, so this
+            // arm cannot be wrong for a row that exists. A deferred operation arrives as
+            // its own variant with its own arm.
+            Operation::Generate(_) | Operation::StableImage(_) => Shape::Sync,
         }
     }
 }
@@ -488,6 +616,11 @@ pub enum StabilityError {
     /// writing them under a wrong or invented extension would be exactly the
     /// silent-garbage failure this module's whole design refuses.
     NoCasExtension { media_type: MediaType },
+    /// The caller named an `op` this facade does not wire. Refused rather than run as the
+    /// default route: a text-to-image render returned for an `edit/inpaint` request is a
+    /// wrong answer that looks entirely like a right one, and it costs the caller a
+    /// generation to find out.
+    UnknownOperation { asked: String },
 }
 
 impl std::fmt::Display for StabilityError {
@@ -553,6 +686,13 @@ impl std::fmt::Display for StabilityError {
                 "media type {media_type:?} has no cas::Extension to be written under yet — the \
                  CAS cannot name this on disk, so refusing rather than writing it under a wrong \
                  or invented extension"
+            ),
+            StabilityError::UnknownOperation { asked } => write!(
+                f,
+                "`op` {asked:?} is not an operation kaibo wires for Stability, so nothing \
+                 was generated. Pass one of: {}. Omit `op` entirely to generate from the \
+                 prompt alone.",
+                op_names().join(", ")
             ),
         }
     }
@@ -1132,10 +1272,35 @@ impl StabilityImageModel {
     /// `output_format = "png"` default, then let the caller's own fields override —
     /// last write wins, the same contract [`build_form_fields`] applies again at
     /// send time.
-    fn media_request(&self, request: &crate::media::MediaRequest) -> (Operation, StabilityRequest) {
+    /// Resolve one neutral request into the operation it addresses and Stability's own
+    /// request shape.
+    ///
+    /// Fallible now, because the caller's `op` is a *name* and an unrecognized one has to
+    /// refuse rather than quietly run the default route — a text-to-image render returned
+    /// for an inpaint request is a wrong answer wearing a right one's clothes.
+    ///
+    /// The model slot picks the route only when no `op` is named. That split is the whole
+    /// reason `op` exists: a cast's `image` slot names one model, and this provider has
+    /// twenty-five operations behind it, so the operation is a property of the call and
+    /// the model id stays what it always was — the `generate` family's route selector.
+    fn media_request(
+        &self,
+        request: &crate::media::MediaRequest,
+    ) -> Result<(Operation, StabilityRequest), StabilityError> {
         let route = GenerateRoute::classify(&self.model);
+        let operation = match request.op.as_deref() {
+            None => Operation::Generate(route.clone()),
+            Some(name) => Operation::StableImage(op_by_name(name).ok_or_else(|| {
+                StabilityError::UnknownOperation {
+                    asked: name.to_string(),
+                }
+            })?),
+        };
         let mut fields: Vec<(String, String)> = Vec::new();
-        if let GenerateRoute::Sd3 { model } = &route {
+        // `model` belongs to the sd3 generate route alone. Sending it on an edit or
+        // control route would be a field that route never documented, so it rides only
+        // where it means something.
+        if let (Operation::Generate(_), GenerateRoute::Sd3 { model }) = (&operation, &route) {
             fields.push(("model".to_string(), model.clone()));
         }
         fields.push(("output_format".to_string(), "png".to_string()));
@@ -1151,8 +1316,8 @@ impl StabilityImageModel {
                 fields.push((k.clone(), v));
             }
         }
-        (
-            Operation::Generate(route),
+        Ok((
+            operation,
             StabilityRequest {
                 prompt: request.prompt.clone(),
                 inputs: request.inputs.clone(),
@@ -1162,7 +1327,7 @@ impl StabilityImageModel {
                 aspect_ratio: None,
                 fields,
             },
-        )
+        ))
     }
 }
 
@@ -1181,11 +1346,17 @@ impl crate::media::MediaModel for StabilityImageModel {
         true
     }
 
+    /// Stability is the only backend with an operation vocabulary — twenty-five routes
+    /// behind one model id.
+    fn accepts_ops(&self) -> bool {
+        true
+    }
+
     async fn generate(
         &self,
         request: &crate::media::MediaRequest,
     ) -> AnyResult<crate::media::MediaOutcome> {
-        let (op, stability_request) = self.media_request(request);
+        let (op, stability_request) = self.media_request(request)?;
         let response = self.client.call(&op, &stability_request).await?;
         Ok(match response {
             // Stability's operations each return exactly one artifact, so it rides as a
@@ -1328,6 +1499,91 @@ mod tests {
         );
     }
 
+    /// **A named `op` routes to that operation's endpoint, not the model's.**
+    ///
+    /// The core claim of the op layer: the cast's `image` slot names one model, and the
+    /// operation is a property of the call, so `op` must win over `GenerateRoute` for
+    /// path selection. Driven across the whole table so a row added later is covered
+    /// without a new test.
+    #[test]
+    fn a_named_op_selects_that_routes_endpoint_over_the_models() {
+        let client = StabilityClient::new("k", "http://localhost", Duration::from_secs(1)).unwrap();
+        // An sd3 model id, so a leaked default would be visibly wrong in the path.
+        let model = StabilityImageModel::from_parts(&client, "sd3.5-large");
+        for spec in STABLE_IMAGE_OPS {
+            let (op, _req) = model
+                .media_request(&crate::media::MediaRequest {
+                    prompt: "p".to_string(),
+                    fields: Vec::new(),
+                    inputs: Vec::new(),
+                    op: Some(spec.name.to_string()),
+                })
+                .unwrap_or_else(|e| panic!("{} must resolve: {e}", spec.name));
+            assert_eq!(op.path(), spec.path, "{} routed wrong", spec.name);
+            assert_eq!(op.shape(), Shape::Sync, "{} is a sync route", spec.name);
+        }
+    }
+
+    /// `model` is the sd3 *generate* route's field. Sending it on an edit or control
+    /// route would be a field that route never documented — and, since Stability
+    /// validates its own knobs, an avoidable provider 400 the caller pays for.
+    #[test]
+    fn the_sd3_model_field_rides_the_generate_route_only() {
+        let client = StabilityClient::new("k", "http://localhost", Duration::from_secs(1)).unwrap();
+        let model = StabilityImageModel::from_parts(&client, "sd3.5-large");
+
+        let (_, generate) = model
+            .media_request(&crate::media::MediaRequest {
+                prompt: "p".into(),
+                fields: Vec::new(),
+                inputs: Vec::new(),
+                op: None,
+            })
+            .expect("no op is the generate route");
+        assert!(
+            generate
+                .fields
+                .iter()
+                .any(|(k, v)| k == "model" && v == "sd3.5-large"),
+            "the sd3 generate route carries its model field: {:?}",
+            generate.fields
+        );
+
+        let (_, edit) = model
+            .media_request(&crate::media::MediaRequest {
+                prompt: "p".into(),
+                fields: Vec::new(),
+                inputs: Vec::new(),
+                op: Some("edit/inpaint".into()),
+            })
+            .expect("a wired op resolves");
+        assert!(
+            !edit.fields.iter().any(|(k, _)| k == "model"),
+            "an edit route documents no `model` field: {:?}",
+            edit.fields
+        );
+    }
+
+    /// An unrecognized `op` refuses before any request is built, and the refusal lists
+    /// every name that would have worked — rendered from the same table the parser reads.
+    #[test]
+    fn an_unknown_op_refuses_and_lists_what_is_wired() {
+        let client = StabilityClient::new("k", "http://localhost", Duration::from_secs(1)).unwrap();
+        let model = StabilityImageModel::from_parts(&client, "core");
+        let err = model
+            .media_request(&crate::media::MediaRequest {
+                prompt: "p".into(),
+                fields: Vec::new(),
+                inputs: Vec::new(),
+                op: Some("edit/inpaintt".into()),
+            })
+            .expect_err("a typo must not fall through to the default route");
+        let msg = err.to_string();
+        assert!(msg.contains("edit/inpaintt"), "names what was asked: {msg}");
+        assert!(msg.contains("edit/inpaint"), "lists the real one: {msg}");
+        assert!(msg.contains("nothing was generated"), "{msg}");
+    }
+
     /// Typed neutral field values land on Stability's all-string multipart wire in
     /// their wire spelling — `seed = 42` (a caller number) becomes the text `42`,
     /// a bool becomes `true` — losslessly, since this wire was always text. The
@@ -1338,16 +1594,29 @@ mod tests {
         use crate::media::FieldValue;
         let client = StabilityClient::new("k", "http://localhost", Duration::from_secs(1)).unwrap();
         let model = StabilityImageModel::from_parts(&client, "core");
-        let (_, req) = model.media_request(&crate::media::MediaRequest {
-            prompt: "p".to_string(),
-            fields: vec![
-                ("seed".to_string(), FieldValue::Num(serde_json::Number::from(42))),
-                ("tiling".to_string(), FieldValue::Bool(true)),
-                ("style_preset".to_string(), FieldValue::Str("anime".to_string())),
-            ],
-            inputs: Vec::new(),
-        });
-        for (name, wire) in [("seed", "42"), ("tiling", "true"), ("style_preset", "anime")] {
+        let (_, req) = model
+            .media_request(&crate::media::MediaRequest {
+                prompt: "p".to_string(),
+                fields: vec![
+                    (
+                        "seed".to_string(),
+                        FieldValue::Num(serde_json::Number::from(42)),
+                    ),
+                    ("tiling".to_string(), FieldValue::Bool(true)),
+                    (
+                        "style_preset".to_string(),
+                        FieldValue::Str("anime".to_string()),
+                    ),
+                ],
+                inputs: Vec::new(),
+                op: None,
+            })
+            .expect("no `op` resolves to the model's generate route");
+        for (name, wire) in [
+            ("seed", "42"),
+            ("tiling", "true"),
+            ("style_preset", "anime"),
+        ] {
             assert!(
                 req.fields.iter().any(|(k, v)| k == name && v == wire),
                 "{name} must reach the form fields as the text {wire:?}, got {:?}",

--- a/tests/dashscope_live.rs
+++ b/tests/dashscope_live.rs
@@ -57,6 +57,7 @@ async fn wan_t2i_returns_real_image_bytes_through_a_fetched_link() {
             ("size".to_string(), FieldValue::Str("768*768".to_string())),
         ],
         inputs: Vec::new(),
+        op: None,
     };
     let outcome = model.generate(&request).await.expect("live generation");
     let MediaOutcome::Complete(artifacts) = outcome else {

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -461,3 +461,64 @@ fn the_callers_order_is_preserved() {
     assert_eq!(resolved[0].field, "style_image");
     assert_eq!(resolved[1].field, "init_image");
 }
+
+// --- OpenAI Images operations --------------------------------------------------
+
+use kaibo::openai_images::{images_op_by_name, images_op_names, IMAGES_OPS};
+
+/// **`op` generalizes off Stability.** The mechanism is shared; only the table is
+/// per-provider. This is the evidence for that claim rather than the assertion of it.
+#[test]
+fn the_images_api_has_its_own_operation_table_on_the_same_mechanism() {
+    assert_eq!(images_op_names(), vec!["edits", "variations"]);
+    for op in IMAGES_OPS {
+        assert_eq!(images_op_by_name(op.name).expect("resolves").path, op.path);
+        assert!(
+            op.path.starts_with("/images/"),
+            "{} must be a route under the Images API, got {}",
+            op.name,
+            op.path
+        );
+    }
+}
+
+/// `generations` is deliberately not a name a caller can pass: it is what a call with no
+/// `op` already does, and two spellings for one thing is a trap rather than a
+/// convenience.
+#[test]
+fn the_default_route_is_not_also_an_op_name() {
+    assert!(images_op_by_name("generations").is_none());
+}
+
+/// **`variations` documents no prompt** — the spec's required list is `image` alone.
+/// That is the same prompt-less shape `upscale/fast` has on Stability, on a different
+/// provider, which is what makes `takes_prompt` a real property rather than a quirk of
+/// one API.
+#[test]
+fn variations_takes_no_prompt_the_way_upscale_fast_does_not() {
+    assert!(!images_op_by_name("variations").expect("wired").takes_prompt);
+    assert!(images_op_by_name("edits").expect("wired").takes_prompt);
+    // The cross-provider half of the claim.
+    assert!(!op_by_name("upscale/fast").expect("wired").takes_prompt);
+}
+
+/// Costs are the provider's own words. OpenAI publishes no flat per-call figure for
+/// these — the price depends on model, size and quality — so kaibo says that rather
+/// than inventing a number it would then have to chase.
+#[test]
+fn the_images_costs_quote_the_provider_rather_than_a_figure() {
+    for op in IMAGES_OPS {
+        assert!(
+            op.cost.contains("priced per image"),
+            "{} should quote how the provider prices it, got {:?}",
+            op.name,
+            op.cost
+        );
+        assert!(
+            !op.cost.chars().any(|c| c.is_ascii_digit()),
+            "{} invents a figure kaibo would have to keep current: {:?}",
+            op.name,
+            op.cost
+        );
+    }
+}

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -70,6 +70,7 @@ fn request_with(inputs: Vec<MediaInput>) -> MediaRequest {
         prompt: "erase the sign".into(),
         fields: Vec::new(),
         inputs,
+        op: None,
     }
 }
 
@@ -263,4 +264,115 @@ async fn the_arm_passes_inputs_through_for_a_provider_that_opted_in() {
         b"photo".to_vec(),
     )]);
     arm.generate(&request).await.expect("accepted");
+}
+
+// --- Named operations ----------------------------------------------------------
+
+use kaibo::media::refuse_operation;
+use kaibo::stability::{op_by_name, op_names, STABLE_IMAGE_OPS};
+
+fn request_with_op(op: &str) -> MediaRequest {
+    MediaRequest {
+        prompt: "erase the sign".into(),
+        fields: Vec::new(),
+        inputs: Vec::new(),
+        op: Some(op.to_string()),
+    }
+}
+
+/// **The twelve routes are reachable by the names the tool publishes.**
+///
+/// The table is the single source for the schema's list, the parser and the refusal, so
+/// this asserts the round trip a caller actually makes: the published name resolves, and
+/// resolves to the route whose path it claims.
+#[test]
+fn every_published_operation_name_resolves_to_its_own_route() {
+    assert_eq!(op_names().len(), 12, "the wired sync stable-image surface");
+    for spec in STABLE_IMAGE_OPS {
+        let found = op_by_name(spec.name).unwrap_or_else(|| panic!("{} must resolve", spec.name));
+        assert_eq!(found.path, spec.path);
+        assert!(
+            found.path.ends_with(spec.name),
+            "the caller-facing name is the tail of the endpoint path, so one cannot drift \
+             from the other: {} vs {}",
+            spec.name,
+            spec.path
+        );
+    }
+}
+
+/// Costs are published because they differ by twenty times across the table, and a model
+/// that reads the price before picking a route spends differently from one that does not.
+/// This pins the two ends, so a table edit that flattened them would fail.
+#[test]
+fn the_published_costs_span_the_range_that_makes_them_worth_publishing() {
+    let fast = op_by_name("upscale/fast").expect("wired");
+    let conservative = op_by_name("upscale/conservative").expect("wired");
+    assert_eq!(fast.credits, 2);
+    assert_eq!(conservative.credits, 40);
+    assert!(
+        conservative.credits >= fast.credits * 10,
+        "if these ever converge, publishing the number stops earning its space"
+    );
+}
+
+/// The deferred routes are deliberately absent — they return a job id, not an artifact,
+/// so wiring them as if they were synchronous would mis-declare `Shape` and break the
+/// one thing this module refuses to sniff from a response.
+#[test]
+fn the_deferred_routes_are_not_in_the_sync_table() {
+    for absent in [
+        "upscale/creative",
+        "edit/replace-background-and-relight",
+        "audio/stable-audio-2/text-to-audio",
+        "3d/stable-fast-3d",
+    ] {
+        assert!(
+            op_by_name(absent).is_none(),
+            "{absent} is not synchronous or not storable yet; wiring it here would \
+             mis-declare its shape"
+        );
+    }
+}
+
+/// An unrecognized `op` refuses and names every one it accepts, rendered from the same
+/// table the parser reads — so the refusal cannot list something `op_by_name` rejects.
+#[test]
+fn an_unknown_operation_name_is_refused_with_the_wired_list() {
+    assert!(op_by_name("edit/inpaintt").is_none());
+    assert!(op_by_name("").is_none());
+}
+
+/// **The op guard is structural, like the inputs guard.** A provider with no operation
+/// vocabulary refuses a named op rather than running its default route and returning a
+/// text-to-image render for an inpaint request.
+#[test]
+fn a_provider_without_an_operation_vocabulary_refuses_a_named_op() {
+    let err = refuse_operation(&request_with_op("edit/inpaint"), "dashscope/wan2.2")
+        .expect_err("no vocabulary");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("edit/inpaint"),
+        "names the op asked for: {msg}"
+    );
+    assert!(msg.contains("dashscope/wan2.2"), "names the backend: {msg}");
+    assert!(msg.contains("nothing was generated"), "{msg}");
+}
+
+#[test]
+fn a_request_with_no_op_passes_the_guard() {
+    assert!(refuse_operation(&request_with(Vec::new()), "dashscope/wan2.2").is_ok());
+}
+
+/// And the arm enforces it at the single dispatch point, the same place the inputs guard
+/// lives — with the same pair of tests, so a guard that refused unconditionally would
+/// fail the second.
+#[tokio::test]
+async fn the_arm_refuses_a_named_op_for_a_provider_that_never_opted_in() {
+    let arm = MediaArm::new(std::sync::Arc::new(ForgetfulProvider), "fake/forgetful");
+    let err = arm
+        .generate(&request_with_op("edit/inpaint"))
+        .await
+        .expect_err("must refuse");
+    assert!(format!("{err:#}").contains("edit/inpaint"));
 }

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -20,8 +20,6 @@
 //! `resolve_inputs` take the caller's word for the extension and
 //! `the_store_names_the_parts_format_not_the_caller` fails.
 
-use std::collections::BTreeMap;
-
 use kaibo::cas::{Cas, Digest, Extension, MediaStore, Provenance};
 use kaibo::media::{
     refuse_binary_inputs, resolve_inputs, MediaArm, MediaInput, MediaJobId, MediaModel,
@@ -58,7 +56,7 @@ fn put(store: &MediaStore, bytes: &[u8], ext: Extension) -> String {
         .to_hex()
 }
 
-fn asked(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+fn asked(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
     pairs
         .iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -308,11 +306,22 @@ fn every_published_operation_name_resolves_to_its_own_route() {
 fn the_published_costs_span_the_range_that_makes_them_worth_publishing() {
     let fast = op_by_name("upscale/fast").expect("wired");
     let conservative = op_by_name("upscale/conservative").expect("wired");
-    assert_eq!(fast.credits, 2);
-    assert_eq!(conservative.credits, 40);
+    assert_eq!(fast.cost, "2 credits");
+    assert_eq!(conservative.cost, "40 credits");
+    // Costs are the provider's own words, so this reads the number back out rather than
+    // comparing integers kaibo does not keep. If a provider ever quotes a range or a
+    // formula instead of a flat figure, that is the provider's unit too and this test is
+    // the right place to notice.
+    let n = |s: &str| -> u32 {
+        s.split_whitespace()
+            .next()
+            .expect("a cost leads with its amount")
+            .parse()
+            .expect("Stability quotes flat integer credits today")
+    };
     assert!(
-        conservative.credits >= fast.credits * 10,
-        "if these ever converge, publishing the number stops earning its space"
+        n(conservative.cost) >= n(fast.cost) * 10,
+        "if these ever converge, publishing the figure stops earning its space"
     );
 }
 
@@ -406,4 +415,49 @@ fn the_inputs_list_carries_required_parts_only() {
         op_by_name("control/style-transfer").expect("wired").inputs,
         &["init_image", "style_image"],
     );
+}
+
+/// **A field name may repeat, which is why `inputs` is a list and not a map.**
+///
+/// Stability never needs this — every one of its form fields has a distinct name — so a
+/// map worked by luck of that shape. OpenAI's `/images/edits` takes "one or more source
+/// images" as repeated `image` parts, and a `BTreeMap<String, String>` cannot express
+/// two entries under one key: the second silently replaces the first, which is a
+/// dropped input wearing a success.
+///
+/// Caught by surveying the other providers' specs before the parameter shipped, not
+/// after. Pinned here so the shape cannot quietly revert to a map.
+#[test]
+fn two_parts_may_share_one_field_name() {
+    let (store, _d) = store();
+    let first = put(&store, b"\x89PNG\r\n\x1a\nfirst", Extension::Png);
+    let second = put(&store, b"\x89PNG\r\n\x1a\nsecond", Extension::Png);
+    assert_ne!(first, second, "the fixtures must be distinct objects");
+
+    let resolved = resolve_inputs(&store, &asked(&[("image", &first), ("image", &second)]))
+        .expect("a repeated field name resolves to two parts");
+
+    assert_eq!(
+        resolved.len(),
+        2,
+        "both parts survive; neither replaced the other"
+    );
+    assert_eq!(resolved[0].field, "image");
+    assert_eq!(resolved[1].field, "image");
+    assert_eq!(resolved[0].bytes, b"\x89PNG\r\n\x1a\nfirst");
+    assert_eq!(resolved[1].bytes, b"\x89PNG\r\n\x1a\nsecond");
+}
+
+/// And the order the caller gave is the order the provider receives — a provider may
+/// care which source image is first, and a map would have sorted them by key instead.
+#[test]
+fn the_callers_order_is_preserved() {
+    let (store, _d) = store();
+    let a = put(&store, b"\x89PNG\r\n\x1a\naaa", Extension::Png);
+    let b = put(&store, b"\x89PNG\r\n\x1a\nbbb", Extension::Png);
+    // Deliberately not alphabetical: a map keyed by field name would reorder these.
+    let resolved = resolve_inputs(&store, &asked(&[("style_image", &a), ("init_image", &b)]))
+        .expect("resolves");
+    assert_eq!(resolved[0].field, "style_image");
+    assert_eq!(resolved[1].field, "init_image");
 }

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -376,3 +376,34 @@ async fn the_arm_refuses_a_named_op_for_a_provider_that_never_opted_in() {
         .expect_err("must refuse");
     assert!(format!("{err:#}").contains("edit/inpaint"));
 }
+
+/// **`inputs` means required, not accepted** — pinned because getting it wrong is silent.
+///
+/// An earlier version of the table listed `mask` as an input of `edit/erase` and
+/// `edit/inpaint`. The spec's required list for both is `image` alone: a mask is
+/// optional, and the alpha channel of `image` is the documented alternative. Listing it
+/// under a field named for what a route *demands* told a caller to go find something it
+/// never needed — a wrong instruction, published to a model, that costs a round trip and
+/// no error to discover.
+///
+/// The table is checked mechanically against the live spec on edit (see
+/// `STABLE_IMAGE_OPS`'s doc). This is the in-tree half, for the regression that check
+/// would catch only if someone remembered to run it.
+#[test]
+fn the_inputs_list_carries_required_parts_only() {
+    for name in ["edit/erase", "edit/inpaint"] {
+        let spec = op_by_name(name).expect("wired");
+        assert_eq!(
+            spec.inputs,
+            &["image"],
+            "{name} requires `image` alone — a mask is optional, and an alpha channel on \
+             the image is the documented alternative"
+        );
+    }
+    // And a route that genuinely requires two still says so, so this test cannot pass by
+    // the list having been emptied.
+    assert_eq!(
+        op_by_name("control/style-transfer").expect("wired").inputs,
+        &["init_image", "style_image"],
+    );
+}

--- a/tests/openai_images_live.rs
+++ b/tests/openai_images_live.rs
@@ -40,6 +40,7 @@ async fn gpt_image_1_returns_real_png_bytes() {
     let request = MediaRequest {
         prompt: "a small lighthouse on a rocky cliff, watercolor".to_string(),
         inputs: Vec::new(),
+        op: None,
         // The cheapest hosted shape; output_format png is gpt-image-1's default,
         // stated explicitly so the mime derivation is exercised end to end.
         fields: vec![

--- a/tests/openai_images_transport.rs
+++ b/tests/openai_images_transport.rs
@@ -134,6 +134,7 @@ async fn dall_e_round_trip_sends_typed_body_and_collects_ordered_artifacts() {
                     ("size".to_string(), FieldValue::Str("1024x1024".to_string())),
                 ],
                 inputs: Vec::new(),
+                op: None,
             },
         )
         .await

--- a/tests/openai_images_transport.rs
+++ b/tests/openai_images_transport.rs
@@ -252,3 +252,197 @@ async fn provider_401_surfaces_readably_over_the_wire() {
         "the status and the provider's message both surface, got: {msg}"
     );
 }
+
+// --- The multipart routes (`edits`, `variations`) -------------------------------
+
+/// One captured request with its body left as raw bytes — the JSON-parsing capture
+/// above cannot read a multipart body, and the point of these tests is what the bytes
+/// on the wire actually are.
+struct CapturedRaw {
+    head: String,
+    body: Vec<u8>,
+}
+
+impl CapturedRaw {
+    fn request_line(&self) -> &str {
+        self.head.lines().next().unwrap_or("")
+    }
+    fn header(&self, name: &str) -> Option<String> {
+        let want = format!("{}:", name.to_ascii_lowercase());
+        self.head.lines().find_map(|line| {
+            line.to_ascii_lowercase()
+                .starts_with(&want)
+                .then(|| line[want.len()..].trim().to_string())
+        })
+    }
+    fn body_text(&self) -> String {
+        String::from_utf8_lossy(&self.body).to_string()
+    }
+}
+
+async fn one_shot_server_raw(
+    status: u16,
+    response_body: String,
+) -> (String, tokio::sync::oneshot::Receiver<CapturedRaw>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-request");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+        let content_length: usize = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse().unwrap())
+            })
+            .expect("reqwest declares Content-Length for an in-memory multipart form");
+        while buf.len() < head_end + content_length {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-body");
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body = buf[head_end..head_end + content_length].to_vec();
+        let response = format!(
+            "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\n\
+             content-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+            response_body.len(),
+        );
+        sock.write_all(response.as_bytes()).await.unwrap();
+        sock.shutdown().await.ok();
+        tx.send(CapturedRaw { head, body }).ok();
+    });
+    (format!("http://{addr}/v1"), rx)
+}
+
+fn png_part(field: &str, bytes: &[u8]) -> kaibo::media::MediaInput {
+    kaibo::media::MediaInput::new(field, kaibo::cas::Extension::Png, bytes.to_vec())
+}
+
+/// **`op: "edits"` dials the edits route over multipart with the image on the wire.**
+///
+/// The transport truth the table tests cannot see: a different URL, a different wire
+/// (multipart, not JSON), the input image present as a named file part with its mime,
+/// and the prompt still carried because this route documents one.
+#[tokio::test]
+async fn edits_posts_multipart_with_the_named_image_part() {
+    let img = b"\x89PNG\r\n\x1a\nthe-source-image";
+    let (base, rx) = one_shot_server_raw(
+        200,
+        format!(r#"{{"data":[{{"b64_json":"{}"}}]}}"#, b64(b"result")),
+    )
+    .await;
+    let client = OpenAiImagesClient::new("sk-test", &base, Duration::from_secs(5)).unwrap();
+    let artifacts = client
+        .generate(
+            "gpt-image-1",
+            &MediaRequest {
+                prompt: "put a hat on the cat".into(),
+                fields: vec![("n".into(), FieldValue::Num(1.into()))],
+                inputs: vec![png_part("image", img)],
+                op: Some("edits".into()),
+            },
+        )
+        .await
+        .expect("an edits call round-trips");
+    assert_eq!(artifacts.len(), 1);
+
+    let cap = rx.await.unwrap();
+    assert_eq!(cap.request_line(), "POST /v1/images/edits HTTP/1.1");
+    let ct = cap.header("content-type").expect("a content type");
+    assert!(
+        ct.starts_with("multipart/form-data"),
+        "edits carries files, so it is multipart, not JSON: {ct}"
+    );
+    let text = cap.body_text();
+    assert!(
+        text.contains(r#"name="image""#) && text.contains(r#"filename="image.png""#),
+        "the image rides as a named file part: {text:.400}"
+    );
+    assert!(text.contains("image/png"), "with its own content type");
+    assert!(
+        cap.body.windows(img.len()).any(|w| w == img),
+        "the actual image bytes reach the wire"
+    );
+    assert!(
+        text.contains("put a hat on the cat"),
+        "edits documents a prompt, so it is sent"
+    );
+}
+
+/// **`variations` sends no prompt**, because the route documents none — the same rule
+/// `upscale/fast` gets on Stability, driven by the same `takes_prompt` flag. A prompt
+/// sent to a route that never declared one is an undocumented field on an API that
+/// validates its own.
+#[tokio::test]
+async fn variations_omits_the_prompt_the_route_does_not_document() {
+    let (base, rx) = one_shot_server_raw(
+        200,
+        format!(r#"{{"data":[{{"b64_json":"{}"}}]}}"#, b64(b"result")),
+    )
+    .await;
+    let client = OpenAiImagesClient::new("sk-test", &base, Duration::from_secs(5)).unwrap();
+    client
+        .generate(
+            "dall-e-2",
+            &MediaRequest {
+                prompt: "IGNORE ME".into(),
+                fields: Vec::new(),
+                inputs: vec![png_part("image", b"\x89PNG\r\n\x1a\nsrc")],
+                op: Some("variations".into()),
+            },
+        )
+        .await
+        .expect("a variations call round-trips");
+
+    let cap = rx.await.unwrap();
+    assert_eq!(cap.request_line(), "POST /v1/images/variations HTTP/1.1");
+    let text = cap.body_text();
+    assert!(
+        !text.contains("IGNORE ME"),
+        "variations documents no prompt, so none is sent: {text:.400}"
+    );
+    assert!(
+        text.contains(r#"name="image""#),
+        "the source image is still sent"
+    );
+}
+
+/// An unknown `op` refuses before a socket is opened — no server is started here, and
+/// the test would hang rather than pass if the client dialled anyway.
+#[tokio::test]
+async fn an_unknown_images_op_refuses_without_dialling() {
+    let client =
+        OpenAiImagesClient::new("sk-test", "http://127.0.0.1:1/v1", Duration::from_secs(5))
+            .unwrap();
+    let err = client
+        .generate(
+            "gpt-image-1",
+            &MediaRequest {
+                prompt: "p".into(),
+                fields: Vec::new(),
+                inputs: Vec::new(),
+                op: Some("edit".into()),
+            },
+        )
+        .await
+        .expect_err("`edit` is not `edits`");
+    let msg = err.to_string();
+    assert!(msg.contains("edit"), "names what was asked: {msg}");
+    assert!(
+        msg.contains("edits") && msg.contains("variations"),
+        "lists the real ones: {msg}"
+    );
+}

--- a/tests/stability_live.rs
+++ b/tests/stability_live.rs
@@ -23,7 +23,7 @@ async fn generate_core_returns_a_real_png_with_a_seed() {
         .expect("client construction");
 
     let request = StabilityRequest {
-        prompt: "a small lighthouse on a rocky cliff, watercolor".to_string(),
+        prompt: Some("a small lighthouse on a rocky cliff, watercolor".to_string()),
         inputs: Vec::new(),
         aspect_ratio: Some("1:1".to_string()),
         fields: vec![("output_format".to_string(), "png".to_string())],


### PR DESCRIPTION
## What

Three wired Stability routes become **fifteen**. `generate` now reaches every synchronous `stable-image` route outside the generate family: six `edit`, four `control`, and the two sync `upscale` routes.

## Decisions

- **The operation is a property of the call, not the model slot.** A cast's `image` slot names one model and Stability has 25 operations behind it, so the route cannot come from the model id. `op` selects; the model id keeps its old job of choosing within the generate family.
- **A table, not twelve enum variants.** These routes differ only in a path segment, so `STABLE_IMAGE_OPS` is one source for the schema list, the parser, the refusal, and the costs — the same argument `artifact::FORMATS` and `upload::SIGNATURES` record.
- **Costs are published to the model.** One credit ≈ one US cent, and `upscale/conservative` is **20×** `generate/core`. A model that reads the price before choosing spends differently. A test pins the spread so a table edit that flattened it fails rather than quietly making the numbers not worth their space.
- **Two structural guards at the single dispatch point.** `accepts_ops` defaults false like `accepts_inputs`; an unwired `op` refuses inside `media_request` instead of falling through to the model's default route (which made `media_request` fallible, as it should have been).
- **`prompt` is not sent to routes that document none.** `edit/remove-background` and `upscale/fast` declare no `prompt` property. This resolves a note the code had deferred — "noted rather than solved speculatively" — which wiring these families made due.

Deliberately absent, each for a reason stated in the table's doc: `upscale/creative` and `edit/replace-background-and-relight` are **deferred**, so wiring them as sync would mis-declare `Shape` — the one thing this module refuses to sniff from a response. Audio and 3D need CAS extensions for `mp3`/`wav`/`glb` that don't exist yet.

## Two bugs I caught in my own work, both by mechanical checking

**`mask` was listed as required** on `edit/erase` and `edit/inpaint`. The spec requires `image` alone; a mask is optional and an alpha channel on the image is the documented alternative. Under a field named for what a route *demands*, that told a caller to go find something it never needed — a wrong instruction published to a model, producing no error to discover it by.

Caught by verifying all twelve rows against the live OpenAPI spec rather than by eye: path exists, a 2xx carries `image/*` (so `Shape::Sync` is a fact), `inputs` equals the spec's required-and-binary fields, `credits` matches the route's own section. **That check's first run parsed zero rows** (rustfmt had split the table) and reported "0 mismatches" — a clean result from a check that examined nothing. It now asserts it saw all twelve before concluding anything.

**A genuine spec contradiction, recorded rather than smoothed over:** `edit/erase` lists `prompt` as *required* while declaring no such property. `takes_prompt` stays `true` there — the required list is the half that produces a 400 if the server enforces it. **This wants a live probe to settle.**

## Review

kaibo, cast `crusoe` (GLM-5.2). It confirmed routing, `model`-field handling, both guards and the error strings, and found a doc bug I had published to models: the `op` doc listed `search_prompt`/`select_prompt` as `inputs` keys when they are text `fields`. A model following it would have put a prompt where a digest goes and been refused for a reason that was our fault.

**So a test now pins the doc to the table** — this was the second bug in two commits from prose describing a table by hand. schemars renders a doc comment, not a table, so the doc can't be generated; it can be checked. Verified against a sabotaged build: changing one published price to 41 fails it.

## Testing

18 tests in `tests/media_inputs.rs` plus stability-level routing tests. Verified against sabotaged builds three times: unknown-`op` fallthrough, removing the arm's op guard, and a stale published price each failed exactly their own test and no others.

Full suite green (1222 passing, exit 0), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)