### PR TITLE
feat(openai-images): edits and variations behind the same `op`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ record. Each later release appends a new section at the top.
 - **`kaibo cas write FILE`** stores an image from the command line and prints its
   digest — the CLI half of `write_cas`, so an operator can put an image in without an
   MCP client.
+- **`generate` reaches an OpenAI-compatible images backend's `edits` and `variations`
+  routes** through the same `op` parameter, over multipart where `generations` is JSON.
 - **`generate` reaches Stability's edit, control and upscale routes** through a new `op`
   parameter — twelve operations where three were wired.
 - **Each operation's cost is published on the `op` parameter** in the provider's own

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -185,6 +185,10 @@ pub enum OpenAiImagesError {
     /// build, before the call — any value, even a redundant `"b64_json"`, so the
     /// contract stays one-sided.
     CallerResponseFormat,
+    /// The caller named an `op` this client does not wire. Refused rather than run as a
+    /// plain generation: an edit request answered with a fresh unrelated image is a wrong
+    /// answer that looks like a right one, and the caller pays for it.
+    UnknownOperation { asked: String },
 }
 
 impl std::fmt::Display for OpenAiImagesError {
@@ -243,6 +247,13 @@ impl std::fmt::Display for OpenAiImagesError {
                  as base64 (`url` would spend credits on artifacts kaibo refuses to \
                  fetch), and kaibo already sends the right value per model family. \
                  Omit the field"
+            ),
+            OpenAiImagesError::UnknownOperation { asked } => write!(
+                f,
+                "`op` {asked:?} is not an operation kaibo wires for the Images API, so \
+                 nothing was generated. Pass one of: {}. Omit `op` entirely to generate \
+                 from the prompt alone.",
+                images_op_names().join(", ")
             ),
         }
     }
@@ -405,6 +416,110 @@ pub fn parse_response(
 /// An Images API connection: the `reqwest::Client` (ring-installed —
 /// [`crate::tls::https_client`] is the one build site in this codebase), the
 /// resolved key, and the base URL (a root through `/v1`; this client appends
+/// Turn the JSON body plus the request's input parts into a multipart form.
+///
+/// The scalars ride as text parts under the same names the JSON body uses — OpenAI
+/// documents the multipart form as the same field set — so one `build_request_body`
+/// serves both wires and the two cannot drift on what a knob is called. `prompt` is
+/// dropped for a route that documents none (`variations`), the same rule Stability's
+/// table drives.
+fn multipart_body(
+    body: &Value,
+    request: &MediaRequest,
+    op: &ImagesOp,
+) -> Result<reqwest::multipart::Form, OpenAiImagesError> {
+    let mut form = reqwest::multipart::Form::new();
+    if let Some(map) = body.as_object() {
+        for (k, v) in map {
+            if k == "prompt" && !op.takes_prompt {
+                continue;
+            }
+            let text = match v {
+                Value::String(s) => s.clone(),
+                Value::Null => continue,
+                other => other.to_string(),
+            };
+            form = form.text(k.clone(), text);
+        }
+    }
+    for input in &request.inputs {
+        form = form.part(
+            input.field.clone(),
+            reqwest::multipart::Part::bytes(input.bytes.clone())
+                .file_name(input.filename.clone())
+                .mime_str(&input.mime)
+                .map_err(|e| {
+                    OpenAiImagesError::Transport(format!(
+                        "input part `{}` has mime {:?}, which is not a valid content \
+                         type: {e}",
+                        input.field, input.mime
+                    ))
+                })?,
+        );
+    }
+    Ok(form)
+}
+
+/// One Images API route this client can address, beyond the default `generations`.
+///
+/// The same shape `stability::OpSpec` carries, for the same reason — one source for the
+/// parser, the refusal and the published cost — and deliberately *not* a shared type.
+/// These two providers agree on the idea of a named operation and on nothing else: the
+/// path is a different URL suffix, one wire is JSON and the other multipart, and the
+/// cost is a different unit. A common struct here would be three fields of coincidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImagesOp {
+    /// What a caller passes as `op`.
+    pub name: &'static str,
+    /// The path appended to the base URL.
+    pub path: &'static str,
+    /// Required binary parts, by form-field name.
+    pub inputs: &'static [&'static str],
+    /// Whether this route documents a `prompt`.
+    pub takes_prompt: bool,
+    /// What it costs, in the provider's own words — see `stability::OpSpec::cost` for
+    /// why kaibo quotes rather than converts. OpenAI publishes no flat per-call figure
+    /// for these; the price depends on the model, the size and the quality, so that is
+    /// what kaibo says rather than inventing a number.
+    pub cost: &'static str,
+}
+
+/// The Images API routes that take an input image, confirmed against
+/// `openai/openai-openapi`'s `openapi.yaml` (2026-08-22).
+///
+/// `generations` is absent on purpose: it is what a call with no `op` already does, and
+/// listing it would offer two spellings for one thing.
+pub const IMAGES_OPS: &[ImagesOp] = &[
+    ImagesOp {
+        name: "edits",
+        path: "/images/edits",
+        inputs: &["image"],
+        takes_prompt: true,
+        cost: "priced per image by model, size and quality",
+    },
+    ImagesOp {
+        name: "variations",
+        path: "/images/variations",
+        inputs: &["image"],
+        // The spec's required list is `image` alone — no `prompt` property at all. The
+        // same prompt-less shape `upscale/fast` has on Stability, which is the first
+        // evidence that flag was worth having rather than a Stability quirk.
+        takes_prompt: false,
+        cost: "priced per image by model and size",
+    },
+];
+
+/// Look up one Images operation by the name a caller passed.
+pub fn images_op_by_name(name: &str) -> Option<&'static ImagesOp> {
+    IMAGES_OPS.iter().find(|o| o.name == name)
+}
+
+/// Every operation name a caller may pass, rendered from the table so a refusal cannot
+/// list something [`images_op_by_name`] rejects.
+pub fn images_op_names() -> Vec<&'static str> {
+    IMAGES_OPS.iter().map(|o| o.name).collect()
+}
+
 /// `/images/generations`).
 #[derive(Clone)]
 pub struct OpenAiImagesClient {
@@ -437,13 +552,32 @@ impl OpenAiImagesClient {
         model: &str,
         request: &MediaRequest,
     ) -> Result<Vec<MediaArtifact>, OpenAiImagesError> {
+        // Two wires on one API, chosen by the route rather than sniffed: `generations`
+        // is JSON, `edits` and `variations` are multipart because they carry files.
+        // Whichever wire it is, `parse_response` sees the same `{data:[{b64_json}]}`.
+        let op = match request.op.as_deref() {
+            None => None,
+            Some(name) => Some(images_op_by_name(name).ok_or_else(|| {
+                OpenAiImagesError::UnknownOperation {
+                    asked: name.to_string(),
+                }
+            })?),
+        };
         let (body, format) = build_request_body(model, request)?;
-        let url = format!("{}/images/generations", self.base_url.trim_end_matches('/'));
-        let resp = self
-            .http
-            .post(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.api_key))
-            .json(&body)
+        let base = self.base_url.trim_end_matches('/');
+        let mut req = self.http.post(match op {
+            Some(o) => format!("{base}{}", o.path),
+            None => format!("{base}/images/generations"),
+        });
+        req = req.header(AUTHORIZATION, format!("Bearer {}", self.api_key));
+        req = match op {
+            // The JSON body's scalars become text parts; the input images become file
+            // parts under the caller's own field names, so an operation taking several
+            // images under one name sends several parts under that name.
+            Some(o) => req.multipart(multipart_body(&body, request, o)?),
+            None => req.json(&body),
+        };
+        let resp = req
             .send()
             .await
             .map_err(|e| OpenAiImagesError::Transport(e.to_string()))?;
@@ -481,6 +615,17 @@ impl OpenAiImagesModel {
 impl crate::media::MediaModel for OpenAiImagesModel {
     /// Always resolves to [`MediaOutcome::Complete`] — the Images API is
     /// synchronous, and `n` makes a multi-artifact list the normal shape.
+    /// The Images API takes an input image on `edits` and `variations`.
+    fn accepts_inputs(&self) -> bool {
+        true
+    }
+
+    /// Three routes behind one model id — `generations` (the default), `edits` and
+    /// `variations`.
+    fn accepts_ops(&self) -> bool {
+        true
+    }
+
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
         let artifacts = self.client.generate(&self.model, request).await?;
         Ok(MediaOutcome::Complete(artifacts))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -768,7 +768,7 @@ pub struct GenerateInput {
     /// through unconverted — work out what that means in money yourself if you need to,
     /// and note the spread: `upscale/conservative` costs twenty times `generate/core`.
     ///
-    /// `edit/erase` 5 credits (image), `edit/inpaint` 5 credits (image),
+    /// **Stability:** `edit/erase` 5 credits (image), `edit/inpaint` 5 credits (image),
     /// `edit/outpaint` 4 credits (image), `edit/search-and-replace` 5 credits (image),
     /// `edit/search-and-recolor` 5 credits (image), `edit/remove-background` 5 credits
     /// (image), `control/sketch` 5 credits (image), `control/structure` 5 credits
@@ -776,11 +776,16 @@ pub struct GenerateInput {
     /// (init_image, style_image), `upscale/fast` 2 credits (image),
     /// `upscale/conservative` 40 credits (image).
     ///
+    /// **An OpenAI-compatible images backend:** `edits` priced per image by model, size
+    /// and quality (image; up to 16 `image` entries), `variations` priced per image by
+    /// model and size (image; takes no prompt).
+    ///
     /// `edit/erase` and `edit/inpaint` also take an optional `mask` in `inputs`, or an
     /// alpha channel on the image instead. Text knobs ride `fields`, not `inputs`:
     /// `edit/search-and-replace` needs `search_prompt` there, `edit/search-and-recolor`
-    /// needs `select_prompt`. `prompt` is ignored on `edit/remove-background` and
-    /// `upscale/fast`, which document none.
+    /// needs `select_prompt`. `prompt` is ignored on any route that documents none —
+    /// Stability's `edit/remove-background` and `upscale/fast`, and the Images API's
+    /// `variations`.
     #[serde(default)]
     pub op: Option<String>,
 }
@@ -6709,21 +6714,39 @@ enabled = false
             .nth(1)
             .expect("the schema carries the op property")
             // Backticks are markdown for the reader, noise for a match — the doc writes
-            // "`edit/erase` 5 (image)" and the fact being pinned is "edit/erase 5".
+            // "`edit/erase` 5 credits" and the fact being pinned is "edit/erase 5
+            // credits". Whitespace is collapsed for the same reason: a doc comment wraps
+            // where the line ends, so "size\nand quality" and "size and quality" are the
+            // same sentence and only one of them is what the author wrote.
             .replace('`', "");
+        // The doc arrives JSON-escaped, so a line break is the two characters `\` and
+        // `n`, which no whitespace routine can see. Unescape first, then collapse.
+        let doc: String = doc
+            .replace("\\n", " ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
 
-        for spec in crate::stability::STABLE_IMAGE_OPS {
+        // Both provider tables: the doc is one parameter and has to describe every
+        // operation a caller may pass, whichever backend staffs the slot.
+        let wired: Vec<(&str, &str)> = crate::stability::STABLE_IMAGE_OPS
+            .iter()
+            .map(|o| (o.name, o.cost))
+            .chain(
+                crate::openai_images::IMAGES_OPS
+                    .iter()
+                    .map(|o| (o.name, o.cost)),
+            )
+            .collect();
+        for (name, cost) in wired {
             assert!(
-                doc.contains(spec.name),
-                "the `op` doc must name {}, or a caller cannot discover it",
-                spec.name
+                doc.contains(name),
+                "the `op` doc must name {name}, or a caller cannot discover it"
             );
             assert!(
-                doc.contains(&format!("{} {}", spec.name, spec.cost)),
-                "the `op` doc must carry {}'s cost as {:?} — a stale price is worse than \
-                 none, because it is trusted",
-                spec.name,
-                spec.cost
+                doc.contains(&format!("{name} {cost}")),
+                "the `op` doc must carry {name}'s cost as {cost:?} — a stale price is \
+                 worse than none, because it is trusted"
             );
         }
         // And nothing the table does not wire: a doc naming a route that refuses is a

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -461,3 +461,64 @@ fn the_callers_order_is_preserved() {
     assert_eq!(resolved[0].field, "style_image");
     assert_eq!(resolved[1].field, "init_image");
 }
+
+// --- OpenAI Images operations --------------------------------------------------
+
+use kaibo::openai_images::{images_op_by_name, images_op_names, IMAGES_OPS};
+
+/// **`op` generalizes off Stability.** The mechanism is shared; only the table is
+/// per-provider. This is the evidence for that claim rather than the assertion of it.
+#[test]
+fn the_images_api_has_its_own_operation_table_on_the_same_mechanism() {
+    assert_eq!(images_op_names(), vec!["edits", "variations"]);
+    for op in IMAGES_OPS {
+        assert_eq!(images_op_by_name(op.name).expect("resolves").path, op.path);
+        assert!(
+            op.path.starts_with("/images/"),
+            "{} must be a route under the Images API, got {}",
+            op.name,
+            op.path
+        );
+    }
+}
+
+/// `generations` is deliberately not a name a caller can pass: it is what a call with no
+/// `op` already does, and two spellings for one thing is a trap rather than a
+/// convenience.
+#[test]
+fn the_default_route_is_not_also_an_op_name() {
+    assert!(images_op_by_name("generations").is_none());
+}
+
+/// **`variations` documents no prompt** — the spec's required list is `image` alone.
+/// That is the same prompt-less shape `upscale/fast` has on Stability, on a different
+/// provider, which is what makes `takes_prompt` a real property rather than a quirk of
+/// one API.
+#[test]
+fn variations_takes_no_prompt_the_way_upscale_fast_does_not() {
+    assert!(!images_op_by_name("variations").expect("wired").takes_prompt);
+    assert!(images_op_by_name("edits").expect("wired").takes_prompt);
+    // The cross-provider half of the claim.
+    assert!(!op_by_name("upscale/fast").expect("wired").takes_prompt);
+}
+
+/// Costs are the provider's own words. OpenAI publishes no flat per-call figure for
+/// these — the price depends on model, size and quality — so kaibo says that rather
+/// than inventing a number it would then have to chase.
+#[test]
+fn the_images_costs_quote_the_provider_rather_than_a_figure() {
+    for op in IMAGES_OPS {
+        assert!(
+            op.cost.contains("priced per image"),
+            "{} should quote how the provider prices it, got {:?}",
+            op.name,
+            op.cost
+        );
+        assert!(
+            !op.cost.chars().any(|c| c.is_ascii_digit()),
+            "{} invents a figure kaibo would have to keep current: {:?}",
+            op.name,
+            op.cost
+        );
+    }
+}

--- a/tests/openai_images_transport.rs
+++ b/tests/openai_images_transport.rs
@@ -252,3 +252,197 @@ async fn provider_401_surfaces_readably_over_the_wire() {
         "the status and the provider's message both surface, got: {msg}"
     );
 }
+
+// --- The multipart routes (`edits`, `variations`) -------------------------------
+
+/// One captured request with its body left as raw bytes — the JSON-parsing capture
+/// above cannot read a multipart body, and the point of these tests is what the bytes
+/// on the wire actually are.
+struct CapturedRaw {
+    head: String,
+    body: Vec<u8>,
+}
+
+impl CapturedRaw {
+    fn request_line(&self) -> &str {
+        self.head.lines().next().unwrap_or("")
+    }
+    fn header(&self, name: &str) -> Option<String> {
+        let want = format!("{}:", name.to_ascii_lowercase());
+        self.head.lines().find_map(|line| {
+            line.to_ascii_lowercase()
+                .starts_with(&want)
+                .then(|| line[want.len()..].trim().to_string())
+        })
+    }
+    fn body_text(&self) -> String {
+        String::from_utf8_lossy(&self.body).to_string()
+    }
+}
+
+async fn one_shot_server_raw(
+    status: u16,
+    response_body: String,
+) -> (String, tokio::sync::oneshot::Receiver<CapturedRaw>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-request");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+        let content_length: usize = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse().unwrap())
+            })
+            .expect("reqwest declares Content-Length for an in-memory multipart form");
+        while buf.len() < head_end + content_length {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-body");
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body = buf[head_end..head_end + content_length].to_vec();
+        let response = format!(
+            "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\n\
+             content-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+            response_body.len(),
+        );
+        sock.write_all(response.as_bytes()).await.unwrap();
+        sock.shutdown().await.ok();
+        tx.send(CapturedRaw { head, body }).ok();
+    });
+    (format!("http://{addr}/v1"), rx)
+}
+
+fn png_part(field: &str, bytes: &[u8]) -> kaibo::media::MediaInput {
+    kaibo::media::MediaInput::new(field, kaibo::cas::Extension::Png, bytes.to_vec())
+}
+
+/// **`op: "edits"` dials the edits route over multipart with the image on the wire.**
+///
+/// The transport truth the table tests cannot see: a different URL, a different wire
+/// (multipart, not JSON), the input image present as a named file part with its mime,
+/// and the prompt still carried because this route documents one.
+#[tokio::test]
+async fn edits_posts_multipart_with_the_named_image_part() {
+    let img = b"\x89PNG\r\n\x1a\nthe-source-image";
+    let (base, rx) = one_shot_server_raw(
+        200,
+        format!(r#"{{"data":[{{"b64_json":"{}"}}]}}"#, b64(b"result")),
+    )
+    .await;
+    let client = OpenAiImagesClient::new("sk-test", &base, Duration::from_secs(5)).unwrap();
+    let artifacts = client
+        .generate(
+            "gpt-image-1",
+            &MediaRequest {
+                prompt: "put a hat on the cat".into(),
+                fields: vec![("n".into(), FieldValue::Num(1.into()))],
+                inputs: vec![png_part("image", img)],
+                op: Some("edits".into()),
+            },
+        )
+        .await
+        .expect("an edits call round-trips");
+    assert_eq!(artifacts.len(), 1);
+
+    let cap = rx.await.unwrap();
+    assert_eq!(cap.request_line(), "POST /v1/images/edits HTTP/1.1");
+    let ct = cap.header("content-type").expect("a content type");
+    assert!(
+        ct.starts_with("multipart/form-data"),
+        "edits carries files, so it is multipart, not JSON: {ct}"
+    );
+    let text = cap.body_text();
+    assert!(
+        text.contains(r#"name="image""#) && text.contains(r#"filename="image.png""#),
+        "the image rides as a named file part: {text:.400}"
+    );
+    assert!(text.contains("image/png"), "with its own content type");
+    assert!(
+        cap.body.windows(img.len()).any(|w| w == img),
+        "the actual image bytes reach the wire"
+    );
+    assert!(
+        text.contains("put a hat on the cat"),
+        "edits documents a prompt, so it is sent"
+    );
+}
+
+/// **`variations` sends no prompt**, because the route documents none — the same rule
+/// `upscale/fast` gets on Stability, driven by the same `takes_prompt` flag. A prompt
+/// sent to a route that never declared one is an undocumented field on an API that
+/// validates its own.
+#[tokio::test]
+async fn variations_omits_the_prompt_the_route_does_not_document() {
+    let (base, rx) = one_shot_server_raw(
+        200,
+        format!(r#"{{"data":[{{"b64_json":"{}"}}]}}"#, b64(b"result")),
+    )
+    .await;
+    let client = OpenAiImagesClient::new("sk-test", &base, Duration::from_secs(5)).unwrap();
+    client
+        .generate(
+            "dall-e-2",
+            &MediaRequest {
+                prompt: "IGNORE ME".into(),
+                fields: Vec::new(),
+                inputs: vec![png_part("image", b"\x89PNG\r\n\x1a\nsrc")],
+                op: Some("variations".into()),
+            },
+        )
+        .await
+        .expect("a variations call round-trips");
+
+    let cap = rx.await.unwrap();
+    assert_eq!(cap.request_line(), "POST /v1/images/variations HTTP/1.1");
+    let text = cap.body_text();
+    assert!(
+        !text.contains("IGNORE ME"),
+        "variations documents no prompt, so none is sent: {text:.400}"
+    );
+    assert!(
+        text.contains(r#"name="image""#),
+        "the source image is still sent"
+    );
+}
+
+/// An unknown `op` refuses before a socket is opened — no server is started here, and
+/// the test would hang rather than pass if the client dialled anyway.
+#[tokio::test]
+async fn an_unknown_images_op_refuses_without_dialling() {
+    let client =
+        OpenAiImagesClient::new("sk-test", "http://127.0.0.1:1/v1", Duration::from_secs(5))
+            .unwrap();
+    let err = client
+        .generate(
+            "gpt-image-1",
+            &MediaRequest {
+                prompt: "p".into(),
+                fields: Vec::new(),
+                inputs: Vec::new(),
+                op: Some("edit".into()),
+            },
+        )
+        .await
+        .expect_err("`edit` is not `edits`");
+    let msg = err.to_string();
+    assert!(msg.contains("edit"), "names what was asked: {msg}");
+    assert!(
+        msg.contains("edits") && msg.contains("variations"),
+        "lists the real ones: {msg}"
+    );
+}


### PR DESCRIPTION
Stacked on #166 (base `feat/media-ops`) — merge that first.

## What

OpenAI's `/images/edits` and `/images/variations` reach `generate` through the **same `op` parameter** Stability uses. This is the test of whether `op` is a kaibo mechanism or a Stability one.

**It's a kaibo mechanism.** A second provider's operation table, and nothing about the seam changed.

## Three things the spec said, that shaped the work

Confirmed against `openai/openai-openapi`'s `openapi.yaml`, not memory:

- **`edits` takes up to 16 images under one `image` field.** That's the concrete case the `inputs` list change was made for one commit earlier, on the strength of the survey. A map would have silently kept the last one — this is the thing that would have shipped.
- **`variations` documents no `prompt` at all** (required is `image` alone). That's the same prompt-less shape `upscale/fast` has on Stability, on a *different provider* — which is what turns `takes_prompt` from a Stability quirk into a real property.
- **Two wires on one API.** `generations` is JSON; `edits`/`variations` are multipart because they carry files. Chosen by the route rather than sniffed, and both share `build_request_body` so they can't drift on what a knob is called.

## Deliberate non-abstraction

`ImagesOp` is **not** a shared type with `stability::OpSpec`. These providers agree on the idea of a named operation and on nothing else — different path shape, different wire, different cost unit. A common struct would be three fields of coincidence.

## Costs

Per Amy's ruling, kaibo quotes the provider rather than converting. OpenAI publishes no flat per-call figure here, so the cost reads "priced per image by model, size and quality". **A test asserts these costs carry no digits at all**, so a future well-meaning edit can't quietly turn a quote into a stale figure.

The `op` doc now covers both providers and the drift test walks both tables — one parameter has to describe every operation a caller may pass, whichever backend staffs the slot.

## Testing

Three transport tests over a real socket, offline: `edits` dials `/images/edits` as multipart with the image bytes present as a named part carrying its mime; `variations` omits the prompt the route doesn't document; an unknown `op` refuses **without dialling** (the test would hang rather than pass if it did).

Negative-controlled the drift test against both tables. Worth noting the first OpenAI probe *passed* — because my `sed` hadn't matched, not because the test was weak. Re-ran it with a sabotage that actually landed, and it failed correctly. A probe that doesn't modify its subject proves nothing.

Full suite green (1231 passing, exit 0), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)