### PR TITLE
feat(gemini): image generation through `generate`, like every other backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **A `gemini-images` backend kind** — Gemini image generation through `generate`, the
+  same face as every other image backend. Takes input images; has no named operations.
+- **`generate` shows what the model said** above the digests, for a backend whose image
+  generation is a conversation and answers with words as well as bytes.
+
 - **`kaibo cas write FILE`** stores an image from the command line and prints its
   digest — the CLI half of `write_cas`, so an operator can put an image in without an
   MCP client.

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ config has three concepts for configuring models:
 
 - **backend** — a *connection*: which wire protocol (the completion kinds `anthropic`
   | `deepseek` | `gemini` | `openrouter` | `openai`, or the media kinds `stability` |
-  `openai-images` | `dashscope` behind the `image` role), base URL, and where its key
+  `openai-images` | `gemini-images` | `dashscope` behind the `image` role), base URL, and where its key
   comes from.
   Secrets never live in the TOML — only the *name* of an env var or the path to a key
   file. `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -395,7 +395,7 @@ scratch_limit_bytes = 67108864
 # ---------------------------------------------------------------------------
 # [backends.<name>] — CONNECTIONS only: `kind` picks the wire and its client. The
 # completion wires (anthropic | deepseek | gemini | openrouter | openai) serve the
-# reasoning slots; the media kinds (stability | openai-images | dashscope) serve `image` slots
+# reasoning slots; the media kinds (stability | openai-images | gemini-images | dashscope) serve `image` slots
 # only. The rest describes the wire (endpoint, key source, per-request deadline).
 # Models live on cast slots, never here.
 #
@@ -405,7 +405,8 @@ scratch_limit_bytes = 67108864
 # (required for a new backend), the anthropic and gemini kinds (optional —
 # unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com),
 # and the media kinds (optional — unset dials api.stability.ai for stability,
-# api.openai.com/v1 for openai-images, dashscope-intl.aliyuncs.com for dashscope);
+# api.openai.com/v1 for openai-images, generativelanguage.googleapis.com for
+# gemini-images, dashscope-intl.aliyuncs.com for dashscope);
 # set it to point the same wire at a
 # compatible gateway/proxy (or a local server) instead — a ROOT in every case,
 # since the client appends its own path. Every other keyed kind rejects
@@ -521,7 +522,7 @@ wire = "responses"
 # `deep-dive`) so it can route by name without reading this file.
 #
 # Roles: explorer, synth (the reasoning phases), and image (the media member — it
-# points at a media backend, kind stability, openai-images, or dashscope, and staffs `generate`;
+# points at a media backend, kind stability, openai-images, gemini-images, or dashscope, and staffs `generate`;
 # see the image-slot examples below). A typo'd role is a loud load
 # error. A cast may omit roles — the tool that needs a missing role fails at call time,
 # naming the gap ("cast `notes` has no synth slot"); absent = capability absent.
@@ -574,7 +575,7 @@ explorer = "llama/qwen2.5-coder-7b"                              # bare ref: jus
 synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 # --- The `image` slot: a MEDIA member on the team. It points at a media backend
-#     (kind = "stability", "openai-images", or "dashscope") and produces artifacts instead of
+#     (kind = "stability", "openai-images", "gemini-images", or "dashscope") and produces artifacts instead of
 #     text, so the reasoning tunables (effort, thinking_budget, temperature, ...)
 #     do not apply to it — writing one there is inert and kaibo://config flags it.
 #     A cast carries it beside its reasoning slots; a cast without one cannot staff
@@ -612,6 +613,19 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 # [casts.local-artist]
 # image = "sdcpp/sd3.5-large"             # whatever the local server loaded
+
+# --- The gemini-images kind is the odd one: Gemini has no images endpoint. Image
+# generation is models/{model}:generateContent — the same call as text — with
+# responseModalities naming what comes back. It is a separate kind from `gemini` so a
+# cast slot knows which use it points at; a reasoning slot aimed here would resolve a
+# completion model that answers in pictures. Same key as `gemini`.
+# [backends.gemini-images]
+# kind = "gemini-images"          # key: GEMINI_API_KEY / ~/.gemini-api-key
+# # base_url defaults to https://generativelanguage.googleapis.com
+#
+# It takes input images (an edit is an instruction plus the picture it refers to) and
+# has no named operations, so `generate`'s `op` parameter is refused on it. It answers
+# with words as well as bytes; kaibo shows what the model said above the digests.
 
 # --- The dashscope kind reaches Alibaba's wan image family. base_url is optional
 #     (unset dials dashscope-intl.aliyuncs.com); a dedicated-endpoint subscription

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,7 +20,7 @@ of backends and casts. A missing file at the default path is not an error.
 
 ```
 ProviderKind = anthropic | deepseek | gemini | openrouter | openai   (completion wires)
-             | stability | openai-images | dashscope                 (media kinds)
+             | stability | openai-images | gemini-images | dashscope (media kinds)
 Backend      = { name, kind, base_url?, key source, request_timeout }
 Cast         = { name, role → ModelSlot }                  (freely spans backends)
 ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
@@ -32,12 +32,12 @@ Each concept owns one idea:
   selects the client and the request shape), `base_url`, a key source, and
   `request_timeout`. Answers "how do I reach Gemini". Kinds divide into two classes:
   the completion wires (everything through rig's completion clients) and the media
-  kinds (`stability`, `openai-images`, `dashscope` — image-generation APIs with no
+  kinds (`stability`, `openai-images`, `gemini-images`, `dashscope` — image-generation APIs with no
   completion surface).
 - **role** — a *job* a model serves. Three exist: `explorer` and `synth`, the two
   reasoning phases, and `image`, the media member that staffs the `generate` tool.
   A reasoning role takes a completion backend; the `image` role takes a media backend
-  (kind `stability`, `openai-images`, or `dashscope`) — pairing either with the wrong class is a
+  (kind `stability`, `openai-images`, `gemini-images`, or `dashscope`) — pairing either with the wrong class is a
   load error naming the fix. Image *input* is a slot capability (the `vision` pin on
   a reasoning slot), not a role.
 - **cast** — a *composition*. A named assignment of models to roles. This is what the
@@ -54,7 +54,7 @@ Connection settings only. Models are never declared here.
 
 | key | type | default | notes |
 |---|---|---|---|
-| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` \| `dashscope` | required on a new backend | closed enum; selects client + request shape (`stability`, `openai-images`, and `dashscope` are the media kinds — image slots only) |
+| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` \| `gemini-images` \| `dashscope` | required on a new backend | closed enum; selects client + request shape (`stability`, `openai-images`, `gemini-images`, and `dashscope` are the media kinds — image slots only) |
 | `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini` and the media kinds; load error elsewhere |
 | `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
 | `api_key_env` | env var *name* | seeded from `kind` | env source, checked first |
@@ -83,6 +83,13 @@ by re-declaration.
 - **`kind = "stability"`** — optional, same contract: unset dials
   `https://api.stability.ai`; set, it points the media wire at a compatible
   gateway or proxy.
+- **`kind = "gemini-images"`** — optional. Unset dials
+  `https://generativelanguage.googleapis.com`. Gemini has no images endpoint: image
+  generation is `models/{model}:generateContent`, the same call as text, with the
+  requested modalities naming what comes back — which is why this is a separate kind
+  from `gemini`, so a cast slot knows which use it points at. Same key as `gemini`
+  (`GEMINI_API_KEY` / `~/.gemini-api-key`). It takes input images and has no named
+  operations, so `generate`'s `op` is refused on it.
 - **`kind = "openai-images"`** — optional. Unset dials hosted OpenAI
   (`https://api.openai.com/v1`). Set, it points the same wire at any server speaking
   `/v1/images/generations` — a local stable-diffusion.cpp `sd-server`
@@ -112,7 +119,8 @@ The value is a root the client versions itself, never a full endpoint path. rig'
 `ClientBuilder` appends the provider-specific path (Gemini's `/v1beta/models/...`),
 the batch lane's `GeminiBatch` versions a configured host root with `/v1beta` the
 same way, and the media clients append their own route (`/v2beta/...` for
-`stability`; `/images/generations` for `openai-images`, so give that one a URL
+`stability`; `/v1beta/models/{model}:generateContent` for `gemini-images`;
+`/images/generations` for `openai-images`, so give that one a URL
 through `/v1`; the multimodal-generation route for `dashscope`, so give that one a
 bare host).
 
@@ -227,7 +235,7 @@ synth    = "claude/claude-sonnet-4-6"       # the model that answers
 per-slot key, is a load error rather than a silent no-op. The `image` slot is the
 media member: it points at a media-kind backend and staffs the `generate` tool. Its
 model id means what that kind says it means — for `stability` it picks the route
-(`core`, `ultra`, or an SD3.5 variant); for `openai-images` it is the `model` field
+(`core`, `ultra`, or an SD3.5 variant); for `gemini-images` it is the model in the request path; for `openai-images` it is the `model` field
 (`gpt-image-1` hosted, or whatever a local sd-server loaded); for `dashscope` it is
 the `model` field too (`wan2.6-t2i`). It sends one
 generation request, not a reasoning loop, so the reasoning tunables (`effort`,
@@ -681,7 +689,7 @@ Which cast shape staffs which tool:
 | `explore` | a cast with an `explorer` slot |
 | `batch_submit` | a cast whose synth runs on `lane = "batch"` (or the `batch = true` sugar) |
 | `deliberate` | a cast with an `explorer` **and** an offline synth (`lane = "batch"` or `lane = "direct"`) |
-| `generate` | a cast with an `image` slot (a media backend: kind `stability`, `openai-images`, or `dashscope`) — plus `[cas]` on |
+| `generate` | a cast with an `image` slot (a media backend: kind `stability`, `openai-images`, `gemini-images`, or `dashscope`) — plus `[cas]` on |
 | `job_get`, `job_cancel`, `job_list`, `job_wait` | at least one live handle *producer*; they follow whatever survives above |
 | `run_kaish`, `list_models` | no cast at all; advertised whenever their flag is on |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2104,7 +2104,16 @@ async fn generate_inner(
     // the call deadline, then says plainly that kaibo stopped watching while the provider
     // may not have stopped working.
     let artifacts = match outcome {
-        crate::media::MediaOutcome::Complete { artifacts, .. } => artifacts,
+        crate::media::MediaOutcome::Complete { artifacts, note } => {
+            // The model's own account of what it did, for a backend whose image
+            // generation is a conversation. To stderr, because stdout is the payload —
+            // and shown rather than dropped, for the same reason the MCP tool shows it:
+            // it is often the only explanation of what came back.
+            if let Some(note) = note.as_deref().map(str::trim).filter(|n| !n.is_empty()) {
+                eprintln!("kaibo: {note}");
+            }
+            artifacts
+        }
         crate::media::MediaOutcome::Deferred(job) => {
             eprintln!(
                 "kaibo: the provider is rendering in the background — this process waits \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2104,7 +2104,7 @@ async fn generate_inner(
     // the call deadline, then says plainly that kaibo stopped watching while the provider
     // may not have stopped working.
     let artifacts = match outcome {
-        crate::media::MediaOutcome::Complete(artifacts) => artifacts,
+        crate::media::MediaOutcome::Complete { artifacts, .. } => artifacts,
         crate::media::MediaOutcome::Deferred(job) => {
             eprintln!(
                 "kaibo: the provider is rendering in the background — this process waits \

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -72,6 +72,17 @@ pub enum ProviderKind {
     /// `key_optional = true` beside its explicit local `base_url`. Like Stability,
     /// it is not in the built-in backend list and staffs only `image` cast slots.
     OpenAiImages,
+    /// Gemini's image generation — the third media kind, via `src/gemini_images.rs`.
+    ///
+    /// A *separate kind* from [`ProviderKind::Gemini`] for the same reason
+    /// [`ProviderKind::OpenAiImages`] is separate from [`ProviderKind::Openai`]: one
+    /// vendor, two APIs, and a cast slot has to know which one it is pointing at. The
+    /// twist here is that Gemini's image generation is not a distinct *endpoint* — it is
+    /// `models/{model}:generateContent`, the same call as text, with
+    /// `responseModalities` naming what comes back. So this kind is a media kind whose
+    /// wire is a completion wire, which is exactly why it needs its own name: a reasoning
+    /// slot pointed here would resolve a completion model that answers in pictures.
+    GeminiImages,
     /// Alibaba's DashScope multimodal-generation route — the third media kind, via
     /// `src/dashscope.rs`, covering the `wan` image family. Media-only on purpose:
     /// the same host serves text through an OpenAI-compatible endpoint, so a text
@@ -91,7 +102,7 @@ impl ProviderKind {
     /// new kind can never be accepted by `FromStr` while staying unlisted in the message
     /// a user actually reads — a hand-maintained list in that string had already drifted
     /// once (`openrouter` shipped before it was named there).
-    pub const ALL: [ProviderKind; 8] = [
+    pub const ALL: [ProviderKind; 9] = [
         Self::Anthropic,
         Self::DeepSeek,
         Self::Gemini,
@@ -99,6 +110,7 @@ impl ProviderKind {
         Self::Openai,
         Self::Stability,
         Self::OpenAiImages,
+        Self::GeminiImages,
         Self::DashScope,
     ];
 
@@ -144,6 +156,7 @@ impl ProviderKind {
             // Reached only when an operator sets `key_optional = true` for a local
             // sd-server: header-bearer shaped, value ignored by such a server.
             | ProviderKind::OpenAiImages
+            | ProviderKind::GeminiImages
             // Never reached: neither Stability nor DashScope is `key_optional`, so a
             // missing key is a hard error long before a stand-in is wanted. Both are
             // header-bearer wires, so they take the same shape as the others if that
@@ -167,6 +180,7 @@ impl ProviderKind {
             ProviderKind::Openai => "openai",
             ProviderKind::Stability => "stability",
             ProviderKind::OpenAiImages => "openai-images",
+            ProviderKind::GeminiImages => "gemini-images",
             ProviderKind::DashScope => "dashscope",
         }
     }
@@ -190,7 +204,7 @@ impl ProviderKind {
         match self {
             ProviderKind::Anthropic => "ANTHROPIC_API_KEY",
             ProviderKind::DeepSeek => "DEEPSEEK_API_KEY",
-            ProviderKind::Gemini => "GEMINI_API_KEY",
+            ProviderKind::Gemini | ProviderKind::GeminiImages => "GEMINI_API_KEY",
             ProviderKind::OpenRouter => "OPENROUTER_API_KEY",
             // The images kind shares the completion kind's key sources on purpose:
             // both talk to the same OpenAI account when hosted, and both cover a
@@ -213,7 +227,7 @@ impl ProviderKind {
         match self {
             ProviderKind::Anthropic => ".anthropic-key.txt",
             ProviderKind::DeepSeek => ".deepseek-key",
-            ProviderKind::Gemini => ".gemini-api-key",
+            ProviderKind::Gemini | ProviderKind::GeminiImages => ".gemini-api-key",
             ProviderKind::OpenRouter => ".openrouter-key",
             // Shared with the images kind — see `env_var`.
             ProviderKind::Openai | ProviderKind::OpenAiImages => ".openai-key",
@@ -244,6 +258,7 @@ impl ProviderKind {
             ProviderKind::Openai => ProviderClass::Wire(WireKind::Openai),
             ProviderKind::Stability => ProviderClass::Media(MediaKind::Stability),
             ProviderKind::OpenAiImages => ProviderClass::Media(MediaKind::OpenAiImages),
+            ProviderKind::GeminiImages => ProviderClass::Media(MediaKind::GeminiImages),
             ProviderKind::DashScope => ProviderClass::Media(MediaKind::DashScope),
         }
     }
@@ -293,6 +308,8 @@ pub enum MediaKind {
     /// OpenAI's Images API shape (`/v1/images/generations`), via
     /// `src/openai_images.rs` — hosted OpenAI or a local sd-server.
     OpenAiImages,
+    /// Gemini's `generateContent` asked for image output, via `src/gemini_images.rs`.
+    GeminiImages,
     /// Alibaba DashScope's multimodal-generation route, via `src/dashscope.rs` —
     /// the `wan` image family, delivered as presigned URLs kaibo fetches.
     DashScope,
@@ -333,6 +350,7 @@ impl std::str::FromStr for ProviderKind {
             "openai" | "local" | "lemonade" | "gemma" | "gemma4" => Ok(ProviderKind::Openai),
             "stability" => Ok(ProviderKind::Stability),
             "openai-images" => Ok(ProviderKind::OpenAiImages),
+            "gemini-images" => Ok(ProviderKind::GeminiImages),
             "dashscope" => Ok(ProviderKind::DashScope),
             other => Err(anyhow!(
                 "unknown provider {other:?} (expected one of: {})",

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -72,7 +72,7 @@ pub enum ProviderKind {
     /// `key_optional = true` beside its explicit local `base_url`. Like Stability,
     /// it is not in the built-in backend list and staffs only `image` cast slots.
     OpenAiImages,
-    /// Gemini's image generation — the third media kind, via `src/gemini_images.rs`.
+    /// Gemini's image generation — the fourth media kind, via `src/gemini_images.rs`.
     ///
     /// A *separate kind* from [`ProviderKind::Gemini`] for the same reason
     /// [`ProviderKind::OpenAiImages`] is separate from [`ProviderKind::Openai`]: one

--- a/src/dashscope.rs
+++ b/src/dashscope.rs
@@ -422,7 +422,7 @@ impl crate::media::MediaModel for DashScopeImageModel {
                 seed: None,
             });
         }
-        Ok(MediaOutcome::Complete(artifacts))
+        Ok(MediaOutcome::complete(artifacts))
     }
 
     /// Unreachable: every operation on this route is synchronous, so `generate`

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -157,6 +157,11 @@ pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Resul
                 crate::credentials::MediaKind::OpenAiImages,
             ) => "the endpoint's own model names, e.g. gpt-image-1 hosted or whatever a \
                   local sd-server has loaded",
+            crate::credentials::ProviderClass::Media(
+                crate::credentials::MediaKind::GeminiImages,
+            ) => "a Gemini model that returns images, e.g. a gemini-*-image variant. \
+                  Image generation rides the same generateContent endpoint as text, so a \
+                  `kind = \"gemini\"` backend lists the catalog",
             crate::credentials::ProviderClass::Media(crate::credentials::MediaKind::DashScope) => {
                 "the wan image models, e.g. wan2.6-t2i. A DashScope host serves its \
                  catalog on an OpenAI-compatible endpoint, so point a `kind = \"openai\"` \

--- a/src/gemini_images.rs
+++ b/src/gemini_images.rs
@@ -91,6 +91,20 @@ pub enum GeminiImagesError {
     )]
     NoCandidates,
 
+    /// The model stopped without producing content, and said why.
+    ///
+    /// Distinct from [`GeminiImagesError::NoCandidates`] because the two are opposite
+    /// situations that a single message would describe wrongly: this one *has* a
+    /// candidate, or a prompt-level verdict, and the reason it carries is the whole
+    /// value of the error. Reporting "no candidates" here would be false and would throw
+    /// away the one field that says what to change.
+    #[error(
+        "gemini-images produced no content: {reason}. That is the model declining or \
+         stopping rather than a fault — the reason names which policy or limit it hit, so \
+         change the prompt or the input image to suit it."
+    )]
+    Blocked { reason: String },
+
     /// Parts came back, but none of them were image data.
     ///
     /// The most valuable error this module has, and the reason the model's own words are
@@ -160,33 +174,17 @@ pub fn build_request_body(request: &MediaRequest) -> Value {
     })
 }
 
-/// Walk one `generateContent` response into artifacts plus whatever the model said.
+/// Walk one candidate's parts into artifacts and commentary.
 ///
-/// Written for parts in general rather than images in particular: an `inlineData` part is
-/// an artifact whatever its mime, so the day a speech model rides this shape, the walk
-/// does not change.
-pub fn parse_response(status: u16, body: &[u8]) -> Result<MediaOutcome, GeminiImagesError> {
-    if !(200..300).contains(&status) {
-        return Err(GeminiImagesError::Provider {
-            status,
-            body: String::from_utf8_lossy(body).trim().to_string(),
-        });
-    }
-    let parsed: Value =
-        serde_json::from_slice(body).map_err(|e| GeminiImagesError::InvalidBody(e.to_string()))?;
-    let candidate = parsed
-        .get("candidates")
-        .and_then(Value::as_array)
-        .and_then(|c| c.first())
-        .ok_or(GeminiImagesError::NoCandidates)?;
-    let parts = candidate
-        .get("content")
-        .and_then(|c| c.get("parts"))
-        .and_then(Value::as_array)
-        .ok_or(GeminiImagesError::NoCandidates)?;
-
-    let mut artifacts = Vec::new();
-    let mut said: Vec<String> = Vec::new();
+/// Split out so every candidate goes through the same walk, and written for parts in
+/// general: an `inlineData` part is an artifact whatever its mime, so the day a speech
+/// model rides this shape the walk does not change.
+fn walk_parts(
+    parts: &[Value],
+    artifacts: &mut Vec<MediaArtifact>,
+    said: &mut Vec<String>,
+    unknown: &mut std::collections::BTreeSet<String>,
+) -> Result<(), GeminiImagesError> {
     for part in parts {
         if let Some(text) = part.get("text").and_then(Value::as_str) {
             if !text.trim().is_empty() {
@@ -199,6 +197,12 @@ pub fn parse_response(status: u16, body: &[u8]) -> Result<MediaOutcome, GeminiIm
         // shape emits the second. Accepting both costs one line and refusing one of them
         // would be a silent empty result.
         let Some(blob) = part.get("inlineData").or_else(|| part.get("inline_data")) else {
+            // Not text, not a blob. Recorded rather than dropped: if nothing usable comes
+            // back, the caller is told which shapes it *did* get, which is the difference
+            // between a debuggable response and "(nothing)".
+            if let Some(obj) = part.as_object() {
+                unknown.extend(obj.keys().cloned());
+            }
             continue;
         };
         let mime = blob
@@ -217,11 +221,77 @@ pub fn parse_response(status: u16, body: &[u8]) -> Result<MediaOutcome, GeminiIm
             seed: None,
         });
     }
+    Ok(())
+}
 
+/// Walk one `generateContent` response into artifacts plus whatever the model said.
+///
+/// Written for parts in general rather than images in particular: an `inlineData` part is
+/// an artifact whatever its mime, so the day a speech model rides this shape, the walk
+/// does not change.
+pub fn parse_response(status: u16, body: &[u8]) -> Result<MediaOutcome, GeminiImagesError> {
+    if !(200..300).contains(&status) {
+        return Err(GeminiImagesError::Provider {
+            status,
+            body: String::from_utf8_lossy(body).trim().to_string(),
+        });
+    }
+    let parsed: Value =
+        serde_json::from_slice(body).map_err(|e| GeminiImagesError::InvalidBody(e.to_string()))?;
+    // A prompt-level refusal has no candidates at all and puts its verdict here, so it
+    // is read before the candidate list is even looked for.
+    if let Some(block) = parsed
+        .get("promptFeedback")
+        .and_then(|f| f.get("blockReason"))
+        .and_then(Value::as_str)
+    {
+        return Err(GeminiImagesError::Blocked {
+            reason: format!("the prompt was blocked ({block})"),
+        });
+    }
+    let candidates = parsed
+        .get("candidates")
+        .and_then(Value::as_array)
+        .filter(|c| !c.is_empty())
+        .ok_or(GeminiImagesError::NoCandidates)?;
+
+    let mut artifacts = Vec::new();
+    let mut said: Vec<String> = Vec::new();
+    // Every candidate, not just the first. `candidateCount` rides `fields` straight into
+    // `generationConfig`, so a caller can ask for several — and each one is paid for.
+    // Keeping only `.first()` would drop artifacts the caller was billed for, silently.
+    let mut unknown_parts: std::collections::BTreeSet<String> = Default::default();
+    for candidate in candidates {
+        let Some(parts) = candidate
+            .get("content")
+            .and_then(|c| c.get("parts"))
+            .and_then(Value::as_array)
+        else {
+            // A candidate with no content stopped for a reason it names. Only fatal if
+            // no other candidate produced anything, which the emptiness check below
+            // decides — one blocked candidate among several is not the whole answer.
+            if let Some(reason) = candidate.get("finishReason").and_then(Value::as_str) {
+                said.push(format!("(stopped: {reason})"));
+            }
+            continue;
+        };
+        walk_parts(parts, &mut artifacts, &mut said, &mut unknown_parts)?;
+    }
     let note = (!said.is_empty()).then(|| said.join("\n\n"));
     if artifacts.is_empty() {
         return Err(GeminiImagesError::NoImageParts {
-            said: note.unwrap_or_else(|| "(nothing)".to_string()),
+            said: note.unwrap_or_else(|| {
+                if unknown_parts.is_empty() {
+                    "(nothing)".to_string()
+                } else {
+                    // Naming the shapes that did arrive is what makes a malformed
+                    // response debuggable instead of a shrug.
+                    format!(
+                        "(no text; the response carried only these part kinds: {})",
+                        unknown_parts.into_iter().collect::<Vec<_>>().join(", ")
+                    )
+                }
+            }),
         });
     }
     Ok(MediaOutcome::Complete { artifacts, note })
@@ -479,6 +549,74 @@ mod tests {
             parse_response(200, body.to_string().as_bytes()),
             Err(GeminiImagesError::MissingMime)
         ));
+    }
+
+    /// **A prompt-level block is not "no candidates".** Gemini refuses a prompt before
+    /// producing anything, with the verdict in `promptFeedback.blockReason` and no
+    /// candidate list at all. Reporting "returned no candidates" there would be false
+    /// and would throw away the one field that says what to change.
+    #[test]
+    fn a_blocked_prompt_reports_the_reason_not_an_empty_result() {
+        let body = serde_json::json!({ "promptFeedback": { "blockReason": "SAFETY" } });
+        let err = parse_response(200, body.to_string().as_bytes()).expect_err("blocked");
+        assert!(matches!(err, GeminiImagesError::Blocked { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("SAFETY"), "the verdict survives: {msg}");
+        assert!(msg.contains("prompt was blocked"), "{msg}");
+    }
+
+    /// A candidate that stopped without content names why in `finishReason`, and that
+    /// reason reaches the caller instead of being swallowed as an empty walk.
+    #[test]
+    fn a_candidate_that_stopped_carries_its_finish_reason() {
+        let body = serde_json::json!({
+            "candidates": [{ "finishReason": "IMAGE_SAFETY" }]
+        });
+        let err = parse_response(200, body.to_string().as_bytes()).expect_err("no image");
+        assert!(
+            err.to_string().contains("IMAGE_SAFETY"),
+            "the finish reason is the whole diagnosis: {err}"
+        );
+    }
+
+    /// **Every candidate is walked, not just the first.** `candidateCount` rides
+    /// `fields` straight into `generationConfig`, so a caller can ask for several — and
+    /// each is billed. Keeping only the first would drop paid-for artifacts silently.
+    #[test]
+    fn artifacts_from_every_candidate_survive() {
+        let body = serde_json::json!({
+            "candidates": [
+                {"content": {"parts": [
+                    {"inlineData": {"mimeType": "image/png", "data": b64(b"one")}}
+                ]}},
+                {"content": {"parts": [
+                    {"inlineData": {"mimeType": "image/png", "data": b64(b"two")}}
+                ]}}
+            ]
+        });
+        let MediaOutcome::Complete { artifacts, .. } =
+            parse_response(200, body.to_string().as_bytes()).expect("parses")
+        else {
+            panic!("synchronous")
+        };
+        assert_eq!(artifacts.len(), 2, "both paid-for images are kept");
+        assert_eq!(artifacts[0].bytes, b"one");
+        assert_eq!(artifacts[1].bytes, b"two");
+    }
+
+    /// When nothing usable comes back, the error names the part kinds that *did* arrive
+    /// — the difference between a debuggable response and "(nothing)".
+    #[test]
+    fn unrecognized_parts_are_named_rather_than_reported_as_nothing() {
+        let body = serde_json::json!({
+            "candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "whatever"}}
+            ]}}]
+        });
+        let err = parse_response(200, body.to_string().as_bytes()).expect_err("no image");
+        let msg = err.to_string();
+        assert!(msg.contains("functionCall"), "names what did arrive: {msg}");
+        assert!(!msg.contains("(nothing)"), "and does not shrug: {msg}");
     }
 
     #[test]

--- a/src/gemini_images.rs
+++ b/src/gemini_images.rs
@@ -1,0 +1,496 @@
+//! Gemini image generation — a media backend whose wire is a *completion* wire.
+//!
+//! # Why this is its own module and its own provider kind
+//!
+//! Every other media backend kaibo speaks is an images API: a distinct endpoint that
+//! takes a prompt and answers with bytes. Gemini has no such endpoint. Image generation
+//! is `models/{model}:generateContent` — the identical call as text — with
+//! `generationConfig.responseModalities` naming what should come back, confirmed against
+//! the live discovery document (`generativelanguage.googleapis.com/$discovery/rest?version=v1beta`,
+//! 2026-08-22).
+//!
+//! That single fact drives the whole design:
+//!
+//! - **It is a separate `ProviderKind` from `Gemini`**, the way `openai-images` is
+//!   separate from `openai`. One vendor, two uses of one endpoint, and a cast slot has
+//!   to know which it points at — a reasoning slot aimed here would resolve a completion
+//!   model that answers in pictures.
+//! - **It answers with words as well as bytes.** A `generateContent` response is a list
+//!   of parts, and a model that generated an image frequently says something about it in
+//!   the same breath. Those words ride [`crate::media::MediaOutcome::Complete::note`]
+//!   rather than being dropped — they are often the only account of what the model
+//!   actually did, and on a refusal they are the *only* thing that comes back.
+//! - **The TTS door is the same field.** `responseModalities` is an enum of
+//!   `TEXT`/`IMAGE`/`AUDIO`, and `generationConfig` carries `speechConfig` beside
+//!   `imageConfig`. A speech model is this module's shape with a different modality and a
+//!   different config block, which is why the note channel and the part-walking below are
+//!   written for parts in general rather than for images specifically.
+//!
+//! # `TEXT` is requested alongside `IMAGE`, deliberately
+//!
+//! The spec says `responseModalities` is "an exact match to the modalities of the
+//! response" and that a request outside a model's supported combinations is an error.
+//! Image-only is not universally supported, so the default asks for `["TEXT", "IMAGE"]`
+//! — the combination that works everywhere — and kaibo carries the text rather than
+//! suppressing it. An operator who knows their model accepts image-only can say so
+//! through `fields`.
+//!
+//! # No operation vocabulary
+//!
+//! There are no named operations here: "edit this image" is prose in the prompt, with the
+//! image itself as an input part. So [`crate::media::MediaModel::accepts_ops`] stays at
+//! its `false` default and a caller passing `op` is refused by the arm — an `op` this
+//! provider silently ignored would run a plain generation and return something unrelated.
+
+use std::time::Duration;
+
+use base64::Engine as _;
+use serde_json::{json, Map, Value};
+
+use crate::media::{MediaArtifact, MediaJobId, MediaOutcome, MediaPollOutcome, MediaRequest};
+
+/// The default base URL for Google's public endpoint. A root, not a route — the client
+/// appends its own path, the contract every configurable base URL in kaibo follows.
+pub const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+
+/// The modalities asked for when the caller does not say. See the module doc for why
+/// `TEXT` rides along rather than being suppressed.
+const DEFAULT_MODALITIES: &[&str] = &["TEXT", "IMAGE"];
+
+/// The `fields` names kaibo routes into `generationConfig.imageConfig` rather than
+/// leaving at the top of `generationConfig`.
+///
+/// A table so the mapping is one list rather than scattered `if`s, and so a caller
+/// reading the tool description and this module cannot disagree about where a knob
+/// lands. Anything not named here rides `generationConfig` verbatim — the same
+/// passthrough posture `fields` has everywhere else in kaibo.
+const IMAGE_CONFIG_FIELDS: &[(&str, &str)] = &[
+    ("aspect_ratio", "aspectRatio"),
+    ("aspectRatio", "aspectRatio"),
+    ("image_size", "imageSize"),
+    ("imageSize", "imageSize"),
+];
+
+/// Why a Gemini image call failed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum GeminiImagesError {
+    #[error("gemini-images transport failure: {0}")]
+    Transport(String),
+
+    #[error("gemini-images returned HTTP {status}: {body}")]
+    Provider { status: u16, body: String },
+
+    #[error("gemini-images returned a body that is not JSON: {0}")]
+    InvalidBody(String),
+
+    /// The response parsed but carried no candidate at all.
+    #[error(
+        "gemini-images returned no candidates, so there is nothing to store. This is the \
+         provider answering with an empty result rather than an error; retry, or try a \
+         different prompt."
+    )]
+    NoCandidates,
+
+    /// Parts came back, but none of them were image data.
+    ///
+    /// The most valuable error this module has, and the reason the model's own words are
+    /// carried into it: a safety refusal, a clarifying question, and "I cannot do that"
+    /// all arrive exactly this way — a normal `200` with text and no picture. Reporting
+    /// "no image" without the text would throw away the only explanation the caller gets.
+    #[error(
+        "gemini-images returned no image, only text. The model said: {said:?}. That is \
+         usually a refusal or a request for clarification rather than a fault — read what \
+         it said, then adjust the prompt or the input image."
+    )]
+    NoImageParts { said: String },
+
+    #[error("gemini-images returned an image part whose data is not valid base64: {0}")]
+    InvalidB64(String),
+
+    #[error(
+        "gemini-images returned an image part with no `mimeType`, so kaibo cannot say what \
+         the bytes are and refuses to store them under a guessed type."
+    )]
+    MissingMime,
+}
+
+/// Build the `generateContent` request body for one media request.
+///
+/// Pure, so the wire shape is testable without a socket. The prompt leads the parts list
+/// and every input image follows as an `inlineData` blob, which is the order a
+/// conversational model reads: instruction first, material after.
+pub fn build_request_body(request: &MediaRequest) -> Value {
+    let mut parts: Vec<Value> = vec![json!({ "text": request.prompt })];
+    for input in &request.inputs {
+        parts.push(json!({
+            "inlineData": {
+                "mimeType": input.mime,
+                "data": base64::engine::general_purpose::STANDARD.encode(&input.bytes),
+            }
+        }));
+    }
+
+    let mut generation_config = Map::new();
+    let mut image_config = Map::new();
+    for (name, value) in &request.fields {
+        match IMAGE_CONFIG_FIELDS
+            .iter()
+            .find(|(neutral, _)| neutral == name)
+        {
+            Some((_, wire)) => {
+                image_config.insert((*wire).to_string(), value.to_json());
+            }
+            None => {
+                generation_config.insert(name.clone(), value.to_json());
+            }
+        }
+    }
+    if !image_config.is_empty() {
+        generation_config.insert("imageConfig".to_string(), Value::Object(image_config));
+    }
+    // Seeded, not forced: a caller that named `responseModalities` in `fields` has already
+    // landed it above and keeps it.
+    generation_config
+        .entry("responseModalities".to_string())
+        .or_insert_with(|| json!(DEFAULT_MODALITIES));
+
+    json!({
+        "contents": [{ "role": "user", "parts": parts }],
+        "generationConfig": Value::Object(generation_config),
+    })
+}
+
+/// Walk one `generateContent` response into artifacts plus whatever the model said.
+///
+/// Written for parts in general rather than images in particular: an `inlineData` part is
+/// an artifact whatever its mime, so the day a speech model rides this shape, the walk
+/// does not change.
+pub fn parse_response(status: u16, body: &[u8]) -> Result<MediaOutcome, GeminiImagesError> {
+    if !(200..300).contains(&status) {
+        return Err(GeminiImagesError::Provider {
+            status,
+            body: String::from_utf8_lossy(body).trim().to_string(),
+        });
+    }
+    let parsed: Value =
+        serde_json::from_slice(body).map_err(|e| GeminiImagesError::InvalidBody(e.to_string()))?;
+    let candidate = parsed
+        .get("candidates")
+        .and_then(Value::as_array)
+        .and_then(|c| c.first())
+        .ok_or(GeminiImagesError::NoCandidates)?;
+    let parts = candidate
+        .get("content")
+        .and_then(|c| c.get("parts"))
+        .and_then(Value::as_array)
+        .ok_or(GeminiImagesError::NoCandidates)?;
+
+    let mut artifacts = Vec::new();
+    let mut said: Vec<String> = Vec::new();
+    for part in parts {
+        if let Some(text) = part.get("text").and_then(Value::as_str) {
+            if !text.trim().is_empty() {
+                said.push(text.trim().to_string());
+            }
+            continue;
+        }
+        // Both spellings appear in the wild: the REST JSON uses `inlineData`, the proto
+        // field name is `inline_data`, and a proxy that round-trips through the proto
+        // shape emits the second. Accepting both costs one line and refusing one of them
+        // would be a silent empty result.
+        let Some(blob) = part.get("inlineData").or_else(|| part.get("inline_data")) else {
+            continue;
+        };
+        let mime = blob
+            .get("mimeType")
+            .or_else(|| blob.get("mime_type"))
+            .and_then(Value::as_str)
+            .ok_or(GeminiImagesError::MissingMime)?;
+        let data = blob.get("data").and_then(Value::as_str).unwrap_or_default();
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .map_err(|e| GeminiImagesError::InvalidB64(e.to_string()))?;
+        artifacts.push(MediaArtifact {
+            bytes,
+            mime: mime.to_string(),
+            // `generationConfig.seed` is an input knob; the response does not echo one.
+            seed: None,
+        });
+    }
+
+    let note = (!said.is_empty()).then(|| said.join("\n\n"));
+    if artifacts.is_empty() {
+        return Err(GeminiImagesError::NoImageParts {
+            said: note.unwrap_or_else(|| "(nothing)".to_string()),
+        });
+    }
+    Ok(MediaOutcome::Complete { artifacts, note })
+}
+
+/// The HTTP client for one `gemini-images` backend.
+#[derive(Clone)]
+pub struct GeminiImagesClient {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl GeminiImagesClient {
+    pub fn new(api_key: &str, base_url: &str, timeout: Duration) -> anyhow::Result<Self> {
+        Ok(Self {
+            http: crate::tls::https_client(timeout)?,
+            api_key: api_key.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// `POST {base}/v1beta/models/{model}:generateContent`.
+    ///
+    /// The key rides the `x-goog-api-key` header rather than a `?key=` query parameter:
+    /// both are accepted, and a header keeps the credential out of anything that logs a
+    /// URL.
+    pub async fn generate(
+        &self,
+        model: &str,
+        request: &MediaRequest,
+    ) -> Result<MediaOutcome, GeminiImagesError> {
+        let url = format!("{}/v1beta/models/{}:generateContent", self.base_url, model);
+        let resp = self
+            .http
+            .post(&url)
+            .header("x-goog-api-key", &self.api_key)
+            .json(&build_request_body(request))
+            .send()
+            .await
+            .map_err(|e| GeminiImagesError::Transport(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| GeminiImagesError::Transport(e.to_string()))?;
+        parse_response(status, &bytes)
+    }
+}
+
+/// The [`crate::media::MediaModel`] behind an `image = "backend/model-id"` slot on a
+/// `gemini-images` backend.
+#[derive(Clone)]
+pub struct GeminiImagesModel {
+    client: GeminiImagesClient,
+    model: String,
+}
+
+impl GeminiImagesModel {
+    pub fn from_parts(client: &GeminiImagesClient, model: impl Into<String>) -> Self {
+        Self {
+            client: client.clone(),
+            model: model.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::media::MediaModel for GeminiImagesModel {
+    /// An input image is how you ask for an edit here — there is no edit *route*, only an
+    /// instruction and the material it refers to.
+    fn accepts_inputs(&self) -> bool {
+        true
+    }
+
+    async fn generate(&self, request: &MediaRequest) -> anyhow::Result<MediaOutcome> {
+        Ok(self.client.generate(&self.model, request).await?)
+    }
+
+    /// `generateContent` is synchronous, so no caller ever holds a job id for this
+    /// backend. Bails rather than pretending — a poll arriving here means a job id was
+    /// invented or a future change broke the sync-only declaration.
+    async fn poll(&self, _job: &MediaJobId) -> anyhow::Result<MediaPollOutcome> {
+        anyhow::bail!(
+            "gemini-images declares no deferred operations — every generation completes \
+             in-call, so there is no provider job to poll"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cas::Extension;
+    use crate::media::{FieldValue, MediaInput};
+
+    fn request(prompt: &str) -> MediaRequest {
+        MediaRequest {
+            prompt: prompt.to_string(),
+            fields: Vec::new(),
+            inputs: Vec::new(),
+            op: None,
+        }
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    /// The prompt leads and every input image follows as an `inlineData` blob carrying
+    /// the store's own mime — instruction first, material after, which is the order a
+    /// conversational model reads.
+    #[test]
+    fn the_prompt_leads_and_inputs_follow_as_inline_blobs() {
+        let mut r = request("put a hat on the cat");
+        r.inputs = vec![MediaInput::new(
+            "image",
+            Extension::Png,
+            b"\x89PNG\r\n\x1a\ncat".to_vec(),
+        )];
+        let body = build_request_body(&r);
+        let parts = body["contents"][0]["parts"].as_array().expect("parts");
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["text"], "put a hat on the cat");
+        assert_eq!(parts[1]["inlineData"]["mimeType"], "image/png");
+        assert_eq!(
+            parts[1]["inlineData"]["data"],
+            b64(b"\x89PNG\r\n\x1a\ncat"),
+            "the bytes ride base64 in the blob"
+        );
+    }
+
+    /// `TEXT` is asked for beside `IMAGE` by default — image-only is not a combination
+    /// every model supports, and the spec makes a mismatched request an error rather
+    /// than a downgrade.
+    #[test]
+    fn text_is_requested_alongside_image_by_default() {
+        let body = build_request_body(&request("a lighthouse"));
+        assert_eq!(
+            body["generationConfig"]["responseModalities"],
+            serde_json::json!(["TEXT", "IMAGE"])
+        );
+    }
+
+    /// Seeded, not forced. An operator who knows their model takes image-only says so
+    /// through `fields` and keeps it — kaibo does not overwrite a stated choice.
+    #[test]
+    fn a_caller_stated_modality_survives_the_default() {
+        let mut r = request("a lighthouse");
+        r.fields = vec![(
+            "responseModalities".to_string(),
+            FieldValue::Str("IMAGE".to_string()),
+        )];
+        let body = build_request_body(&r);
+        assert_eq!(body["generationConfig"]["responseModalities"], "IMAGE");
+    }
+
+    /// Image knobs land in `imageConfig`; everything else stays at the top of
+    /// `generationConfig`, the passthrough posture `fields` has everywhere in kaibo.
+    #[test]
+    fn image_knobs_route_into_image_config_and_the_rest_passes_through() {
+        let mut r = request("a lighthouse");
+        r.fields = vec![
+            ("aspect_ratio".to_string(), FieldValue::Str("16:9".into())),
+            (
+                "seed".to_string(),
+                FieldValue::Num(serde_json::Number::from(42)),
+            ),
+        ];
+        let body = build_request_body(&r);
+        assert_eq!(
+            body["generationConfig"]["imageConfig"]["aspectRatio"],
+            "16:9"
+        );
+        assert_eq!(body["generationConfig"]["seed"], 42);
+        assert!(
+            body["generationConfig"]["aspect_ratio"].is_null(),
+            "a routed knob does not also stay at the top level"
+        );
+    }
+
+    /// Images and text arrive interleaved in one response. Both are kept: the bytes
+    /// become artifacts, the words become the note.
+    #[test]
+    fn text_and_image_parts_both_survive_the_walk() {
+        let body = serde_json::json!({
+            "candidates": [{"content": {"parts": [
+                {"text": "I moved the sign left; the original crop cut it off."},
+                {"inlineData": {"mimeType": "image/png", "data": b64(b"the-image")}}
+            ]}}]
+        });
+        let outcome = parse_response(200, body.to_string().as_bytes()).expect("parses");
+        let MediaOutcome::Complete { artifacts, note } = outcome else {
+            panic!("generateContent is synchronous")
+        };
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].bytes, b"the-image");
+        assert_eq!(artifacts[0].mime, "image/png");
+        assert_eq!(
+            note.as_deref(),
+            Some("I moved the sign left; the original crop cut it off."),
+            "the model's account of what it did is not dropped"
+        );
+    }
+
+    /// **The refusal path, and the reason the note exists at all.** A safety refusal is
+    /// a normal `200` with text and no picture. Reporting "no image" without the text
+    /// would throw away the only explanation the caller gets.
+    #[test]
+    fn text_with_no_image_is_an_error_that_carries_what_the_model_said() {
+        let body = serde_json::json!({
+            "candidates": [{"content": {"parts": [
+                {"text": "I can't create an image of a real person."}
+            ]}}]
+        });
+        let err = parse_response(200, body.to_string().as_bytes()).expect_err("no image");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("I can't create an image of a real person."),
+            "the refusal carries the model's own words: {msg}"
+        );
+        assert!(
+            msg.contains("usually a refusal"),
+            "and says what it means: {msg}"
+        );
+    }
+
+    /// The proto spelling round-trips through some proxies. Accepting both costs a line;
+    /// refusing one would be a silently empty result.
+    #[test]
+    fn the_snake_case_blob_spelling_is_also_accepted() {
+        let body = serde_json::json!({
+            "candidates": [{"content": {"parts": [
+                {"inline_data": {"mime_type": "image/jpeg", "data": b64(b"jpg")}}
+            ]}}]
+        });
+        let MediaOutcome::Complete { artifacts, .. } =
+            parse_response(200, body.to_string().as_bytes()).expect("parses")
+        else {
+            panic!("synchronous")
+        };
+        assert_eq!(artifacts[0].mime, "image/jpeg");
+    }
+
+    /// A blob with no mime is refused rather than stored under a guess — the same rule
+    /// `write_cas` applies from the other direction.
+    #[test]
+    fn a_blob_without_a_mime_is_refused_rather_than_guessed() {
+        let body = serde_json::json!({
+            "candidates": [{"content": {"parts": [
+                {"inlineData": {"data": b64(b"bytes")}}
+            ]}}]
+        });
+        assert!(matches!(
+            parse_response(200, body.to_string().as_bytes()),
+            Err(GeminiImagesError::MissingMime)
+        ));
+    }
+
+    #[test]
+    fn a_non_2xx_carries_the_providers_own_body() {
+        let err = parse_response(429, br#"{"error":{"message":"quota"}}"#).expect_err("429");
+        let msg = err.to_string();
+        assert!(msg.contains("429") && msg.contains("quota"), "{msg}");
+    }
+
+    #[test]
+    fn an_empty_candidate_list_is_refused_clearly() {
+        let err = parse_response(200, br#"{"candidates":[]}"#).expect_err("no candidates");
+        assert!(matches!(err, GeminiImagesError::NoCandidates));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod credentials;
 pub mod dashscope;
 pub mod discover;
 pub mod explorer;
+pub mod gemini_images;
 pub mod jobs;
 pub mod kaish_syntax;
 pub mod mcp_log;

--- a/src/media.rs
+++ b/src/media.rs
@@ -501,13 +501,30 @@ impl MediaArm {
     /// binary-input guard belongs: one check the arm fastens, rather than a convention
     /// each provider impl has to remember. See [`MediaModel::accepts_inputs`].
     pub async fn generate(&self, request: &MediaRequest) -> Result<MediaOutcome> {
+        self.refuse_unsupported(request)?;
+        self.model.generate(request).await
+    }
+
+    /// Whether this arm's provider can serve everything the request asks for.
+    ///
+    /// One implementation, two callers, so they cannot drift. The handler calls it
+    /// *before* dispatching so a caller mistake is reported as a bad parameter — which
+    /// is what it is, and what tells the caller to drop `op` rather than file a bug.
+    /// [`MediaArm::generate`] calls it again as the structural backstop: it is the single
+    /// dispatch point every media call passes through, so a provider added later that
+    /// never considers `op` or `inputs` still fails closed.
+    ///
+    /// Found by running it: the refusal fired correctly on a live Gemini call and was
+    /// then wrapped in "this is a kaibo-side error — please report it", which would send
+    /// a caller to the issue tracker over a parameter they could simply drop.
+    pub fn refuse_unsupported(&self, request: &MediaRequest) -> Result<()> {
         if !self.model.accepts_inputs() {
             refuse_binary_inputs(request, &self.slot_ref)?;
         }
         if !self.model.accepts_ops() {
             refuse_operation(request, &self.slot_ref)?;
         }
-        self.model.generate(request).await
+        Ok(())
     }
 
     /// Collect one deferred job's result.

--- a/src/media.rs
+++ b/src/media.rs
@@ -304,8 +304,33 @@ pub struct MediaJobId(pub String);
 /// blesses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MediaOutcome {
-    Complete(Vec<MediaArtifact>),
+    Complete {
+        artifacts: Vec<MediaArtifact>,
+        /// What the model said alongside the artifacts, when it says anything.
+        ///
+        /// Empty for an images API: Stability, the Images API and DashScope answer with
+        /// bytes and nothing else. It exists for the providers whose image generation is
+        /// a *completion* call — Gemini's `generateContent` returns text parts and image
+        /// parts interleaved in one response, and a model that says "I moved the sign
+        /// left instead, the original crop cut it off" has told the caller something the
+        /// bytes do not.
+        ///
+        /// Carried rather than dropped because dropping it is a silent loss of the only
+        /// explanation of what happened. The same channel is what a speech model's
+        /// transcript will ride when that wave lands.
+        note: Option<String>,
+    },
     Deferred(MediaJobId),
+}
+
+impl MediaOutcome {
+    /// A completed outcome with no commentary — what every images API returns.
+    pub fn complete(artifacts: Vec<MediaArtifact>) -> Self {
+        MediaOutcome::Complete {
+            artifacts,
+            note: None,
+        }
+    }
 }
 
 /// One poll's outcome: still running, or done. A poll is never itself deferred
@@ -402,6 +427,20 @@ impl MediaArm {
                 let client =
                     crate::stability::StabilityClient::new(key, base_url, backend.request_timeout)?;
                 let model = crate::stability::StabilityImageModel::from_parts(&client, &slot.id);
+                Ok(Self::new(Arc::new(model), slot.qualified()))
+            }
+            ProviderClass::Media(MediaKind::GeminiImages) => {
+                let key = backend.resolve_key()?;
+                let base_url = backend
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| crate::gemini_images::DEFAULT_BASE_URL.to_string());
+                let client = crate::gemini_images::GeminiImagesClient::new(
+                    &key,
+                    &base_url,
+                    backend.request_timeout,
+                )?;
+                let model = crate::gemini_images::GeminiImagesModel::from_parts(&client, &slot.id);
                 Ok(Self::new(Arc::new(model), slot.qualified()))
             }
             ProviderClass::Media(MediaKind::OpenAiImages) => {

--- a/src/media.rs
+++ b/src/media.rs
@@ -15,9 +15,11 @@
 //! a mime string, and a seed) — providers translate their native shapes at their own
 //! impl, exactly as rig providers translate into rig's completion types. Three live
 //! implementations today: Stability's (`src/stability.rs`, multipart form wire, sync
-//! and deferred shapes, and the only one with an operation vocabulary), OpenAI Images
-//! (`src/openai_images.rs`, JSON body wire, sync only), and DashScope
-//! (`src/dashscope.rs`).
+//! and deferred shapes), OpenAI Images (`src/openai_images.rs`, JSON body for
+//! `generations` and multipart for the two routes that carry files), DashScope
+//! (`src/dashscope.rs`), and Gemini (`src/gemini_images.rs`) — the odd one, whose wire
+//! is a *completion* endpoint rather than an images API, and the only one that answers
+//! with words as well as bytes.
 //!
 //! # The construction point
 //!
@@ -674,6 +676,25 @@ mod tests {
         let slot = ModelSlot::bare("wan", "wan2.6-t2i");
         let arm = MediaArm::from_slot(backend, &slot).expect("a dashscope backend staffs");
         assert_eq!(arm.slot_ref(), "wan/wan2.6-t2i");
+    }
+
+    /// The Gemini arm staffs an image slot — the construction half of the media kind
+    /// whose wire is a completion endpoint.
+    #[test]
+    fn from_slot_staffs_a_gemini_images_backend() {
+        let cfg = crate::config::Config::from_toml_str(
+            r#"
+            [backends.gimg]
+            kind = "gemini-images"
+            key_optional = true
+            api_key_file = "/nonexistent-kaibo-test/gemini"
+            "#,
+        )
+        .expect("config parses");
+        let backend = cfg.backends.get("gimg").expect("backend exists");
+        let slot = ModelSlot::bare("gimg", "gemini-3-flash-image");
+        let arm = MediaArm::from_slot(backend, &slot).expect("a gemini-images backend staffs");
+        assert_eq!(arm.slot_ref(), "gimg/gemini-3-flash-image");
     }
 
     /// The Stability arm still staffs — the sibling-kind regression guard for the

--- a/src/openai_images.rs
+++ b/src/openai_images.rs
@@ -628,7 +628,7 @@ impl crate::media::MediaModel for OpenAiImagesModel {
 
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
         let artifacts = self.client.generate(&self.model, request).await?;
-        Ok(MediaOutcome::Complete(artifacts))
+        Ok(MediaOutcome::complete(artifacts))
     }
 
     /// Unreachable in practice: `generate` above never returns

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3202,6 +3202,12 @@ impl KaiboHandler {
             inputs,
             op: input.op.clone(),
         };
+        // Asked before dispatch so an operation or an input this backend has no route
+        // for is reported as the bad parameter it is, rather than as a failed call the
+        // caller is told to report. `MediaArm::generate` asks again as the structural
+        // backstop — see `MediaArm::refuse_unsupported`.
+        arm.refuse_unsupported(&request)
+            .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
         let span = tracing::info_span!("generate", cast = %cast.name, model = %arm.slot_ref());
         match arm.generate(&request).instrument(span).await {
             Ok(crate::media::MediaOutcome::Complete { artifacts, note }) => {
@@ -6674,6 +6680,51 @@ enabled = false
             "named from the store's record, not the caller's belief"
         );
         assert_eq!(seen.inputs[0].mime, "image/png");
+    }
+
+    /// **An unsupported `op` is a bad parameter, not a kaibo fault.**
+    ///
+    /// The arm's guard was already refusing correctly, but the handler mapped every arm
+    /// error through `consultation_failed`, which tells the caller "this is a kaibo-side
+    /// error — please report it". That framing sends someone to the issue tracker over a
+    /// parameter they could drop. Found by running a real Gemini call, not by reading the
+    /// code.
+    #[tokio::test]
+    async fn generate_reports_an_unsupported_op_as_a_parameter_error() {
+        let provider = Arc::new(RecordingProvider::default());
+        let h = media_handler(provider.clone());
+
+        let err = h
+            .generate(Parameters(GenerateInput {
+                prompt: "anything".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+                inputs: None,
+                // `RecordingProvider` accepts inputs but declares no operations.
+                op: Some("edit/remove-background".to_string()),
+            }))
+            .await
+            .expect_err("a provider with no operations refuses");
+
+        assert!(
+            !err.message.contains("report it"),
+            "a caller mistake must not be dressed as a kaibo bug: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("no named operations"),
+            "and it must say what is wrong: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("drop `op`"),
+            "and what to do instead: {}",
+            err.message
+        );
+        assert!(
+            provider.0.lock().unwrap().is_none(),
+            "nothing reached the provider, so nothing was billed"
+        );
     }
 
     /// A digest the store does not hold refuses at the tool face, before any provider

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -955,7 +955,8 @@ const CAST_ENUM_RULES: &[CastEnumRule] = &[
         &["generate"],
         Config::cast_can_generate,
         "a cast with an `image` slot pointing at a media backend (kind `stability`, \
-         `openai-images`, or `dashscope`) — see the image-slot examples in \
+         `openai-images`, `gemini-images`, or `dashscope`) — see the image-slot \
+         examples in \
          docs/config.example.toml",
     ),
 ];
@@ -3090,8 +3091,8 @@ impl KaiboHandler {
     #[tool(
         description = "Generate images from a text prompt with the cast's `image` \
             model (a media backend: Stability, an OpenAI-compatible images endpoint — \
-            hosted gpt-image or a local stable-diffusion.cpp sd-server — or DashScope's \
-            wan family). \
+            hosted gpt-image or a local stable-diffusion.cpp sd-server — Gemini, or \
+            DashScope's wan family). \
             Bytes are never inlined: each artifact lands in kaibo's content-addressed \
             media store and the result lists per-artifact digests — a \
             kaibo://cas/<digest> address, the mime, the provider's seed when reported, \
@@ -3105,7 +3106,7 @@ impl KaiboHandler {
             `inputs {\"image\": \"<digest>\"}` with `fields {\"strength\": 0.6}` is \
             image-to-image. Digests come from `write_cas` or an earlier `generate`, so \
             an image already in the store is reused by address and never re-sent. \
-            Stability accepts input images; the other media backends do not and say so. \
+            Stability and Gemini accept input images; the others do not and say so. \
             `op` picks an operation when the backend has more than one — Stability's \
             edit, control and upscale routes, each with its required `inputs` keys and \
             its credit cost listed on the parameter, so you can see the price before you \

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3203,7 +3203,7 @@ impl KaiboHandler {
         };
         let span = tracing::info_span!("generate", cast = %cast.name, model = %arm.slot_ref());
         match arm.generate(&request).instrument(span).await {
-            Ok(crate::media::MediaOutcome::Complete(artifacts)) => {
+            Ok(crate::media::MediaOutcome::Complete { artifacts, note }) => {
                 let rendered = match store_generated_artifacts(
                     &store,
                     &artifacts,
@@ -3213,6 +3213,15 @@ impl KaiboHandler {
                 ) {
                     Ok(text) => text,
                     Err(e) => return Ok(consultation_failed("generate", &cast.name, e)),
+                };
+                // A provider whose image generation is a completion call answers with
+                // words as well as bytes, and those words are often the only account of
+                // what it actually did. Shown above the digests rather than dropped.
+                let rendered = match note {
+                    Some(note) if !note.trim().is_empty() => {
+                        format!("{}\n\n{rendered}", note.trim())
+                    }
+                    _ => rendered,
                 };
                 Ok(CallToolResult::success(vec![ContentBlock::text(
                     with_provenance(
@@ -5631,7 +5640,7 @@ mod tests {
             &self,
             _request: &crate::media::MediaRequest,
         ) -> anyhow::Result<crate::media::MediaOutcome> {
-            Ok(crate::media::MediaOutcome::Complete(self.0.clone()))
+            Ok(crate::media::MediaOutcome::complete(self.0.clone()))
         }
 
         async fn poll(
@@ -6600,7 +6609,7 @@ enabled = false
             request: &crate::media::MediaRequest,
         ) -> anyhow::Result<crate::media::MediaOutcome> {
             *self.0.lock().unwrap() = Some(request.clone());
-            Ok(crate::media::MediaOutcome::Complete(vec![png(b"result")]))
+            Ok(crate::media::MediaOutcome::complete(vec![png(b"result")]))
         }
 
         async fn poll(

--- a/src/stability.rs
+++ b/src/stability.rs
@@ -1423,7 +1423,7 @@ impl crate::media::MediaModel for StabilityImageModel {
             // one-element list — the neutral outcome is a Vec because many image models
             // return several per call, and the CAS story is per-artifact digests.
             StabilityResponse::Complete(a) => {
-                crate::media::MediaOutcome::Complete(vec![media_artifact(a)])
+                crate::media::MediaOutcome::complete(vec![media_artifact(a)])
             }
             StabilityResponse::Deferred(id) => crate::media::MediaOutcome::Deferred(
                 crate::media::MediaJobId(id.as_str().to_string()),

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1991,7 +1991,9 @@ fn openai_images_backend_parses_and_seeds_openai_key_sources() {
     assert_eq!(b.kind, kaibo::credentials::ProviderKind::OpenAiImages);
     assert_eq!(b.api_key_env.as_deref(), Some("OPENAI_API_KEY"));
     assert!(
-        b.api_key_file.as_deref().is_some_and(|f| f.ends_with("/.openai-key")),
+        b.api_key_file
+            .as_deref()
+            .is_some_and(|f| f.ends_with("/.openai-key")),
         "the key file mirrors the openai completion kind's, got: {:?}",
         b.api_key_file
     );
@@ -2175,7 +2177,10 @@ fn cas_defaults_to_the_xdg_data_dir_and_no_cap() {
         c.cas.max_bytes, None,
         "the CAS ships uncapped — a cap costs an O(objects) walk per write, so it is opt-in"
     );
-    let dir = c.cas.dir.expect("a default CAS dir resolves from XDG_DATA_HOME or HOME");
+    let dir = c
+        .cas
+        .dir
+        .expect("a default CAS dir resolves from XDG_DATA_HOME or HOME");
     assert!(
         dir.ends_with("kaibo/cas"),
         "the default CAS dir is <data>/kaibo/cas, got {}",
@@ -2226,10 +2231,7 @@ fn cas_mode_follows_persistence_and_the_off_switch_wins() {
 /// The file layer sets both knobs, and `$VAR`/`~` in `dir` expand like every other path.
 #[test]
 fn cas_file_layer_sets_dir_and_cap() {
-    let c = Config::from_toml_str(
-        "[cas]\ndir = \"/srv/art\"\nmax_bytes = 1024\n",
-    )
-    .unwrap();
+    let c = Config::from_toml_str("[cas]\ndir = \"/srv/art\"\nmax_bytes = 1024\n").unwrap();
     assert_eq!(c.cas.dir.unwrap(), std::path::PathBuf::from("/srv/art"));
     assert_eq!(c.cas.max_bytes, Some(1024));
 }
@@ -2239,8 +2241,8 @@ fn cas_file_layer_sets_dir_and_cap() {
 /// fails on first use with a capacity error no operator could explain.
 #[test]
 fn cas_zero_max_bytes_is_a_loud_load_error() {
-    let err = Config::from_toml_str("[cas]\nmax_bytes = 0\n")
-        .expect_err("max_bytes = 0 must be refused");
+    let err =
+        Config::from_toml_str("[cas]\nmax_bytes = 0\n").expect_err("max_bytes = 0 must be refused");
     let msg = format!("{err:#}");
     assert!(
         msg.contains("max_bytes") && msg.contains("> 0"),
@@ -2280,8 +2282,7 @@ fn cas_env_overrides_the_file() {
 /// grammar every other optional flag here uses.
 #[test]
 fn cas_cli_wins_and_absent_flags_do_not_clobber() {
-    let mut c =
-        Config::from_toml_str("[cas]\ndir = \"/from/file\"\nmax_bytes = 111\n").unwrap();
+    let mut c = Config::from_toml_str("[cas]\ndir = \"/from/file\"\nmax_bytes = 111\n").unwrap();
     c.apply_cli(
         None,
         None,
@@ -2696,4 +2697,81 @@ fn no_otel_environment_leaves_telemetry_off() {
     let c = load_env(&[]);
     assert!(!c.telemetry.enabled);
     assert!(!c.telemetry.capture_content);
+}
+
+// --- the gemini-images kind ------------------------------------------------------
+
+/// The `gemini-images` kind parses and **shares `gemini`'s key sources** — one Google
+/// credential per account, not one per use of the endpoint. That sharing is the
+/// difference from `dashscope`, which deliberately keeps its own: there the two wires
+/// are separate protocols against one host, whereas here they are literally the same
+/// endpoint asked for a different modality.
+///
+/// The key is required: the default target is Google's hosted service, so a keyless
+/// seed would 401 on the first paid call instead of failing at load.
+#[test]
+fn gemini_images_backend_parses_and_shares_the_gemini_key_sources() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.gimg]
+        kind = "gemini-images"
+        "#,
+    )
+    .expect("the gemini-images kind must parse");
+    let b = c.backends.get("gimg").expect("backend exists");
+    assert_eq!(b.kind, kaibo::credentials::ProviderKind::GeminiImages);
+    assert_eq!(b.api_key_env.as_deref(), Some("GEMINI_API_KEY"));
+    assert!(
+        b.api_key_file
+            .as_deref()
+            .is_some_and(|f| f.ends_with("/.gemini-api-key")),
+        "it shares the `gemini` key file rather than minting a second name, got: {:?}",
+        b.api_key_file
+    );
+    assert!(
+        !b.key_optional,
+        "the default target is Google's hosted service, so the key is required"
+    );
+}
+
+/// An `image` slot may point at it — the whole reason the kind exists.
+#[test]
+fn an_image_slot_can_point_at_a_gemini_images_backend() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.gimg]
+        kind = "gemini-images"
+
+        [casts.painter]
+        image = "gimg/gemini-3-flash-image"
+        "#,
+    )
+    .expect("an image slot on a gemini-images backend is the supported pairing");
+    assert!(c.casts.contains_key("painter"));
+}
+
+/// **A reasoning slot pointed at `gemini-images` is refused at load**, and this is the
+/// pairing most likely to be got wrong: `gemini` and `gemini-images` are the same vendor
+/// on the same endpoint, so an operator who types the wrong one has made a plausible
+/// mistake rather than an obvious one. Text belongs on `kind = "gemini"`.
+#[test]
+fn a_reasoning_slot_cannot_point_at_a_gemini_images_backend() {
+    for role in ["explorer", "synth"] {
+        let toml = format!(
+            r#"
+            [backends.gimg]
+            kind = "gemini-images"
+
+            [casts.broken]
+            {role} = "gimg/gemini-3-flash"
+            "#
+        );
+        let err = Config::from_toml_str(&toml)
+            .expect_err("a reasoning slot on a gemini-images backend must be refused at load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(role) && msg.contains("gemini-images") && msg.contains("media kind"),
+            "the error names the slot, the kind, and its class, got: {msg}"
+        );
+    }
 }

--- a/tests/dashscope_live.rs
+++ b/tests/dashscope_live.rs
@@ -60,7 +60,7 @@ async fn wan_t2i_returns_real_image_bytes_through_a_fetched_link() {
         op: None,
     };
     let outcome = model.generate(&request).await.expect("live generation");
-    let MediaOutcome::Complete(artifacts) = outcome else {
+    let MediaOutcome::Complete { artifacts, .. } = outcome else {
         panic!("this route is synchronous, so the outcome is always Complete");
     };
 

--- a/tests/gemini_images_transport.rs
+++ b/tests/gemini_images_transport.rs
@@ -1,0 +1,168 @@
+//! The gemini-images client over a real socket, offline.
+//!
+//! The transport truths the pure-function tests cannot see: the URL actually dialled
+//! (Gemini puts the model *in the path* with a `:generateContent` suffix, which is
+//! unlike every other backend kaibo speaks), and the credential riding a header rather
+//! than the `?key=` query parameter Google also accepts — a header keeps the key out of
+//! anything that logs a URL.
+//!
+//! Pattern precedent: `tests/openai_images_transport.rs`. Teeth: change the path or move
+//! the key to a query parameter and these fail.
+
+use std::time::Duration;
+
+use base64::Engine as _;
+use kaibo::gemini_images::GeminiImagesClient;
+use kaibo::media::{MediaOutcome, MediaRequest};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+struct Captured {
+    head: String,
+    body: serde_json::Value,
+}
+
+impl Captured {
+    fn request_line(&self) -> &str {
+        self.head.lines().next().unwrap_or("")
+    }
+    fn header(&self, name: &str) -> Option<String> {
+        let want = format!("{}:", name.to_ascii_lowercase());
+        self.head.lines().find_map(|l| {
+            l.to_ascii_lowercase()
+                .starts_with(&want)
+                .then(|| l[want.len()..].trim().to_string())
+        })
+    }
+}
+
+async fn one_shot(
+    status: u16,
+    response_body: String,
+) -> (String, tokio::sync::oneshot::Receiver<Captured>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-request");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(p) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break p + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+        let len: usize = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse().unwrap())
+            })
+            .expect("a JSON POST declares Content-Length");
+        while buf.len() < head_end + len {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-body");
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body = serde_json::from_slice(&buf[head_end..head_end + len]).unwrap();
+        let response = format!(
+            "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\n\
+             content-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+            response_body.len()
+        );
+        sock.write_all(response.as_bytes()).await.unwrap();
+        sock.shutdown().await.ok();
+        tx.send(Captured { head, body }).ok();
+    });
+    (format!("http://{addr}"), rx)
+}
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// The model rides in the path with a `:generateContent` suffix, the key rides a header,
+/// and an interleaved text-plus-image response walks back into artifacts plus the note.
+#[tokio::test]
+async fn the_model_is_in_the_path_and_the_key_is_in_a_header() {
+    let response = serde_json::json!({
+        "candidates": [{"content": {"parts": [
+            {"text": "Here it is, with the sign moved left."},
+            {"inlineData": {"mimeType": "image/png", "data": b64(b"the-bytes")}}
+        ]}}]
+    })
+    .to_string();
+    let (base, rx) = one_shot(200, response).await;
+    let client = GeminiImagesClient::new("k-secret", &base, Duration::from_secs(5)).unwrap();
+
+    let outcome = client
+        .generate(
+            "gemini-3-flash-image",
+            &MediaRequest {
+                prompt: "a lighthouse".into(),
+                fields: Vec::new(),
+                inputs: Vec::new(),
+                op: None,
+            },
+        )
+        .await
+        .expect("round trips");
+
+    let MediaOutcome::Complete { artifacts, note } = outcome else {
+        panic!("generateContent is synchronous")
+    };
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].bytes, b"the-bytes");
+    assert_eq!(
+        note.as_deref(),
+        Some("Here it is, with the sign moved left.")
+    );
+
+    let cap = rx.await.unwrap();
+    assert_eq!(
+        cap.request_line(),
+        "POST /v1beta/models/gemini-3-flash-image:generateContent HTTP/1.1",
+        "the model is a path segment here, not a body field"
+    );
+    assert_eq!(cap.header("x-goog-api-key").as_deref(), Some("k-secret"));
+    assert!(
+        !cap.request_line().contains("key="),
+        "the credential must not reach the URL, where it would be logged"
+    );
+    assert_eq!(cap.body["contents"][0]["parts"][0]["text"], "a lighthouse");
+    assert_eq!(
+        cap.body["generationConfig"]["responseModalities"],
+        serde_json::json!(["TEXT", "IMAGE"])
+    );
+}
+
+/// A 200 carrying only text is the refusal shape, and the client turns it into an error
+/// that repeats what the model said — over the wire, not just in the parser.
+#[tokio::test]
+async fn a_text_only_answer_becomes_an_error_carrying_the_models_words() {
+    let response = serde_json::json!({
+        "candidates": [{"content": {"parts": [{"text": "I can't do that."}]}}]
+    })
+    .to_string();
+    let (base, _rx) = one_shot(200, response).await;
+    let client = GeminiImagesClient::new("k", &base, Duration::from_secs(5)).unwrap();
+    let err = client
+        .generate(
+            "gemini-3-flash-image",
+            &MediaRequest {
+                prompt: "something refused".into(),
+                fields: Vec::new(),
+                inputs: Vec::new(),
+                op: None,
+            },
+        )
+        .await
+        .expect_err("no image came back");
+    assert!(err.to_string().contains("I can't do that."), "{err}");
+}

--- a/tests/media_inputs.rs
+++ b/tests/media_inputs.rs
@@ -222,7 +222,7 @@ impl MediaModel for AcceptingProvider {
             1,
             "the parts reach the provider intact"
         );
-        Ok(MediaOutcome::Complete(Vec::new()))
+        Ok(MediaOutcome::complete(Vec::new()))
     }
     async fn poll(&self, _job: &MediaJobId) -> anyhow::Result<MediaPollOutcome> {
         unreachable!("this test never defers")


### PR DESCRIPTION
## What

A `gemini-images` backend kind. Gemini image generation reaches the existing `generate` tool, and from the caller's side nothing distinguishes it from Stability or the Images API.

Amy's call on the shape: *"couldn't we drive that in the background and make it look like the other image generators?"* — so **no new tool**. I had proposed a separate conversational lane; this is better. It costs no resident tool-description budget, reuses the whole media path, and leaves the genuinely conversational case where it belongs: *"if the image model really is conversational, it's a consultation having it create images."*

## A media kind whose wire is a completion wire

Gemini has no images endpoint. Image generation is `models/{model}:generateContent` — the same call as text — with `generationConfig.responseModalities` naming what comes back. So `gemini-images` is a separate `ProviderKind` from `gemini`, exactly as `openai-images` is from `openai`: one vendor, two uses of one endpoint, and a cast slot has to know which. A reasoning slot aimed here would resolve a completion model that answers in pictures.

## One seam change, and it isn't Gemini-specific

`MediaOutcome::Complete` becomes `{ artifacts, note }`. A `generateContent` response interleaves text and image parts, and a model that says *"I moved the sign left, the original crop cut it off"* has told the caller something the bytes don't.

**That channel is the TTS door.** `responseModalities` is an enum of TEXT/IMAGE/**AUDIO**, and `generationConfig` carries `speechConfig` beside `imageConfig`. Gemini TTS is this module's shape with a different modality — so the part-walk is written for parts in general, not images in particular. When that wave lands it should be a config block and a CAS extension, not a new module.

## The most valuable error carries the model's own words

A safety refusal, a clarifying question and "I can't do that" all arrive as a normal 200 with text and no picture. Reporting "no image" without the text would throw away the only explanation the caller gets.

## Review

kaibo, cast `crusoe`. Its best finding was one I'd have hated to ship: **`generate`'s description had become false** — "Stability accepts input images; the other media backends do not" — in text a calling agent reads to decide what to send. A stale description is bad; an actively wrong one is worse, because it's trusted.

Also fixed: eight stale enumeration sites in `docs/config.md` (embedded in the binary, served as `kaibo://config/guide`), including the per-kind `base_url` section, so an operator couldn't discover how to configure this at all. And a real API gap — **a blocked prompt was reported as "no candidates"**. Gemini refuses at two levels (`promptFeedback.blockReason`, and a candidate with `finishReason` and no content); both now carry the reason. Plus: every candidate is walked, not just the first, since `candidateCount` rides `fields` and each candidate is billed.

Two review items I didn't take as given: `imageConfig.imageSize` **is** real (`512`/`1K`/`2K`/`4K` in the discovery doc), and on the "third media kind" comment, **mine** was the wrong one — DashScope genuinely was third, Gemini is fourth.

## Testing

19 tests, including two over a real socket for truths the pure functions can't see: the model rides in the *path* with a `:generateContent` suffix, and the key rides a header rather than the `?key=` query parameter Google also accepts, so it stays out of anything that logs a URL.

Writing the unknown-parts test immediately caught a bug in the line I'd just written — the recording sat after the blob branch, so blob parts were recorded as unknown and genuinely unknown parts were skipped by an early `continue`.

Full suite green (1251 passing, exit 0), clippy clean.

## Wants a live probe

`responseModalities` defaults to `["TEXT", "IMAGE"]` because the spec makes it an exact match and errors on an unsupported combination, and image-only isn't universally supported. **That's my reading of the spec, not a verified fact** — it, and Stability's `edit/erase` prompt contradiction, are the two open questions a small amount of real spend would settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)