### PR TITLE
fix(batch): a failed batch says where it failed and what is recoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ record. Each later release appends a new section at the top.
   content is redacted by default.
 - **An explicit `[telemetry] enabled = false` beats the environment**, and
   `OTEL_SDK_DISABLED` beats every source.
+- **A failed batch now names where the failure happened** — the provider accepted the
+  batch and failed it afterward, so a bare provider string no longer reads as a kaibo bug.
+- **A failed batch now counts its unspent prompts** and points at `batch_submit`, in the
+  rendered poll and as `submitted` in `batch get --json`.
+- **A failed batch now names the cast that ran it**, the provenance footer a completed
+  batch already carried.
 
 ### Fixed
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -164,7 +164,18 @@ pub enum BatchPoll {
     /// Anthropic's interim `Cancelling`). `state` is the provider's raw state string;
     /// `message` is its reason. Distinct from `Done(vec![])` — that would render as
     /// "0 results" and read like success; this names the failure honestly.
-    Failed { state: String, message: String },
+    ///
+    /// `submitted` is how many items the batch was sent with, when kaibo recorded it.
+    /// Not a cross-check here (there are no results to check against): it is what the
+    /// render counts when it tells the caller how many prompts are unspent, because
+    /// rebuilding those prompts from the caller's own context is the expensive part of
+    /// a failed batch. `None` when the count was never recorded, and the render then
+    /// offers the recovery without inventing a number.
+    Failed {
+        state: String,
+        message: String,
+        submitted: Option<u64>,
+    },
 }
 
 /// One batch as the provider's list endpoint reports it — enough to re-address and
@@ -657,8 +668,26 @@ pub fn render_poll(poll: &BatchPoll, label: &str) -> String {
             s.push_str(&format!("\n———\nkaibo · batch · {label}"));
             s
         }
-        BatchPoll::Failed { state, message } => {
-            format!("Batch ended in {state} — {message}. No per-item results to return.")
+        BatchPoll::Failed {
+            state,
+            message,
+            submitted,
+        } => {
+            // "Unspent", not "never ran": a zero-result poll proves no answer came back,
+            // not that no item started. Cancel and expire reach this arm too, and there an
+            // item may have begun before the terminal event. The counted line restates the
+            // first line rather than inferring past it.
+            let prompts = match submitted {
+                Some(n) => format!("The {n} submitted prompt(s) are unspent"),
+                None => "The submitted prompts are unspent".to_string(),
+            };
+            format!(
+                "Batch ended in {state} — {message}. No item returned an answer.\n\n\
+                 kaibo sent the request and the provider accepted the batch. This state and \
+                 the message above came from the provider after that.\n\n\
+                 {prompts}. Resubmit them with `batch_submit` once the cause is cleared.\n\
+                 \n———\nkaibo · batch · {label}"
+            )
         }
     }
 }
@@ -1125,6 +1154,7 @@ fn parse_gemini_poll(v: &Value, submitted: Option<u64>) -> Result<BatchPoll> {
             Ok(BatchPoll::Failed {
                 state: state.to_string(),
                 message,
+                submitted,
             })
         }
         other => Err(anyhow!("unknown gemini batch state {other:?}: {v}")),
@@ -2017,6 +2047,7 @@ impl BatchProvider for OpenaiBatch {
                         message: openai_batch_error_text(&v).unwrap_or_else(|| {
                             "the provider returned no result file and no error detail".to_string()
                         }),
+                        submitted,
                     });
                 }
                 Ok(BatchPoll::Done(finalize_openai_answers(
@@ -3541,7 +3572,8 @@ mod tests {
             parse_gemini_poll(&v, None).unwrap(),
             BatchPoll::Failed {
                 state: "BATCH_STATE_CANCELLED".into(),
-                message: "Batch x failed without error.".into()
+                message: "Batch x failed without error.".into(),
+                submitted: None,
             }
         );
     }
@@ -4218,11 +4250,135 @@ mod tests {
             &BatchPoll::Failed {
                 state: "BATCH_STATE_EXPIRED".into(),
                 message: "ran past its 24h window".into(),
+                submitted: None,
             },
             "gemini · gemini-3-pro-preview",
         );
         assert!(out.contains("BATCH_STATE_EXPIRED"));
         assert!(out.contains("ran past its 24h window"));
+    }
+
+    /// The reason a whole-batch failure is hard to act on is that the provider's text
+    /// arrives bare: "Cannot find file ..." reads like a kaibo bug. The render names the
+    /// step boundary — kaibo sent it, the provider accepted it, this state came after —
+    /// so a caller can tell a request-construction fault from a provider/account one.
+    #[test]
+    fn render_failed_names_where_the_failure_happened() {
+        let out = render_poll(
+            &BatchPoll::Failed {
+                state: "failed".into(),
+                message: "Cannot find file file-VC5eF687ZfDPFKkBrPGZpa".into(),
+                submitted: Some(3),
+            },
+            "gpt · gpt-5.6-sol",
+        );
+        assert!(
+            out.contains("accepted"),
+            "the render must say the provider accepted the batch: {out}"
+        );
+        assert!(
+            out.contains("provider"),
+            "the render must attribute the message to the provider: {out}"
+        );
+    }
+
+    /// A failed batch returned no answer, so its prompts are unspent — and the caller has
+    /// to be told, because reconstructing them from its own context is the expensive part.
+    #[test]
+    fn render_failed_names_the_unspent_prompts() {
+        let out = render_poll(
+            &BatchPoll::Failed {
+                state: "failed".into(),
+                message: "Cannot find file file-VC5eF687ZfDPFKkBrPGZpa".into(),
+                submitted: Some(3),
+            },
+            "gpt · gpt-5.6-sol",
+        );
+        assert!(
+            out.contains("3 submitted prompt"),
+            "the render must count the unspent prompts: {out}"
+        );
+        assert!(
+            out.contains("batch_submit"),
+            "the render must name the action that recovers them: {out}"
+        );
+    }
+
+    /// The render says the prompts are *unspent*, never that they "never ran". A zero-result
+    /// poll proves no answer came back; it does not prove no item started. Cancel and expire
+    /// reach this arm too, and there an item may well have begun before the terminal event —
+    /// so the counted line restates what the first line knows instead of escalating past it.
+    #[test]
+    fn render_failed_claims_unspent_not_unstarted() {
+        let out = render_poll(
+            &BatchPoll::Failed {
+                state: "BATCH_STATE_CANCELLED".into(),
+                message: "cancelled by request".into(),
+                submitted: Some(3),
+            },
+            "gemini · gemini-pro-latest",
+        );
+        assert!(out.contains("unspent"), "{out}");
+        assert!(
+            !out.contains("never ran"),
+            "kaibo cannot know an item never started: {out}"
+        );
+    }
+
+    /// A failed batch names who ran it, exactly as a completed one does. Without the footer
+    /// a cross-model study loses the provenance trail at the moment it most needs it — the
+    /// failure — and cannot tell which cast the provider refused.
+    #[test]
+    fn render_failed_carries_the_provenance_footer() {
+        let out = render_poll(
+            &BatchPoll::Failed {
+                state: "failed".into(),
+                message: "Cannot find file file-VC5eF687ZfDPFKkBrPGZpa".into(),
+                submitted: Some(3),
+            },
+            "gpt · gpt-5.6-sol",
+        );
+        assert!(
+            out.contains("kaibo · batch · gpt · gpt-5.6-sol"),
+            "a failed batch must name its cast too: {out}"
+        );
+    }
+
+    /// With no count recorded the render still offers the recovery, and invents no number.
+    #[test]
+    fn render_failed_without_a_count_still_offers_resubmission() {
+        let out = render_poll(
+            &BatchPoll::Failed {
+                state: "failed".into(),
+                message: "no detail".into(),
+                submitted: None,
+            },
+            "gpt · gpt-5.6-sol",
+        );
+        assert!(out.contains("batch_submit"), "{out}");
+        assert!(
+            !out.contains("0 submitted prompt"),
+            "an unknown count must not render as zero: {out}"
+        );
+    }
+
+    /// The submitted count reaches the failure arm, not just the cross-check on the
+    /// succeeded arm — it is what the recovery line counts.
+    #[test]
+    fn gemini_poll_failed_carries_the_submitted_count() {
+        let v = json!({
+            "metadata": { "state": "BATCH_STATE_FAILED",
+                "batchStats": { "requestCount": "4", "pendingRequestCount": "4" } },
+            "error": { "code": 13, "message": "Batch x failed without error." }
+        });
+        assert_eq!(
+            parse_gemini_poll(&v, Some(4)).unwrap(),
+            BatchPoll::Failed {
+                state: "BATCH_STATE_FAILED".into(),
+                message: "Batch x failed without error.".into(),
+                submitted: Some(4),
+            }
+        );
     }
 
     /// The scripted provider drives a full submit → pending → done flow offline.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2968,8 +2968,20 @@ fn batch_poll_envelope(poll: &BatchPoll) -> serde_json::Value {
                 Err(reason) => serde_json::json!({ "custom_id": a.custom_id, "ok": false, "error": reason }),
             }).collect::<Vec<_>>(),
         }),
-        BatchPoll::Failed { state, message } => {
-            serde_json::json!({ "status": "failed", "state": state, "message": message })
+        BatchPoll::Failed {
+            state,
+            message,
+            submitted,
+        } => {
+            // `submitted` rides the envelope so a script can see how many prompts are
+            // unspent without parsing the rendered prose; `null` when it was never
+            // recorded, never 0 — a batch is never submitted with no items.
+            serde_json::json!({
+                "status": "failed",
+                "state": state,
+                "message": message,
+                "submitted": submitted,
+            })
         }
     }
 }
@@ -3568,10 +3580,21 @@ mod tests {
         let failed = batch_poll_envelope(&BatchPoll::Failed {
             state: "expired".into(),
             message: "too late".into(),
+            submitted: Some(3),
         });
         assert_eq!(failed["status"], "failed");
         assert_eq!(failed["state"], "expired");
         assert_eq!(failed["message"], "too late");
+        assert_eq!(failed["submitted"], 3);
+
+        // An unrecorded count is `null`, not 0 — a batch is never submitted with no items,
+        // so a 0 here would read as a real count and mislead a script.
+        let failed = batch_poll_envelope(&BatchPoll::Failed {
+            state: "expired".into(),
+            message: "too late".into(),
+            submitted: None,
+        });
+        assert!(failed["submitted"].is_null(), "{failed}");
     }
 
     #[test]


### PR DESCRIPTION
## Why

A real incident, not a hypothetical. Three OpenAI batches failed with the provider's bare string:

```
Cannot find file file-VC5eF687ZfDPFKkBrPGZpa, or organization
org-Rem6LBmDPt1bJQcMV8ARko4o does not have access to it.
```

That reads like a kaibo bug. It is not. The same failure reproduces **four times with plain `curl` and no kaibo in the picture** — a fresh file uploaded by hand, kaibo's own failed input resubmitted, an upload→create with no gap, and a `/v1/chat/completions` batch instead of `/v1/responses`. Meanwhile `GET /v1/files/{id}` returns 200 and `/content` hands back the JSONL verbatim for the very files the validator says do not exist. The Files API and the Batch validator contradict each other inside OpenAI's own platform.

kaibo's code was correct the whole time. A session was spent establishing that, and the two costs that made it expensive are what this PR fixes.

## What changed

**1. The render names the step boundary.** Nothing in the output separated kaibo's request construction from the provider's processing, so a caller could not tell which side to look at.

This is deliberately a boundary, not a verdict. A batch can also fail validation because the submitted request was wrong, so the text says where the state came from and never says whose fault it is.

**2. A failed batch counts its unspent prompts.** The caller's prompts vanished with no sign they were recoverable — attempt 1 carried three long prompts and 215 KB of attachments, retyped from the caller's context. `BatchPoll::Failed` gained `submitted`, the count both providers' poll paths already had in hand. `batch get --json` publishes it too, `null` when unrecorded and never `0`.

**3. A failed batch carries the provenance footer** a completed one always had. Losing the cast name at the moment of failure is backwards for the cross-model study the footer exists to serve.

The result:

```
Batch ended in failed — Cannot find file file-VC5eF687ZfDPFKkBrPGZpa. No item returned an answer.

kaibo sent the request and the provider accepted the batch. This state and the message
above came from the provider after that.

The 3 submitted prompt(s) are unspent. Resubmit them with `batch_submit` once the cause
is cleared.

———
kaibo · batch · gpt · gpt-5.6-sol
```

## The review changed the text

Cross-family review by kaibo cast `crusoe` (GLM-5.2 synth). Its substantive finding: the first draft said the prompts **"never ran"**, and that overclaims. A zero-result poll proves no answer came back, not that no item started — and cancel and expire reach this same arm, where an item may well have begun before the terminal event. "Unspent" is what kaibo can actually back, and it is the word the enum doc already used. Every cited line was verified before acting on it.

The review also flagged the missing provenance footer (pre-existing, fixed here) and confirmed no other construction site or renderer was missed: Anthropic never constructs `Failed`, and `batch_poll_brief` ignoring `submitted` is correct for a one-line `job_wait` footer.

## Tests

Six render tests plus the JSON envelope's `null`-not-`0` case. **Negative control run:** with the old bare render restored, three of the new tests fail and the pre-existing `render_failed_names_state_and_reason` still passes — it only ever checked state and reason, which the old text also carried.

`cargo test` green (36 suites), `cargo clippy --all-targets` clean.

## Not done here, deliberately

Persisting prompt text alongside the handle. The store keeps `{backend, provider_id, label, created_at, submitted_count}`; writing prompt bodies to a fixed XDG path is a privacy posture change that is @tobert's call, not something to slip inside an error-message PR.

## Operator note

The `gpt` batch lane is still down provider-side as of this writing, and `anthropic`/`chimera` batch is separately dead on billing. **Gemini is the only healthy batch lane right now.** Full evidence in `~/exomemory/kaibo/openai-batch-file-not-found.md`; the next move there is an OpenAI support ticket, not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)