### PR TITLE
feat(bfl): FLUX image generation through generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ record. Each later release appends a new section at the top.
 
 ### Added
 
+- **A `bfl` backend kind** — Black Forest Labs' FLUX image family through `generate`,
+  five named operations, polled in-call for a fast generation and as a `job-N` handle
+  only past that budget.
 - **A `gemini-images` backend kind** — Gemini image generation through `generate`, the
   same face as every other image backend. Takes input images; has no named operations.
 - **`generate` shows what the model said** above the digests, for a backend whose image

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ config has three concepts for configuring models:
 
 - **backend** — a *connection*: which wire protocol (the completion kinds `anthropic`
   | `deepseek` | `gemini` | `openrouter` | `openai`, or the media kinds `stability` |
-  `openai-images` | `gemini-images` | `dashscope` behind the `image` role), base URL, and where its key
+  `openai-images` | `gemini-images` | `dashscope` | `bfl` behind the `image` role), base URL, and where its key
   comes from.
   Secrets never live in the TOML — only the *name* of an env var or the path to a key
   file. `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every

--- a/docs/bfl.md
+++ b/docs/bfl.md
@@ -25,6 +25,19 @@ media lane. The motivating use is concept images.
   returned `polling_url` verbatim (regional host — never reconstruct it from
   the base URL) until `ResultResponse.status` leaves
   `Pending`/`Reasoning`/`Generating`.
+- **The poll leg is https-only with no redirects.** `polling_url` is an
+  address BFL chose, not the operator's own `base_url`, and the poll request
+  carries the `x-key` credential — the same trust shape
+  `crate::cas::fetch_artifact_bytes` already takes for `result.sample`, and
+  worse, since the key rides along. A plain `http://` `polling_url` is
+  refused before a single byte of the request leaves (no connection is
+  attempted at all — `crate::tls::artifact_fetch_client`'s `https_only(true)`),
+  and a redirecting `polling_url` is refused rather than followed
+  (`Policy::none()`) — reqwest strips the standard `Authorization` header on a
+  cross-host redirect but not a custom header like `x-key`, so following one
+  would carry the key to whatever host it names. The create call itself keeps
+  the general client: `base_url` is the operator's own configured endpoint,
+  and where that redirects is the operator's business.
 - Terminal statuses: `Ready` (the artifact), `Error`, `Request Moderated`,
   `Content Moderated`, `Task not found` — each of the last four is its own loud
   error naming what the provider said and what the caller can change.
@@ -115,3 +128,11 @@ one does.
   `media.rs`, `discover.rs`, `server/mod.rs`, and the config docs the same way
   #168 wired `gemini-images`. Still no `BFL_API_KEY`; `tests/bfl_live.rs` is
   `#[ignore]`d and ready for one.
+- 2026-08-31 — review finding fixed: the poll leg shared `create`'s general
+  client, so a plaintext or redirecting `polling_url` (provider-chosen,
+  carrying the `x-key` credential) would have dialled or followed it. `poll_once`
+  now runs over `crate::tls::artifact_fetch_client` (https-only, no redirects) —
+  the same posture the `result.sample` fetch already had, extended to
+  `polling_url`. Failing-first: a new transport test proved today's code makes a
+  real connection to a plaintext `polling_url`; it passes now that the poll
+  client refuses one before dialling.

--- a/docs/bfl.md
+++ b/docs/bfl.md
@@ -103,3 +103,15 @@ one does.
 
 - 2026-08-31 — spec written from the live OpenAPI dump; implementation
   delegated. No key yet; offline build first.
+- 2026-08-31 — `src/bfl.rs` landed: the five starter ops, request/response parsing,
+  and every terminal-status error, all offline and failing-first. Shape decided:
+  hybrid inline-poll-then-`Deferred` — `generate` polls in-call for
+  `INLINE_POLL_BUDGET` (30s) and falls back to the existing `Deferred`/`job-N` lane
+  only past that, so the common fast case returns bytes and the rare slow one still
+  gets a handle; this is the first shape from the spec's two options, with `Deferred`
+  as its documented bound. `AsyncResponse.cost` rides `MediaOutcome::Complete`'s
+  `note` channel on the fast path only — no note channel exists on the deferred
+  path today, recorded as a future widening. Wired into `credentials.rs`,
+  `media.rs`, `discover.rs`, `server/mod.rs`, and the config docs the same way
+  #168 wired `gemini-images`. Still no `BFL_API_KEY`; `tests/bfl_live.rs` is
+  `#[ignore]`d and ready for one.

--- a/docs/bfl.md
+++ b/docs/bfl.md
@@ -136,3 +136,8 @@ one does.
   `polling_url`. Failing-first: a new transport test proved today's code makes a
   real connection to a plaintext `polling_url`; it passes now that the poll
   client refuses one before dialling.
+- 2026-08-31 — live-validated end to end with a real key: `kaibo generate --cast
+  flux` (op `flux-2-pro`) returned a real artifact into the CAS on the inline
+  path, cost reported as BFL's own 3 credits / 1 output MP, and the TLS-strict
+  poll client worked against the real regional `polling_url`. The `#[ignore]`d
+  live test remains for regression runs.

--- a/docs/bfl.md
+++ b/docs/bfl.md
@@ -1,0 +1,105 @@
+# BFL (FLUX) media kind — spec
+
+Living spec for the `bfl` media kind: Black Forest Labs' FLUX image API behind
+`generate`, the same facade every other media kind speaks. Branch `bfl`,
+worktree `~/src/wt/kaibo-bfl`. Written 2026-08-31 from the live OpenAPI spec at
+`https://api.bfl.ai/openapi.json` (snapshot in the drafting session's
+scratchpad; re-fetch when in doubt — the spec is the ground truth, this doc is
+the map).
+
+## Why
+
+FLUX covers the aesthetic ground Midjourney owns, and Midjourney has no lawful
+API (their ToS bans automated access; the third-party wrappers puppet Discord
+accounts). BFL's own API is keyed, documented, and one-PR-shaped for kaibo's
+media lane. The motivating use is concept images.
+
+## The wire
+
+- Base `https://api.bfl.ai`, auth header `x-key: <api key>`, JSON request
+  bodies (not multipart — unlike Stability).
+- One endpoint per operation, like Stability: the `op` call parameter maps to a
+  path (`POST /v1/flux-2-pro`, `POST /v1/flux-kontext-pro`, …).
+- **Every operation is asynchronous.** A create returns
+  `AsyncResponse{id, polling_url, cost, input_mp, output_mp}`. Poll the
+  returned `polling_url` verbatim (regional host — never reconstruct it from
+  the base URL) until `ResultResponse.status` leaves
+  `Pending`/`Reasoning`/`Generating`.
+- Terminal statuses: `Ready` (the artifact), `Error`, `Request Moderated`,
+  `Content Moderated`, `Task not found` — each of the last four is its own loud
+  error naming what the provider said and what the caller can change.
+- On `Ready`, `result.sample` is a **signed delivery URL that expires in ~10
+  minutes** — fetch into the media CAS immediately on observing `Ready`, via
+  `crate::tls::artifact_fetch_client` (one hop, https-only; the DashScope
+  precedent). A `3xx` or expired link is its own error, not a generic failure.
+
+## Mapping to the facade
+
+- `MediaRequest.prompt` → `prompt` (required everywhere).
+- `MediaRequest.inputs` (named, from #164) → the `input_image` …
+  `input_image_8` request fields, base64-encoded strings in the JSON body. The
+  name in `inputs` is the field name verbatim.
+- `MediaRequest.fields` → passthrough scalars (`width`, `height`, `seed`,
+  `safety_tolerance`, `output_format`, `disable_pup`, …), the #166 pattern:
+  seed nothing the caller did not say, refuse unknown fields loudly if that is
+  what the existing kinds do — mirror them.
+- Cost: `AsyncResponse.cost` is credits, reported by the provider **per
+  request**. Publish it verbatim in the outcome/provenance (native-unit ruling,
+  2026-08-22: kaibo converts nothing). No static per-op cost table — the
+  response is the table.
+
+## Deferred vs. complete
+
+Mirror the existing deferred-operation handling (Stability's five deferred ops
+are the precedent — read how `stability.rs` and the `generate` face decide
+between `MediaOutcome::Complete` and `Deferred` and do exactly that). If the
+existing shape polls inline within the request timeout for fast ops, use it —
+FLUX generations are seconds-fast and a concept-image caller wants bytes, not a
+handle. If the facade's shape is strictly Deferred-with-job-N for async
+providers, use that. State which shape resulted in the report; do not invent a
+third shape.
+
+## Starter op table
+
+Five ops, the subset discipline from #166. Path, purpose, one line each in the
+`op` schema doc:
+
+| op | path | why in the starter set |
+|---|---|---|
+| `flux-dev` | `/v1/flux-dev` | the cheap rung — probing and drafts |
+| `flux-2-pro` | `/v1/flux-2-pro` | the quality default |
+| `flux-2-flex` | `/v1/flux-2-flex` | parameter-heavy control |
+| `flux-pro-1.1-ultra` | `/v1/flux-pro-1.1-ultra` | high-resolution stills |
+| `flux-kontext-pro` | `/v1/flux-kontext-pro` | image editing with reference inputs |
+
+## Config
+
+`[backends.bfl]` with `kind = "bfl"`, key sourced the way the other media
+backends source theirs (mirror `stability`/`dashscope` exactly), plus whatever
+cast/slot wiring `generate` needs to staff the kind — #168 (Gemini images) is
+the freshest merged example of adding a kind end to end; use it as the
+template.
+
+## Out of scope, on record
+
+- `flux-3-video` and `flux-tools/video-upscale-v1` — blocked on the CAS
+  extension gap (no video extensions in `to_cas_extension`; it refuses loudly
+  today, the right direction).
+- The `flux-tools/*` image family (erase, deblur, outpainting, vto) — a table
+  extension once the kind exists.
+- Finetune routes, webhooks (`webhook_url`/`webhook_secret`) — kaibo polls;
+  it does not bind sockets or receive callbacks (stdio-only invariant).
+
+## Testing
+
+Offline-first like every other kind: unit tests over request construction and
+response parsing (the `AsyncResponse`/`ResultResponse`/status-enum shapes
+above), error mapping for each terminal status, and the expiring-URL fetch
+path. Live probes are `#[ignore]`d and keyed (`BFL_API_KEY` or the config
+key) — no key exists yet at the time of writing; live validation happens when
+one does.
+
+## Status log
+
+- 2026-08-31 — spec written from the live OpenAPI dump; implementation
+  delegated. No key yet; offline build first.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -398,7 +398,7 @@ scratch_limit_bytes = 67108864
 # ---------------------------------------------------------------------------
 # [backends.<name>] — CONNECTIONS only: `kind` picks the wire and its client. The
 # completion wires (anthropic | deepseek | gemini | openrouter | openai) serve the
-# reasoning slots; the media kinds (stability | openai-images | gemini-images | dashscope) serve `image` slots
+# reasoning slots; the media kinds (stability | openai-images | gemini-images | dashscope | bfl) serve `image` slots
 # only. The rest describes the wire (endpoint, key source, per-request deadline).
 # Models live on cast slots, never here.
 #
@@ -414,7 +414,7 @@ scratch_limit_bytes = 67108864
 # unset still dials rig's built-in api.anthropic.com / generativelanguage.googleapis.com),
 # and the media kinds (optional — unset dials api.stability.ai for stability,
 # api.openai.com/v1 for openai-images, generativelanguage.googleapis.com for
-# gemini-images, dashscope-intl.aliyuncs.com for dashscope);
+# gemini-images, dashscope-intl.aliyuncs.com for dashscope, api.bfl.ai for bfl);
 # set it to point the same wire at a
 # compatible gateway/proxy (or a local server) instead — a ROOT in every case,
 # since the client appends its own path. Every other keyed kind rejects
@@ -545,8 +545,8 @@ api_key_cmd = ["op", "read", "op://Vault/Kaibo/Deepseek-key"]
 # `deep-dive`) so it can route by name without reading this file.
 #
 # Roles: explorer, synth (the reasoning phases), and image (the media member — it
-# points at a media backend, kind stability, openai-images, gemini-images, or dashscope, and staffs `generate`;
-# see the image-slot examples below). A typo'd role is a loud load
+# points at a media backend, kind stability, openai-images, gemini-images, dashscope,
+# or bfl, and staffs `generate`; see the image-slot examples below). A typo'd role is a loud load
 # error. A cast may omit roles — the tool that needs a missing role fails at call time,
 # naming the gap ("cast `notes` has no synth slot"); absent = capability absent.
 #
@@ -598,7 +598,8 @@ explorer = "llama/qwen2.5-coder-7b"                              # bare ref: jus
 synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 # --- The `image` slot: a MEDIA member on the team. It points at a media backend
-#     (kind = "stability", "openai-images", "gemini-images", or "dashscope") and produces artifacts instead of
+#     (kind = "stability", "openai-images", "gemini-images", "dashscope", or "bfl")
+#     and produces artifacts instead of
 #     text, so the reasoning tunables (effort, thinking_budget, temperature, ...)
 #     do not apply to it — writing one there is inert and kaibo://config flags it.
 #     A cast carries it beside its reasoning slots; a cast without one cannot staff
@@ -669,6 +670,20 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 # [casts.wan-artist]
 # image = "wan/wan2.6-t2i"        # the request's `model` field
+
+# --- The bfl kind reaches Black Forest Labs' FLUX family. base_url is optional
+#     (unset dials api.bfl.ai). Every operation is asynchronous — a create call
+#     returns a job id and a polling_url kaibo polls, in-call for a fast generation
+#     and as a `job-N` handle only past that budget. The slot's model id names one of
+#     five operations (flux-dev, flux-2-pro, flux-2-flex, flux-pro-1.1-ultra,
+#     flux-kontext-pro) and doubles as `generate`'s default `op`; a per-call `op`
+#     overrides it. Every operation takes input_image..input_image_8 in `inputs`. ---
+
+# [backends.bfl]
+# kind = "bfl"                    # key: BFL_API_KEY / ~/.bfl-key
+
+# [casts.flux-artist]
+# image = "bfl/flux-2-pro"        # the default operation; override per call with `op`
 
 # --- The table form, part 2: per-slot tunables. Each overrides its [defaults]
 #     per-role value for THIS slot only; knobs you omit fall back. Available:

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,7 +20,7 @@ of backends and casts. A missing file at the default path is not an error.
 
 ```
 ProviderKind = anthropic | deepseek | gemini | openrouter | openai   (completion wires)
-             | stability | openai-images | gemini-images | dashscope (media kinds)
+             | stability | openai-images | gemini-images | dashscope | bfl (media kinds)
 Backend      = { name, kind, base_url?, key source, request_timeout }
 Cast         = { name, role → ModelSlot }                  (freely spans backends)
 ModelSlot    = "backend/model-id"  or  { backend, id, pins…, tunables… }
@@ -32,12 +32,12 @@ Each concept owns one idea:
   selects the client and the request shape), `base_url`, a key source, and
   `request_timeout`. Answers "how do I reach Gemini". Kinds divide into two classes:
   the completion wires (everything through rig's completion clients) and the media
-  kinds (`stability`, `openai-images`, `gemini-images`, `dashscope` — image-generation APIs with no
+  kinds (`stability`, `openai-images`, `gemini-images`, `dashscope`, `bfl` — image-generation APIs with no
   completion surface).
 - **role** — a *job* a model serves. Three exist: `explorer` and `synth`, the two
   reasoning phases, and `image`, the media member that staffs the `generate` tool.
   A reasoning role takes a completion backend; the `image` role takes a media backend
-  (kind `stability`, `openai-images`, `gemini-images`, or `dashscope`) — pairing either with the wrong class is a
+  (kind `stability`, `openai-images`, `gemini-images`, `dashscope`, or `bfl`) — pairing either with the wrong class is a
   load error naming the fix. Image *input* is a slot capability (the `vision` pin on
   a reasoning slot), not a role.
 - **cast** — a *composition*. A named assignment of models to roles. This is what the
@@ -54,7 +54,7 @@ Connection settings only. Models are never declared here.
 
 | key | type | default | notes |
 |---|---|---|---|
-| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` \| `gemini-images` \| `dashscope` | required on a new backend | closed enum; selects client + request shape (`stability`, `openai-images`, `gemini-images`, and `dashscope` are the media kinds — image slots only) |
+| `kind` | `anthropic` \| `deepseek` \| `gemini` \| `openrouter` \| `openai` \| `stability` \| `openai-images` \| `gemini-images` \| `dashscope` \| `bfl` | required on a new backend | closed enum; selects client + request shape (`stability`, `openai-images`, `gemini-images`, `dashscope`, and `bfl` are the media kinds — image slots only) |
 | `base_url` | string | kind-dependent | required for a new `openai` backend; optional for `anthropic`/`gemini` and the media kinds; load error elsewhere |
 | `wire` | `responses` \| `chat` | inferred | `kind = "openai"` only; load error elsewhere |
 | `api_key_env` | env var *name* | unset — declared by you | env source, checked first |
@@ -120,6 +120,17 @@ by re-declaration.
   returns artifacts as presigned links, so kaibo fetches each over TLS and stores
   the bytes; the artifact's mime is the fetch response's `Content-Type`, and one the
   media store cannot name is refused rather than guessed.
+- **`kind = "bfl"`** — optional. Unset dials `https://api.bfl.ai`. Every FLUX
+  operation is asynchronous: a create call answers `{id, polling_url, ...}`, and
+  `generate` polls `polling_url` (a regional host, dialled verbatim — never rebuilt
+  from `base_url`) in-call for the common fast case, falling back to a `job-N` handle
+  only when a generation is still running past that budget. The key is required, from
+  its own sources (`BFL_API_KEY` / `~/.bfl-key`). The image-slot model id names one of
+  five operations (`flux-dev`, `flux-2-pro`, `flux-2-flex`, `flux-pro-1.1-ultra`,
+  `flux-kontext-pro`) and is also `generate`'s default `op`. The generated artifact
+  arrives as a signed link good for about ten minutes, fetched the same way
+  DashScope's is; the mime comes from the fetched bytes, and one the media store
+  cannot name is refused rather than guessed.
 - **Every other kind** — a load error. rig fixes those endpoints.
 
 The value is a root the client versions itself, never a full endpoint path. rig's
@@ -129,7 +140,7 @@ same way, and the media clients append their own route (`/v2beta/...` for
 `stability`; `/v1beta/models/{model}:generateContent` for `gemini-images`;
 `/images/generations` for `openai-images`, so give that one a URL
 through `/v1`; the multimodal-generation route for `dashscope`, so give that one a
-bare host).
+bare host; one path per operation for `bfl`, e.g. `/v1/flux-2-pro`).
 
 #### `wire`
 
@@ -285,7 +296,8 @@ media member: it points at a media-kind backend and staffs the `generate` tool. 
 model id means what that kind says it means — for `stability` it picks the route
 (`core`, `ultra`, or an SD3.5 variant); for `gemini-images` it is the model in the request path; for `openai-images` it is the `model` field
 (`gpt-image-1` hosted, or whatever a local sd-server loaded); for `dashscope` it is
-the `model` field too (`wan2.6-t2i`). It sends one
+the `model` field too (`wan2.6-t2i`); for `bfl` it names one of five operations
+(`flux-2-pro`, ...) and doubles as `generate`'s default `op`. It sends one
 generation request, not a reasoning loop, so the reasoning tunables (`effort`,
 `thinking_budget`, `temperature`, ...) written on it are inert — `kaibo://config`
 flags them under `inert_tunables`.
@@ -742,7 +754,7 @@ Which cast shape staffs which tool:
 | `explore` | a cast with an `explorer` slot |
 | `batch_submit` | a cast whose synth runs on `lane = "batch"` (or the `batch = true` sugar) |
 | `deliberate` | a cast with an `explorer` **and** an offline synth (`lane = "batch"` or `lane = "direct"`) |
-| `generate` | a cast with an `image` slot (a media backend: kind `stability`, `openai-images`, `gemini-images`, or `dashscope`) — plus `[cas]` on |
+| `generate` | a cast with an `image` slot (a media backend: kind `stability`, `openai-images`, `gemini-images`, `dashscope`, or `bfl`) — plus `[cas]` on |
 | `job_get`, `job_cancel`, `job_list`, `job_wait` | at least one live handle *producer*; they follow whatever survives above |
 | `run_kaish`, `list_models` | no cast at all; advertised whenever their flag is on |
 

--- a/src/bfl.rs
+++ b/src/bfl.rs
@@ -275,7 +275,10 @@ pub enum BflError {
     ReadyWithNoSample,
 
     /// `status: "Error"` — the provider ran the request and failed on it.
-    #[error("BFL reported a generation error: {detail}")]
+    #[error(
+        "BFL reported a generation error: {detail}. The provider ran the request \
+         and failed on its own side — retry the generation"
+    )]
     GenerationError { detail: String },
 
     /// `status: "Request Moderated"` — refused before generation ran.

--- a/src/bfl.rs
+++ b/src/bfl.rs
@@ -1,0 +1,1063 @@
+//! Black Forest Labs' FLUX image API — kaibo's fifth media kind
+//! (`ProviderKind::Bfl`), a sibling of `src/stability.rs` and `src/dashscope.rs`.
+//! See `docs/bfl.md` for the spec this module implements.
+//!
+//! # One endpoint per operation, every one of them asynchronous
+//!
+//! Unlike Stability (mostly synchronous, five ops deferred) or DashScope/Gemini
+//! (always synchronous), **every** BFL operation is asynchronous: a create POST
+//! answers with `{id, polling_url, cost, input_mp, output_mp}` (`AsyncResponse`), and
+//! the artifact comes from polling `polling_url` — a regional host that must be
+//! dialled **verbatim**, never rebuilt from `base_url` — until its status leaves
+//! `Pending`/`Reasoning`/`Generating`.
+//!
+//! # The shape: inline-poll-then-defer, not strictly one or the other
+//!
+//! `docs/bfl.md` offers two shapes and asks which one lands: poll inline within the
+//! request for a fast op (a concept-image caller wants bytes, not a handle), or
+//! answer strictly `Deferred` like an async provider. FLUX generations are seconds-
+//! fast, so [`BflImageModel::generate`] does both in sequence: it polls
+//! [`INLINE_POLL_BUDGET`] worth of cadence right there in the call, and only when the
+//! provider is still working after that budget does it fall back to
+//! [`crate::media::MediaOutcome::Deferred`] — the existing job lane
+//! (`server.rs`'s background task, or the CLI's own wait loop) picks up the exact same
+//! `polling_url` from there via [`BflImageModel::poll`], which stays a single GET, no
+//! sleep, exactly like every other kind's `poll`. This is not a third shape: it is the
+//! first shape (inline, bounded) with the second shape (`Deferred`) as its own
+//! documented fallback, which is what "within the request" already implies — a bound
+//! must resolve to *something* once it is hit, and `Deferred` is the shape that
+//! already exists for "still working, hand back a job".
+//!
+//! One more thing this shape buys for free: **`AsyncResponse.cost`** (credits,
+//! `input_mp`, `output_mp`) is data the create call returns and nothing else ever
+//! echoes back. On the common fast path it rides [`crate::media::MediaOutcome::Complete::note`]
+//! (see [`cost_note`]) — the same channel #168 added for Gemini's commentary,
+//! generalized here to "what the provider said about this call" rather than "what the
+//! model said". On the rare slow path (fallen back to `Deferred`), the cost is not
+//! carried forward — [`crate::media::MediaOutcome::Deferred`] and
+//! [`crate::media::MediaPollOutcome::Complete`] have no note channel today. Recorded
+//! here rather than silently accepted: a real per-artifact cost field in
+//! `cas::Provenance`, mirroring `seed`, would close this gap for every media kind at
+//! once, but it is a shared-seam change well outside a first BFL landing.
+//!
+//! # Which op runs
+//!
+//! The starter set is five named operations (`BFL_OPS`), one endpoint each. A
+//! caller's `op` picks one directly; omitting `op` runs the cast's `image` slot model
+//! id as the operation name — the same role Stability's model id plays for its
+//! `generate` family (`GenerateRoute::classify`). Either way the name is checked
+//! against `BFL_OPS`, so a typo'd slot model id and a typo'd `op` fail the same loud
+//! way ([`BflError::UnknownOperation`]).
+//!
+//! # Webhooks are refused, not silently dropped
+//!
+//! `webhook_url`/`webhook_secret` ride `fields` like any other provider knob — except
+//! kaibo is stdio-only and never binds a socket or receives a callback (see AGENTS.md).
+//! Passing them through unchanged would have the provider answer
+//! `AsyncWebhookResponse` (no `polling_url` at all) for money kaibo cannot collect, so
+//! [`refuse_webhook_fields`] refuses both names before any request is sent.
+//!
+//! # Inputs and cost are wire-identical
+//!
+//! `MediaRequest.inputs` field names ride verbatim as JSON string keys
+//! (`input_image`..`input_image_8`), base64-encoded — no field-name translation table
+//! the way Gemini's `IMAGE_CONFIG_FIELDS` needs, because BFL's JSON body already uses
+//! the same names `MediaInput::field` carries.
+//!
+//! # The artifact arrives as a signed, expiring URL
+//!
+//! `result.sample` on a `Ready` poll is a delivery link good for about ten minutes —
+//! fetched immediately via [`crate::cas::fetch_artifact_bytes`] (the DashScope
+//! precedent: https-only, no redirect followed, size-bounded), never stored as a
+//! reference. The mime is read from the bytes themselves
+//! ([`crate::view_image::sniff_mime`]), not trusted from a header, for the same reason
+//! DashScope's `artifact_mime` does that: an object store commonly answers with the
+//! wrong or a missing `Content-Type`, and the bytes cannot lie about themselves.
+
+use std::time::Duration;
+
+use anyhow::Result as AnyResult;
+use base64::Engine as _;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::media::{MediaArtifact, MediaJobId, MediaOutcome, MediaPollOutcome, MediaRequest};
+
+/// BFL's API host. A root, not a route — every op appends its own path, the
+/// client-appends-its-path contract every configurable base URL in kaibo follows.
+pub const DEFAULT_BASE_URL: &str = "https://api.bfl.ai";
+
+/// The env var that overrides the key-file.
+pub const BFL_KEY_ENV_VAR: &str = "BFL_API_KEY";
+
+/// The key-file's name within `$HOME`.
+pub const BFL_KEY_FILE_NAME: &str = ".bfl-key";
+
+/// How long [`BflImageModel::generate`] keeps polling in-call before handing back a
+/// [`crate::media::MediaOutcome::Deferred`] job instead. FLUX generations are
+/// documented as seconds-fast, so this is generous headroom for the common case, not
+/// a measured ceiling — a real one wants a live probe once a key exists (see
+/// `docs/bfl.md`'s testing section and this PR's report).
+pub const INLINE_POLL_BUDGET: Duration = Duration::from_secs(30);
+
+/// The cadence between in-call polls while under [`INLINE_POLL_BUDGET`].
+pub const INLINE_POLL_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// The `fields` names refused outright rather than sent through — see the module
+/// doc's "Webhooks are refused" section.
+const WEBHOOK_FIELDS: &[&str] = &["webhook_url", "webhook_secret"];
+
+/// One BFL operation this facade wires: its caller-facing name, its endpoint path,
+/// and one line on why it is in the starter set — rendered into the `op` schema doc
+/// verbatim, the #166 pattern (`Stability::OpSpec`, `docs/bfl.md`'s starter table).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpSpec {
+    pub name: &'static str,
+    /// The path segment after the base URL, leading slash included.
+    pub path: &'static str,
+    pub why: &'static str,
+}
+
+/// The starter op table — five endpoints, confirmed against the live
+/// `https://api.bfl.ai/openapi.json` (2026-08-31). See `docs/bfl.md` for the full
+/// FLUX family this deliberately does not wire yet (`flux-tools/*`, finetunes,
+/// video).
+pub const BFL_OPS: &[OpSpec] = &[
+    OpSpec {
+        name: "flux-dev",
+        path: "/v1/flux-dev",
+        why: "the cheap rung — probing and drafts",
+    },
+    OpSpec {
+        name: "flux-2-pro",
+        path: "/v1/flux-2-pro",
+        why: "the quality default",
+    },
+    OpSpec {
+        name: "flux-2-flex",
+        path: "/v1/flux-2-flex",
+        why: "parameter-heavy control",
+    },
+    OpSpec {
+        name: "flux-pro-1.1-ultra",
+        path: "/v1/flux-pro-1.1-ultra",
+        why: "high-resolution stills",
+    },
+    OpSpec {
+        name: "flux-kontext-pro",
+        path: "/v1/flux-kontext-pro",
+        why: "image editing with reference inputs",
+    },
+];
+
+/// Look up one operation by the name a caller (or a slot's model id) named.
+pub fn op_by_name(name: &str) -> Option<&'static OpSpec> {
+    BFL_OPS.iter().find(|o| o.name == name)
+}
+
+/// Every operation name this facade wires, in table order — for a schema enum or a
+/// refusal, rendered from the table so it cannot drift from what [`op_by_name`]
+/// accepts.
+pub fn op_names() -> Vec<&'static str> {
+    BFL_OPS.iter().map(|o| o.name).collect()
+}
+
+/// Which operation one call runs: the caller's `op` when given, else the cast's
+/// `image` slot model id — the same role Stability's slot id plays for its `generate`
+/// family. Both sources are checked against [`BFL_OPS`] the same way, by the caller of
+/// this function.
+pub fn resolve_op_name<'a>(request: &'a MediaRequest, slot_model: &'a str) -> &'a str {
+    request.op.as_deref().unwrap_or(slot_model)
+}
+
+// --- Errors --------------------------------------------------------------------
+
+/// Everything that can go wrong building or interpreting a BFL call. Its own type,
+/// for the same reason its siblings have one: the pure functions below stay
+/// unit-testable with no reqwest type in the loop.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum BflError {
+    /// The HTTP request itself failed (DNS, connect, TLS, a dropped connection).
+    #[error("BFL request failed: {0}")]
+    Transport(String),
+
+    /// A non-2xx response from either the create call or a poll. `body` is BFL's
+    /// `{detail: [...]}` validation shape rendered readably when it parses, the raw
+    /// text otherwise.
+    #[error("BFL returned {status}: {body}")]
+    Provider { status: u16, body: String },
+
+    /// A 2xx create response that is not `{id, polling_url, ...}` and not the
+    /// webhook shape either — this module has no third shape to fall back to.
+    #[error("BFL's create response didn't parse as {{id, polling_url, ...}}: {0}")]
+    InvalidBody(String),
+
+    /// A 2xx create response carrying `webhook_url` instead of `polling_url` — only
+    /// reachable if [`refuse_webhook_fields`] were bypassed, since that is the one
+    /// thing that shape needs to appear. Refused here as the structural backstop
+    /// rather than assumed unreachable: this module has no polling_url to poll.
+    #[error(
+        "BFL answered with a webhook-shaped response (a `webhook_url`, no `polling_url`), \
+         which kaibo has nothing to poll — kaibo never asks for a webhook, so seeing one \
+         means the request carried `webhook_url`/`webhook_secret` some other way. Drop \
+         those fields; kaibo polls the provider itself"
+    )]
+    UnexpectedWebhookResponse,
+
+    /// A 2xx poll response that is not `{id, status, ...}`.
+    #[error("BFL's poll response didn't parse as {{id, status, ...}}: {0}")]
+    InvalidPollBody(String),
+
+    /// The caller named an `op` (or the slot's model id resolved to one) that this
+    /// facade does not wire. Refused rather than run as a guessed default: an
+    /// unrelated FLUX variant returned for the wrong endpoint is a wrong answer that
+    /// looks entirely like a right one, and it costs a paid generation to find out.
+    #[error(
+        "`op` {asked:?} is not an operation kaibo wires for BFL, so nothing was generated. \
+         Pass one of: {}. Omit `op` to run the cast's image-slot model id as the \
+         operation instead.",
+        op_names().join(", ")
+    )]
+    UnknownOperation { asked: String },
+
+    /// A `fields` entry named a webhook parameter — refused before any request is
+    /// sent, so nothing is billed for a callback kaibo cannot receive.
+    #[error(
+        "`fields.{field}` asks BFL to call back a webhook, and kaibo is stdio-only — it \
+         never binds a socket or receives a callback, so the notification would go \
+         nowhere and the generation would still be paid for. Drop `fields.{field}`; \
+         kaibo already polls the provider for you"
+    )]
+    WebhookNotSupported { field: &'static str },
+
+    /// A `Ready` poll whose `result` carries no `sample` string — the one field this
+    /// module actually needs from a successful result. Refused rather than treated
+    /// as "no artifacts", since `Ready` is documented to always carry one.
+    #[error(
+        "BFL reported status Ready but the result carries no `sample` link to fetch — \
+         kaibo has nothing to store. This is the provider answering outside its \
+         documented shape; retry the generation"
+    )]
+    ReadyWithNoSample,
+
+    /// `status: "Error"` — the provider ran the request and failed on it.
+    #[error("BFL reported a generation error: {detail}")]
+    GenerationError { detail: String },
+
+    /// `status: "Request Moderated"` — refused before generation ran.
+    #[error(
+        "BFL refused this request before generating anything (Request Moderated): \
+         {detail}. Change the prompt or the input images and try again"
+    )]
+    RequestModerated { detail: String },
+
+    /// `status: "Content Moderated"` — the generation ran but its output was blocked.
+    #[error(
+        "BFL generated an image and then blocked it (Content Moderated): {detail}. \
+         Change the prompt or the input images and try again"
+    )]
+    ContentModerated { detail: String },
+
+    /// `status: "Task not found"` — the id has expired or was never valid on this
+    /// host. Named separately from a generic provider error because the fix is
+    /// different: there is no result to retry collecting, only a fresh generation.
+    #[error(
+        "BFL reports this task as not found — the id has expired or this polling_url \
+         no longer resolves to a result. Generate again; a task id is not durable \
+         across a long wait"
+    )]
+    TaskNotFound,
+
+    /// A poll `status` outside the six documented values. Refused rather than
+    /// silently treated as still-pending, the same discipline `StabilityError::UnknownMediaType`
+    /// applies to an unrecognized content type: a seventh status is BFL shipping
+    /// something this module has a real decision to make about.
+    #[error(
+        "BFL reported poll status {0:?}, which is none of the six this module \
+         recognizes (Pending, Reasoning, Generating, Ready, Error, Request Moderated, \
+         Content Moderated, Task not found) — refusing rather than guessing whether to \
+         keep polling"
+    )]
+    UnknownStatus(String),
+
+    /// Fetching `result.sample` failed. Pre-rendered from [`crate::cas::FetchError`],
+    /// whose own messages name the fix (https-only, no redirects, a size ceiling).
+    #[error("fetching the generated image: {0}")]
+    Fetch(String),
+
+    /// The fetched bytes are not one of the four formats the media store can name on
+    /// disk (png/jpeg/webp/gif) — read from the bytes themselves, not trusted from a
+    /// header. See the module doc's "signed, expiring URL" section.
+    #[error(
+        "the fetched image is not png, jpeg, webp, or gif — the bytes match none of \
+         them, and the server called it {got:?}. kaibo stores an artifact under the \
+         format its bytes actually are, so there is nothing to store here"
+    )]
+    UnusableContentType { got: Option<String> },
+}
+
+fn provider_error(status: u16, body: &[u8]) -> BflError {
+    let text = String::from_utf8_lossy(body);
+    if let Ok(value) = serde_json::from_slice::<Value>(body) {
+        if let Some(rendered) = render_validation_detail(&value) {
+            return BflError::Provider {
+                status,
+                body: rendered,
+            };
+        }
+    }
+    BflError::Provider {
+        status,
+        body: text.trim().to_string(),
+    }
+}
+
+/// Render BFL's `HTTPValidationError` shape (`{"detail": [{"loc": [...], "msg": ...}]}`)
+/// readably, when the body is that shape. `None` for anything else, so the caller
+/// falls back to the raw text rather than a `null` string.
+fn render_validation_detail(value: &Value) -> Option<String> {
+    let detail = value.get("detail")?;
+    if let Some(msg) = detail.as_str() {
+        return Some(msg.to_string());
+    }
+    let items = detail.as_array()?;
+    let rendered: Vec<String> = items
+        .iter()
+        .filter_map(|item| {
+            let loc = item
+                .get("loc")
+                .and_then(Value::as_array)
+                .map(|l| {
+                    l.iter()
+                        .map(|part| match part {
+                            Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join(".")
+                })
+                .unwrap_or_default();
+            let msg = item.get("msg").and_then(Value::as_str).unwrap_or("");
+            (!msg.is_empty()).then(|| format!("{loc}: {msg}"))
+        })
+        .collect();
+    (!rendered.is_empty()).then(|| rendered.join("; "))
+}
+
+// --- Request -------------------------------------------------------------------
+
+/// Refuse a request naming a webhook field — see the module doc's "Webhooks are
+/// refused" section. Checked before any request is built.
+pub fn refuse_webhook_fields(request: &MediaRequest) -> Result<(), BflError> {
+    for field in WEBHOOK_FIELDS {
+        if request.fields.iter().any(|(name, _)| name == field) {
+            return Err(BflError::WebhookNotSupported { field });
+        }
+    }
+    Ok(())
+}
+
+/// Build the JSON request body for one operation. Pure: no network, no clock.
+///
+/// `prompt` leads, then every named input rides verbatim as a base64 string under
+/// its own field name (`input_image`, `input_image_2`, ...), then every caller field
+/// passes through with its stated JSON type. A `fields` entry sharing a name with an
+/// input part replaces it — the same later-entry-wins rule `Stability::build_form_fields`
+/// already uses — which is a caller's own mistake to make, not one kaibo prevents:
+/// `fields` is typed scalars only, so overwriting an image with one produces a
+/// provider 400, not silent corruption.
+pub fn build_request_body(request: &MediaRequest) -> Value {
+    let mut body = Map::new();
+    body.insert("prompt".to_string(), Value::String(request.prompt.clone()));
+    for input in &request.inputs {
+        body.insert(
+            input.field.clone(),
+            Value::String(base64::engine::general_purpose::STANDARD.encode(&input.bytes)),
+        );
+    }
+    for (name, value) in &request.fields {
+        body.insert(name.clone(), value.to_json());
+    }
+    Value::Object(body)
+}
+
+// --- Create response -------------------------------------------------------------
+
+/// The parsed `AsyncResponse` — the create call's success shape.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AsyncResponse {
+    pub id: String,
+    pub polling_url: String,
+    /// Credits, verbatim — kaibo converts nothing (native-unit ruling, 2026-08-22).
+    pub cost: Option<f64>,
+    pub input_mp: Option<f64>,
+    pub output_mp: Option<f64>,
+}
+
+#[derive(Deserialize)]
+struct RawAsyncResponse {
+    id: Option<String>,
+    polling_url: Option<String>,
+    cost: Option<f64>,
+    input_mp: Option<f64>,
+    output_mp: Option<f64>,
+    /// Present only on the webhook-shaped sibling response — see
+    /// [`BflError::UnexpectedWebhookResponse`].
+    webhook_url: Option<String>,
+}
+
+/// Interpret one create-call HTTP response. Pure.
+pub fn parse_create_response(status: u16, body: &[u8]) -> Result<AsyncResponse, BflError> {
+    if !(200..300).contains(&status) {
+        return Err(provider_error(status, body));
+    }
+    let raw: RawAsyncResponse =
+        serde_json::from_slice(body).map_err(|e| BflError::InvalidBody(e.to_string()))?;
+    match raw.polling_url {
+        Some(polling_url) => Ok(AsyncResponse {
+            id: raw.id.unwrap_or_default(),
+            polling_url,
+            cost: raw.cost,
+            input_mp: raw.input_mp,
+            output_mp: raw.output_mp,
+        }),
+        None if raw.webhook_url.is_some() => Err(BflError::UnexpectedWebhookResponse),
+        None => Err(BflError::InvalidBody(
+            "the response has neither `polling_url` nor `webhook_url`".to_string(),
+        )),
+    }
+}
+
+/// What the provider said about one call's cost, for
+/// [`crate::media::MediaOutcome::Complete::note`] — see the module doc's "cost" section.
+/// `None` when the create response carried none of the three fields, so a bare
+/// artifact list is not followed by an empty line.
+pub fn cost_note(created: &AsyncResponse) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(cost) = created.cost {
+        parts.push(format!("{cost} credits"));
+    }
+    if let Some(mp) = created.input_mp {
+        parts.push(format!("{mp} input MP"));
+    }
+    if let Some(mp) = created.output_mp {
+        parts.push(format!("{mp} output MP"));
+    }
+    (!parts.is_empty()).then(|| format!("BFL reports this request cost {}.", parts.join(", ")))
+}
+
+// --- Poll response ---------------------------------------------------------------
+
+/// One poll's outcome, before the artifact is fetched.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PollDecision {
+    Pending,
+    Ready { sample_url: String },
+}
+
+#[derive(Deserialize)]
+struct RawResultResponse {
+    status: String,
+    result: Option<Value>,
+    details: Option<Value>,
+}
+
+/// Render whatever detail a terminal status carried, for the error variants that
+/// need one. Prefers `details`, falls back to `result`, and never returns an empty
+/// string — BFL's own words when it has them, "(no detail given)" when it doesn't.
+fn render_detail(raw: &RawResultResponse) -> String {
+    let carried = raw.details.as_ref().or(raw.result.as_ref());
+    match carried {
+        Some(Value::String(s)) if !s.is_empty() => s.clone(),
+        Some(other) => other.to_string(),
+        None => "(no detail given)".to_string(),
+    }
+}
+
+/// Interpret one poll-call HTTP response. Pure.
+pub fn parse_poll_response(status: u16, body: &[u8]) -> Result<PollDecision, BflError> {
+    if !(200..300).contains(&status) {
+        return Err(provider_error(status, body));
+    }
+    let raw: RawResultResponse =
+        serde_json::from_slice(body).map_err(|e| BflError::InvalidPollBody(e.to_string()))?;
+    match raw.status.as_str() {
+        "Pending" | "Reasoning" | "Generating" => Ok(PollDecision::Pending),
+        "Ready" => {
+            let sample = raw
+                .result
+                .as_ref()
+                .and_then(|r| r.get("sample"))
+                .and_then(Value::as_str)
+                .ok_or(BflError::ReadyWithNoSample)?;
+            Ok(PollDecision::Ready {
+                sample_url: sample.to_string(),
+            })
+        }
+        "Error" => Err(BflError::GenerationError {
+            detail: render_detail(&raw),
+        }),
+        "Request Moderated" => Err(BflError::RequestModerated {
+            detail: render_detail(&raw),
+        }),
+        "Content Moderated" => Err(BflError::ContentModerated {
+            detail: render_detail(&raw),
+        }),
+        "Task not found" => Err(BflError::TaskNotFound),
+        other => Err(BflError::UnknownStatus(other.to_string())),
+    }
+}
+
+/// The mime for one fetched artifact, read from the bytes — see the module doc.
+fn artifact_mime(content_type: Option<&str>, bytes: &[u8]) -> Result<String, BflError> {
+    match crate::view_image::sniff_mime(bytes) {
+        Some(mime) => Ok(mime.to_string()),
+        None => Err(BflError::UnusableContentType {
+            got: content_type.map(|raw| raw.split(';').next().unwrap_or(raw).trim().to_string()),
+        }),
+    }
+}
+
+// --- The HTTP client -------------------------------------------------------------
+
+/// A configured BFL connection: credential, base URL, and the one HTTPS client built
+/// through kaibo's TLS seam.
+#[derive(Clone)]
+pub struct BflClient {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+    request_timeout: Duration,
+}
+
+impl std::fmt::Debug for BflClient {
+    /// Manual: never render the key.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BflClient")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BflClient {
+    pub fn new(
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+        request_timeout: Duration,
+    ) -> AnyResult<Self> {
+        Ok(Self {
+            http: crate::tls::https_client(request_timeout)?,
+            api_key: api_key.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            request_timeout,
+        })
+    }
+
+    /// `POST {base}{op.path}`, authenticated with `x-key`.
+    async fn create(&self, op: &OpSpec, request: &MediaRequest) -> Result<AsyncResponse, BflError> {
+        let url = format!("{}{}", self.base_url, op.path);
+        let resp = self
+            .http
+            .post(&url)
+            .header("x-key", &self.api_key)
+            .json(&build_request_body(request))
+            .send()
+            .await
+            .map_err(|e| BflError::Transport(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| BflError::Transport(e.to_string()))?;
+        parse_create_response(status, &bytes)
+    }
+
+    /// `GET polling_url` **verbatim** — never rebuilt from `base_url`. See the module
+    /// doc: `polling_url` is a regional host BFL names in the create response.
+    async fn poll_once(&self, polling_url: &str) -> Result<PollDecision, BflError> {
+        let resp = self
+            .http
+            .get(polling_url)
+            .header("x-key", &self.api_key)
+            .send()
+            .await
+            .map_err(|e| BflError::Transport(e.to_string()))?;
+        let status = resp.status().as_u16();
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| BflError::Transport(e.to_string()))?;
+        parse_poll_response(status, &bytes)
+    }
+
+    /// Fetch a `Ready` poll's `result.sample` and shape it into a [`MediaArtifact`].
+    async fn fetch_artifact(&self, sample_url: &str) -> Result<MediaArtifact, BflError> {
+        let (bytes, content_type) =
+            crate::cas::fetch_artifact_bytes(sample_url, self.request_timeout)
+                .await
+                .map_err(|e| BflError::Fetch(e.to_string()))?;
+        let mime = artifact_mime(content_type.as_deref(), &bytes)?;
+        Ok(MediaArtifact {
+            bytes,
+            mime,
+            // BFL's poll response reports no seed even when the request pinned one —
+            // a caller's own `seed` field rides `fields` and is the reproduction
+            // handle, the same posture DashScope's artifact takes.
+            seed: None,
+        })
+    }
+}
+
+/// One BFL image model, bound to a cast's `image` slot: the client, the slot's model
+/// id (the default operation — see [`resolve_op_name`]), and the inline-poll cadence.
+#[derive(Clone)]
+pub struct BflImageModel {
+    client: BflClient,
+    model: String,
+    inline_poll_budget: Duration,
+    inline_poll_interval: Duration,
+}
+
+impl BflImageModel {
+    /// Bind a client to one model id — the shape `MediaArm::from_slot` builds.
+    pub fn from_parts(client: &BflClient, model: impl Into<String>) -> Self {
+        Self {
+            client: client.clone(),
+            model: model.into(),
+            inline_poll_budget: INLINE_POLL_BUDGET,
+            inline_poll_interval: INLINE_POLL_INTERVAL,
+        }
+    }
+
+    /// Override the inline-poll cadence. Meant for tests exercising the
+    /// falls-back-to-`Deferred` path, which would otherwise need real wall-clock
+    /// time to reach — the same "overridable for tests" posture
+    /// `StabilityClient::new`'s `base_url` parameter already has.
+    pub fn with_inline_poll_timing(mut self, budget: Duration, interval: Duration) -> Self {
+        self.inline_poll_budget = budget;
+        self.inline_poll_interval = interval;
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::media::MediaModel for BflImageModel {
+    /// Every op in [`BFL_OPS`] takes `input_image`..`input_image_8` — an edit is an
+    /// image plus the instruction that refers to it.
+    fn accepts_inputs(&self) -> bool {
+        true
+    }
+
+    /// Five named endpoints behind one slot — see the module doc's "Which op runs".
+    fn accepts_ops(&self) -> bool {
+        true
+    }
+
+    async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
+        refuse_webhook_fields(request)?;
+        let op_name = resolve_op_name(request, &self.model);
+        let op = op_by_name(op_name).ok_or_else(|| BflError::UnknownOperation {
+            asked: op_name.to_string(),
+        })?;
+        let created = self.client.create(op, request).await?;
+        let note = cost_note(&created);
+        let started = tokio::time::Instant::now();
+        loop {
+            match self.client.poll_once(&created.polling_url).await? {
+                PollDecision::Ready { sample_url } => {
+                    let artifact = self.client.fetch_artifact(&sample_url).await?;
+                    return Ok(MediaOutcome::Complete {
+                        artifacts: vec![artifact],
+                        note,
+                    });
+                }
+                PollDecision::Pending => {
+                    if started.elapsed() >= self.inline_poll_budget {
+                        // Still working after the in-call budget: hand back the same
+                        // polling_url as a job the caller's own cadence (the
+                        // background job lane, or the CLI's wait loop) continues
+                        // from `poll` — a single GET, no sleep, same as every other
+                        // deferred kind.
+                        return Ok(MediaOutcome::Deferred(MediaJobId(created.polling_url)));
+                    }
+                    tokio::time::sleep(self.inline_poll_interval).await;
+                }
+            }
+        }
+    }
+
+    /// Collect one deferred job: a single GET on the `polling_url` this job id
+    /// carries, no sleep — the caller (the background job lane, or the CLI's own
+    /// loop) owns the cadence, exactly like `StabilityClient::poll`.
+    async fn poll(&self, job: &MediaJobId) -> AnyResult<MediaPollOutcome> {
+        match self.client.poll_once(&job.0).await? {
+            PollDecision::Pending => Ok(MediaPollOutcome::Pending),
+            PollDecision::Ready { sample_url } => {
+                let artifact = self.client.fetch_artifact(&sample_url).await?;
+                Ok(MediaPollOutcome::Complete(vec![artifact]))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::{FieldValue, MediaInput};
+
+    fn request(prompt: &str) -> MediaRequest {
+        MediaRequest {
+            prompt: prompt.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    // --- op table ---------------------------------------------------------------
+
+    #[test]
+    fn every_starter_op_resolves_by_name() {
+        for name in [
+            "flux-dev",
+            "flux-2-pro",
+            "flux-2-flex",
+            "flux-pro-1.1-ultra",
+            "flux-kontext-pro",
+        ] {
+            let op = op_by_name(name).unwrap_or_else(|| panic!("{name} must be wired"));
+            assert_eq!(op.name, name);
+            assert!(op.path.starts_with("/v1/"));
+        }
+        assert_eq!(op_names().len(), 5);
+    }
+
+    #[test]
+    fn an_unwired_op_name_resolves_to_nothing() {
+        assert!(
+            op_by_name("flux-3-video").is_none(),
+            "out of scope per docs/bfl.md"
+        );
+    }
+
+    #[test]
+    fn resolve_op_name_prefers_the_callers_op_over_the_slot_model() {
+        let mut r = request("a lighthouse");
+        r.op = Some("flux-dev".to_string());
+        assert_eq!(resolve_op_name(&r, "flux-2-pro"), "flux-dev");
+    }
+
+    #[test]
+    fn resolve_op_name_falls_back_to_the_slot_model_when_op_is_omitted() {
+        let r = request("a lighthouse");
+        assert_eq!(resolve_op_name(&r, "flux-2-pro"), "flux-2-pro");
+    }
+
+    // --- request building ---------------------------------------------------------
+
+    #[test]
+    fn the_prompt_and_typed_fields_ride_the_body_verbatim() {
+        let mut r = request("a red cube");
+        r.fields = vec![
+            ("seed".to_string(), FieldValue::Num(42.into())),
+            ("output_format".to_string(), FieldValue::Str("png".into())),
+            ("disable_pup".to_string(), FieldValue::Bool(true)),
+        ];
+        let body = build_request_body(&r);
+        assert_eq!(body["prompt"], "a red cube");
+        assert_eq!(body["seed"], 42);
+        assert!(
+            body["seed"].is_i64(),
+            "an integer must reach the wire as one"
+        );
+        assert_eq!(body["output_format"], "png");
+        assert_eq!(body["disable_pup"], true);
+    }
+
+    #[test]
+    fn named_inputs_ride_the_body_as_base64_under_their_own_field_name() {
+        let mut r = request("edit this");
+        r.inputs = vec![MediaInput::new(
+            "input_image",
+            crate::cas::Extension::Png,
+            b"\x89PNG\r\n\x1a\ncat".to_vec(),
+        )];
+        let body = build_request_body(&r);
+        assert_eq!(
+            body["input_image"],
+            b64(b"\x89PNG\r\n\x1a\ncat"),
+            "the field name in `inputs` is the JSON key verbatim, per docs/bfl.md"
+        );
+    }
+
+    #[test]
+    fn multiple_named_inputs_each_land_under_their_own_field() {
+        let mut r = request("multiref edit");
+        r.inputs = vec![
+            MediaInput::new("input_image", crate::cas::Extension::Png, b"one".to_vec()),
+            MediaInput::new("input_image_2", crate::cas::Extension::Png, b"two".to_vec()),
+        ];
+        let body = build_request_body(&r);
+        assert_eq!(body["input_image"], b64(b"one"));
+        assert_eq!(body["input_image_2"], b64(b"two"));
+    }
+
+    // --- webhook refusal ---------------------------------------------------------
+
+    #[test]
+    fn a_webhook_url_field_is_refused_before_any_request_is_built() {
+        let mut r = request("a red cube");
+        r.fields = vec![(
+            "webhook_url".to_string(),
+            FieldValue::Str("https://example.test/hook".into()),
+        )];
+        let err = refuse_webhook_fields(&r).expect_err("must refuse");
+        assert!(matches!(
+            err,
+            BflError::WebhookNotSupported {
+                field: "webhook_url"
+            }
+        ));
+        let msg = err.to_string();
+        assert!(msg.contains("stdio-only"), "names why: {msg}");
+        assert!(
+            msg.contains("Drop `fields.webhook_url`"),
+            "names the fix: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_webhook_secret_field_is_also_refused() {
+        let mut r = request("a red cube");
+        r.fields = vec![("webhook_secret".to_string(), FieldValue::Str("s".into()))];
+        assert!(refuse_webhook_fields(&r).is_err());
+    }
+
+    #[test]
+    fn a_request_with_no_webhook_fields_passes() {
+        let r = request("a red cube");
+        assert!(refuse_webhook_fields(&r).is_ok());
+    }
+
+    // --- create response ----------------------------------------------------------
+
+    #[test]
+    fn a_successful_create_response_parses_every_field() {
+        let body = serde_json::json!({
+            "id": "t-1",
+            "polling_url": "https://api.us1.bfl.ai/v1/get_result?id=t-1",
+            "cost": 0.05,
+            "input_mp": 1.05,
+            "output_mp": 1.05,
+        })
+        .to_string();
+        let resp = parse_create_response(200, body.as_bytes()).expect("parses");
+        assert_eq!(resp.id, "t-1");
+        assert_eq!(
+            resp.polling_url,
+            "https://api.us1.bfl.ai/v1/get_result?id=t-1"
+        );
+        assert_eq!(resp.cost, Some(0.05));
+        assert_eq!(resp.input_mp, Some(1.05));
+        assert_eq!(resp.output_mp, Some(1.05));
+    }
+
+    #[test]
+    fn a_webhook_shaped_response_is_refused_as_unexpected() {
+        let body = serde_json::json!({
+            "id": "t-1",
+            "status": "Queued",
+            "webhook_url": "https://example.test/hook",
+        })
+        .to_string();
+        let err = parse_create_response(200, body.as_bytes()).expect_err("no polling_url");
+        assert_eq!(err, BflError::UnexpectedWebhookResponse);
+    }
+
+    #[test]
+    fn a_422_validation_error_renders_its_field_and_message() {
+        let body = serde_json::json!({
+            "detail": [{"loc": ["body", "width"], "msg": "Input should be a multiple of 32", "type": "value_error"}]
+        })
+        .to_string();
+        let err = parse_create_response(422, body.as_bytes()).expect_err("422");
+        let msg = err.to_string();
+        assert!(msg.contains("422"), "{msg}");
+        assert!(msg.contains("body.width"), "{msg}");
+        assert!(msg.contains("multiple of 32"), "{msg}");
+    }
+
+    #[test]
+    fn a_non_json_error_body_keeps_its_raw_text() {
+        let err = parse_create_response(500, b"upstream timeout").expect_err("500");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("500") && msg.contains("upstream timeout"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn an_unparseable_2xx_body_is_refused() {
+        let err = parse_create_response(200, b"not json at all").expect_err("garbage 2xx");
+        assert!(matches!(err, BflError::InvalidBody(_)));
+    }
+
+    #[test]
+    fn cost_note_renders_every_reported_figure() {
+        let resp = AsyncResponse {
+            id: "t".into(),
+            polling_url: "https://x/y".into(),
+            cost: Some(0.05),
+            input_mp: Some(1.0),
+            output_mp: Some(1.05),
+        };
+        let note = cost_note(&resp).expect("some figure was reported");
+        assert!(note.contains("0.05 credits"), "{note}");
+        assert!(note.contains("1 input MP"), "{note}");
+        assert!(note.contains("1.05 output MP"), "{note}");
+    }
+
+    #[test]
+    fn cost_note_is_absent_when_nothing_was_reported() {
+        let resp = AsyncResponse {
+            id: "t".into(),
+            polling_url: "https://x/y".into(),
+            cost: None,
+            input_mp: None,
+            output_mp: None,
+        };
+        assert_eq!(cost_note(&resp), None);
+    }
+
+    // --- poll response --------------------------------------------------------------
+
+    #[test]
+    fn pending_reasoning_and_generating_all_mean_keep_polling() {
+        for status in ["Pending", "Reasoning", "Generating"] {
+            let body = serde_json::json!({"id": "t", "status": status}).to_string();
+            assert_eq!(
+                parse_poll_response(200, body.as_bytes()).unwrap(),
+                PollDecision::Pending,
+                "status {status} must mean keep polling"
+            );
+        }
+    }
+
+    #[test]
+    fn ready_carries_the_sample_url_out() {
+        let body = serde_json::json!({
+            "id": "t",
+            "status": "Ready",
+            "result": {"sample": "https://delivery.bfl.ai/results/t/0.png"},
+        })
+        .to_string();
+        assert_eq!(
+            parse_poll_response(200, body.as_bytes()).unwrap(),
+            PollDecision::Ready {
+                sample_url: "https://delivery.bfl.ai/results/t/0.png".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn ready_with_no_sample_is_refused_rather_than_treated_as_empty() {
+        let body = serde_json::json!({"id": "t", "status": "Ready", "result": {}}).to_string();
+        let err = parse_poll_response(200, body.as_bytes()).expect_err("no sample");
+        assert_eq!(err, BflError::ReadyWithNoSample);
+    }
+
+    #[test]
+    fn error_status_carries_the_providers_detail() {
+        let body = serde_json::json!({
+            "id": "t",
+            "status": "Error",
+            "details": {"reason": "internal failure"},
+        })
+        .to_string();
+        let err = parse_poll_response(200, body.as_bytes()).expect_err("Error status");
+        assert!(
+            matches!(err, BflError::GenerationError { .. }),
+            "got {err:?}"
+        );
+        assert!(err.to_string().contains("internal failure"), "{err}");
+    }
+
+    #[test]
+    fn request_moderated_names_what_to_change() {
+        let body = serde_json::json!({
+            "id": "t",
+            "status": "Request Moderated",
+            "details": {"reason": "flagged prompt"},
+        })
+        .to_string();
+        let err = parse_poll_response(200, body.as_bytes()).expect_err("moderated");
+        assert!(matches!(err, BflError::RequestModerated { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("flagged prompt"), "{msg}");
+        assert!(msg.contains("Change the prompt"), "{msg}");
+    }
+
+    #[test]
+    fn content_moderated_is_distinct_from_request_moderated() {
+        let body = serde_json::json!({"id": "t", "status": "Content Moderated"}).to_string();
+        let err = parse_poll_response(200, body.as_bytes()).expect_err("moderated");
+        assert!(matches!(err, BflError::ContentModerated { .. }));
+        assert!(err.to_string().contains("blocked it"));
+    }
+
+    #[test]
+    fn task_not_found_says_to_generate_again_not_retry_the_poll() {
+        let body = serde_json::json!({"id": "t", "status": "Task not found"}).to_string();
+        let err = parse_poll_response(200, body.as_bytes()).expect_err("expired");
+        assert_eq!(err, BflError::TaskNotFound);
+        assert!(err.to_string().contains("Generate again"));
+    }
+
+    #[test]
+    fn an_unrecognized_status_is_refused_rather_than_treated_as_pending() {
+        let body = serde_json::json!({"id": "t", "status": "Queued"}).to_string();
+        let err = parse_poll_response(200, body.as_bytes()).expect_err("unknown status");
+        assert_eq!(err, BflError::UnknownStatus("Queued".to_string()));
+    }
+
+    #[test]
+    fn a_non_2xx_poll_is_a_provider_error() {
+        let err = parse_poll_response(404, b"{}").expect_err("404");
+        assert!(matches!(err, BflError::Provider { status: 404, .. }));
+    }
+
+    // --- mime sniffing --------------------------------------------------------------
+
+    #[test]
+    fn a_real_png_is_recognized_from_its_bytes() {
+        let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        assert_eq!(artifact_mime(Some("image/png"), &png).unwrap(), "image/png");
+    }
+
+    #[test]
+    fn unrecognizable_bytes_are_refused_naming_the_claimed_type() {
+        let err = artifact_mime(Some("application/xml"), b"<Error/>").expect_err("not an image");
+        assert_eq!(
+            err,
+            BflError::UnusableContentType {
+                got: Some("application/xml".to_string())
+            }
+        );
+    }
+
+    // --- unknown operation ------------------------------------------------------------
+
+    #[test]
+    fn unknown_operation_names_the_ask_and_the_valid_list() {
+        let err = BflError::UnknownOperation {
+            asked: "flux-3-video".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("flux-3-video"), "{msg}");
+        assert!(msg.contains("flux-2-pro"), "{msg}");
+        assert!(msg.contains("Omit `op`"), "{msg}");
+    }
+}

--- a/src/bfl.rs
+++ b/src/bfl.rs
@@ -11,6 +11,27 @@
 //! dialled **verbatim**, never rebuilt from `base_url` — until its status leaves
 //! `Pending`/`Reasoning`/`Generating`.
 //!
+//! # Polling is TLS-strict, and carries the credential
+//!
+//! `polling_url` is an address BFL chose, not one the operator configured — the same
+//! trust shape [`crate::cas::fetch_artifact_bytes`] already takes for `result.sample`
+//! (see [`crate::tls::artifact_fetch_client`]'s doc: "every property kaibo checked
+//! before dialling is a promise only the first hop keeps"). It is worse here, because
+//! the poll request also carries the `x-key` credential: a plain `http://`
+//! `polling_url` would send that key in the clear, and reqwest strips the standard
+//! `Authorization` header on a cross-host redirect but **not** a custom header like
+//! `x-key` — so a redirecting `polling_url` would carry the key onward to whatever
+//! host the redirect names. [`BflClient`] therefore polls through
+//! [`crate::tls::artifact_fetch_client`] rather than the general client `create` uses:
+//! `https_only(true)` refuses a plain-`http` `polling_url` before a single byte of the
+//! request leaves (no connection is even attempted), and `Policy::none()` means a
+//! redirect is never followed — it surfaces as its own refusal
+//! ([`BflError::UnsafePollingUrl`]) instead of the key riding onward. `create` keeps
+//! the general client: `base_url` is the operator's own configured endpoint, and
+//! where the operator's endpoint redirects is the operator's business — exactly the
+//! split [`crate::tls::artifact_fetch_client`]'s own doc draws between "an operator's
+//! configured `base_url`" and "an address that arrives inside a provider's response".
+//!
 //! # The shape: inline-poll-then-defer, not strictly one or the other
 //!
 //! `docs/bfl.md` offers two shapes and asks which one lands: poll inline within the
@@ -207,6 +228,19 @@ pub enum BflError {
     /// A 2xx poll response that is not `{id, status, ...}`.
     #[error("BFL's poll response didn't parse as {{id, status, ...}}: {0}")]
     InvalidPollBody(String),
+
+    /// `polling_url` — a provider-chosen address carrying the `x-key` credential on
+    /// every poll — is not a plain `https` address, or its response redirected.
+    /// Refused rather than dialled: see the module doc's "Polling is TLS-strict"
+    /// section. This names BFL's own response, not a mistake in the caller's request.
+    #[error(
+        "BFL's poll response named an address kaibo will not dial: {polling_url:?} \
+         ({reason}). kaibo's API key rides this request, so it only follows a plain \
+         https link with no redirect — an unverified hop would carry the key onward. \
+         This is BFL's own response, not a mistake in your request; retry the \
+         generation"
+    )]
+    UnsafePollingUrl { polling_url: String, reason: String },
 
     /// The caller named an `op` (or the slot's model id resolved to one) that this
     /// facade does not wire. Refused rather than run as a guessed default: an
@@ -520,11 +554,18 @@ fn artifact_mime(content_type: Option<&str>, bytes: &[u8]) -> Result<String, Bfl
 
 // --- The HTTP client -------------------------------------------------------------
 
-/// A configured BFL connection: credential, base URL, and the one HTTPS client built
-/// through kaibo's TLS seam.
+/// A configured BFL connection: credential, base URL, and two HTTPS clients built
+/// through kaibo's TLS seam — one per trust shape. See the module doc's "Polling is
+/// TLS-strict" section for why the poll leg does not share `create`'s client.
 #[derive(Clone)]
 pub struct BflClient {
     http: reqwest::Client,
+    /// The poll leg's own client — [`crate::tls::artifact_fetch_client`], the same
+    /// posture [`crate::cas::fetch_artifact_bytes`] takes for `result.sample`:
+    /// `polling_url` is a provider-chosen address carrying the `x-key` credential,
+    /// so it gets `https_only(true)` and no redirects rather than `create`'s general
+    /// client.
+    poll_http: reqwest::Client,
     api_key: String,
     base_url: String,
     request_timeout: Duration,
@@ -547,6 +588,7 @@ impl BflClient {
     ) -> AnyResult<Self> {
         Ok(Self {
             http: crate::tls::https_client(request_timeout)?,
+            poll_http: crate::tls::artifact_fetch_client(request_timeout)?,
             api_key: api_key.into(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             request_timeout,
@@ -572,17 +614,37 @@ impl BflClient {
         parse_create_response(status, &bytes)
     }
 
-    /// `GET polling_url` **verbatim** — never rebuilt from `base_url`. See the module
-    /// doc: `polling_url` is a regional host BFL names in the create response.
+    /// `GET polling_url` **verbatim** — never rebuilt from `base_url` — over the
+    /// TLS-strict poll client. See the module doc's "Polling is TLS-strict" section:
+    /// `polling_url` is a provider-chosen address that carries the `x-key`
+    /// credential, so it is checked before dialling (a plain `http` address is
+    /// refused with zero connection attempts) and again after the first hop answers
+    /// (a redirect is refused rather than followed, since `Policy::none()` hands
+    /// back the 3xx response itself rather than an error).
     async fn poll_once(&self, polling_url: &str) -> Result<PollDecision, BflError> {
+        if !polling_url.starts_with("https://") {
+            return Err(BflError::UnsafePollingUrl {
+                polling_url: polling_url.to_string(),
+                reason: "not an https address".to_string(),
+            });
+        }
         let resp = self
-            .http
+            .poll_http
             .get(polling_url)
             .header("x-key", &self.api_key)
             .send()
             .await
             .map_err(|e| BflError::Transport(e.to_string()))?;
-        let status = resp.status().as_u16();
+        let status = resp.status();
+        if status.is_redirection() {
+            return Err(BflError::UnsafePollingUrl {
+                polling_url: polling_url.to_string(),
+                reason: format!(
+                    "the response redirected ({status}), and a redirect is never followed"
+                ),
+            });
+        }
+        let status = status.as_u16();
         let bytes = resp
             .bytes()
             .await
@@ -640,6 +702,33 @@ impl BflImageModel {
     }
 }
 
+/// What the inline poll loop in [`BflImageModel::generate`] does with one poll
+/// outcome, given whether the in-call budget is already spent. Pure and unit-tested
+/// directly, extracted for exactly one reason: once the poll leg is TLS-strict (see
+/// [`BflClient::poll_once`]), an offline transport test can no longer drive the loop
+/// over a live "still pending" poll target, so the budget-exhausted branch needs a
+/// seam that does not require a socket at all.
+#[derive(Debug, Clone, PartialEq)]
+enum InlineStep {
+    /// Keep polling: sleep [`INLINE_POLL_INTERVAL`], then poll again.
+    KeepPolling,
+    /// The provider is done; fetch this URL and resolve.
+    Ready { sample_url: String },
+    /// Still `Pending` past the budget: hand back a job carrying the exact
+    /// `polling_url` that was being polled — see the module doc's "shape" section.
+    Defer(MediaJobId),
+}
+
+fn inline_step(decision: PollDecision, budget_spent: bool, polling_url: &str) -> InlineStep {
+    match decision {
+        PollDecision::Ready { sample_url } => InlineStep::Ready { sample_url },
+        PollDecision::Pending if budget_spent => {
+            InlineStep::Defer(MediaJobId(polling_url.to_string()))
+        }
+        PollDecision::Pending => InlineStep::KeepPolling,
+    }
+}
+
 #[async_trait::async_trait]
 impl crate::media::MediaModel for BflImageModel {
     /// Every op in [`BFL_OPS`] takes `input_image`..`input_image_8` — an edit is an
@@ -663,23 +752,24 @@ impl crate::media::MediaModel for BflImageModel {
         let note = cost_note(&created);
         let started = tokio::time::Instant::now();
         loop {
-            match self.client.poll_once(&created.polling_url).await? {
-                PollDecision::Ready { sample_url } => {
+            let decision = self.client.poll_once(&created.polling_url).await?;
+            let budget_spent = started.elapsed() >= self.inline_poll_budget;
+            match inline_step(decision, budget_spent, &created.polling_url) {
+                InlineStep::Ready { sample_url } => {
                     let artifact = self.client.fetch_artifact(&sample_url).await?;
                     return Ok(MediaOutcome::Complete {
                         artifacts: vec![artifact],
                         note,
                     });
                 }
-                PollDecision::Pending => {
-                    if started.elapsed() >= self.inline_poll_budget {
-                        // Still working after the in-call budget: hand back the same
-                        // polling_url as a job the caller's own cadence (the
-                        // background job lane, or the CLI's wait loop) continues
-                        // from `poll` — a single GET, no sleep, same as every other
-                        // deferred kind.
-                        return Ok(MediaOutcome::Deferred(MediaJobId(created.polling_url)));
-                    }
+                InlineStep::Defer(job) => {
+                    // Still working after the in-call budget: hand back the same
+                    // polling_url as a job the caller's own cadence (the background
+                    // job lane, or the CLI's wait loop) continues from `poll` — a
+                    // single GET, no sleep, same as every other deferred kind.
+                    return Ok(MediaOutcome::Deferred(job));
+                }
+                InlineStep::KeepPolling => {
                     tokio::time::sleep(self.inline_poll_interval).await;
                 }
             }
@@ -1027,6 +1117,98 @@ mod tests {
     fn a_non_2xx_poll_is_a_provider_error() {
         let err = parse_poll_response(404, b"{}").expect_err("404");
         assert!(matches!(err, BflError::Provider { status: 404, .. }));
+    }
+
+    // --- polling_url safety ----------------------------------------------------------
+
+    /// The scheme check fires with no client and no network at all: a plaintext
+    /// `polling_url` is refused before `BflClient` ever touches the socket. See the
+    /// module doc's "Polling is TLS-strict" section — the real-socket proof that
+    /// zero connections happen lives in `tests/bfl_transport.rs`.
+    #[tokio::test]
+    async fn poll_once_refuses_a_plaintext_polling_url_without_dialing() {
+        let client = BflClient::new("k", "https://example.test", Duration::from_secs(5)).unwrap();
+        let err = client
+            .poll_once("http://127.0.0.1:1/get_result?id=t-1")
+            .await
+            .expect_err("plaintext must be refused");
+        match err {
+            BflError::UnsafePollingUrl {
+                polling_url,
+                reason,
+            } => {
+                assert_eq!(polling_url, "http://127.0.0.1:1/get_result?id=t-1");
+                assert!(reason.contains("https"), "{reason}");
+            }
+            other => panic!("expected UnsafePollingUrl, got {other:?}"),
+        }
+    }
+
+    /// The refusal names what was refused, why (the credential rides this request),
+    /// and that it is BFL's own response rather than a mistake in the caller's
+    /// request — the house rule for a refusal string.
+    #[test]
+    fn unsafe_polling_url_names_what_why_and_whose_mistake_it_is_not() {
+        let err = BflError::UnsafePollingUrl {
+            polling_url: "http://evil.example/x".to_string(),
+            reason: "not an https address".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("http://evil.example/x"),
+            "names the url: {msg}"
+        );
+        assert!(
+            msg.contains("API key rides this request"),
+            "names why: {msg}"
+        );
+        assert!(
+            msg.contains("not a mistake in your request"),
+            "says whose fault it is: {msg}"
+        );
+    }
+
+    // --- inline poll decision ----------------------------------------------------------
+
+    /// A `Ready` decision resolves regardless of the budget — the artifact is in
+    /// hand, so there is nothing left to defer.
+    #[test]
+    fn ready_resolves_even_with_the_budget_already_spent() {
+        let step = inline_step(
+            PollDecision::Ready {
+                sample_url: "https://delivery.bfl.ai/0.png".to_string(),
+            },
+            true,
+            "https://api.us1.bfl.ai/v1/get_result?id=t-1",
+        );
+        assert_eq!(
+            step,
+            InlineStep::Ready {
+                sample_url: "https://delivery.bfl.ai/0.png".to_string()
+            }
+        );
+    }
+
+    /// Still pending and the budget isn't spent yet: keep polling.
+    #[test]
+    fn pending_before_the_budget_keeps_polling() {
+        let step = inline_step(
+            PollDecision::Pending,
+            false,
+            "https://api.us1.bfl.ai/v1/get_result?id=t-1",
+        );
+        assert_eq!(step, InlineStep::KeepPolling);
+    }
+
+    /// **The decision this extraction exists for.** Still pending once the in-call
+    /// budget is spent: defer, and the job carries the *exact* `polling_url` that
+    /// was being polled — the caller's own cadence (the background job lane, or the
+    /// CLI's wait loop) has to reach the same address, not one reconstructed later.
+    #[test]
+    fn pending_past_the_budget_defers_with_the_identical_polling_url() {
+        let polling_url = "https://api.us1.bfl.ai/v1/get_result?id=t-1";
+        let step = inline_step(PollDecision::Pending, true, polling_url);
+        assert_eq!(step, InlineStep::Defer(MediaJobId(polling_url.to_string())));
     }
 
     // --- mime sniffing --------------------------------------------------------------

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -101,6 +101,15 @@ pub enum ProviderKind {
     /// are in hand (see `crate::cas::fetch_artifact_bytes`). Keyed and not built-in,
     /// like the other media kinds: generation costs money per image.
     DashScope,
+    /// Black Forest Labs' FLUX image family — the fifth media kind, via
+    /// `src/bfl.rs`. One endpoint per named operation (`flux-dev`, `flux-2-pro`, ...),
+    /// and every one of them asynchronous: a create call returns a job id and a
+    /// `polling_url` to poll — unlike Stability (mostly synchronous) or
+    /// DashScope/Gemini (always synchronous). `generate` polls in-call for the
+    /// common fast case and falls back to a `job-N` handle only when the provider is
+    /// still working past that budget; see `src/bfl.rs`'s module doc. Keyed and not
+    /// built-in, like the other media kinds: generation costs money per image.
+    Bfl,
 }
 
 impl ProviderKind {
@@ -108,7 +117,7 @@ impl ProviderKind {
     /// new kind can never be accepted by `FromStr` while staying unlisted in the message
     /// a user actually reads — a hand-maintained list in that string had already drifted
     /// once (`openrouter` shipped before it was named there).
-    pub const ALL: [ProviderKind; 9] = [
+    pub const ALL: [ProviderKind; 10] = [
         Self::Anthropic,
         Self::DeepSeek,
         Self::Gemini,
@@ -118,6 +127,7 @@ impl ProviderKind {
         Self::OpenAiImages,
         Self::GeminiImages,
         Self::DashScope,
+        Self::Bfl,
     ];
 
     /// Whether a missing credential is tolerated rather than a hard error. Only the
@@ -163,12 +173,13 @@ impl ProviderKind {
             // sd-server: header-bearer shaped, value ignored by such a server.
             | ProviderKind::OpenAiImages
             | ProviderKind::GeminiImages
-            // Never reached: neither Stability nor DashScope is `key_optional`, so a
-            // missing key is a hard error long before a stand-in is wanted. Both are
-            // header-bearer wires, so they take the same shape as the others if that
-            // ever changes.
+            // Never reached: none of Stability, DashScope, or BFL is `key_optional`,
+            // so a missing key is a hard error long before a stand-in is wanted. All
+            // three are header-bearer wires, so they take the same shape as the
+            // others if that ever changes.
             | ProviderKind::Stability
-            | ProviderKind::DashScope => PLACEHOLDER_OPENAI_KEY,
+            | ProviderKind::DashScope
+            | ProviderKind::Bfl => PLACEHOLDER_OPENAI_KEY,
         }
     }
 
@@ -188,6 +199,7 @@ impl ProviderKind {
             ProviderKind::OpenAiImages => "openai-images",
             ProviderKind::GeminiImages => "gemini-images",
             ProviderKind::DashScope => "dashscope",
+            ProviderKind::Bfl => "bfl",
         }
     }
 
@@ -223,6 +235,9 @@ impl ProviderKind {
             // serves text on an OpenAI-compatible route, and an operator who runs both
             // wants one name per account, not one name per protocol.
             ProviderKind::DashScope => crate::dashscope::DASHSCOPE_KEY_ENV_VAR,
+            // Reuses the constant `src/bfl.rs` already resolves keys with, so the
+            // facade and the config layer can never disagree about which var to read.
+            ProviderKind::Bfl => crate::bfl::BFL_KEY_ENV_VAR,
         }
     }
 
@@ -241,6 +256,8 @@ impl ProviderKind {
             ProviderKind::Stability => crate::stability::STABILITY_KEY_FILE_NAME,
             // Same reasoning as `env_var`: DashScope's own credential name.
             ProviderKind::DashScope => crate::dashscope::DASHSCOPE_KEY_FILE_NAME,
+            // Same constant `src/bfl.rs` uses, for the same reason as `env_var`.
+            ProviderKind::Bfl => crate::bfl::BFL_KEY_FILE_NAME,
         }
     }
 
@@ -266,6 +283,7 @@ impl ProviderKind {
             ProviderKind::OpenAiImages => ProviderClass::Media(MediaKind::OpenAiImages),
             ProviderKind::GeminiImages => ProviderClass::Media(MediaKind::GeminiImages),
             ProviderKind::DashScope => ProviderClass::Media(MediaKind::DashScope),
+            ProviderKind::Bfl => ProviderClass::Media(MediaKind::Bfl),
         }
     }
 
@@ -319,6 +337,9 @@ pub enum MediaKind {
     /// Alibaba DashScope's multimodal-generation route, via `src/dashscope.rs` —
     /// the `wan` image family, delivered as presigned URLs kaibo fetches.
     DashScope,
+    /// Black Forest Labs' FLUX image family, via `src/bfl.rs` — every operation
+    /// asynchronous, delivered as a signed URL kaibo fetches.
+    Bfl,
 }
 
 /// The two families a [`ProviderKind`] can belong to — see [`ProviderKind::class`].
@@ -358,6 +379,7 @@ impl std::str::FromStr for ProviderKind {
             "openai-images" => Ok(ProviderKind::OpenAiImages),
             "gemini-images" => Ok(ProviderKind::GeminiImages),
             "dashscope" => Ok(ProviderKind::DashScope),
+            "bfl" => Ok(ProviderKind::Bfl),
             other => Err(anyhow!(
                 "unknown provider {other:?} (expected one of: {})",
                 ProviderKind::ALL

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -167,6 +167,11 @@ pub fn discovery_endpoint_page(backend: &Backend, cursor: Option<&str>) -> Resul
                  catalog on an OpenAI-compatible endpoint, so point a `kind = \"openai\"` \
                  backend at that base URL to list them"
             }
+            crate::credentials::ProviderClass::Media(crate::credentials::MediaKind::Bfl) => {
+                "the documented FLUX operations: flux-dev, flux-2-pro, flux-2-flex, \
+                 flux-pro-1.1-ultra, or flux-kontext-pro — the cast's image-slot model id \
+                 names one directly"
+            }
             // The `else` above already proved this kind has no completion wire.
             crate::credentials::ProviderClass::Wire(_) => unreachable!("wire() was None"),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod artifact;
 pub mod attach;
 pub mod batch;
+pub mod bfl;
 pub mod cas;
 pub mod cli;
 pub mod completion_retry;

--- a/src/media.rs
+++ b/src/media.rs
@@ -480,6 +480,17 @@ impl MediaArm {
                 let model = crate::dashscope::DashScopeImageModel::from_parts(&client, &slot.id);
                 Ok(Self::new(Arc::new(model), slot.qualified()))
             }
+            ProviderClass::Media(MediaKind::Bfl) => {
+                // Keyed with no keyless target, same as Stability/DashScope.
+                let key = backend.resolve_key()?;
+                let base_url = backend
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| crate::bfl::DEFAULT_BASE_URL.to_string());
+                let client = crate::bfl::BflClient::new(key, base_url, backend.request_timeout)?;
+                let model = crate::bfl::BflImageModel::from_parts(&client, &slot.id);
+                Ok(Self::new(Arc::new(model), slot.qualified()))
+            }
             ProviderClass::Wire(_) => bail!(
                 "backend {:?} is kind `{}`, a completion wire — it cannot staff a media \
                  slot. Point the `image` slot at a media backend, and use this backend \
@@ -712,6 +723,27 @@ mod tests {
         let slot = ModelSlot::bare("gimg", "gemini-3-flash-image");
         let arm = MediaArm::from_slot(backend, &slot).expect("a gemini-images backend staffs");
         assert_eq!(arm.slot_ref(), "gimg/gemini-3-flash-image");
+    }
+
+    /// A BFL backend staffs an image slot. Keyed, so the key must resolve — this
+    /// fixture supplies one through `key_optional = true` plus a nonexistent
+    /// `api_key_file`, the same shape `from_slot_staffs_a_dashscope_backend` uses.
+    /// Construction only; no network.
+    #[test]
+    fn from_slot_staffs_a_bfl_backend() {
+        let cfg = crate::config::Config::from_toml_str(
+            r#"
+            [backends.bfl]
+            kind = "bfl"
+            key_optional = true
+            api_key_file = "/nonexistent-kaibo-test/bfl"
+            "#,
+        )
+        .expect("config parses");
+        let backend = cfg.backends.get("bfl").expect("backend exists");
+        let slot = ModelSlot::bare("bfl", "flux-2-pro");
+        let arm = MediaArm::from_slot(backend, &slot).expect("a bfl backend staffs");
+        assert_eq!(arm.slot_ref(), "bfl/flux-2-pro");
     }
 
     /// The Stability arm still staffs — the sibling-kind regression guard for the

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -740,9 +740,12 @@ pub struct GenerateInput {
     /// pass `n` as a number and ids like `user` as strings. (Stability:
     /// aspect_ratio "16:9", output_format png|jpeg|webp, seed, negative_prompt,
     /// style_preset, ...; OpenAI-compatible images endpoints: size "1024x1024", n,
-    /// quality, output_format png|jpeg|webp, ...). The provider validates its own
-    /// knobs. `prompt` and `model` are reserved: use the prompt parameter and the
-    /// cast's image slot.
+    /// quality, output_format png|jpeg|webp, ...; BFL: width and height in pixels,
+    /// seed, output_format, safety_tolerance 0-5). The provider validates its own
+    /// knobs, and the spellings are per-backend — BFL ignores a field it does not
+    /// know (an `aspect_ratio` there changes nothing, measured), so size a FLUX
+    /// image with width and height. `prompt` and `model` are reserved: use the
+    /// prompt parameter and the cast's image slot.
     #[serde(default)]
     pub fields: Option<std::collections::BTreeMap<String, GenerateFieldValue>>,
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -780,6 +780,13 @@ pub struct GenerateInput {
     /// and quality (image; up to 16 `image` entries), `variations` priced per image by
     /// model and size (image; takes no prompt).
     ///
+    /// **BFL (FLUX):** `flux-dev` (the cheap rung — probing and drafts), `flux-2-pro`
+    /// (the quality default), `flux-2-flex` (parameter-heavy control),
+    /// `flux-pro-1.1-ultra` (high-resolution stills), `flux-kontext-pro` (editing with
+    /// reference inputs) — every one takes `input_image`..`input_image_8` in `inputs`.
+    /// Omit `op` to run the cast's image-slot model id as the operation instead. Cost
+    /// is reported per request, not a fixed table — read it in the result.
+    ///
     /// `edit/erase` and `edit/inpaint` also take an optional `mask` in `inputs`, or an
     /// alpha channel on the image instead. Text knobs ride `fields`, not `inputs`:
     /// `edit/search-and-replace` needs `search_prompt` there, `edit/search-and-recolor`
@@ -955,7 +962,7 @@ const CAST_ENUM_RULES: &[CastEnumRule] = &[
         &["generate"],
         Config::cast_can_generate,
         "a cast with an `image` slot pointing at a media backend (kind `stability`, \
-         `openai-images`, `gemini-images`, or `dashscope`) — see the image-slot \
+         `openai-images`, `gemini-images`, `dashscope`, or `bfl`) — see the image-slot \
          examples in \
          docs/config.example.toml",
     ),
@@ -3091,8 +3098,8 @@ impl KaiboHandler {
     #[tool(
         description = "Generate images from a text prompt with the cast's `image` \
             model (a media backend: Stability, an OpenAI-compatible images endpoint — \
-            hosted gpt-image or a local stable-diffusion.cpp sd-server — Gemini, or \
-            DashScope's wan family). \
+            hosted gpt-image or a local stable-diffusion.cpp sd-server — Gemini, \
+            DashScope's wan family, or Black Forest Labs' FLUX). \
             Bytes are never inlined: each artifact lands in kaibo's content-addressed \
             media store and the result lists per-artifact digests — a \
             kaibo://cas/<digest> address, the mime, the provider's seed when reported, \
@@ -3106,13 +3113,13 @@ impl KaiboHandler {
             `inputs {\"image\": \"<digest>\"}` with `fields {\"strength\": 0.6}` is \
             image-to-image. Digests come from `write_cas` or an earlier `generate`, so \
             an image already in the store is reused by address and never re-sent. \
-            Stability and Gemini accept input images; the others do not and say so. \
-            `op` picks an operation when the backend has more than one — Stability's \
-            edit, control and upscale routes, each with its required `inputs` keys and \
-            its credit cost listed on the parameter, so you can see the price before you \
-            pick. Omit `op` to generate from the prompt. An \
-            operation the provider declares deferred returns a `job-N` handle for \
-            job_wait/job_get instead (every route wired today answers in-call). \
+            Stability, Gemini, and BFL accept input images; the others do not and say \
+            so. `op` picks an operation when the backend has more than one — \
+            Stability's edit, control and upscale routes, each with its required \
+            `inputs` keys and its credit cost listed on the parameter; BFL's five FLUX \
+            endpoints, priced per request. Omit `op` to generate from the prompt (BFL: \
+            runs the image slot's model id). Most operations answer in-call; one still \
+            generating past its budget returns a `job-N` handle for job_wait/job_get. \
             Provenance (prompt, model, cast, seed) is recorded beside every artifact."
     )]
     pub async fn generate(

--- a/tests/bfl_live.rs
+++ b/tests/bfl_live.rs
@@ -1,0 +1,92 @@
+//! Live BFL probe — `#[ignore]`d, following `tests/dashscope_live.rs` and
+//! `tests/stability_live.rs`: never run by `cargo test`, run by hand with
+//! `--ignored` once a real credential is present. Spends real money (one
+//! `flux-dev` image — the cheap rung, deliberately, per `docs/bfl.md`'s starter
+//! table).
+//!
+//! No `BFL_API_KEY` existed at the time this landed (`docs/bfl.md`'s status log), so
+//! this is unexercised against the real API — it proves the offline path builds and
+//! is trivially skippable, and is the first thing to run once a key exists. It is
+//! the only witness to the whole path end to end: the artifact fetch takes `https`
+//! and so cannot run against the offline sockets in `tests/bfl_transport.rs` —
+//! generation → poll → signed link → fetched bytes → `MediaArtifact` with a mime the
+//! CAS can store.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kaibo::bfl::{BflClient, BflImageModel};
+use kaibo::media::{MediaModel, MediaOutcome, MediaRequest};
+
+/// The key sources the `bfl` kind seeds: `BFL_API_KEY`, then `~/.bfl-key`, env
+/// winning.
+fn bfl_key() -> anyhow::Result<String> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("$HOME is not set; cannot locate the key-file"))?;
+    let env_value = std::env::var(kaibo::bfl::BFL_KEY_ENV_VAR).ok();
+    kaibo::credentials::resolve(
+        env_value.as_deref(),
+        &home.join(kaibo::bfl::BFL_KEY_FILE_NAME),
+    )
+}
+
+#[tokio::test]
+#[ignore = "hits BFL (flux-dev, one image, real money); run with --ignored and \
+            ~/.bfl-key or BFL_API_KEY present"]
+async fn flux_dev_returns_real_image_bytes_through_a_polled_link() {
+    let key = match bfl_key() {
+        Ok(k) => k,
+        Err(e) => panic!("no BFL credential for live test: {e}"),
+    };
+    let client = BflClient::new(key, kaibo::bfl::DEFAULT_BASE_URL, Duration::from_secs(300))
+        .expect("client construction");
+    let model = BflImageModel::from_parts(&client, "flux-dev");
+
+    let request = MediaRequest {
+        prompt: "a small lighthouse on a rocky cliff, watercolor".to_string(),
+        ..Default::default()
+    };
+    let outcome = model.generate(&request).await.expect("live generation");
+    let artifacts = match outcome {
+        MediaOutcome::Complete { artifacts, note } => {
+            if let Some(note) = note {
+                eprintln!("kaibo: {note}");
+            }
+            artifacts
+        }
+        MediaOutcome::Deferred(job) => {
+            eprintln!(
+                "kaibo: still generating after the inline budget, polling job {}",
+                job.0
+            );
+            loop {
+                match model.poll(&job).await.expect("poll") {
+                    kaibo::media::MediaPollOutcome::Complete(a) => break a,
+                    kaibo::media::MediaPollOutcome::Pending => {
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                }
+            }
+        }
+    };
+
+    assert_eq!(artifacts.len(), 1);
+    let artifact = &artifacts[0];
+    assert!(
+        artifact.bytes.len() > 1024,
+        "a real image is more than a kilobyte, got {} bytes",
+        artifact.bytes.len()
+    );
+    let ext = kaibo::cas::Extension::from_mime(&artifact.mime).unwrap_or_else(|| {
+        panic!(
+            "the CAS must know the fetched mime, got {:?}",
+            artifact.mime
+        )
+    });
+    assert!(
+        ext.is_image(),
+        "a generated artifact stores as an image, got {:?}",
+        artifact.mime
+    );
+}

--- a/tests/bfl_transport.rs
+++ b/tests/bfl_transport.rs
@@ -1,0 +1,259 @@
+//! The BFL client driven over real sockets, offline — the transport truths the
+//! pure-function tests in `src/bfl.rs` cannot see: the create call dials the named
+//! op's own path with an `x-key` header, and the *poll* call dials the create
+//! response's `polling_url` **verbatim** — a different host/port than the create
+//! call's own base URL, proving it is never rebuilt from `base_url`. See the module
+//! doc in `src/bfl.rs` for why that distinction matters (a regional polling host).
+//!
+//! Two one-shot servers stand in for the two hops: a "create" server answers the
+//! POST, naming a "poll" server's address as its `polling_url`; if kaibo ever
+//! reconstructed that URL from the create server's own base instead, the poll
+//! server would never see a connection and the test would hang until the request
+//! times out — the same negative-control shape `tests/gemini_images_transport.rs`
+//! and `tests/dashscope_transport.rs` already rely on for their own "dials the
+//! right place" assertions.
+//!
+//! The final hop — fetching `result.sample` — takes `https` only
+//! (`cas::fetch_artifact_bytes`), so a plain `TcpListener` cannot serve it; that walk
+//! is covered by `artifact_mime`'s unit tests in `src/bfl.rs` and, end to end, by the
+//! `#[ignore]`d live probe in `tests/bfl_live.rs`. Keeping the scheme check
+//! un-mocked here is the point, same as the DashScope precedent: an offline test
+//! that could reach a plaintext artifact URL would be testing a kaibo that does not
+//! exist.
+
+use std::time::Duration;
+
+use kaibo::bfl::{BflClient, BflImageModel};
+use kaibo::media::{MediaModel, MediaOutcome, MediaRequest};
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// One captured HTTP request: the head as raw text, the body as JSON (or `Value::Null`
+/// for a request with no body, e.g. every poll GET).
+struct Captured {
+    head: String,
+    body: Value,
+}
+
+impl Captured {
+    fn request_line(&self) -> &str {
+        self.head.lines().next().unwrap_or("")
+    }
+
+    fn header(&self, name: &str) -> Option<String> {
+        let want = format!("{}:", name.to_ascii_lowercase());
+        self.head.lines().find_map(|line| {
+            line.to_ascii_lowercase()
+                .starts_with(&want)
+                .then(|| line[want.len()..].trim().to_string())
+        })
+    }
+}
+
+/// Serve exactly one HTTP exchange (GET or POST) and hand back the captured request.
+/// Returns the base URL to dial — an API root, since the client appends its own path.
+async fn one_shot_server(
+    status: u16,
+    response_body: String,
+) -> (String, tokio::sync::oneshot::Receiver<Captured>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut buf = Vec::new();
+        let head_end = loop {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-request");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+        let content_length: usize = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse().unwrap())
+            })
+            .unwrap_or(0);
+        while buf.len() < head_end + content_length {
+            let mut chunk = [0u8; 4096];
+            let n = sock.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client hung up mid-body");
+            buf.extend_from_slice(&chunk[..n]);
+        }
+        let body = if content_length == 0 {
+            Value::Null
+        } else {
+            serde_json::from_slice(&buf[head_end..head_end + content_length]).unwrap()
+        };
+        let response = format!(
+            "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\n\
+             content-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+            response_body.len(),
+        );
+        sock.write_all(response.as_bytes()).await.unwrap();
+        sock.shutdown().await.ok();
+        tx.send(Captured { head, body }).ok();
+    });
+    (format!("http://{addr}"), rx)
+}
+
+fn request(prompt: &str) -> MediaRequest {
+    MediaRequest {
+        prompt: prompt.to_string(),
+        ..Default::default()
+    }
+}
+
+/// The create call dials `{base}{op.path}` with `x-key`, and the poll call dials the
+/// create response's `polling_url` **verbatim** — a different host entirely, which
+/// only a literal (not reconstructed) URL can reach. The poll server answers `Ready`
+/// with a plaintext `sample` link, which the fetch guard then refuses — proving the
+/// whole create → poll → fetch chain ran, with TLS enforcement never bypassed offline.
+#[tokio::test]
+async fn poll_dials_the_polling_url_verbatim_not_the_create_bases_host() {
+    let (poll_base, poll_captured) = one_shot_server(
+        200,
+        serde_json::json!({
+            "id": "t-99",
+            "status": "Ready",
+            "result": {"sample": "http://artifact.test/0.png"},
+        })
+        .to_string(),
+    )
+    .await;
+    let polling_url = format!("{poll_base}/v1/get_result?id=t-99");
+
+    let (create_base, create_captured) = one_shot_server(
+        200,
+        serde_json::json!({
+            "id": "t-99",
+            "polling_url": polling_url,
+            "cost": 0.05,
+        })
+        .to_string(),
+    )
+    .await;
+
+    let client = BflClient::new("test-key-1", create_base, Duration::from_secs(5)).unwrap();
+    let model = BflImageModel::from_parts(&client, "flux-2-pro");
+    let err = model
+        .generate(&request("a red cube on a white table"))
+        .await
+        .expect_err("the sample link is plaintext, so the fetch guard refuses it");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("https") && msg.contains("http://artifact.test/0.png"),
+        "the refusal names the requirement and the offending URL, got: {msg}"
+    );
+
+    let create = create_captured
+        .await
+        .expect("create server saw one request");
+    assert_eq!(
+        create.request_line(),
+        "POST /v1/flux-2-pro HTTP/1.1",
+        "the client appends the op's own path to the configured base URL"
+    );
+    assert_eq!(create.header("x-key").as_deref(), Some("test-key-1"));
+    assert_eq!(create.body["prompt"], "a red cube on a white table");
+
+    let poll = poll_captured.await.expect("poll server saw one request");
+    assert!(
+        poll.request_line()
+            .starts_with("GET /v1/get_result?id=t-99 "),
+        "the poll dialled the create response's polling_url verbatim, got: {}",
+        poll.request_line()
+    );
+    assert_eq!(
+        poll.header("x-key").as_deref(),
+        Some("test-key-1"),
+        "the poll call authenticates too"
+    );
+}
+
+/// A 422 validation error on the create call renders readably, and no poll is ever
+/// attempted — the create server is the only server started, so a second connection
+/// would have nowhere to land.
+#[tokio::test]
+async fn a_422_on_create_renders_the_validation_detail_and_never_polls() {
+    let (base, _captured) = one_shot_server(
+        422,
+        serde_json::json!({
+            "detail": [{"loc": ["body", "width"], "msg": "Input should be a multiple of 32", "type": "value_error"}]
+        })
+        .to_string(),
+    )
+    .await;
+    let client = BflClient::new("k", base, Duration::from_secs(5)).unwrap();
+    let model = BflImageModel::from_parts(&client, "flux-dev");
+    let err = model
+        .generate(&request("a red cube"))
+        .await
+        .expect_err("a 422 must surface");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("422"), "{msg}");
+    assert!(msg.contains("body.width"), "{msg}");
+    assert!(msg.contains("multiple of 32"), "{msg}");
+}
+
+/// `Task not found` on the poll surfaces its own clear error, distinct from a
+/// generic provider error, over the real wire — not just the pure-function tests.
+#[tokio::test]
+async fn task_not_found_on_poll_is_reported_over_the_wire() {
+    let (poll_base, _poll_captured) = one_shot_server(
+        200,
+        serde_json::json!({"id": "t-1", "status": "Task not found"}).to_string(),
+    )
+    .await;
+    let polling_url = format!("{poll_base}/v1/get_result?id=t-1");
+    let (create_base, _create_captured) = one_shot_server(
+        200,
+        serde_json::json!({"id": "t-1", "polling_url": polling_url}).to_string(),
+    )
+    .await;
+    let client = BflClient::new("k", create_base, Duration::from_secs(5)).unwrap();
+    let model = BflImageModel::from_parts(&client, "flux-dev");
+    let err = model
+        .generate(&request("a red cube"))
+        .await
+        .expect_err("an expired task id must surface");
+    assert!(format!("{err:#}").contains("Generate again"));
+}
+
+/// When the provider is still working past the inline-poll budget, `generate`
+/// returns `Deferred` carrying the same `polling_url` the create call handed
+/// back — the fallback shape the background job lane (or the CLI's own wait loop)
+/// continues from via a single `poll` GET. The budget is forced to zero so this
+/// resolves after exactly one poll, not real wall-clock time.
+#[tokio::test]
+async fn a_still_pending_generation_defers_with_the_same_polling_url() {
+    let (poll_base, _poll_captured) = one_shot_server(
+        200,
+        serde_json::json!({"id": "t-7", "status": "Pending"}).to_string(),
+    )
+    .await;
+    let polling_url = format!("{poll_base}/v1/get_result?id=t-7");
+    let (create_base, _create_captured) = one_shot_server(
+        200,
+        serde_json::json!({"id": "t-7", "polling_url": polling_url}).to_string(),
+    )
+    .await;
+    let client = BflClient::new("k", create_base, Duration::from_secs(5)).unwrap();
+    let model = BflImageModel::from_parts(&client, "flux-dev")
+        .with_inline_poll_timing(Duration::ZERO, Duration::from_millis(1));
+    let outcome = model
+        .generate(&request("a red cube"))
+        .await
+        .expect("a pending generation is not an error");
+    let MediaOutcome::Deferred(job) = outcome else {
+        panic!("expected Deferred, got {outcome:?}");
+    };
+    assert_eq!(job.0, polling_url, "the same polling_url rides the job id");
+}

--- a/tests/bfl_transport.rs
+++ b/tests/bfl_transport.rs
@@ -3,7 +3,11 @@
 //! op's own path with an `x-key` header, and the *poll* call dials the create
 //! response's `polling_url` **verbatim** — a different host/port than the create
 //! call's own base URL, proving it is never rebuilt from `base_url`. See the module
-//! doc in `src/bfl.rs` for why that distinction matters (a regional polling host).
+//! doc in `src/bfl.rs`'s "Polling is TLS-strict" section for the trust-shape
+//! reasoning this file also exercises: `polling_url` is a provider-chosen address
+//! carrying the `x-key` credential, so the poll leg runs over
+//! `crate::tls::artifact_fetch_client` (https-only, no redirects) rather than the
+//! general client `create` uses.
 //!
 //! Two one-shot servers stand in for the two hops: a "create" server answers the
 //! POST, naming a "poll" server's address as its `polling_url`; if kaibo ever
@@ -13,18 +17,25 @@
 //! and `tests/dashscope_transport.rs` already rely on for their own "dials the
 //! right place" assertions.
 //!
-//! The final hop — fetching `result.sample` — takes `https` only
-//! (`cas::fetch_artifact_bytes`), so a plain `TcpListener` cannot serve it; that walk
-//! is covered by `artifact_mime`'s unit tests in `src/bfl.rs` and, end to end, by the
-//! `#[ignore]`d live probe in `tests/bfl_live.rs`. Keeping the scheme check
-//! un-mocked here is the point, same as the DashScope precedent: an offline test
-//! that could reach a plaintext artifact URL would be testing a kaibo that does not
-//! exist.
+//! The poll leg being TLS-strict means an offline plain-`TcpListener` can no longer
+//! stand in for a *successful* poll exchange the way it used to — the same reason
+//! `result.sample` (`cas::fetch_artifact_bytes`) never could. An offline test that
+//! could reach a plaintext `polling_url` would be testing a kaibo that does not
+//! exist, so this file proves the refusal instead: a plaintext `polling_url` is
+//! refused with the poll listener seeing zero connections, and an `https://`
+//! `polling_url` at a plain listener is dialled (proving the verbatim address) and
+//! then fails its TLS handshake, since a bare `TcpListener` speaks no TLS. Every
+//! poll outcome *other* than "refused before/at the wire" — `Pending`, `Ready`,
+//! `Task not found`, and the rest — is covered by `src/bfl.rs`'s unit tests over
+//! `parse_poll_response` and, for the inline-poll-then-defer decision specifically,
+//! `inline_step`; a live exchange is `tests/bfl_live.rs`'s job.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use kaibo::bfl::{BflClient, BflImageModel};
-use kaibo::media::{MediaModel, MediaOutcome, MediaRequest};
+use kaibo::media::{MediaModel, MediaRequest};
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -111,25 +122,79 @@ fn request(prompt: &str) -> MediaRequest {
     }
 }
 
-/// The create call dials `{base}{op.path}` with `x-key`, and the poll call dials the
-/// create response's `polling_url` **verbatim** — a different host entirely, which
-/// only a literal (not reconstructed) URL can reach. The poll server answers `Ready`
-/// with a plaintext `sample` link, which the fetch guard then refuses — proving the
-/// whole create → poll → fetch chain ran, with TLS enforcement never bypassed offline.
+/// **The security-relevant case.** A plaintext `polling_url` — a provider-chosen
+/// address that would carry the `x-key` credential — is refused with the poll
+/// listener seeing ZERO connections: proof the refusal happens client-side, before
+/// any byte of the poll request leaves, not merely that the eventual round trip goes
+/// badly. Asserting on the returned error text alone would not rule out kaibo having
+/// dialled the listener first; checking the listener's own accept count is what
+/// does. The create server DOES see its POST, proving the chain reached the poll
+/// step rather than failing earlier for an unrelated reason — a check that examines
+/// nothing is the failure this test is written to avoid.
 #[tokio::test]
-async fn poll_dials_the_polling_url_verbatim_not_the_create_bases_host() {
-    let (poll_base, poll_captured) = one_shot_server(
+async fn a_plaintext_polling_url_is_refused_with_the_poll_listener_seeing_no_connection() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let poll_addr = listener.local_addr().unwrap();
+
+    let polling_url = format!("http://{poll_addr}/v1/get_result?id=t-1");
+    let (create_base, create_captured) = one_shot_server(
         200,
-        serde_json::json!({
-            "id": "t-99",
-            "status": "Ready",
-            "result": {"sample": "http://artifact.test/0.png"},
-        })
-        .to_string(),
+        serde_json::json!({"id": "t-1", "polling_url": polling_url}).to_string(),
     )
     .await;
-    let polling_url = format!("{poll_base}/v1/get_result?id=t-99");
 
+    let client = BflClient::new("k", create_base, Duration::from_secs(2)).unwrap();
+    let model = BflImageModel::from_parts(&client, "flux-dev");
+    let err = model
+        .generate(&request("a red cube"))
+        .await
+        .expect_err("a plaintext polling_url must be refused");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("https"), "names the requirement: {msg}");
+    assert!(msg.contains(&polling_url), "names the offending URL: {msg}");
+
+    // The listener must see zero connections — refused client-side, before any byte
+    // of the request left, not discovered only after a real round trip failed.
+    let accept_attempt = tokio::time::timeout(Duration::from_millis(200), listener.accept()).await;
+    assert!(
+        accept_attempt.is_err(),
+        "the poll listener must see zero connections — refused client-side"
+    );
+
+    // The chain reached the poll step: the create call happened and was answered,
+    // so the refusal above is the poll leg's, not an earlier unrelated failure.
+    let create = create_captured
+        .await
+        .expect("create server saw one request");
+    assert_eq!(create.request_line(), "POST /v1/flux-dev HTTP/1.1");
+}
+
+/// The poll call dials the create response's `polling_url` **verbatim** — a
+/// different host/port entirely than the create call's own base, which only a
+/// literal (not reconstructed) address can reach. Proven by handing back an
+/// `https://` URL at a bare `TcpListener`: the poll client dials it — the listener
+/// observes a real TCP connection, which is only possible if the exact address was
+/// used — and then fails its TLS handshake, since a bare listener speaks no TLS.
+/// That failure is the expected shape here, not a test bug: this file cannot stand
+/// up a real TLS endpoint, so proving the *dial* is the offline ceiling; a full
+/// exchange is `tests/bfl_live.rs`'s job. The `x-key`-on-poll header assertion this
+/// test used to make when the poll leg ran over plain HTTP is no longer observable
+/// this way — TLS never completes, so no HTTP request is ever readable on the wire
+/// — and now belongs to the live probe instead (an unauthenticated poll answers 401
+/// there).
+#[tokio::test]
+async fn poll_dials_the_polling_url_verbatim_not_the_create_bases_host() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let poll_addr = listener.local_addr().unwrap();
+    let connected = Arc::new(AtomicBool::new(false));
+    let connected_flag = connected.clone();
+    tokio::spawn(async move {
+        if listener.accept().await.is_ok() {
+            connected_flag.store(true, Ordering::SeqCst);
+        }
+    });
+
+    let polling_url = format!("https://{poll_addr}/v1/get_result?id=t-99");
     let (create_base, create_captured) = one_shot_server(
         200,
         serde_json::json!({
@@ -143,14 +208,17 @@ async fn poll_dials_the_polling_url_verbatim_not_the_create_bases_host() {
 
     let client = BflClient::new("test-key-1", create_base, Duration::from_secs(5)).unwrap();
     let model = BflImageModel::from_parts(&client, "flux-2-pro");
-    let err = model
+    model
         .generate(&request("a red cube on a white table"))
         .await
-        .expect_err("the sample link is plaintext, so the fetch guard refuses it");
-    let msg = format!("{err:#}");
+        .expect_err("a bare TCP listener speaks no TLS, so the handshake must fail");
+
+    // The connection attempt itself is the proof the poll dialled the exact
+    // polling_url handed back by create, rather than reconstructing something
+    // pointed at create_base — the accept only fires if the address was verbatim.
     assert!(
-        msg.contains("https") && msg.contains("http://artifact.test/0.png"),
-        "the refusal names the requirement and the offending URL, got: {msg}"
+        connected.load(Ordering::SeqCst),
+        "the poll listener must see a real connection attempt, proving the verbatim dial"
     );
 
     let create = create_captured
@@ -163,19 +231,6 @@ async fn poll_dials_the_polling_url_verbatim_not_the_create_bases_host() {
     );
     assert_eq!(create.header("x-key").as_deref(), Some("test-key-1"));
     assert_eq!(create.body["prompt"], "a red cube on a white table");
-
-    let poll = poll_captured.await.expect("poll server saw one request");
-    assert!(
-        poll.request_line()
-            .starts_with("GET /v1/get_result?id=t-99 "),
-        "the poll dialled the create response's polling_url verbatim, got: {}",
-        poll.request_line()
-    );
-    assert_eq!(
-        poll.header("x-key").as_deref(),
-        Some("test-key-1"),
-        "the poll call authenticates too"
-    );
 }
 
 /// A 422 validation error on the create call renders readably, and no poll is ever
@@ -201,59 +256,4 @@ async fn a_422_on_create_renders_the_validation_detail_and_never_polls() {
     assert!(msg.contains("422"), "{msg}");
     assert!(msg.contains("body.width"), "{msg}");
     assert!(msg.contains("multiple of 32"), "{msg}");
-}
-
-/// `Task not found` on the poll surfaces its own clear error, distinct from a
-/// generic provider error, over the real wire — not just the pure-function tests.
-#[tokio::test]
-async fn task_not_found_on_poll_is_reported_over_the_wire() {
-    let (poll_base, _poll_captured) = one_shot_server(
-        200,
-        serde_json::json!({"id": "t-1", "status": "Task not found"}).to_string(),
-    )
-    .await;
-    let polling_url = format!("{poll_base}/v1/get_result?id=t-1");
-    let (create_base, _create_captured) = one_shot_server(
-        200,
-        serde_json::json!({"id": "t-1", "polling_url": polling_url}).to_string(),
-    )
-    .await;
-    let client = BflClient::new("k", create_base, Duration::from_secs(5)).unwrap();
-    let model = BflImageModel::from_parts(&client, "flux-dev");
-    let err = model
-        .generate(&request("a red cube"))
-        .await
-        .expect_err("an expired task id must surface");
-    assert!(format!("{err:#}").contains("Generate again"));
-}
-
-/// When the provider is still working past the inline-poll budget, `generate`
-/// returns `Deferred` carrying the same `polling_url` the create call handed
-/// back — the fallback shape the background job lane (or the CLI's own wait loop)
-/// continues from via a single `poll` GET. The budget is forced to zero so this
-/// resolves after exactly one poll, not real wall-clock time.
-#[tokio::test]
-async fn a_still_pending_generation_defers_with_the_same_polling_url() {
-    let (poll_base, _poll_captured) = one_shot_server(
-        200,
-        serde_json::json!({"id": "t-7", "status": "Pending"}).to_string(),
-    )
-    .await;
-    let polling_url = format!("{poll_base}/v1/get_result?id=t-7");
-    let (create_base, _create_captured) = one_shot_server(
-        200,
-        serde_json::json!({"id": "t-7", "polling_url": polling_url}).to_string(),
-    )
-    .await;
-    let client = BflClient::new("k", create_base, Duration::from_secs(5)).unwrap();
-    let model = BflImageModel::from_parts(&client, "flux-dev")
-        .with_inline_poll_timing(Duration::ZERO, Duration::from_millis(1));
-    let outcome = model
-        .generate(&request("a red cube"))
-        .await
-        .expect("a pending generation is not an error");
-    let MediaOutcome::Deferred(job) = outcome else {
-        panic!("expected Deferred, got {outcome:?}");
-    };
-    assert_eq!(job.0, polling_url, "the same polling_url rides the job id");
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -3010,4 +3010,105 @@ fn a_key_commands_stdout_never_reaches_kaibos_own_stdout() {
         "the run must fail on the dead transport AFTER resolving the key (proving the \
          command ran):\n{stderr}"
     );
+
+// --- the bfl kind ------------------------------------------------------------------
+
+/// The `bfl` kind parses from TOML. Declared-only, like every other kind: the
+/// operator names `api_key_env`/`api_key_file`/`api_key_cmd` themselves — kaibo
+/// seeds nothing, not even BFL's own conventional `BFL_API_KEY` / `.bfl-key` names.
+/// The key is required: like Stability and DashScope, this kind has no keyless
+/// target.
+#[test]
+fn bfl_backend_parses_without_seeding_key_sources() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.flux]
+        kind = "bfl"
+        "#,
+    )
+    .expect("the bfl kind must parse");
+    let b = c.backends.get("flux").expect("backend exists");
+    assert_eq!(b.kind, kaibo::credentials::ProviderKind::Bfl);
+    // Declared-only: a fresh media stanza declares its own source or fails loudly.
+    assert_eq!(b.api_key_env, None);
+    assert_eq!(b.api_key_file, None);
+    assert_eq!(b.api_key_cmd, None);
+    assert!(!b.key_optional, "key_optional seeds FALSE — BFL is keyed");
+}
+
+/// base_url is optional and legal on a bfl backend: unset dials api.bfl.ai, and a
+/// compatible gateway/proxy sets its own host. The client appends the op path
+/// either way, so the value is a ROOT.
+#[test]
+fn bfl_base_url_is_optional_and_legal() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.hosted]
+        kind = "bfl"
+
+        [backends.gateway]
+        kind = "bfl"
+        base_url = "https://llm-gateway.example.internal/bfl"
+        "#,
+    )
+    .expect("a bfl backend may set a base_url, and may omit it");
+    assert!(
+        c.backends.get("hosted").expect("exists").base_url.is_none(),
+        "unset means the kind's own default, resolved when the arm is staffed"
+    );
+    assert_eq!(
+        c.backends
+            .get("gateway")
+            .expect("exists")
+            .base_url
+            .as_deref(),
+        Some("https://llm-gateway.example.internal/bfl")
+    );
+}
+
+/// A bfl backend staffs an image slot — the config half of the media pairing. The
+/// slot's model id is one of BFL's named operations, and also `generate`'s default
+/// `op`.
+#[test]
+fn an_image_slot_can_point_at_a_bfl_backend() {
+    let c = Config::from_toml_str(
+        r#"
+        [backends.flux]
+        kind = "bfl"
+
+        [casts.art]
+        image = "flux/flux-2-pro"
+        "#,
+    )
+    .expect("an image slot on a bfl backend loads");
+    let cast = c.casts.get("art").expect("cast exists");
+    let slot = cast
+        .slot(kaibo::config::ModelRole::Image)
+        .expect("image slot resolves");
+    assert_eq!(slot.backend, "flux");
+    assert_eq!(slot.id, "flux-2-pro");
+}
+
+/// A reasoning slot pointed at a bfl backend is refused at load — the same
+/// class-based guard every other media kind gets.
+#[test]
+fn a_reasoning_slot_cannot_point_at_a_bfl_backend() {
+    for role in ["explorer", "synth"] {
+        let toml = format!(
+            r#"
+            [backends.flux]
+            kind = "bfl"
+
+            [casts.broken]
+            {role} = "flux/flux-2-pro"
+            "#
+        );
+        let err = Config::from_toml_str(&toml)
+            .expect_err("a reasoning slot on a bfl backend must be refused at load");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(role) && msg.contains("bfl") && msg.contains("media kind"),
+            "the error names the slot, the kind, and its class, got: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
Adds a `bfl` backend kind — Black Forest Labs' FLUX image family — as the fifth media kind behind `generate`. Same face, no new tool: `[backends.bfl]` plus a cast with an `image` slot, five starter operations (`flux-dev`, `flux-2-pro`, `flux-2-flex`, `flux-pro-1.1-ultra`, `flux-kontext-pro`).

## The decisions

**Why FLUX.** The ask was Midjourney-style concept images. Midjourney has no lawful API — its ToS (2026-05-27) bans automated access, and the third-party "Midjourney API" wrappers puppet Discord accounts. FLUX is the buildable version of that request: keyed, documented, and shaped for kaibo's media lane. Checked live before building, not from memory.

**Every BFL operation is asynchronous**, unlike any existing kind: a create returns `{id, polling_url, cost}` and the artifact comes from polling. The shape chosen is a hybrid — `generate` polls in-call for a 30s budget (FLUX is seconds-fast; a concept-image caller wants bytes, not a handle) and falls back to the existing `Deferred`/`job-N` lane past that. The spec (`docs/bfl.md`) offered exactly these two shapes; this is the first with the second as its bound, not a third invention.

**The poll leg is TLS-strict, and that came from review.** The first cut polled the provider-chosen `polling_url` through the general client with the `x-key` credential attached — but that client follows redirects (reqwest strips `Authorization` on cross-host redirects, not custom headers) and permits plaintext. `polling_url` is the same trust shape as `result.sample`, plus the credential, so it now gets the `artifact_fetch_client` posture: https-only, zero redirects, refused before a byte leaves. Fixed failing-first — the pre-fix code demonstrably dialled a plaintext listener; the fixed code was refused with the listener seeing zero connections.

**Cost is the provider's own unit, per request.** `AsyncResponse.cost` (credits) rides the result verbatim — no static cost table to go stale, per the 2026-08-22 native-units ruling. The deferred path has no note channel today, so cost is dropped on the rare slow path; recorded in the module doc as a gap a shared `Provenance` cost field would close for every kind.

**Field spellings are per-backend, and BFL ignores unknowns silently** — measured on the first live call (an `aspect_ratio` changed nothing). The `fields` doc now names BFL's own spellings (`width`/`height`, `seed`, `safety_tolerance`) and says so.

**Out of scope, on record** (`docs/bfl.md`): `flux-3-video` (CAS has no video extensions yet — refused loudly today), the `flux-tools/*` image family (a table extension later), finetunes, and webhooks (kaibo is stdio-only and receives no callbacks; `webhook_url`/`webhook_secret` are refused at the tool boundary before money is spent).

## Validation

Offline: 34 unit tests (every terminal status, request/response parsing, the inline-step decision), 3 real-socket transport tests (verbatim `polling_url` dial proven via TCP-accept under the strict client; plaintext refused with a zero-connections assertion and the create leg proven to have run), 5 config tests, one media-arm construction test. Live, with a real key: `generate --cast flux` returned a real artifact into the CAS on the inline path, cost reported as BFL's own 3 credits, and the strict poll client worked against the real regional polling host. Full suite green, clippy clean, `cargo tree -i aws-lc-rs` / `-i mimalloc` both empty, `tests/no_write_path.rs` marker count unchanged.

A cross-family kaibo review of the branch follows as a PR comment.

Co-authored-by: Claude Sonnet 5 (implementation), reviewed in-session by Claude Fable 5 (the poll-leg finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
