### PR TITLE
fix(tests): restore the brace #170's merge swallowed in tests/config.rs

### DIFF
--- a/tests/config.rs
+++ b/tests/config.rs
@@ -3010,6 +3010,7 @@ fn a_key_commands_stdout_never_reaches_kaibos_own_stdout() {
         "the run must fail on the dead transport AFTER resolving the key (proving the \
          command ran):\n{stderr}"
     );
+}
 
 // --- the bfl kind ------------------------------------------------------------------
 


### PR DESCRIPTION
`tests/config.rs` has not compiled on `main` since #170 landed. The merge dropped the closing `}` of `a_key_commands_stdout_never_reaches_kaibos_own_stdout` where the new `// --- the bfl kind ---` section was spliced in, so the file fails with `this file contains an unclosed delimiter` and its **138 tests have not run** since.

Found while bumping `kaish-kernel` to 0.17.0 — `cargo clippy --all-targets` on a fresh worktree off `main` refused to compile the test target, and the file was unmodified from `origin/main`.

**The loss is the brace alone.** The pre-merge body at `0e18e00` is byte-identical to what is on `main` up to that line, so no assertion went with it. With the brace back, all 138 pass.

This is the second instance of the same casualty in one merge — the #170 rebase already restored one conflict-swallowed closing brace, and this one rode in behind it. The lesson worth keeping: a rebase whose conflicts are resolved by hand needs `cargo test`, not just `cargo build`, before the push. A test file that fails to *compile* reports as a build error on a target nobody looks at, not as a failing test — so the suite goes quiet instead of going red.

No changelog entry: nothing a user notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)