### PR TITLE
docs(readme): the cosign floor was 3; a release verifies from 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **The README's cosign floor said 3, and 2.5 verifies a release** — the old floor turned
+  away working installs.
 - **Bump `kaish-kernel` to 0.14.1** — the explorer's shell no longer drops piped or
   buffered stdin across `read`/`grep`/`cat`, and a loop or `if` that exits early keeps
   what it already printed.

--- a/README.md
+++ b/README.md
@@ -143,10 +143,12 @@ against any file from the release:
 gh attestation verify kaibo-v0.2.0-x86_64-unknown-linux-musl.tar.gz -R tobert/kaibo
 ```
 
-With [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) ≥ 3
+With [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) ≥ 2.5
 (no GitHub tooling needed), verify the signed checksum manifest once and it
-covers every file it lists. Grab `checksums.txt` and `checksums.txt.sigstore.json`
-from the release, substituting the tag you downloaded in the identity:
+covers every file it lists. 2.4 and older cannot read the bundle format and
+answer `bundle does not contain cert for verification`. Grab `checksums.txt` and
+`checksums.txt.sigstore.json` from the release, substituting the tag you
+downloaded in the identity:
 
 ```sh
 cosign verify-blob \


### PR DESCRIPTION
The README told operators they need cosign **≥ 3** to verify a kaibo release
(`README.md:146`). They do not. The wrong floor turns away a working install — the
failure mode is someone concluding they cannot check a signature they can in fact check.

## Measured, not reasoned about

"Which cosign can read this bundle" is not a question to answer from memory, so I ran
each version against v0.3.0's **real** signed `checksums.txt` and its
`checksums.txt.sigstore.json`:

| cosign | result |
|---|---|
| 2.4.0 | **FAILS** — `bundle does not contain cert for verification, please provide public key` |
| 2.5.0 | `Verified OK` |
| 2.6.0 | `Verified OK` |
| 2.6.4 | `Verified OK` |

So the floor is **2.5**, not 3. There is a real boundary — 2.4 genuinely cannot read the
bundle format — which is why the fix lowers the floor to a measured number rather than
deleting the constraint.

2.4's message is quoted in the README because it is what an operator on an older cosign
actually sees, and it names the *bundle format*, not the version — so it does not explain
itself.

## Negative controls

Each `Verified OK` above is backed by two controls, on both 2.5.0 and 2.6.4 — otherwise
"verified" only proves the command ran:

- **tampered `checksums.txt`** → `failed to verify signature: could not verify message:
  invalid signature when validating ASN.1 encoded signature`
- **wrong tag identity** (`v9.9.9`) → `failed to verify certificate identity: no matching
  CertificateIdentity found … got "…@refs/tags/v0.3.0"`

Both refuse. The check is real in both directions.

## Provenance

Carried since the v0.3.0 release check on 2026-08-13, where cosign 2.6.4 verified fine
and contradicted the README's floor. It sat as a known-suspect line rather than a
measured one; this closes it with a number.

Docs only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)