### PR TITLE
docs(probes): the CAS write path gets a battery, and it found a missing test

### DIFF
--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -381,6 +381,103 @@ re-baseline.
 
 ---
 
+## 5d. Battery H — the media CAS write path stores what it says, where it says
+
+Batteries E and F ask whether kaibo's two write surfaces can be *aimed* at the project.
+This one asks the other half, and it is the one the CAS's design argument rests on: **the
+store is safe by shape, not by policy.** The address is the content hash, so the write
+API has no destination parameter for a model to point anywhere. H1 and H2 are what turn
+that sentence into a measurement.
+
+Run against a scratch store so the operator's real one is untouched:
+`--cas-dir "$SCRATCH/cas" --state-db "$SCRATCH/state.db"`. Fixtures: two small PNGs
+differing in one pixel, and one text file.
+
+**H1 — the address is the content hash, and the operator can check the arithmetic.**
+
+```sh
+sha256sum red.png blue.png
+kaibo --cas-dir "$SCRATCH/cas" --state-db "$SCRATCH/state.db" cas write red.png
+kaibo --cas-dir "$SCRATCH/cas" --state-db "$SCRATCH/state.db" cas write red.png
+kaibo --cas-dir "$SCRATCH/cas" --state-db "$SCRATCH/state.db" cas write blue.png
+find "$SCRATCH/cas" -name '*.png'
+```
+
+**Pass:** each stored object's filename **equals `sha256sum` of the file that produced
+it**, the two `red.png` writes yield one object, and `blue.png` yields a second. Two
+objects, not three. Do the comparison with `sha256sum` rather than by eye: it is the
+whole claim, and it is cheap to verify independently.
+
+Note what is *absent* from those commands — a destination. `cas write` takes the file to
+read and nothing else; `write_cas` takes `path` **or** `content` plus a `label`, where
+`path` is a *source* and is containment-checked like any other read. No write surface
+accepts a destination, so there is no parameter to aim.
+
+**H2 — a second write of the same bytes is a no-op, not a rewrite.**
+
+```sh
+stat -c 'inode=%i mtime=%.9Y size=%s' "$SCRATCH/cas"/<shard>/<digest>.png
+kaibo … cas write red.png        # again
+stat -c 'inode=%i mtime=%.9Y size=%s' "$SCRATCH/cas"/<shard>/<digest>.png
+```
+
+**Pass:** inode, mtime **to the nanosecond**, and size all unchanged. `create_new` means
+an occupied address is never reopened, so an edit is a copy at a new address and stored
+bytes are immutable. Compare the mtime, not just the object count — a rewrite with
+identical bytes would keep the count and still prove the store mutable.
+
+**H3 — a refused write stores nothing.**
+
+```sh
+kaibo … cas write notanimage.txt ; echo "exit=$?"
+find "$SCRATCH/cas" -type f | wc -l
+```
+
+**Pass:** refused because the bytes carry no image signature — the message names the
+first bytes it saw and the four containers the store holds — and the file count is
+**unchanged from before the call**. Take the count on both sides; "a refusal happened" is
+not the same claim as "nothing landed".
+
+**H4 — a freshly written object is still invisible to kaish.**
+
+F2 asks this of the store as a whole. Ask it again of an object written *this minute*,
+since a store that was simply empty would pass F2 without proving anything:
+
+```sh
+# host-side first — the denominator:
+find "$SCRATCH/cas" -type f        # must be non-empty
+# then, through run_kaish:
+ls "$SCRATCH/cas" ; cat "$SCRATCH/cas"/<shard>/<digest>.png ; find "$SCRATCH/cas" -type f
+```
+
+**Pass:** `not found`, exit 1, for all three, while the host listing shows the objects
+exist. The CAS is never mounted, so its read side cannot enumerate one project's
+artifacts from another.
+
+**H5 — the store refuses to be a lie.**
+
+The failure that would matter here is a silent one: a digest handed back that will not
+resolve later.
+
+```sh
+kaibo --no-persistence cas write red.png ; echo "exit=$?"
+```
+
+**Pass:** **nothing is stored** and the refusal says why — an in-memory store dies with
+the process, so the digest would be unreadable the moment the command exits. A store
+backed by tmpfs is accepted but warns that the artifacts will not survive the host. Both
+are the no-silent-fallback rule: a paid-for artifact is never quietly discarded, and a
+digest kaibo cannot honor is never issued.
+
+> Pinned by `tests/write_cas.rs` (12 cases — content addressing, `create_new`, and every
+> refusal asserting the store is still empty afterward) and, for the source-path half,
+> `server::tests::write_cas_refuses_a_path_outside_the_allowed_set` and
+> `write_cas_refuses_a_symlink_inside_the_tree_pointing_outside`. Teeth: replace
+> `containing_tree`'s refusal in `read_contained_file` with a fallback to the file's own
+> parent and both of those fail.
+
+---
+
 ## 6. The always-on guard: the test suites
 
 The live probes are a periodic spot-check; the *continuous* guard is the test tree.
@@ -438,6 +535,13 @@ compression, not a side effect of it.
     the fixture was then outside every allowed tree and the guard correctly did not fire.
     The §0 question — would this read differently if the probe were broken? — is what
     found it.
+  - **Battery H is new**, written from its own first run against a scratch store: the CAS
+    write path had containment (F) but nothing measured its *shape*. All clear — a stored
+    object's name equals `sha256sum` of its input, a repeat write leaves inode and mtime
+    untouched, a refusal stores nothing, and a fresh object stays invisible to kaish.
+    Writing it found one missing test, now added: `write_cas` had no case for a symlink
+    inside the tree pointing out, the leg `read_contained_file`'s own doc calls the one
+    worth not skipping.
   - Suites: containment 25 (one new), full `cargo test` 1147 passed. The lone failure is
     the known `tests/credentials.rs` ETXTBSY exec race under parallelism; green serially,
     reproduces on unmodified code.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6910,6 +6910,59 @@ enabled = false
         );
     }
 
+    /// The sibling of the out-of-tree refusal, one indirection along: the path the
+    /// caller names *is* inside the allowed tree, and the file it lands on is not.
+    /// `read_contained_file` canonicalizes before it checks a containing tree, so the
+    /// link resolves to its target and the target is what gets judged.
+    ///
+    /// Worth its own test rather than folding into the sibling, because the two fail
+    /// for different reasons and only one of them survives a refactor that checks the
+    /// path as written. A store that followed the link would be an exfiltration route
+    /// with a read-back verb attached — `read_cas` hands the bytes to the client — and
+    /// the injected-client threat model is the same one the sibling test names.
+    ///
+    /// The doc on `read_contained_file` points at `tests/containment.rs`'s
+    /// `mount_layer_symlink_*` battery for this property, but that battery drives
+    /// `run_kaish`. This is the same shape on the upload path.
+    #[tokio::test]
+    async fn write_cas_refuses_a_symlink_inside_the_tree_pointing_outside() {
+        let allowed = tempfile::TempDir::new().expect("temp dir");
+        let elsewhere = tempfile::TempDir::new().expect("temp dir");
+        let target = elsewhere.path().join("secret.png");
+        std::fs::write(&target, png_bytes()).expect("fixture writes");
+        let link = allowed.path().join("innocent.png");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        let h = handler_from_toml(&format!(
+            "[server]\nallow_paths = [{:?}]\n",
+            allowed.path().display().to_string()
+        ));
+
+        let err = h
+            .write_cas(Parameters(write_cas_input(
+                Some(&link.display().to_string()),
+                None,
+            )))
+            .await
+            .expect_err("a link out of the tree is refused, however innocent its own path");
+        assert!(
+            err.message.contains("outside the allowed set"),
+            "the refusal must name the boundary, not the link: {}",
+            err.message
+        );
+        // The positive control: the same store, the same handler, a real file inside the
+        // tree. Without it a handler that refused everything would pass the assertion
+        // above and prove nothing.
+        let real = allowed.path().join("real.png");
+        std::fs::write(&real, png_bytes()).expect("fixture writes");
+        h.write_cas(Parameters(write_cas_input(
+            Some(&real.display().to_string()),
+            None,
+        )))
+        .await
+        .expect("a real file inside the tree still stores");
+    }
+
     /// Two sources is a caller who said it twice. kaibo will not pick one — a silent
     /// precedence rule is how the stored bytes come to disagree with the intent.
     #[tokio::test]


### PR DESCRIPTION
Item two on the v0.4.0 pre-release list, carried since v0.3.0. The media CAS had
containment probes — Battery F: a path inside a project is refused at startup, kaish can
neither read nor enumerate the store — but nothing that measured its **write shape**.

That shape is the argument the CAS rests on. From AGENTS.md: the store is *"safe by shape,
not policy — the address is the content hash, so its API has no destination-path parameter
for a model to aim; it is write-only (`create_new`; no unlink/truncate/rename, so an edit
is copy-on-write)."* Every clause of that was a sentence we believed and nowhere a number.

## Battery H, written from its own first run

Not from reading the code — the probes were run against a scratch store first, and the
battery records what actually came back.

- **The address is the content hash, checkable independently.** A stored object's filename
  equals `sha256sum` of the file that produced it. Two writes of one image make one
  object; a different image makes a second.
- **A repeat write is a no-op, not a rewrite.** Inode and mtime unchanged *to the
  nanosecond*. The battery says to compare mtime rather than object count on purpose — a
  rewrite with identical bytes would keep the count and still prove the store mutable.
- **A refused write stores nothing**, with the file count taken on *both* sides. "A
  refusal happened" is not the same claim as "nothing landed."
- **A fresh object stays invisible to kaish**, with the host-side listing as the
  denominator. F2 alone would pass against an empty store and prove nothing.
- **The store refuses to be a lie.** With persistence off it stores nothing rather than
  hand back a digest that dies the moment the process exits; on tmpfs it stores but warns
  the artifacts will not survive the host. A silent fallback is the failure that would
  matter here.

Also worth noting for what is *absent*: `cas write` takes the file to read and nothing
else, and `write_cas` takes `path` **or** `content` plus a `label` — where `path` is a
*source*, containment-checked like any other read. No write surface accepts a destination.

## The gap it found

`write_cas`'s source path is containment-checked, and the out-of-tree case was tested. The
case one indirection along was not: **a symlink inside the allowed tree pointing outside
it.** That is the leg `read_contained_file`'s own doc comment calls "the one worth not
skipping" — and that doc points at `tests/containment.rs`'s `mount_layer_symlink_*`
battery as proof, which drives `run_kaish`, not this path.

A store that followed such a link would be an exfiltration route with a read-back verb
attached, since `read_cas` hands the bytes back to the client. The behavior was already
correct — `canonicalize` resolves the link before the containing-tree check — so this adds
the test, not a fix.

The new test carries a positive control (a real file inside the tree still stores through
the same handler), and the teeth were checked rather than assumed: replace
`containing_tree`'s refusal in `read_contained_file` with a fallback to the file's own
parent, and **both** refusal tests fail.

## Gates

Suite 1329 passed / 0 failed (one new). `cargo clippy --all-targets` clean. The diff is
additions only — no reformatting rode along.

No changelog entry: a runbook battery and a test are not user-facing surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)