### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-09-03
+
 ### Added
 
 - **`bfl` and `gemini-images` backend kinds** — the FLUX and Gemini image families

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "kaibo — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
The mechanical half of the release ritual, so the tag is the only thing left to do by
hand. `version` → 0.4.0 in `Cargo.toml` and the lockfile, the unreleased section retitled,
a fresh empty one opened above it.

0.4.0 rather than 0.3.1 was your call on 2026-08-16, and the section earns it: three
backend kinds arrived (`bfl`, `gemini-images`, `dashscope`), `write_cas` and `kaibo cas
write` are new surfaces, telemetry gained the metrics signal, and backends stopped seeding
their own key sources. A minor, not a patch.

## ⚠️ One thing to check before tagging

**The date reads `2026-09-03` and it is a guess** — you said you'd likely pick this up in
the morning. It must match the day the tag is pushed:

```sh
sed -i 's/^## \[0.4.0\] — .*/## [0.4.0] — YYYY-MM-DD/' CHANGELOG.md
```

It is the one thing in this PR a later reader cannot infer or correct from context.

## Pre-tag gates — run, not assumed

Every item in AGENTS.md's **Cutting a release**, checked in the session that produced this
branch:

| gate | result |
|---|---|
| kaish pin current **and** no known unfixed bug | 0.17.1 — the `readlink -f` break that held this release is fixed and measured |
| turso pin current | `=0.7.1` holds; 0.8.0-pre.7 is a prerelease |
| `cargo tree -i` empty | aws-lc-rs, aws-lc-sys, mimalloc, openssl-sys — all absent on the musl target, with `ring` as the control that the query works |
| musl binary static | `statically linked, stripped` / `not a dynamic executable`, runs and reports its version |
| sandbox probes re-run | A–G against **both** kaish pins and diffed — required by the kernel bump |

The static assertion was also run against a *dynamic* binary to confirm it discriminates,
because a check nobody has seen fail is a check nobody has tested.

Suite 1329 passed / 0 failed. `kaibo --version` reports `kaibo 0.4.0`.

## After the tag

`.github/workflows/release.yml` builds the matrix on `v*`. Then the ritual's last steps,
both deliberately manual:

1. Verify a fresh asset the way a user would — `gh attestation verify`, and `cosign
   verify-blob` with the new tag's identity. Note the floor is now **cosign ≥ 2.5**,
   measured this session (2.4.0 genuinely cannot read the bundle).
2. `scripts/bump-tap.sh v0.4.0` to point the Homebrew tap at the new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)