### PR TITLE
docs: the cosign floor was wrong in two more places, one of them the release page

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -33,7 +33,7 @@ gh attestation verify kaibo-${TAG}-x86_64-unknown-linux-musl.tar.gz -R tobert/ka
 gh attestation verify oci://ghcr.io/tobert/kaibo:${VERSION} -R tobert/kaibo
 ```
 
-Or keyless-verify the signed checksum manifest with cosign ≥ 3 (covers every file it lists, works offline):
+Or keyless-verify the signed checksum manifest with cosign ≥ 2.5 (covers every file it lists, works offline):
 
 ```sh
 cosign verify-blob \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,8 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
-- **The README's cosign floor said 3, and 2.5 verifies a release** — the old floor turned
-  away working installs.
+- **The cosign floor said 3, and 2.5 verifies a release** — the old floor turned away
+  working installs, and the release page repeated it.
 - **The explorer's shell no longer drops piped or buffered stdin** across
   `read`/`grep`/`cat`, and a loop that exits early keeps what it already printed.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -59,7 +59,7 @@ publish job, so a `workflow_dispatch` smoke run never mints an OIDC identity (bu
 keep `contents: read`; the publish job adds `id-token: write` + `attestations: write`).
 The layout, decided with Amy: **one signed aggregate `checksums.txt`** (cosign keyless —
 verify once, `sha256sum -c` covers any file it lists; one signature shape, the
-self-contained `.sigstore.json` bundle, which verifies offline with cosign ≥ 3; the
+self-contained `.sigstore.json` bundle, which verifies offline with cosign ≥ 2.5; the
 per-artifact `.sha256` sidecars stay for the README's download one-liner),
 **per-artifact SLSA provenance** via `actions/attest-build-provenance` (stored in
 GitHub's attestation store — `gh attestation verify <file> -R tobert/kaibo`, zero extra

--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -21,8 +21,9 @@ What we're verifying, concretely:
 1. **No write reaches the project** — every mutation path is refused, and nothing
    lands on real disk.
 2. **No external command runs** — the host is unreachable from inside the shell.
-3. **No read escapes the root** — paths outside the mount (absolute, `..`, or via a
-   `path` arg) resolve to nothing; adjacent secrets stay unreadable.
+3. **No read escapes the root** — a file read outside the mount (absolute, `..`, or via
+   a `path` arg) resolves to nothing; adjacent secrets stay unreadable. The mount's own
+   prefix directories list, and only ever name the next component toward it — Battery C.
 4. **No secret leaks via the environment** — the sandbox runs with an empty env.
 
 The structural design these probes exercise lives in `src/sandbox.rs` (the four


### PR DESCRIPTION
**Release-blocking.** #175 measured the cosign floor and corrected `README.md`. It
corrected *only* `README.md` — I grepped one file instead of the repo, on a change whose
entire subject was a claim repeated across surfaces. That is the "an idiom is never in one
file" lesson, and I did not apply it.

Two instances survived:

- **`.github/release-body.md:36` — this becomes the GitHub release page body.**
  `release.yml:235` runs it through `envsubst` into `body_path`, so it is the copy every
  person downloading v0.4.0 reads. It would have shipped with tomorrow's tag telling them
  to go install cosign 3 to verify a signature that 2.5 verifies.
- **`docs/releases.md:62`** — the pipeline plan, asserting the same floor as fact.

Both now say **2.5**, the measured floor: 2.4.0 cannot read the bundle format; 2.5.0,
2.6.0 and 2.6.4 verify a real release, with a tampered file and a wrong tag identity both
refusing.

## How it was found — and why neither half alone would have

A `consult` on the release branch, run as a live end-to-end exercise of the 0.17.1 shell
before tagging. It found `docs/releases.md:62` and missed the release page. The repo-wide
`grep` I ran to *verify its citation* found the release page — the one that actually
mattered.

So the review caught what my grep in #175 missed, and my grep caught what the review
missed. Worth recording as an argument for doing both rather than either.

## Also here — same family, prose the recent changes left stale

`docs/sandbox-probes.md:24` promised "paths outside the mount ... resolve to nothing" in
the summary at the top of the runbook. 0.17.1's walkable prefix directories made that too
broad. Battery C already carves out the exception a hundred lines down, so this is the
headline catching up: it now says what it means (a *file read*) and points at C.

## Not taken from the same review

It also reported `CHANGELOG.md:72`'s *"kaish upgraded to 0.17.1 (from 0.14.0)"* as stale
against AGENTS.md's *"from 0.14.1"*, and recommended changing the changelog.

**The changelog is right.** `git show v0.3.0:Cargo.toml` pins the last release at
kaish-kernel **0.14.0**, and a changelog's baseline is the last release. AGENTS.md's
0.14.1 is the pre-bump *working* pin — a different, internal baseline. Changing it would
have reintroduced exactly the error #178 fixed.

Verified before declining, not assumed.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)