### PR TITLE
fix(generate): provenance names the model that ran, not the slot's

### DIFF
--- a/src/bfl.rs
+++ b/src/bfl.rs
@@ -745,6 +745,14 @@ impl crate::media::MediaModel for BflImageModel {
         true
     }
 
+    /// BFL's ops *are* model ids, so the op that runs is the model that ran — this is
+    /// the provider [`MediaModel::effective_model`] exists for. Resolved the same way
+    /// `generate` resolves it, from the one function, so the recorded model cannot
+    /// drift from the endpoint the call went to.
+    fn effective_model(&self, request: &MediaRequest) -> Option<String> {
+        Some(resolve_op_name(request, &self.model).to_string())
+    }
+
     async fn generate(&self, request: &MediaRequest) -> AnyResult<MediaOutcome> {
         refuse_webhook_fields(request)?;
         let op_name = resolve_op_name(request, &self.model);
@@ -846,6 +854,40 @@ mod tests {
     fn resolve_op_name_falls_back_to_the_slot_model_when_op_is_omitted() {
         let r = request("a lighthouse");
         assert_eq!(resolve_op_name(&r, "flux-2-pro"), "flux-2-pro");
+    }
+
+    /// The provenance half of the two tests above: resolving the op right is only half
+    /// the job, because the sidecar is what an operator reads months later to decide
+    /// whether an artifact can be trusted or reproduced — and BFL's ops are model ids,
+    /// so an `op` changes which model made the bytes.
+    ///
+    /// Measured before this existed: `generate` with `op: "flux-dev"` recorded
+    /// `"model": "bfl/flux-2-pro"`, naming a model that never ran and, at BFL's
+    /// per-request pricing, a different cost.
+    #[test]
+    fn the_recorded_model_is_the_op_that_ran_not_the_slot() {
+        use crate::media::MediaModel;
+        let client = BflClient::new("k", "http://localhost:0", Duration::from_secs(1))
+            .expect("a client builds; no request is made");
+        let model = BflImageModel::from_parts(&client, "flux-2-pro");
+
+        let mut asked = request("a lighthouse");
+        asked.op = Some("flux-dev".to_string());
+        assert_eq!(
+            model.effective_model(&asked).as_deref(),
+            Some("flux-dev"),
+            "an `op` names the model that ran, so provenance must report it"
+        );
+
+        // The control: with no `op`, the slot model is what ran and the arm falls back
+        // to the slot ref. Without this arm the test would pass on an impl that always
+        // reported "flux-dev".
+        let plain = request("a lighthouse");
+        assert_eq!(
+            model.effective_model(&plain).as_deref(),
+            Some("flux-2-pro"),
+            "with no `op` the slot model is the model that ran"
+        );
     }
 
     // --- request building ---------------------------------------------------------

--- a/src/media.rs
+++ b/src/media.rs
@@ -372,6 +372,26 @@ pub trait MediaModel: Send + Sync {
         false
     }
 
+    /// The model id this request actually runs, when the provider's `op` names a
+    /// **model** rather than a route.
+    ///
+    /// Defaults to `None` — "the cast's `image` slot already names it" — which is true
+    /// for every provider whose operations are routes over one model: Stability's
+    /// `edit/inpaint` and the Images API's `edits` change what is done, not what runs.
+    /// BFL is the exception, and the reason this exists: its ops *are* model ids
+    /// (`flux-dev`, `flux-2-pro`), so an `op` there changes which model produced the
+    /// bytes and the slot ref stops describing them.
+    ///
+    /// This carries the same rule that makes `fields.model` a refusal in `generate` —
+    /// **recorded provenance must describe the request that ran.** That guard closed the
+    /// hole a caller could open through `fields`; this closes the one `op` opened. A
+    /// provider that reroutes to another model and stays silent here records a model
+    /// that did not run, which is a quiet wrong answer in the one record an operator
+    /// decides trust from.
+    fn effective_model(&self, _request: &MediaRequest) -> Option<String> {
+        None
+    }
+
     /// Whether this provider has a vocabulary of named operations at all.
     ///
     /// Defaults to `false` for the same reason as [`accepts_inputs`](Self::accepts_inputs),
@@ -504,6 +524,24 @@ impl MediaArm {
     /// The `"backend/model-id"` this arm was staffed from.
     pub fn slot_ref(&self) -> &str {
         &self.slot_ref
+    }
+
+    /// The model ref to record and report for one request: the slot's, unless the
+    /// provider says an `op` rerouted to a different model
+    /// ([`MediaModel::effective_model`]).
+    ///
+    /// Recomposed against the slot ref's own backend, so the recorded id stays in the
+    /// `backend/model` shape every other provenance line uses. Split on the FIRST `/`
+    /// only — a model id may contain more (`crusoe/deepseek-ai/Deepseek-V4-Flash`), so
+    /// the backend is the head and everything after it is the model.
+    pub fn recorded_model(&self, request: &MediaRequest) -> String {
+        match self.model.effective_model(request) {
+            Some(ran) => match self.slot_ref.split_once('/') {
+                Some((backend, _)) => format!("{backend}/{ran}"),
+                None => ran,
+            },
+            None => self.slot_ref.clone(),
+        }
     }
 
     /// Run one generation request on this arm.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3218,14 +3218,18 @@ impl KaiboHandler {
         // backstop — see `MediaArm::refuse_unsupported`.
         arm.refuse_unsupported(&request)
             .map_err(|e| McpError::invalid_params(format!("{e:#}"), None))?;
-        let span = tracing::info_span!("generate", cast = %cast.name, model = %arm.slot_ref());
+        // Every model name below is the one that RAN, not the slot's — a BFL `op`
+        // reroutes to another model, and a record naming the wrong one is worse than no
+        // record. See `MediaArm::recorded_model`.
+        let ran = arm.recorded_model(&request);
+        let span = tracing::info_span!("generate", cast = %cast.name, model = %ran);
         match arm.generate(&request).instrument(span).await {
             Ok(crate::media::MediaOutcome::Complete { artifacts, note }) => {
                 let rendered = match store_generated_artifacts(
                     &store,
                     &artifacts,
                     &input.prompt,
-                    arm.slot_ref(),
+                    &ran,
                     &cast.name,
                 ) {
                     Ok(text) => text,
@@ -3244,7 +3248,7 @@ impl KaiboHandler {
                     with_provenance(
                         rendered,
                         &cast.name,
-                        &[("image", arm.slot_ref())],
+                        &[("image", ran.as_str())],
                         &Usage::new(),
                     ),
                 )]))
@@ -3255,10 +3259,10 @@ impl KaiboHandler {
             // stability::Operation::shape), never a sniffed response.
             Ok(crate::media::MediaOutcome::Deferred(provider_job)) => {
                 let progress_log = Arc::new(ProgressLog::new(Arc::new(TracingSink)));
-                let label = format!("generate · cast {} · image {}", cast.name, arm.slot_ref());
+                let label = format!("generate · cast {} · image {}", cast.name, ran);
                 let prompt = input.prompt.clone();
                 let cast_name = cast.name.clone();
-                let slot_ref = arm.slot_ref().to_string();
+                let slot_ref = ran.clone();
                 let deadline = self.config.defaults.call_deadline;
                 let poll_arm = arm.clone();
                 let id = self.jobs.submit(label, progress_log, async move {
@@ -3305,8 +3309,7 @@ impl KaiboHandler {
                     "Deferred: `{id}` — the provider is generating in the background \
                      (cast `{}`, image `{}`). Collect it with `job_get {id}` or park on \
                      `job_wait`; stop it with `job_cancel {id}`.",
-                    cast.name,
-                    arm.slot_ref()
+                    cast.name, ran
                 ))]))
             }
             Err(e) => Ok(consultation_failed("generate", &cast.name, e)),
@@ -5767,6 +5770,71 @@ mod tests {
         assert!(
             text.contains("cast `artist`") && text.contains("sd/core"),
             "the provenance footer names the cast and image model:\n{text}"
+        );
+    }
+
+    /// A provider whose `op` names a *model* rather than a route — BFL, whose ops are
+    /// model ids — must have that model reach the sidecar and the footer, not the slot's.
+    ///
+    /// The wiring half of `bfl::tests::the_recorded_model_is_the_op_that_ran_not_the_slot`:
+    /// that one proves BFL resolves the op, this one proves the handler carries the
+    /// answer all the way to what an operator reads. Found live before the fix — a
+    /// `generate` with `op: "flux-dev"` recorded `"model": "bfl/flux-2-pro"`.
+    #[tokio::test]
+    async fn generate_records_the_model_an_op_rerouted_to_not_the_slot() {
+        /// Reroutes like BFL: whatever `op` says is the model that ran.
+        struct Rerouting(Vec<crate::media::MediaArtifact>);
+
+        #[async_trait::async_trait]
+        impl crate::media::MediaModel for Rerouting {
+            fn accepts_ops(&self) -> bool {
+                true
+            }
+            fn effective_model(&self, request: &crate::media::MediaRequest) -> Option<String> {
+                request.op.clone()
+            }
+            async fn generate(
+                &self,
+                _request: &crate::media::MediaRequest,
+            ) -> anyhow::Result<crate::media::MediaOutcome> {
+                Ok(crate::media::MediaOutcome::Complete {
+                    artifacts: self.0.clone(),
+                    note: None,
+                })
+            }
+            async fn poll(
+                &self,
+                _job: &crate::media::MediaJobId,
+            ) -> anyhow::Result<crate::media::MediaPollOutcome> {
+                unreachable!("this model completes in-call")
+            }
+        }
+
+        let artifact = png(b"rerouted");
+        let h = media_handler(Arc::new(Rerouting(vec![artifact])));
+        let result = h
+            .generate(Parameters(GenerateInput {
+                prompt: "a red door".to_string(),
+                cast: Some("artist".to_string()),
+                fields: None,
+                inputs: None,
+                op: Some("flux-dev".to_string()),
+            }))
+            .await
+            .expect("generate succeeds");
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
+            .expect("generate answers with text");
+        assert!(
+            text.contains("sd/flux-dev"),
+            "the footer names the model that RAN, recomposed onto the slot's backend:\n{text}"
+        );
+        assert!(
+            !text.contains("sd/core"),
+            "the slot's model did not run, so it must not be reported as though it \
+             had:\n{text}"
         );
     }
 


### PR DESCRIPTION
Found live tonight, running the pre-tag checks against the shipped binary. A `generate`
with `op: "flux-dev"` wrote this beside the artifact:

```json
{ "prompt": "…", "model": "bfl/flux-2-pro", "cast": "flux", "tool": "generate" }
```

The op resolved correctly and the call really did go to `/v1/flux-dev`
(`bfl.rs:191` — `request.op.as_deref().unwrap_or(slot_model)`, with tests already
covering it). Only the **record** was wrong. So the one file an operator reads months
later, to decide whether an artifact can be trusted or reproduced, named a model that
never ran — and at BFL's per-request pricing, a different cost.

## The rule was already written down, and enforced one door over

`generate` refuses `fields.model` with this reasoning (`server/mod.rs:3173-3177`):

> Reserved keys: recorded provenance must describe the request that actually ran. […]
> `fields.model` would reroute the call while the sidecar records the slot's model — so
> both are refused loudly.

`op` reroutes exactly the same way and walked straight past that guard. This closes the
hole `op` opened, with the same principle the existing guard states.

## Fixed where the asymmetry lives

Not by special-casing BFL in the handler. `MediaModel::effective_model` defaults to
`None` — *"the cast's `image` slot already names it"* — which is true for every provider
whose ops are **routes over one model**: Stability's `edit/inpaint`, the Images API's
`edits`. BFL overrides it, because its ops **are** model ids (`flux-dev`, `flux-2-pro`).

That is the same fail-closed shape as `accepts_inputs` and `accepts_ops` sitting beside
it: a provider added later that reroutes and forgets to say so gets the safe answer — a
slot ref — rather than a confidently wrong model.

`MediaArm::recorded_model` recomposes onto the slot's backend so the record keeps its
`backend/model` shape, splitting on the **first** `/` only, since a model id can contain
more (`crusoe/deepseek-ai/Deepseek-V4-Flash`).

All five places the handler names a model now name the one that ran: the sidecar, the
footer the caller reads, the span (cost attribution), and the deferred lane's job label
and handle message.

## Two tests, teeth checked on both

| test | proves | fails when |
|---|---|---|
| `bfl::…::the_recorded_model_is_the_op_that_ran_not_the_slot` | BFL resolves the op as the model | the override is dropped |
| `server::…::generate_records_the_model_an_op_rerouted_to_not_the_slot` | the handler carries it to what an operator reads | the handler reverts to `slot_ref` |

The first carries a control arm for the no-`op` case, so an impl that always answered
`"flux-dev"` would fail it. Both teeth were run, not assumed.

Suite **1331 passed / 0 failed**, clippy clean.

## Scope notes

**No changelog entry.** BFL and `op` are both new in this same unreleased section, so this
bug has never been in a release — the feature bullet describes the behavior that ships.

**Not fixed here, deliberately:** a Stability `op` names a *route*, not a model, so the
slot ref stays the honest answer there. Recording the route as well would genuinely
improve the sidecar, but that is an added field rather than a correction, and it is not
what tonight found.

**Also noticed, not addressed:** the CLI's `generate` has no `--op` flag, so this path is
reachable only over MCP. Worth its own look, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)