### PR TITLE
The turn budget is the server's, not the caller's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+### Removed
+
+- **`explorer_max_turns` / `synth_max_turns` are no longer tool arguments or CLI flags** —
+  the turn budget is the server's, set in `[defaults]` or `KAIBO_*_MAX_TURNS`, so two
+  calls to one server stay comparable. A call still passing one is refused by name.
+
 ## [0.4.0] — 2026-09-03
 
 ### Added

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -111,7 +111,7 @@ generate       = true      # ...and needs a cast with an `image` slot AND [cas] 
 # overridden per slot (table form, below); request_timeout_secs per backend.
 # ---------------------------------------------------------------------------
 [defaults]
-explorer_max_turns = 100     # bounds each cheap explore′ sweep — cheap, let it rip
+explorer_max_turns = 100     # bounds each cheap explore′ sweep — set here only, no per-call arg
 synth_max_turns    = 200     # bounds the consult driver loop (sweeps AND span reads)
 max_tokens         = 16384   # output headroom; MUST sit well above thinking_budget
 thinking_budget    = 8192    # reasoning budget where the provider exposes a toggle

--- a/docs/config.md
+++ b/docs/config.md
@@ -478,8 +478,11 @@ paths sit outside it by nature:
 - **The batch lane** holds no in-process wait at all. The work runs on the provider's
   queue and is collected by polling `job_get`.
 
-**`explorer_max_turns` / `synth_max_turns`.** Available in `[defaults]` and per call
-only. They bound the loop, not the model.
+**`explorer_max_turns` / `synth_max_turns`.** Server-side only — `[defaults]` and the
+env vars, no tool argument and no CLI flag. They bound the loop, not the model, and a
+loop that reaches its cap still answers: kaibo runs one final tools-forbidden turn so the
+caller gets the work, not a stall. Set them for the server so two calls to it stay
+comparable.
 
 **`session_capacity` / `job_capacity`.** Both LRU, capacity-evicted, no TTL.
 `session_capacity` caps multi-turn consult sessions held in memory. `job_capacity` caps
@@ -631,8 +634,8 @@ Highest wins:
 MCP per-call input  >  CLI flag  >  env var  >  config file  >  built-in default
 ```
 
-**Per-call input** is the `cast`, `*_model`, `*_backend`, and `*_max_turns` tool
-arguments. The config supplies the defaults those override.
+**Per-call input** is the `cast`, `*_model`, and `*_backend` tool arguments. The config
+supplies the defaults those override. Turn limits are deliberately not among them.
 
 **A per-call model override** sends the model id verbatim. An id containing `/`
 (HuggingFace style) is still one id: it is never parsed for a backend, so an org prefix
@@ -657,8 +660,8 @@ Everything else follows one naming rule:
 | default cast | `server.cast` | `KAIBO_CAST` | `--cast` |
 | disable a tool | `server.tools.<t> = false` | `KAIBO_NO_<T>` | `--no-<t>` |
 | log filter | `server.log` | `RUST_LOG` *(wins)* / `KAIBO_LOG` | — |
-| explorer max turns | `defaults.explorer_max_turns` | `KAIBO_EXPLORER_MAX_TURNS` | *(per-call only)* |
-| synth max turns | `defaults.synth_max_turns` | `KAIBO_SYNTH_MAX_TURNS` | *(per-call only)* |
+| explorer max turns | `defaults.explorer_max_turns` | `KAIBO_EXPLORER_MAX_TURNS` | — |
+| synth max turns | `defaults.synth_max_turns` | `KAIBO_SYNTH_MAX_TURNS` | — |
 | max output tokens | `defaults.max_tokens` *(per-slot override)* | `KAIBO_MAX_TOKENS` | — |
 | thinking budget | `defaults.thinking_budget` *(per-slot override)* | `KAIBO_THINKING_BUDGET` | — |
 | explorer temperature | `defaults.explorer_temperature` *(per-slot `temperature`)* | `KAIBO_EXPLORER_TEMPERATURE` | — |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -354,13 +354,6 @@ pub struct ConsultArgs {
     #[arg(long, value_name = "BACKEND")]
     pub synth_backend: Option<String>,
 
-    /// Max tool-loop turns per delegated explorer sweep (default 100).
-    #[arg(long, value_name = "N")]
-    pub explorer_max_turns: Option<usize>,
-    /// Max tool-loop turns for the consult driver loop (default 200).
-    #[arg(long, value_name = "N")]
-    pub synth_max_turns: Option<usize>,
-
     /// Also print the explorer's aggregated report. Under --json it is the `report`
     /// field on stdout; otherwise it goes to stderr under a `--- explorer report ---`
     /// header, so a pipe still captures only the answer. Empty when the consult
@@ -432,9 +425,6 @@ pub struct ExploreArgs {
     /// Run the explorer override on this backend (name or alias). Requires --explorer-model.
     #[arg(long, value_name = "BACKEND")]
     pub explorer_backend: Option<String>,
-    /// Max tool-loop turns for the explorer sweep (default 100).
-    #[arg(long, value_name = "N")]
-    pub explorer_max_turns: Option<usize>,
 
     /// Emit a JSON envelope on stdout (report + provenance + usage) instead of prose.
     #[arg(long)]
@@ -489,9 +479,6 @@ pub struct DeliberateArgs {
     /// Run the synth override on this backend (name or alias). Requires --synth-model.
     #[arg(long, value_name = "BACKEND")]
     pub synth_backend: Option<String>,
-    /// Max tool-loop turns for the dossier-building explorer sweep (default 100).
-    #[arg(long, value_name = "N")]
-    pub explorer_max_turns: Option<usize>,
 
     /// Emit a JSON envelope on stdout instead of prose. A batch cast's envelope carries
     /// the handle to collect later; a direct cast's carries the answer it waited for.
@@ -1028,11 +1015,11 @@ async fn resolve_and_run(
                     .map_err(SetupError::setup)?,
                 call_deadline,
             },
-            explorer_max_turns: args.explorer_max_turns.unwrap_or(default_explorer_turns),
+            explorer_max_turns: default_explorer_turns,
             sandbox: sandbox.clone(),
             max_attachments: resolver.config.defaults.max_attachments,
         },
-        synth_max_turns: args.synth_max_turns.unwrap_or(default_synth_turns),
+        synth_max_turns: default_synth_turns,
         attachments,
         // No client key on this front door (see `load_config`), so no sink and no
         // `save_artifact` in the CLI consult's toolset.
@@ -1480,9 +1467,7 @@ async fn explore_inner(
                 .map_err(SetupError::setup)?,
             call_deadline: resolver.config.defaults.call_deadline,
         },
-        explorer_max_turns: args
-            .explorer_max_turns
-            .unwrap_or(resolver.config.defaults.explorer_max_turns),
+        explorer_max_turns: resolver.config.defaults.explorer_max_turns,
         sandbox: resolver.config.sandbox.clone(),
         max_attachments: resolver.config.defaults.max_attachments,
     };
@@ -1587,7 +1572,6 @@ async fn deliberate_inner(
         attach: &args.attach,
         model: args.explorer_model.as_deref(),
         backend: args.explorer_backend.as_deref(),
-        max_turns: args.explorer_max_turns,
     }) {
         return Err(SetupError {
             kind: "usage",
@@ -1676,9 +1660,7 @@ async fn deliberate_inner(
                     .map_err(SetupError::setup)?,
                 call_deadline: resolver.config.defaults.call_deadline,
             },
-            explorer_max_turns: args
-                .explorer_max_turns
-                .unwrap_or(resolver.config.defaults.explorer_max_turns),
+            explorer_max_turns: resolver.config.defaults.explorer_max_turns,
             sandbox: resolver.config.sandbox.clone(),
             max_attachments: resolver.config.defaults.max_attachments,
         };
@@ -4080,8 +4062,10 @@ mod tests {
             "src/b.rs",
             "--synth-model",
             "other-synth",
-            "--explorer-max-turns",
-            "7",
+            "--explorer-backend",
+            "alt",
+            "--explorer-model",
+            "other-explorer",
             "--json",
         ]);
         assert_eq!(cli.common.cast.as_deref(), Some("gemini-deliberate"));
@@ -4091,7 +4075,8 @@ mod tests {
                 assert_eq!(d.path.as_deref(), Some("/tmp/proj"));
                 assert_eq!(d.attach, vec!["src/a.rs", "src/b.rs"]);
                 assert_eq!(d.synth_model.as_deref(), Some("other-synth"));
-                assert_eq!(d.explorer_max_turns, Some(7));
+                assert_eq!(d.explorer_backend.as_deref(), Some("alt"));
+                assert_eq!(d.explorer_model.as_deref(), Some("other-explorer"));
                 assert!(d.json);
                 assert_eq!(d.dossier, None);
             }

--- a/src/server/dossier.rs
+++ b/src/server/dossier.rs
@@ -138,10 +138,10 @@ pub(crate) fn keep_dossier(
 /// The refusal a `deliberate` call earns when it supplies a dossier AND explorer
 /// arguments, or `None` when there is nothing wrong.
 ///
-/// With a dossier supplied there is no sweep, so `attach`, the explorer overrides, and
-/// `explorer_max_turns` have nothing to act on. Ignoring them would hand back an answer
-/// that looks like it honored them, which is the quiet kind of wrong: the caller attached
-/// a file, saw a deliberation, and has no way to learn the file never reached it.
+/// With a dossier supplied there is no sweep, so `attach` and the explorer overrides have
+/// nothing to act on. Ignoring them would hand back an answer that looks like it honored
+/// them, which is the quiet kind of wrong: the caller attached a file, saw a deliberation,
+/// and has no way to learn the file never reached it.
 ///
 /// A call that builds its own dossier can carry every one of them, so only a reuse call
 /// has anything to answer for here. Checked before either front door resolves anything, so
@@ -155,7 +155,6 @@ pub(crate) fn inert_explorer_args(args: ExplorerArgs<'_>) -> Option<String> {
         (!args.attach.is_empty()).then_some("attach"),
         args.model.is_some().then_some("explorer_model"),
         args.backend.is_some().then_some("explorer_backend"),
-        args.max_turns.is_some().then_some("explorer_max_turns"),
     ]
     .into_iter()
     .flatten()
@@ -187,7 +186,6 @@ pub(crate) struct ExplorerArgs<'a> {
     pub attach: &'a [String],
     pub model: Option<&'a str>,
     pub backend: Option<&'a str>,
-    pub max_turns: Option<usize>,
 }
 
 /// Load a dossier the caller supplied by address, for a second synth to reason over.
@@ -536,7 +534,6 @@ mod tests {
             attach: if attach.is_empty() { &none } else { &one },
             model: None,
             backend: None,
-            max_turns: None,
         };
 
         assert_eq!(
@@ -550,12 +547,12 @@ mod tests {
 
         let refusal = inert_explorer_args(ExplorerArgs {
             model: Some("m"),
-            max_turns: Some(10),
+            backend: Some("b"),
             ..reuse(&[])
         })
         .expect("both are inert");
         assert!(
-            refusal.contains("`explorer_model`") && refusal.contains("`explorer_max_turns`"),
+            refusal.contains("`explorer_model`") && refusal.contains("`explorer_backend`"),
             "every inert argument is named, not just the first: {refusal}"
         );
 
@@ -569,7 +566,6 @@ mod tests {
                 attach: &one,
                 model: Some("m"),
                 backend: Some("b"),
-                max_turns: Some(10),
             }),
             None,
             "a sweeping call is what the explorer arguments are for"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -363,14 +363,6 @@ pub struct ConsultInput {
     #[serde(default)]
     pub session_id: Option<String>,
 
-    /// Max tool-loop turns for each delegated `explore′` sweep (default 100).
-    #[serde(default)]
-    pub explorer_max_turns: Option<usize>,
-
-    /// Max tool-loop turns for the consult driver loop itself (default 200).
-    #[serde(default)]
-    pub synth_max_turns: Option<usize>,
-
     /// Attach the explorer's aggregated report as `structured_content` alongside the
     /// answer, for debugging the hand-off. Off by default (it can be large; an empty
     /// report means the consult delegated no sweep).
@@ -430,18 +422,13 @@ pub struct ExploreInput {
     /// `explorer_model`. See `kaibo://tools`.
     #[serde(default)]
     pub explorer_backend: Option<String>,
-
-    /// Max tool-loop turns for the explorer sweep (default 100).
-    #[serde(default)]
-    pub explorer_max_turns: Option<usize>,
 }
 
 /// Arguments to the `deliberate` tool: `explore → offline synth`. The explorer runs
 /// live to build a cited dossier (you wait for this — minutes), then the offline synth
 /// deliberates over it. No `session_id`/`context`: deliberate reads the repo itself,
-/// and the synth is a single offline turn (so no `synth_max_turns`). `attach` reaches
-/// the dossier-building explorer as read-WHOLE directives — one attach semantic across
-/// the exploring tools.
+/// and the synth is a single offline turn. `attach` reaches the dossier-building
+/// explorer as read-WHOLE directives — one attach semantic across the exploring tools.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DeliberateInput {
@@ -489,16 +476,12 @@ pub struct DeliberateInput {
     #[serde(default)]
     pub synth_backend: Option<String>,
 
-    /// Max tool-loop turns for the dossier-building explorer sweep (default 100).
-    #[serde(default)]
-    pub explorer_max_turns: Option<usize>,
-
     /// Reuse a dossier kaibo already built instead of sweeping for a new one: pass the
     /// digest (bare, or as its `kaibo://cas/<digest>` URI) that an earlier `deliberate`
     /// handed back. No explorer runs, so this call costs only the synth — the way to put
     /// the same evidence in front of a second cast. The explorer arguments (`attach`,
-    /// `explorer_model`, `explorer_backend`, `explorer_max_turns`) have nothing to act on
-    /// here, and are refused rather than ignored.
+    /// `explorer_model`, `explorer_backend`) have nothing to act on here, and are refused
+    /// rather than ignored.
     #[serde(default)]
     pub dossier: Option<String>,
 }
@@ -1851,13 +1834,11 @@ impl KaiboHandler {
                     orientation: self.orientation(&root).await?,
                     call_deadline: defaults.call_deadline,
                 },
-                explorer_max_turns: input
-                    .explorer_max_turns
-                    .unwrap_or(defaults.explorer_max_turns),
+                explorer_max_turns: defaults.explorer_max_turns,
                 sandbox: self.config.sandbox.clone(),
                 max_attachments: defaults.max_attachments,
             },
-            synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
+            synth_max_turns: defaults.synth_max_turns,
             attachments,
             artifacts: self.artifact_sink(
                 input.save_artifacts,
@@ -2000,13 +1981,11 @@ impl KaiboHandler {
                     orientation: self.orientation(&root).await?,
                     call_deadline: defaults.call_deadline,
                 },
-                explorer_max_turns: input
-                    .explorer_max_turns
-                    .unwrap_or(defaults.explorer_max_turns),
+                explorer_max_turns: defaults.explorer_max_turns,
                 sandbox: self.config.sandbox.clone(),
                 max_attachments: defaults.max_attachments,
             },
-            synth_max_turns: input.synth_max_turns.unwrap_or(defaults.synth_max_turns),
+            synth_max_turns: defaults.synth_max_turns,
             attachments,
             // Same two-key gate as the sync lane, and refused here for the same reason —
             // synchronously, before a job exists, so a caller asking for something this
@@ -2131,9 +2110,7 @@ impl KaiboHandler {
                 orientation: self.orientation(&root).await?,
                 call_deadline: defaults.call_deadline,
             },
-            explorer_max_turns: input
-                .explorer_max_turns
-                .unwrap_or(defaults.explorer_max_turns),
+            explorer_max_turns: defaults.explorer_max_turns,
             sandbox: self.config.sandbox.clone(),
             max_attachments: defaults.max_attachments,
         };
@@ -2203,7 +2180,6 @@ impl KaiboHandler {
             attach: &input.attach,
             model: input.explorer_model.as_deref(),
             backend: input.explorer_backend.as_deref(),
-            max_turns: input.explorer_max_turns,
         }) {
             return Err(McpError::invalid_params(refusal, None));
         }
@@ -2266,9 +2242,7 @@ impl KaiboHandler {
                     orientation: self.orientation(&root).await?,
                     call_deadline: defaults.call_deadline,
                 },
-                explorer_max_turns: input
-                    .explorer_max_turns
-                    .unwrap_or(defaults.explorer_max_turns),
+                explorer_max_turns: defaults.explorer_max_turns,
                 sandbox: self.config.sandbox.clone(),
                 max_attachments: defaults.max_attachments,
             };
@@ -5384,8 +5358,6 @@ mod tests {
             synth_model: None,
             synth_backend: None,
             session_id: Some("sess-1".into()),
-            explorer_max_turns: None,
-            synth_max_turns: None,
             include_report: false,
             attach: Vec::new(),
             save_artifacts,
@@ -8186,7 +8158,6 @@ enabled = false
                     explorer_backend: None,
                     synth_model: None,
                     synth_backend: None,
-                    explorer_max_turns: None,
                     dossier: Some(kept.digest.clone()),
                 },
                 Arc::new(NullSink),
@@ -8239,7 +8210,6 @@ enabled = false
             explorer_backend: None,
             synth_model: None,
             synth_backend: None,
-            explorer_max_turns: None,
             dossier: Some(digest.to_string()),
         };
 

--- a/tests/turn_limits.rs
+++ b/tests/turn_limits.rs
@@ -1,0 +1,104 @@
+//! The turn budget is a server property, not a per-call argument.
+//!
+//! `explorer_max_turns` and `synth_max_turns` live in `[defaults]` (and their `KAIBO_*`
+//! env spellings), where the operator sets them once for the server. They were once tool
+//! params and CLI flags too, and a calling agent that could see them tuned them — raising
+//! a cap is the reflex a stalled model reaches for, and it bought nothing kaibo's own
+//! defaults and its finalize-after-max-turns recovery do not already handle, while making
+//! two calls to the same server incomparable.
+//!
+//! So the per-call road is closed, and closed *loudly*: with the fields gone,
+//! `deny_unknown_fields` turns a tuning attempt into an invalid-params error naming the
+//! field, never a silent drop into the configured default. These tests pin that end
+//! state on both front doors.
+
+use clap::Parser;
+use kaibo::cli::Cli;
+use kaibo::config::Config;
+use kaibo::server::{ConsultInput, DeliberateInput, ExploreInput};
+use serde_json::json;
+
+/// Every tool that runs a model loop refuses a per-call turn limit by name.
+#[test]
+fn the_mcp_tools_refuse_a_per_call_turn_limit() {
+    let cases: Vec<(&str, &str, Option<String>)> = vec![
+        (
+            "consult",
+            "explorer_max_turns",
+            serde_json::from_value::<ConsultInput>(
+                json!({ "question": "q", "explorer_max_turns": 5 }),
+            )
+            .err()
+            .map(|e| e.to_string()),
+        ),
+        (
+            "consult",
+            "synth_max_turns",
+            serde_json::from_value::<ConsultInput>(
+                json!({ "question": "q", "synth_max_turns": 500 }),
+            )
+            .err()
+            .map(|e| e.to_string()),
+        ),
+        (
+            "explore",
+            "explorer_max_turns",
+            serde_json::from_value::<ExploreInput>(
+                json!({ "question": "q", "explorer_max_turns": 5 }),
+            )
+            .err()
+            .map(|e| e.to_string()),
+        ),
+        (
+            "deliberate",
+            "explorer_max_turns",
+            serde_json::from_value::<DeliberateInput>(
+                json!({ "question": "q", "explorer_max_turns": 5 }),
+            )
+            .err()
+            .map(|e| e.to_string()),
+        ),
+    ];
+
+    for (tool, field, err) in cases {
+        let msg = err.unwrap_or_else(|| {
+            panic!("{tool}: `{field}` must be refused, not accepted as a per-call override")
+        });
+        assert!(
+            msg.contains(field),
+            "{tool}: the refusal must name `{field}`, got: {msg}"
+        );
+    }
+}
+
+/// The CLI closes the same road: the flags do not parse, so a script or an agent
+/// reaching for one exits 2 with usage rather than running on a tuned budget.
+#[test]
+fn the_cli_has_no_turn_limit_flags() {
+    for argv in [
+        vec!["kaibo", "consult", "why?", "--explorer-max-turns", "5"],
+        vec!["kaibo", "consult", "why?", "--synth-max-turns", "500"],
+        vec!["kaibo", "explore", "map it", "--explorer-max-turns", "5"],
+        vec![
+            "kaibo",
+            "deliberate",
+            "is this right?",
+            "--explorer-max-turns",
+            "5",
+        ],
+    ] {
+        let flag = argv[3];
+        Cli::try_parse_from(&argv)
+            .err()
+            .unwrap_or_else(|| panic!("`{flag}` must not parse: {argv:?}"));
+    }
+}
+
+/// The operator keeps the knob. Closing the per-call road moves the decision to the
+/// server's config, so the defaults must still be there to set.
+#[test]
+fn the_operator_still_sets_the_budget_in_config() {
+    let d = Config::builtin().defaults;
+    assert_eq!(d.explorer_max_turns, 100);
+    assert_eq!(d.synth_max_turns, 200);
+}

--- a/tests/turn_limits.rs
+++ b/tests/turn_limits.rs
@@ -58,6 +58,17 @@ fn the_mcp_tools_refuse_a_per_call_turn_limit() {
             .err()
             .map(|e| e.to_string()),
         ),
+        // deliberate's synth is one offline completion, not a loop, so this spelling
+        // never belonged here — pinned anyway, so re-adding it anywhere is one failure.
+        (
+            "deliberate",
+            "synth_max_turns",
+            serde_json::from_value::<DeliberateInput>(
+                json!({ "question": "q", "synth_max_turns": 500 }),
+            )
+            .err()
+            .map(|e| e.to_string()),
+        ),
     ];
 
     for (tool, field, err) in cases {
@@ -79,6 +90,13 @@ fn the_cli_has_no_turn_limit_flags() {
         vec!["kaibo", "consult", "why?", "--explorer-max-turns", "5"],
         vec!["kaibo", "consult", "why?", "--synth-max-turns", "500"],
         vec!["kaibo", "explore", "map it", "--explorer-max-turns", "5"],
+        vec![
+            "kaibo",
+            "deliberate",
+            "is this right?",
+            "--synth-max-turns",
+            "500",
+        ],
         vec![
             "kaibo",
             "deliberate",


### PR DESCRIPTION
`explorer_max_turns` and `synth_max_turns` are gone from every tool schema and CLI flag on `consult`, `explore`, and `deliberate`. `[defaults]` and the `KAIBO_*_MAX_TURNS` env vars keep the knob, where the operator sets it once for the server.

## Why

A calling agent that can see a turn cap tunes it. Amy's report: "codex/astra keeps trying to tune it and it breaks kaibo's patterns." Raising the cap is the reflex a stalled model reaches for, and it buys nothing kaibo does not already do — a loop that reaches its cap runs one final tools-forbidden turn and answers (`finalize_after_max_turns`). What it does buy is two calls to the same server that are not comparable, which is the thing a cross-model study exists to compare.

Turn budget is a property of how this server is provisioned, not of one question. It belongs on the operator surface, next to `max_tokens` and the temperatures, which were never per-call either.

## The road closes loudly

With the fields gone, `deny_unknown_fields` turns a tuning attempt into an invalid-params error naming the field — never a silent drop into the configured default, which would let the caller believe the override applied. rmcp deserializes before the handler body runs, so the refusal costs nothing: no root resolution, no cast, no model request. On the CLI, clap rejects the flag at parse time and exits 2.

## What moved

- `ConsultInput` / `ExploreInput` / `DeliberateInput` lose the params; the four `ExploreConfig` / `ConsultConfig` construction sites fill from `defaults`.
- `ConsultArgs` / `ExploreArgs` / `DeliberateArgs` lose the flags; the three CLI construction sites do the same.
- `dossier::inert_explorer_args` drops `explorer_max_turns` from the arguments a reuse call makes inert — there is no longer an argument to name. `attach`, `explorer_model`, `explorer_backend` still are.
- `docs/config.md` and `docs/config.example.toml` say server-side only, and the precedence table's CLI column for both keys is now `—`.

## Tests

`tests/turn_limits.rs` is new and fails against the code it replaces — verified by running it against `main`:

```
consult: `explorer_max_turns` must be refused, not accepted as a per-call override
`--explorer-max-turns` must not parse: ["kaibo", "consult", "why?", ...]
```

It pins all three halves: the MCP inputs refuse each spelling by name, the CLI flags do not parse, and the `[defaults]` keys survive (the knob has to still exist somewhere for this to be a move rather than a deletion).

## Review

kaibo reviewed itself — cast `crusoe`, GLM-5.2 synth over a Deepseek-V4-Flash explorer, no diff supplied. It confirmed the removal complete across all seven call sites, found no published text left describing these as per-call, and found one real gap: nothing pinned `synth_max_turns` on `DeliberateInput`. Deliberate's synth is a single offline completion, not a loop, so that spelling never belonged there — but re-adding it to that one struct would have passed. Second commit closes it.

Its one other note — `CHANGELOG.md`'s `0.4.0` entry still lists `explorer_max_turns` as an `explore` argument — is left alone deliberately: past-release entries are a historical record, and the unreleased section documents the removal.

Reviewed-by: kaibo cast `crusoe` (zai/GLM-5.2 synth, deepseek-ai/Deepseek-V4-Flash explorer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
