### PR TITLE
The explorer is told who actually reads its report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ record. Each later release appends a new section at the top.
   cast shape it wants, or the absent job producer, plus the tools that are live. A
   misspelled name still reads as `tool not found`.
 
+### Fixed
+
+- **`explore` no longer tells its explorer that a synthesis agent will write the answer** —
+  on a standalone `explore` there is none, and the report is the deliverable.
+
 ### Removed
 
 - **`explorer_max_turns` / `synth_max_turns` are no longer tool arguments or CLI flags** —

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -842,16 +842,30 @@ synth    = { backend = "gemma", id = "Big-Local-70B-GGUF", lane = "direct" }
 # user_files    = ["~/.claude/CLAUDE.md"]
 
 # ---------------------------------------------------------------------------
-# [prompts] — per-PHASE system-prompt overrides. Where [context] ADDS project
-# guidance, [prompts] REPLACES the built-in role framing (full replace — the kaish
-# shell contract rides the run_kaish tool regardless). File-only and operator-only
-# (a calling agent can't inject a prompt). An empty value is a loud load error.
-# Precedence per phase: slot `preamble` (per-model, above) > [prompts].<phase> >
-# built-in. The synth slot feeds both `consult` and `oneshot`, but each keeps
-# its own key, so they can diverge. Phases: `explorer` (every sweep — `explore`,
-# `consult`'s nested explore′, `deliberate`'s dossier),
-# `consult` (the driver), `oneshot` (the thin toolless answer), `batch` (the offline
-# max-thinking answer).
+# [prompts] — replace a phase's role framing.
+#
+# [context] adds project guidance to the built-in prompt. [prompts] replaces the
+# built-in role framing instead, and the replacement is total. The kaish shell
+# contract is not part of it: that text rides the run_kaish tool, so every phase
+# keeps it, whichever prompt it runs.
+#
+# Set these here only. A calling agent cannot set a prompt. An empty value is a
+# load error.
+#
+# Precedence per phase, highest first: a slot's `preamble` (per model, above),
+# then [prompts].<phase>, then the built-in.
+#
+# The synth slot answers both `consult` and `oneshot`. Each keeps its own key
+# here, so the two can differ.
+#
+# One key per phase:
+#   explorer  every survey: standalone `explore`, the survey nested inside
+#             `consult`, and `deliberate`'s dossier. One key, and `explore`'s
+#             report goes to a different reader than the other two — see
+#             `kaibo://config/guide`.
+#   consult   the driver that reads spans and delegates surveys.
+#   oneshot   the toolless answer, with no codebase access.
+#   batch     the offline answer, at maximum thinking depth.
 # ---------------------------------------------------------------------------
 #
 # [prompts]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -848,7 +848,8 @@ synth    = { backend = "gemma", id = "Big-Local-70B-GGUF", lane = "direct" }
 # (a calling agent can't inject a prompt). An empty value is a loud load error.
 # Precedence per phase: slot `preamble` (per-model, above) > [prompts].<phase> >
 # built-in. The synth slot feeds both `consult` and `oneshot`, but each keeps
-# its own key, so they can diverge. Phases: `explorer` (the nested explore′ sweep),
+# its own key, so they can diverge. Phases: `explorer` (every sweep — `explore`,
+# `consult`'s nested explore′, `deliberate`'s dossier),
 # `consult` (the driver), `oneshot` (the thin toolless answer), `batch` (the offline
 # max-thinking answer).
 # ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -1357,16 +1357,18 @@ Prefer architectural answers; name the file:line that carries each claim.
 
 | key | replaces | runs in |
 |---|---|---|
-| `explorer` | `report_preamble` | every explorer sweep: standalone `explore`, `consult`'s nested `explore′`, `deliberate`'s dossier |
+| `explorer` | `report_preamble` | every survey: standalone `explore`, `consult`'s nested `explore′`, `deliberate`'s dossier |
 | `consult` | `consult_preamble` | the `consult` driver |
 | `oneshot` | `oneshot_preamble` | the thin, toolless `oneshot` |
 | `batch` | `batch_preamble` | the offline, max-thinking `batch_submit` |
 
 **One `explorer` key, two readers.** The built-in explorer preamble names who receives the
-report: `consult`'s sweep and `deliberate`'s dossier are told a synthesis agent writes the
-final answer from them, while standalone `explore` is told its report goes straight back to
-the caller and is the finished deliverable. An override is a full replace, so it erases that
-distinction — write one that reads correctly for both, or leave the key unset.
+report. In `consult`'s nested survey and in `deliberate`'s dossier, a synthesis agent writes
+the final answer from it. In standalone `explore`, the report goes straight back to the
+caller and is the finished deliverable.
+
+An override replaces the preamble for both. Write one that reads correctly for either
+reader, or leave the key unset.
 
 **Full replace.** An override *is* the role framing, verbatim; kaibo does not re-wrap it.
 This is safe because the kaish operating contract — how to drive the read-only shell, the

--- a/docs/config.md
+++ b/docs/config.md
@@ -1357,10 +1357,16 @@ Prefer architectural answers; name the file:line that carries each claim.
 
 | key | replaces | runs in |
 |---|---|---|
-| `explorer` | `report_preamble` | the nested `explore′` sweep inside `consult` |
+| `explorer` | `report_preamble` | every explorer sweep: standalone `explore`, `consult`'s nested `explore′`, `deliberate`'s dossier |
 | `consult` | `consult_preamble` | the `consult` driver |
 | `oneshot` | `oneshot_preamble` | the thin, toolless `oneshot` |
 | `batch` | `batch_preamble` | the offline, max-thinking `batch_submit` |
+
+**One `explorer` key, two readers.** The built-in explorer preamble names who receives the
+report: `consult`'s sweep and `deliberate`'s dossier are told a synthesis agent writes the
+final answer from them, while standalone `explore` is told its report goes straight back to
+the caller and is the finished deliverable. An override is a full replace, so it erases that
+distinction — write one that reads correctly for both, or leave the key unset.
 
 **Full replace.** An override *is* the role framing, verbatim; kaibo does not re-wrap it.
 This is safe because the kaish operating contract — how to drive the read-only shell, the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ use crate::batch::{BatchItem, BatchPoll};
 use crate::config::{Config, Lane, ModelRole, ToolDisables};
 use crate::consult::{
     batch_system_prompt, consult, deliberation_prompt, explore_with, oneshot as run_oneshot_engine,
-    ConsultConfig, ConsultOutput, ExploreConfig, ModelCaps, PhaseContext,
+    ConsultConfig, ConsultOutput, ExploreConfig, ModelCaps, PhaseContext, ReportReader,
 };
 use crate::progress::TerminalSink;
 use crate::sandbox::KaishWorker;
@@ -1471,7 +1471,19 @@ async fn explore_inner(
         sandbox: resolver.config.sandbox.clone(),
         max_attachments: resolver.config.defaults.max_attachments,
     };
-    match explore_with(&args.question, root, &explorer, &cfg, &attachments, None).await {
+    // `kaibo explore` prints the report to stdout — the person or script reading it is
+    // the only reader there is.
+    match explore_with(
+        &args.question,
+        root,
+        &explorer,
+        &cfg,
+        &attachments,
+        None,
+        ReportReader::CallingAgent,
+    )
+    .await
+    {
         Ok((report, usage)) => {
             if args.json {
                 println!(
@@ -1704,6 +1716,8 @@ async fn deliberate_inner(
             &cfg,
             &attachments,
             sink.as_ref(),
+            // The dossier is written for the offline synth that reasons over it.
+            ReportReader::SynthesisAgent,
         )
         .await
         {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2662,7 +2662,11 @@ struct RawContext {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawPrompts {
-    /// Replaces the explorer preamble (the nested `explore′` sweep inside `consult`).
+    /// Replaces the explorer preamble — standalone `explore`, the nested `explore′`
+    /// sweep inside `consult`, and `deliberate`'s dossier pass all read it. The
+    /// built-in varies one opening by who receives the report; an override replaces
+    /// that too, so it must read correctly for a report handed to a synth AND for one
+    /// that goes straight back to the caller.
     explorer: Option<String>,
     /// Replaces the `consult` driver preamble.
     consult: Option<String>,

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -46,7 +46,7 @@ use super::config::{ConsultConfig, ExploreConfig, PhaseContext};
 use super::prompts::PromptOverrides;
 use super::prompts::{
     consult_user_prompt, deliberation_prompt, explorer_attach_directive, resolve_phase_preamble,
-    sweep_evidence_block, Phase,
+    sweep_evidence_block, Phase, ReportReader,
 };
 use super::shaping::{ModelCaps, ModelShape};
 
@@ -2165,7 +2165,9 @@ fn consult_tools(
     // flagged as central. The directive orders whole `cat -n` reads (the explorer
     // chooses when, not whether), keeping citation-exact line numbers for free.
     let mut explorer_preamble_owned = resolve_phase_preamble(
-        Phase::Explorer,
+        // The nested sweep always reports to the consult driver — this loop IS the
+        // synthesis agent, so the reader is fixed here rather than plumbed in.
+        Phase::Explorer(ReportReader::SynthesisAgent),
         &cfg.explore.phase.prompts,
         cfg.explore.phase.orientation.as_deref(),
         cfg.explore.phase.house_rules.as_deref(),
@@ -2246,9 +2248,10 @@ pub(crate) async fn explore_with(
     cfg: &ExploreConfig,
     attached: &[super::prompts::ConsultAttachment],
     attach: Option<&Arc<SweepAttachSink>>,
+    reader: ReportReader,
 ) -> Result<(String, Usage)> {
     let mut preamble = resolve_phase_preamble(
-        Phase::Explorer,
+        Phase::Explorer(reader),
         &cfg.phase.prompts,
         cfg.phase.orientation.as_deref(),
         cfg.phase.house_rules.as_deref(),
@@ -4035,6 +4038,7 @@ mod tests {
             &cfg,
             &[],
             None,
+            ReportReader::CallingAgent,
         )
         .await
         .expect("scripted explore should succeed");
@@ -4370,6 +4374,55 @@ mod tests {
         }
     }
 
+    /// The reader reaches the wire. `explore_with` is shared by standalone `explore`
+    /// (whose report goes straight to the calling agent) and `deliberate`'s dossier
+    /// pass (whose report goes to an offline synth), so the parameter has to survive
+    /// the trip into rig's preamble — a hardcoded phase inside the function would
+    /// compile fine and quietly send every sweep the wrong framing.
+    #[tokio::test]
+    async fn the_reader_reaches_the_preamble_rig_forwards() {
+        const EXPLORER: &str = "cheap-explorer";
+
+        let run = |reader| async move {
+            let client = ScriptedClient::builder()
+                .on_model(EXPLORER, |_req| Ok(text_response("REPORT: src/foo.rs:1")))
+                .build();
+            let dir = project_with_marker();
+            explore_with(
+                "what is here?",
+                dir.path().to_path_buf(),
+                &arm(&client, EXPLORER),
+                &ExploreConfig::default(),
+                &[],
+                None,
+                reader,
+            )
+            .await
+            .expect("scripted explore should succeed");
+            client
+                .requests_for(EXPLORER)
+                .first()
+                .and_then(|r| r.preamble.clone())
+                .expect("the explorer request carries a preamble")
+        };
+
+        let caller = run(ReportReader::CallingAgent).await;
+        assert!(
+            !caller.contains("synthesis agent"),
+            "a CallingAgent sweep must not be told a synth reads it: {caller}"
+        );
+        assert!(
+            caller.contains("the agent that asked"),
+            "a CallingAgent sweep still names its reader: {caller}"
+        );
+
+        let synth = run(ReportReader::SynthesisAgent).await;
+        assert!(
+            synth.contains("The synthesis agent writes the final answer"),
+            "a SynthesisAgent sweep keeps the hand-off framing: {synth}"
+        );
+    }
+
     /// The `explore` tool's phase, surfaced directly: `explore_with` runs ONE
     /// explorer arm over `{run_kaish}` against the real repo and returns the
     /// explorer's cited report *verbatim* — no synth, no second phase. Mirrors the
@@ -4414,6 +4467,7 @@ mod tests {
             &cfg,
             &[],
             None,
+            ReportReader::CallingAgent,
         )
         .await
         .expect("scripted explore should succeed");
@@ -4462,6 +4516,7 @@ mod tests {
                 size: 900_000,
             }],
             None,
+            ReportReader::CallingAgent,
         )
         .await
         .expect("scripted explore should succeed");
@@ -4519,6 +4574,7 @@ mod tests {
             &cfg,
             &[],
             None,
+            ReportReader::CallingAgent,
         )
         .await
         .expect("scripted explore should succeed");
@@ -4640,6 +4696,7 @@ mod tests {
             &cfg,
             &[],
             Some(&sink),
+            ReportReader::SynthesisAgent,
         )
         .await
         .expect("scripted explore should succeed");
@@ -4772,6 +4829,7 @@ mod tests {
                 &cfg,
                 &[],
                 None,
+                ReportReader::CallingAgent,
             ),
         )
         .await
@@ -5486,6 +5544,7 @@ mod tests {
             &ExploreConfig::default(),
             &[],
             None,
+            ReportReader::CallingAgent,
         )
         .await
         .expect_err("an explorer that reported nothing must fail, not return an empty report");

--- a/src/consult/mod.rs
+++ b/src/consult/mod.rs
@@ -39,7 +39,7 @@ pub use engine::{
 pub(crate) use engine::{run_phase, run_phase_logged};
 pub use prompts::{
     batch_preamble, batch_system_prompt, consult_preamble, consult_user_prompt,
-    deliberation_prompt, oneshot_preamble, report_preamble, resolve_phase_preamble,
+    deliberation_prompt, oneshot_preamble, report_preamble, resolve_phase_preamble, ReportReader,
     sweep_evidence_block, ConsultAttachment, Phase, PromptOverrides,
 };
 pub use shaping::{

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -66,7 +66,7 @@ pub struct PromptOverrides {
 /// framing → the file map (immediately useful context) → operator house rules.
 fn phase_preamble(
     override_: Option<&str>,
-    default: fn() -> String,
+    default: impl FnOnce() -> String,
     orientation: Option<&str>,
     house_rules: Option<&str>,
 ) -> String {
@@ -84,11 +84,39 @@ fn phase_preamble(
 /// house rules splice) — live in exactly one place, [`resolve_phase_preamble`]. Every
 /// live tool routes through it, and so does the `kaibo://prompts` resource, so what the
 /// resource shows can never drift from what a call actually sends the model.
+/// Who reads an explorer's report when the sweep finishes.
+///
+/// The explorer preamble names its reader five times — that naming is what makes the
+/// report a hand-off rather than an answer, and it is the one fact that genuinely
+/// differs between the three tools sharing [`Phase::Explorer`]. `consult` and
+/// `deliberate` hand the report to a second model on kaibo's team; standalone
+/// `explore` hands it straight back to the agent that called kaibo, with nothing in
+/// between. Telling a standalone `explore` that a synthesis agent will write the final
+/// answer describes a model that does not exist on that call, and a report curated for
+/// a downstream rewrite is not the same artifact as one written to be acted on.
+///
+/// Carried *inside* `Phase::Explorer` rather than passed beside it so the reader cannot
+/// be forgotten at a call site: there is no way to name the explorer phase without
+/// deciding who reads it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportReader {
+    /// A second model on kaibo's team writes the final answer from the report — the
+    /// `consult` driver reading an `explore′` sweep, or `deliberate`'s offline synth
+    /// reading the dossier.
+    SynthesisAgent,
+    /// The agent that called kaibo reads the report itself and acts on it. Standalone
+    /// `explore` only: the report IS the deliverable, so nothing downstream will
+    /// restate it.
+    CallingAgent,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Phase {
-    /// The explorer sweep: `explore`, the nested `explore′` inside `consult`, and
-    /// `deliberate`'s dossier phase all share this one.
-    Explorer,
+    /// The explorer sweep — standalone `explore`, the nested `explore′` inside
+    /// `consult`, and `deliberate`'s dossier pass. They share one role and one body of
+    /// reading guidance, and differ only in who receives the report
+    /// ([`ReportReader`]).
+    Explorer(ReportReader),
     /// The `consult` driver.
     Consult,
     /// The thin, toolless `oneshot`.
@@ -98,9 +126,12 @@ pub enum Phase {
 }
 
 impl Phase {
-    /// The four phases, for callers that enumerate every prompt (the resource).
-    pub const ALL: [Phase; 4] = [
-        Phase::Explorer,
+    /// Every prompt kaibo can send, for callers that enumerate them (the resource).
+    /// Both explorer readers appear: they render different text, so a listing that
+    /// showed one would misreport what the other tool sends.
+    pub const ALL: [Phase; 5] = [
+        Phase::Explorer(ReportReader::SynthesisAgent),
+        Phase::Explorer(ReportReader::CallingAgent),
         Phase::Consult,
         Phase::Oneshot,
         Phase::Batch,
@@ -109,20 +140,24 @@ impl Phase {
     /// A short, stable label for a phase — the resource header and the tools it drives.
     pub fn label(self) -> &'static str {
         match self {
-            Phase::Explorer => "explorer (explore · consult sweep · deliberate dossier)",
+            Phase::Explorer(ReportReader::SynthesisAgent) => {
+                "explorer → synthesis agent (consult sweep · deliberate dossier)"
+            }
+            Phase::Explorer(ReportReader::CallingAgent) => "explorer → calling agent (explore)",
             Phase::Consult => "consult driver",
             Phase::Oneshot => "oneshot",
             Phase::Batch => "batch / deliberate synth (offline)",
         }
     }
 
-    /// The built-in default preamble for this phase.
-    fn default_preamble(self) -> fn() -> String {
+    /// Build this phase's built-in default preamble. Called only when no override
+    /// replaces it, so an overridden phase never pays to compose the text it discards.
+    fn default_preamble(self) -> String {
         match self {
-            Phase::Explorer => report_preamble,
-            Phase::Consult => consult_preamble,
-            Phase::Oneshot => oneshot_preamble,
-            Phase::Batch => batch_preamble,
+            Phase::Explorer(reader) => report_preamble(reader),
+            Phase::Consult => consult_preamble(),
+            Phase::Oneshot => oneshot_preamble(),
+            Phase::Batch => batch_preamble(),
         }
     }
 
@@ -131,7 +166,7 @@ impl Phase {
     /// an active override without re-encoding the phase→key mapping.
     pub fn override_in(self, p: &PromptOverrides) -> Option<&str> {
         match self {
-            Phase::Explorer => p.explorer.as_deref(),
+            Phase::Explorer(_) => p.explorer.as_deref(),
             Phase::Consult => p.consult.as_deref(),
             Phase::Oneshot => p.oneshot.as_deref(),
             Phase::Batch => p.batch.as_deref(),
@@ -144,7 +179,7 @@ impl Phase {
     /// it), so neither project layer reaches them — the seam that used to sit as a bare
     /// `None, None` at each of those call sites now lives here, in one place.
     pub fn reads_project(self) -> bool {
-        matches!(self, Phase::Explorer | Phase::Consult)
+        matches!(self, Phase::Explorer(_) | Phase::Consult)
     }
 
     /// Which cast slot's `preamble` frames this phase: the **explorer** slot drives the
@@ -154,7 +189,7 @@ impl Phase {
     /// mapping [`crate::config::Cast::resolved_prompts`] applies.
     pub fn slot_role(self) -> ModelRole {
         match self {
-            Phase::Explorer => ModelRole::Explorer,
+            Phase::Explorer(_) => ModelRole::Explorer,
             Phase::Consult | Phase::Oneshot | Phase::Batch => ModelRole::Synth,
         }
     }
@@ -180,7 +215,7 @@ pub fn resolve_phase_preamble(
     };
     phase_preamble(
         phase.override_in(prompts),
-        phase.default_preamble(),
+        || phase.default_preamble(),
         orientation,
         house_rules,
     )
@@ -190,20 +225,55 @@ pub fn resolve_phase_preamble(
 /// shared [`kaish_syntax_core`] so the shell idioms and exit-code contract are
 /// stated in exactly one place.
 ///
-/// Opens a *role on a team* rather than a capability: this half of the pair is the
-/// **explorer** and its counterpart is the **synthesis agent**, the same two names
-/// the code uses ([`ModelRole::Explorer`]/[`ModelRole::Synth`]) and the same two the
-/// synth-side preambles use — one vocabulary end to end. It closes on the same
-/// completion obligation the synth carries, aimed at this role's deliverable: the
-/// report is what leaves the loop, so the last turn is the report itself.
-pub fn report_preamble() -> String {
+/// Opens a *role* rather than a capability: this model is the **explorer**, the name
+/// the code already uses ([`ModelRole::Explorer`]). It closes on the same completion
+/// obligation the synth carries, aimed at this role's deliverable: the report is what
+/// leaves the loop, so the last turn is the report itself.
+///
+/// `reader` decides who the report is addressed to, and it is the only thing that
+/// varies (see [`ReportReader`]). Under [`ReportReader::SynthesisAgent`] the pairing
+/// carries the same two names as the synth-side preambles — explorer and synthesis
+/// agent, one vocabulary end to end. Under [`ReportReader::CallingAgent`] there is no
+/// second model to name, so the preamble says so rather than inventing one: a sweep
+/// told its work will be rewritten downstream can reasonably leave a thread for the
+/// rewriter to pull, and on standalone `explore` there is no rewriter.
+pub fn report_preamble(reader: ReportReader) -> String {
     let core = kaish_syntax_core();
+    // Who reads the report leads the preamble, because it decides what a good report
+    // *is*: evidence handed to a model that will rewrite it, or a finished answer the
+    // caller acts on. The rest of the block is identical for both — same role, same
+    // reading guidance, same report shape — so the two readers cannot drift apart.
+    let opening = match reader {
+        ReportReader::SynthesisAgent => {
+            "You are the explorer on a two-model team reading one codebase. You build a \
+             complete, accurate picture of the code a question touches, and you give that \
+             picture to the synthesis agent. The synthesis agent writes the final answer \
+             from what you found. So your work is to gather grounded evidence and cite it \
+             exactly."
+        }
+        ReportReader::CallingAgent => {
+            "You are the explorer, reading one codebase for an agent working outside it. \
+             You build a complete, accurate picture of the code a question touches, and \
+             your report goes straight back to that agent, which acts on it directly. \
+             Your report reaches its reader exactly as you write it, so the report is the \
+             finished deliverable. Your work is to gather grounded evidence and cite it \
+             exactly."
+        }
+    };
+    // The reader named inline, wherever the body refers back to it. One noun phrase,
+    // four sites, so a rewrite of the body cannot leave a stale reader behind.
+    let them = match reader {
+        ReportReader::SynthesisAgent => "the synthesis agent",
+        ReportReader::CallingAgent => "the agent that asked",
+    };
+    // Sentence-initial form. Separate because one of the four sites opens a sentence,
+    // and a lowercase noun phrase there is the kind of seam a reader notices.
+    let they = match reader {
+        ReportReader::SynthesisAgent => "The synthesis agent",
+        ReportReader::CallingAgent => "The agent that asked",
+    };
     format!(
-        "You are the explorer on a two-model team reading one codebase. You build a \
-         complete, accurate picture of the code a question touches, and you give that \
-         picture to the synthesis agent. The synthesis agent writes the final answer \
-         from what you found. So your work is to gather grounded evidence and cite it \
-         exactly. The tools named in this request are your complete set. Every shell \
+        "{opening} The tools named in this request are your complete set. Every shell \
          command is one `run_kaish` call: the tool name is always `run_kaish`, and the \
          command you want to run goes inside its `script` argument. \
          {core}\n\n\
@@ -229,23 +299,23 @@ pub fn report_preamble() -> String {
          HOW TO INVESTIGATE. Read holistically. The question tells you where to start \
          reading, not where to stop. Read the code around each relevant location as \
          well, not only the lines the question names directly. Your report is the only \
-         view of this codebase the synthesis agent receives, so anything you leave out \
-         is missing from its answer. Aim for the complete set of relevant locations. \
+         view of this codebase {them} receives, so anything you leave out is missing \
+         from its answer. Aim for the complete set of relevant locations. \
          Follow each key symbol to where it is defined and to every place it is used. \
          When something in the code confuses you, keep reading until it is clear: a \
          confusing section often holds the detail the question depends on. Follow each \
          thread while you are already reading the code, so that one investigation \
          leaves you with the complete picture.\n\n\
-         WHAT TO PRODUCE. A curated report for the synthesis agent, in these \
+         WHAT TO PRODUCE. A curated report for {them}, in these \
          sections:\n\
          - SummaryOfFindings: state what you concluded.\n\
          - RelevantLocations: for each location that matters, give the concrete \
          `file:line`, the key symbols there (functions, types, fields), a short \
          verbatim snippet, and what it means for the question.\n\
-         - ExplorationTrace: the path you took, when it helps the synthesis agent \
-         trust the result.\n\
-         Keep the report focused and evidence-first. The synthesis agent trusts your \
-         citations and builds on them, so ground every claim in an exact `file:line`. \
+         - ExplorationTrace: the path you took, when it helps {them} trust the \
+         result.\n\
+         Keep the report focused and evidence-first. {they} trusts your citations and \
+         builds on them, so ground every claim in an exact `file:line`. \
          That exactness is the whole value of your report. The report is all you hand \
          over, so your last turn is the report itself, written out in full."
     )
@@ -779,7 +849,7 @@ mod tests {
     /// are written against this shape).
     #[test]
     fn report_preamble_keeps_the_reading_directive_and_report_shape() {
-        let p = report_preamble();
+        let p = report_preamble(ReportReader::SynthesisAgent);
         // Reading strategy: whole files by default, wide spans only for a
         // truncated giant, grep to find which files matter.
         assert!(p.contains("cat -n FILE"), "whole-file read idiom: {p}");
@@ -828,7 +898,7 @@ mod tests {
     /// for a span second.
     #[test]
     fn explorer_reads_a_wide_span_around_a_grep_hit_in_a_large_file() {
-        let p = report_preamble();
+        let p = report_preamble(ReportReader::SynthesisAgent);
         assert!(
             p.contains("Once grep names a file, open that file whole."),
             "whole-file stays the default follow-up to a grep hit: {p}"
@@ -894,7 +964,7 @@ mod tests {
     #[test]
     fn every_sed_range_kaibo_writes_is_quoted() {
         for (label, text) in [
-            ("explorer", report_preamble()),
+            ("explorer", report_preamble(ReportReader::SynthesisAgent)),
             ("consult", consult_preamble()),
             (
                 "oversize attachment",
@@ -930,7 +1000,7 @@ mod tests {
     /// roster is complete without enumerating it.
     #[test]
     fn report_preamble_anchors_the_toolset() {
-        let p = report_preamble();
+        let p = report_preamble(ReportReader::SynthesisAgent);
         assert!(
             p.contains("The tools named in this request are your complete set"),
             "roster completeness is stated: {p}"
@@ -985,8 +1055,108 @@ mod tests {
             "the driver names its explorer counterpart: {c}"
         );
         assert!(
-            report_preamble().contains("the synthesis agent"),
+            report_preamble(ReportReader::SynthesisAgent).contains("the synthesis agent"),
             "the explorer names its synth counterpart"
+        );
+    }
+
+    /// Standalone `explore` hands its report straight back to the calling agent, so the
+    /// preamble must not promise a synthesis agent that will not exist on that call.
+    ///
+    /// This is the failing-first half of the bug it fixes: before `ReportReader`, all
+    /// three explorer tools were told "The synthesis agent writes the final answer from
+    /// what you found", which is true for the `consult` sweep and `deliberate`'s dossier
+    /// and false for `explore`. A model that believes a downstream rewrite is coming can
+    /// reasonably leave a thread for the rewriter to pull; on `explore` nobody pulls it.
+    #[test]
+    fn the_calling_agent_is_never_promised_a_synthesis_agent() {
+        let p = report_preamble(ReportReader::CallingAgent);
+        assert!(
+            !p.contains("synthesis agent"),
+            "explore's explorer must not be told a synthesis agent reads it: {p}"
+        );
+        assert!(
+            !p.to_lowercase().contains("two-model team"),
+            "there is no second model on a standalone explore: {p}"
+        );
+        assert!(
+            p.contains("the agent that asked"),
+            "the report must still name its reader, not go unaddressed: {p}"
+        );
+        assert!(
+            p.contains("the report is the finished deliverable"),
+            "the explorer must know nothing downstream restates its work: {p}"
+        );
+        assert!(
+            p.contains("The agent that asked trusts your citations"),
+            "the reader's name is capitalized where it opens a sentence: {p}"
+        );
+
+        // The counterpart still says what it always said — this fix narrows one claim,
+        // it does not delete the two-model framing where that framing is true.
+        let synth = report_preamble(ReportReader::SynthesisAgent);
+        assert!(
+            synth.contains("The synthesis agent writes the final answer from what you found"),
+            "the sweep and dossier keep their hand-off framing: {synth}"
+        );
+    }
+
+    /// Substituting a noun phrase into prose is how a sentence ends up starting with a
+    /// lowercase word. Both readers get checked because the substitution sites are
+    /// shared, so a seam introduced for one shows up in the other.
+    #[test]
+    fn no_sentence_in_an_explorer_preamble_opens_lowercase() {
+        for reader in [ReportReader::SynthesisAgent, ReportReader::CallingAgent] {
+            let p = report_preamble(reader);
+            for (i, _) in p.match_indices(". ") {
+                let rest = &p[i + 2..];
+                let word = rest.split_whitespace().next().unwrap_or("");
+                let first = match word.chars().next() {
+                    Some(c) => c,
+                    None => continue,
+                };
+                // Skip the shell idioms and back-ticked identifiers the prose quotes —
+                // `cat -n FILE`, `grep -rn PATTERN` — which are lowercase on purpose.
+                if !first.is_alphabetic() || word.starts_with('`') {
+                    continue;
+                }
+                assert!(
+                    first.is_uppercase(),
+                    "{reader:?}: a sentence opens on lowercase {word:?} here: \
+                     ...{}...",
+                    &p[i.saturating_sub(60)..(i + 80).min(p.len())]
+                );
+            }
+        }
+    }
+
+    /// One body, two readers. Everything after the opening is identical once the reader
+    /// is named, so a rewrite of the reading guidance cannot land on one tool and miss
+    /// the other — the drift this parameterization exists to prevent.
+    #[test]
+    fn both_explorer_readers_share_one_body() {
+        const ANCHOR: &str = "The tools named in this request are your complete set";
+        let synth = report_preamble(ReportReader::SynthesisAgent);
+        let caller = report_preamble(ReportReader::CallingAgent);
+
+        let body = |p: &str| {
+            let i = p.find(ANCHOR).expect("both readers reach the shared body");
+            p[i..]
+                .replace("The agent that asked", "The synthesis agent")
+                .replace("the agent that asked", "the synthesis agent")
+        };
+        assert_eq!(
+            body(&synth),
+            body(&caller),
+            "the shared body must be byte-identical once the reader is normalized"
+        );
+
+        // And the openings genuinely differ, so the assertion above is not vacuous.
+        let opening = |p: &str| p[..p.find(ANCHOR).expect("anchor")].to_string();
+        assert_ne!(
+            opening(&synth),
+            opening(&caller),
+            "the readers must actually be addressed differently"
         );
     }
 
@@ -1003,7 +1173,7 @@ mod tests {
     fn built_in_preambles_are_written_without_em_dash_clause_chains() {
         let core = kaish_syntax_core();
         for (label, text) in [
-            ("explorer", report_preamble()),
+            ("explorer", report_preamble(ReportReader::SynthesisAgent)),
             ("consult", consult_preamble()),
             ("oneshot", oneshot_preamble()),
             ("batch", batch_preamble()),
@@ -1095,8 +1265,22 @@ mod tests {
     fn resolve_phase_preamble_routes_each_phase_and_gates_project_layers() {
         let base = PromptOverrides::default();
         assert_eq!(
-            resolve_phase_preamble(Phase::Explorer, &base, None, None),
-            report_preamble()
+            resolve_phase_preamble(
+                Phase::Explorer(ReportReader::SynthesisAgent),
+                &base,
+                None,
+                None
+            ),
+            report_preamble(ReportReader::SynthesisAgent)
+        );
+        assert_eq!(
+            resolve_phase_preamble(
+                Phase::Explorer(ReportReader::CallingAgent),
+                &base,
+                None,
+                None
+            ),
+            report_preamble(ReportReader::CallingAgent)
         );
         assert_eq!(
             resolve_phase_preamble(Phase::Consult, &base, None, None),
@@ -1114,7 +1298,11 @@ mod tests {
         let map = "PROJECT FILES.\nsrc/lib.rs";
         let rules = "operator house rule";
         // The reading phases splice both project layers.
-        for phase in [Phase::Explorer, Phase::Consult] {
+        for phase in [
+            Phase::Explorer(ReportReader::SynthesisAgent),
+            Phase::Explorer(ReportReader::CallingAgent),
+            Phase::Consult,
+        ] {
             let p = resolve_phase_preamble(phase, &base, Some(map), Some(rules));
             assert!(
                 p.contains(map) && p.contains(rules),

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -125,6 +125,52 @@ pub enum Phase {
     Batch,
 }
 
+/// Every phrase in the explorer preamble that varies with the reader. Everything else
+/// is shared, and `both_explorer_readers_share_one_body` proves that by normalizing
+/// through this exact list — so a new varying phrase has to be declared here, or the
+/// test fails rather than letting the two readers quietly drift apart.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReaderWords {
+    /// The opening sentences: who this model is and who receives its report.
+    pub opening: &'static str,
+    /// The reader, mid-sentence.
+    pub them: &'static str,
+    /// The reader, opening a sentence.
+    pub they: &'static str,
+    /// What a gap in the report costs — the consequence differs because one reader
+    /// writes an answer from the report and the other acts on the report itself.
+    pub gap: &'static str,
+}
+
+impl ReportReader {
+    pub(crate) fn words(self) -> ReaderWords {
+        match self {
+            ReportReader::SynthesisAgent => ReaderWords {
+                opening: "You are the explorer on a two-model team reading one codebase. \
+                          You build a complete, accurate picture of the code a question \
+                          touches, and you give that picture to the synthesis agent. The \
+                          synthesis agent writes the final answer from what you found. So \
+                          your work is to gather grounded evidence and cite it exactly.",
+                them: "the synthesis agent",
+                they: "The synthesis agent",
+                gap: "is missing from its answer",
+            },
+            ReportReader::CallingAgent => ReaderWords {
+                opening: "You are the explorer, reading one codebase for an agent working \
+                          outside it. You build a complete, accurate picture of the code a \
+                          question touches, and your report goes straight back to that \
+                          agent, which acts on it directly. Your report reaches its reader \
+                          exactly as you write it, so the report is the finished \
+                          deliverable. Your work is to gather grounded evidence and cite \
+                          it exactly.",
+                them: "the agent that asked",
+                they: "The agent that asked",
+                gap: "is missing from what it can act on",
+            },
+        }
+    }
+}
+
 impl Phase {
     /// Every prompt kaibo can send, for callers that enumerate them (the resource).
     /// Both explorer readers appear: they render different text, so a listing that
@@ -241,37 +287,14 @@ pub fn report_preamble(reader: ReportReader) -> String {
     let core = kaish_syntax_core();
     // Who reads the report leads the preamble, because it decides what a good report
     // *is*: evidence handed to a model that will rewrite it, or a finished answer the
-    // caller acts on. The rest of the block is identical for both — same role, same
-    // reading guidance, same report shape — so the two readers cannot drift apart.
-    let opening = match reader {
-        ReportReader::SynthesisAgent => {
-            "You are the explorer on a two-model team reading one codebase. You build a \
-             complete, accurate picture of the code a question touches, and you give that \
-             picture to the synthesis agent. The synthesis agent writes the final answer \
-             from what you found. So your work is to gather grounded evidence and cite it \
-             exactly."
-        }
-        ReportReader::CallingAgent => {
-            "You are the explorer, reading one codebase for an agent working outside it. \
-             You build a complete, accurate picture of the code a question touches, and \
-             your report goes straight back to that agent, which acts on it directly. \
-             Your report reaches its reader exactly as you write it, so the report is the \
-             finished deliverable. Your work is to gather grounded evidence and cite it \
-             exactly."
-        }
-    };
-    // The reader named inline, wherever the body refers back to it. One noun phrase,
-    // four sites, so a rewrite of the body cannot leave a stale reader behind.
-    let them = match reader {
-        ReportReader::SynthesisAgent => "the synthesis agent",
-        ReportReader::CallingAgent => "the agent that asked",
-    };
-    // Sentence-initial form. Separate because one of the four sites opens a sentence,
-    // and a lowercase noun phrase there is the kind of seam a reader notices.
-    let they = match reader {
-        ReportReader::SynthesisAgent => "The synthesis agent",
-        ReportReader::CallingAgent => "The agent that asked",
-    };
+    // caller acts on. Everything the reader changes is declared in [`ReaderWords`]; the
+    // rest of the block is identical for both, so the two readers cannot drift apart.
+    let ReaderWords {
+        opening,
+        them,
+        they,
+        gap,
+    } = reader.words();
     format!(
         "{opening} The tools named in this request are your complete set. Every shell \
          command is one `run_kaish` call: the tool name is always `run_kaish`, and the \
@@ -299,8 +322,8 @@ pub fn report_preamble(reader: ReportReader) -> String {
          HOW TO INVESTIGATE. Read holistically. The question tells you where to start \
          reading, not where to stop. Read the code around each relevant location as \
          well, not only the lines the question names directly. Your report is the only \
-         view of this codebase {them} receives, so anything you leave out is missing \
-         from its answer. Aim for the complete set of relevant locations. \
+         view of this codebase {them} receives, so anything you leave out {gap}. \
+         Aim for the complete set of relevant locations. \
          Follow each key symbol to where it is defined and to every place it is used. \
          When something in the code confuses you, keep reading until it is clear: a \
          confusing section often holds the detail the question depends on. Follow each \
@@ -1139,15 +1162,21 @@ mod tests {
         let synth = report_preamble(ReportReader::SynthesisAgent);
         let caller = report_preamble(ReportReader::CallingAgent);
 
-        let body = |p: &str| {
+        // Normalize through the declared list, not through hand-written literals: a
+        // new reader-varying phrase that someone forgets to add to `ReaderWords` shows
+        // up here as a body mismatch instead of slipping through.
+        let synth_words = ReportReader::SynthesisAgent.words();
+        let caller_words = ReportReader::CallingAgent.words();
+        let body = |p: &str, w: &ReaderWords| {
             let i = p.find(ANCHOR).expect("both readers reach the shared body");
             p[i..]
-                .replace("The agent that asked", "The synthesis agent")
-                .replace("the agent that asked", "the synthesis agent")
+                .replace(w.they, synth_words.they)
+                .replace(w.them, synth_words.them)
+                .replace(w.gap, synth_words.gap)
         };
         assert_eq!(
-            body(&synth),
-            body(&caller),
+            body(&synth, &synth_words),
+            body(&caller, &caller_words),
             "the shared body must be byte-identical once the reader is normalized"
         );
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -39,7 +39,7 @@ use tracing::Instrument;
 use crate::config::{Backend, Cast, Config, Lane, ModelRole, ModelSlot};
 use crate::consult::{
     consult, explore_with, oneshot, sweep_evidence_block, Arm, ConsultConfig, ExploreConfig,
-    ModelCaps, PhaseContext, PromptOverrides,
+    ModelCaps, PhaseContext, PromptOverrides, ReportReader,
 };
 use crate::explorer::format_output;
 use crate::jobs::{CancelOutcome, JobResult, JobState, JobStore};
@@ -2139,15 +2139,24 @@ impl KaiboHandler {
         // The top-level `explore` tool doesn't inject `attach` (v1 scope) — its
         // report goes straight back to the calling agent's own context, which is
         // exactly the channel `attach` exists to bypass; no consumer to route to.
-        let (report, usage) =
-            match explore_with(&input.question, root, &explorer, &cfg, &attachments, None)
-                .instrument(span)
-                .await
-            {
-                Ok(out) => out,
-                // A provider/model-loop failure is a clean tool-result error, same as `consult`.
-                Err(e) => return Ok(consultation_failed("explore", &cast.name, e)),
-            };
+        let (report, usage) = match explore_with(
+            &input.question,
+            root,
+            &explorer,
+            &cfg,
+            &attachments,
+            None,
+            // The report is the tool result — it lands in the calling agent's own
+            // context, with no synth of ours between the explorer and its reader.
+            ReportReader::CallingAgent,
+        )
+        .instrument(span)
+        .await
+        {
+            Ok(out) => out,
+            // A provider/model-loop failure is a clean tool-result error, same as `consult`.
+            Err(e) => return Ok(consultation_failed("explore", &cast.name, e)),
+        };
         progress.emit(PhaseEvent::PhaseFinished { phase: "explore" });
 
         // The report IS the text (no structured_content). Provenance names the one arm
@@ -2301,6 +2310,8 @@ impl KaiboHandler {
                 &cfg,
                 &attachments,
                 sink.as_ref(),
+                // The dossier is written for the offline synth that reasons over it.
+                ReportReader::SynthesisAgent,
             )
             .instrument(span)
             .await
@@ -4679,9 +4690,11 @@ fn render_prompts_resource(config: &Config, cast: Option<&Cast>) -> String {
              append per call for the project-reading phases (path-dependent).\n\n\
              A phase is a role, not one tool — several tools share a preamble. The \
              **explorer** framing drives standalone `explore`, the delegated sweep inside \
-             `consult`, and `deliberate`'s dossier-building pass; the **offline-synth** \
-             framing serves both `batch_submit` and `deliberate`'s synth. So tuning one \
-             phase moves every tool that wears it.\n",
+             `consult`, and `deliberate`'s dossier-building pass; it is listed twice \
+             because the sweep and the dossier are written for a synthesis agent that \
+             answers from them, while `explore` hands its report straight back to you. \
+             The **offline-synth** framing serves both `batch_submit` and `deliberate`'s \
+             synth. So tuning one phase moves every tool that wears it.\n",
         ),
     }
 
@@ -9227,7 +9240,10 @@ enabled = false
         let text = read_text(PROMPTS_URI, &[]);
         // Each phase's built-in preamble appears verbatim (single-sourced — no drift).
         for body in [
-            report_preamble(),
+            // Both explorer readers: the doc lists them separately because they render
+            // different text, and a doc that showed one would misreport the other tool.
+            report_preamble(ReportReader::SynthesisAgent),
+            report_preamble(ReportReader::CallingAgent),
             consult_preamble(),
             oneshot_preamble(),
             batch_preamble(),


### PR DESCRIPTION
All three explorer-phase tools shared one system preamble that stated, six times, that a synthesis agent would write the final answer from the report. That is true for `consult`'s `explore′` sweep and for `deliberate`'s dossier pass. It is false for standalone `explore`, whose report goes straight back to the calling agent — `src/server/mod.rs` even carried a comment saying so, right beside the call that sent the wrong framing.

This is the first of the prompt changes coming out of the survey in `~/exomemory/briefs/agent-prompt-survey/`, and the one item there that needed no research to justify: a shipped tool was telling a model something untrue about its own situation.

## The decision: name the reader, don't drop the framing

Who reads the report is what makes it a hand-off rather than an answer. An explorer that believes a rewrite is coming can reasonably leave a thread for the rewriter to pull — that is the correct behavior on a sweep. On standalone `explore` nobody pulls it, so the preamble now says the report is the finished deliverable.

`ReportReader::{SynthesisAgent, CallingAgent}` rides **inside** `Phase::Explorer(ReportReader)` rather than beside it. There is no way to name the explorer phase without deciding who reads it, so the reader cannot be forgotten at a call site — the compiler asked all four production sites, and each answers in a comment.

Only the opening and three phrases vary. `ReaderWords` declares them in one place and `both_explorer_readers_share_one_body` normalizes through that exact list, so a rewrite of the reading guidance cannot land on one tool and miss the other, and a fourth varying phrase someone forgets to declare shows up as a body mismatch rather than slipping past.

`kaibo://prompts` now lists the explorer phase twice, because it renders two different texts and a listing that showed one would misreport the other tool — the same class of bug this PR fixes.

## Two bugs found by reading the output rather than the diff

Rendering both preambles and reading them whole caught what the diff hid.

**A lowercase sentence.** The substituted noun phrase opens a sentence at one of the four sites, producing "Keep the report focused and evidence-first. the synthesis agent trusts your citations". Fixed with a capitalized form, and `no_sentence_in_an_explorer_preamble_opens_lowercase` holds it for both readers.

**A contradiction one sentence deep.** "anything you leave out is missing from its answer" still implied the calling agent composes an answer from the report, immediately after the opening said the report *is* the answer. The consequence is now reader-aware: the caller's version reads "is missing from what it can act on".

## Tests

Four, and both of the new text guards were run against the pre-fix behavior and fail there:

```
test the_calling_agent_is_never_promised_a_synthesis_agent ... FAILED
test no_sentence_in_an_explorer_preamble_opens_lowercase ... FAILED
  SynthesisAgent: a sentence opens on lowercase "the" here: ...trust the result.
```

`the_reader_reaches_the_preamble_rig_forwards` is the wiring pin: it runs `explore_with` with each reader against a scripted client and asserts on the preamble rig actually forwarded, so a hardcoded phase inside the function would fail rather than compile.

## Review

kaibo reviewed itself — cast `crusoe`, GLM-5.2 synth over a Deepseek-V4-Flash explorer, no diff supplied. It confirmed the wiring complete across all five sites (it found the consult sweep's hardcoded `SynthesisAgent`, which the question hadn't named), confirmed no bypass path builds an explorer preamble outside `Phase::Explorer(reader)`, and found the "its answer" seam above plus three stale docs describing `[prompts].explorer` as covering only the nested sweep. That staleness predates this branch — the key has always driven all three explorer tools — but the reader split makes it actively misleading, so all three are corrected, and `docs/config.md` now states what an override costs: it is a full replace, so it erases the reader distinction and must read correctly for both.

## One residual, accepted

No test pins *which* reader each of the four production call sites passes. The type forces a choice and the comments document it, but that wiring is guarded by review. Closing it needs a seam that can observe a live call's preamble — a bigger change than this fix, and a natural thing to fold into the composition seam if we build one.

Next in the stack: `consult` and `deliberate`, once this shape is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
