### PR TITLE
Follow worktrees sideways, never up, and never on one end's word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+### Security
+
+- **Following git worktrees could widen the read boundary past the tree you named** —
+  possible exposure of files outside the workspace on every release since `0.2.0`.
+- **An allowed tree now reaches worktrees only when it holds `.git` itself**; kaibo reads
+  no ancestor of it, so a `--root` inside a larger repo no longer reaches that repo.
+- **A forged `.git` in the allowed tree can no longer aim the reach** — the common dir must
+  name that tree back, so a cloned repo cannot point kaibo at a directory you never named.
+
 ### Removed
 
 - **`explorer_max_turns` / `synth_max_turns` are no longer tool arguments or CLI flags** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ record. Each later release appends a new section at the top.
   no ancestor of it, so a `--root` inside a larger repo no longer reaches that repo.
 - **A forged `.git` in the allowed tree can no longer aim the reach** — the common dir must
   name that tree back, so a cloned repo cannot point kaibo at a directory you never named.
+- **A git worktree registration alone no longer vouches for the directory it names** — the
+  worktree must name its registration back, so one file in a repo you cloned to review
+  cannot make any directory on the host readable.
 
 ### Removed
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1588,13 +1588,16 @@ kaibo resolves this by reading git's own link files — a worktree's `.git` file
 repo's `.git/worktrees/<name>/{gitdir,commondir}` — never by running `git`, which is not
 in the build (see [the sandbox probe runbook](sandbox-probes.md)).
 
-**Both sides of the link must agree.** kaibo enumerates the worktrees the allowed tree's
-common git dir vouches for, and uses them only when that common dir names the allowed
-tree back as one of its own worktree roots. So a foreign directory with a forged `gitdir:`
-pointer cannot admit itself, and a forged `.git` *file* inside the allowed tree — content
-kaibo did not author, in a repository cloned to review — cannot aim the reach at a
-directory the operator never named. A vouched worktree that contains the allowed tree is
-dropped for the same reason; reach it with `--allow-path`. The check runs only on the
+**Every link must be named from both ends.** kaibo enumerates the worktrees the allowed
+tree's common git dir vouches for, and uses one only when that common dir names the
+allowed tree back as a worktree root of its own, and when the worktree in question names
+its registration back the way git writes it. So a foreign directory with a forged
+`gitdir:` pointer cannot admit itself; a forged `.git` *file* inside the allowed tree
+cannot aim the reach elsewhere; and a registration file inside the allowed tree cannot
+vouch for a directory that never heard of it. That last one is why the check is per
+entry: for a repository cloned to review, `<tree>/.git` and every registration under it
+are content kaibo did not author. A vouched worktree that contains the allowed tree is
+dropped as well; reach it with `--allow-path`. The check runs only on the
 containment-miss path; a normal in-bounds call is untouched.
 
 Turn it off to keep the boundary strictly static:

--- a/docs/config.md
+++ b/docs/config.md
@@ -1577,15 +1577,25 @@ This is narrower than widening to the parent: `--allow-path ~/src` would grant r
 everything under it, while follow admits exactly the worktrees of an already-allowed repo
 and nothing else.
 
+**An allowed tree reaches worktrees only when it is a worktree root itself** — it must
+hold the `.git` entry, a directory for a main worktree or git's `gitdir:` file for a
+linked one. kaibo reads no ancestor of the tree it was given, so a `--root` inside a
+larger repository (a package in a monorepo, or any directory under a home with dotfiles
+in git) follows nothing rather than reaching that repository's other directories. Name
+the repo root as the tree when you want its worktrees.
+
 kaibo resolves this by reading git's own link files — a worktree's `.git` file and the
 repo's `.git/worktrees/<name>/{gitdir,commondir}` — never by running `git`, which is not
 in the build (see [the sandbox probe runbook](sandbox-probes.md)).
 
-Trust flows outward from the allowed repo only. kaibo enumerates the worktrees the
-*allowed* repo's common git dir vouches for and admits a candidate only if it falls inside
-one. It never consults the candidate's own `.git`, so a foreign directory with a forged
-`gitdir:` pointer cannot admit itself. The check runs only on the containment-miss path;
-a normal in-bounds call is untouched.
+**Both sides of the link must agree.** kaibo enumerates the worktrees the allowed tree's
+common git dir vouches for, and uses them only when that common dir names the allowed
+tree back as one of its own worktree roots. So a foreign directory with a forged `gitdir:`
+pointer cannot admit itself, and a forged `.git` *file* inside the allowed tree — content
+kaibo did not author, in a repository cloned to review — cannot aim the reach at a
+directory the operator never named. A vouched worktree that contains the allowed tree is
+dropped for the same reason; reach it with `--allow-path`. The check runs only on the
+containment-miss path; a normal in-bounds call is untouched.
 
 Turn it off to keep the boundary strictly static:
 

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -244,13 +244,11 @@ impl Resolver {
         }
         if self.config.follow_worktrees {
             for tree in self.allowed_set.iter() {
-                if let Some(common) = crate::worktree::common_git_dir(tree) {
-                    if let Some(wt) = crate::worktree::vouched_worktrees(&common)
-                        .into_iter()
-                        .find(|wt| canon.starts_with(wt))
-                    {
-                        return Some(wt);
-                    }
+                if let Some(wt) = crate::worktree::worktrees_reachable_from(tree)
+                    .into_iter()
+                    .find(|wt| canon.starts_with(wt))
+                {
+                    return Some(wt);
                 }
             }
         }
@@ -292,10 +290,7 @@ impl Resolver {
         }
         let mut found: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
         for tree in self.allowed_set.iter() {
-            let Some(common) = crate::worktree::common_git_dir(tree) else {
-                continue;
-            };
-            for wt in crate::worktree::vouched_worktrees(&common) {
+            for wt in crate::worktree::worktrees_reachable_from(tree) {
                 if !self.allowed_set.iter().any(|t| wt.starts_with(t)) {
                     found.insert(wt);
                 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -26,9 +26,13 @@
 //! "candidate points into us" pull would be spoofable (a hostile dir forging `gitdir:`
 //! to smuggle itself in). And we do not take the allowed tree's own `.git` at its word
 //! either: it is content kaibo did not author, so the common dir it names must name the
-//! allowed tree back before any of its worktrees count. An earlier reading trusted that
+//! allowed tree back before any of its worktrees count, and each worktree it registers
+//! must name that registration back before it counts. An earlier reading trusted that
 //! side because "the operator allowed it" — but allowing kaibo to *read* a directory is
-//! not the same grant as letting that directory *name other directories*.
+//! not the same grant as letting that directory *name other directories*. The everyday
+//! case makes that sharp: a main worktree's common dir is `<tree>/.git`, *inside* the
+//! allowed tree, so in any repository cloned to review every registration file under it
+//! is attacker-authored.
 //!
 //! **The tree we were handed is the only tree that vouches.** [`common_git_dir`] reads
 //! `<tree>/.git` and no ancestor of it, so a tree that merely sits inside a repository
@@ -83,18 +87,42 @@ pub fn vouched_worktrees(common_dir: &Path) -> Vec<PathBuf> {
         }
     }
 
-    // Linked worktrees: each `worktrees/<name>/gitdir` holds the absolute path back
-    // to that worktree's `.git` file; its parent is the worktree root. This is the
-    // vouch — the trusted common dir naming where each of its worktrees lives.
+    // Linked worktrees: each `worktrees/<name>/gitdir` holds the absolute path back to
+    // that worktree's `.git` file; its parent is the worktree root. Git writes the pair
+    // — the registration names the worktree, and the worktree's own `.git` file names
+    // the registration — and BOTH halves have to be present for the vouch to count.
+    //
+    // A one-way read of the registration is a read escape. When the allowed tree is a
+    // main worktree its common dir is `<tree>/.git`, a directory *inside* the tree, so
+    // in any repository kaibo did not author — one cloned to review, the everyday case
+    // — the registration files are written by whoever wrote the repo. Naming
+    // `/etc/.git` in a `gitdir` file would otherwise make `/etc` a vouched worktree
+    // root: one file, and any directory on the host that is not an ancestor of the tree
+    // becomes readable. Requiring the back-link kills it, because the named directory
+    // has to point back and an attacker cannot write inside the directory they are
+    // trying to reach.
     if let Ok(entries) = std::fs::read_dir(common_dir.join("worktrees")) {
         for entry in entries.flatten() {
-            let pointer = entry.path().join("gitdir");
-            let Some(wt_dotgit) = read_gitdir_pointer(&pointer) else {
+            let registration = entry.path();
+            let Some(wt_dotgit) = read_gitdir_pointer(&registration.join("gitdir")) else {
                 continue;
             };
             let Some(wt_root) = wt_dotgit.parent() else {
                 continue;
             };
+            // The other half: `<wt>/.git` must name this exact registration back.
+            let Some(back) = read_gitdir_pointer(&wt_dotgit) else {
+                continue;
+            };
+            let (Ok(back), Ok(registration)) = (
+                std::fs::canonicalize(&back),
+                std::fs::canonicalize(&registration),
+            ) else {
+                continue;
+            };
+            if back != registration {
+                continue;
+            }
             if let Ok(canon) = std::fs::canonicalize(wt_root) {
                 out.push(canon);
             }
@@ -163,6 +191,12 @@ fn resolve_commondir(gitdir: &Path) -> Option<PathBuf> {
 /// itself among its worktree roots: a forged pointer reaches a common dir that has never
 /// heard of `tree`, and the reach collapses to nothing. This is the same two-way check
 /// the candidate side already got, applied to the side the reach starts from.
+///
+/// That handshake alone is not enough, which is why [`vouched_worktrees`] carries its
+/// own: when `tree` is a main worktree the common dir lives *inside* it, so `tree` is a
+/// vouched root by construction and the handshake here passes for free, saying nothing
+/// about the entries beside it. Each registered worktree earns its place separately, by
+/// naming its registration back.
 ///
 /// A vouched tree that strictly *contains* `tree` is dropped as well — a genuine but
 /// unusual layout (`git worktree add` inside the main worktree) would otherwise widen
@@ -246,6 +280,49 @@ mod tests {
             from_main,
             std::fs::canonicalize(repo.join(".git")).unwrap(),
             "the common dir must be the main worktree's own `.git`"
+        );
+    }
+
+    /// `worktrees_reachable_from` hands back only trees whose registration is mutual.
+    /// The allowed tree here is a main worktree, so its common dir sits *inside* it and
+    /// every byte of it belongs to whoever wrote the repo — the shape of any repository
+    /// cloned to review. One `worktrees/<name>/gitdir` naming an outside directory used
+    /// to vouch for it; now the named directory has to point back, which it cannot,
+    /// because writing inside it is the very access being sought.
+    ///
+    /// The `tree`-side handshake cannot catch this on its own: the main worktree entry
+    /// *is* `tree`, so it passes for free and says nothing about its neighbours.
+    #[test]
+    fn a_registration_alone_does_not_vouch_for_the_directory_it_names() {
+        let base = tempdir().unwrap();
+        let project = base.path().join("project");
+        let dotgit = project.join(".git");
+        std::fs::create_dir_all(dotgit.join("worktrees").join("evil")).unwrap();
+        let victim = base.path().join("victim");
+        std::fs::create_dir_all(&victim).unwrap();
+        std::fs::write(
+            dotgit.join("worktrees").join("evil").join("gitdir"),
+            format!("{}\n", victim.join(".git").display()),
+        )
+        .unwrap();
+
+        let canon_project = std::fs::canonicalize(&project).unwrap();
+        let reachable = worktrees_reachable_from(&canon_project);
+        assert_eq!(
+            reachable,
+            vec![canon_project.clone()],
+            "only the allowed tree itself may be reachable, got {reachable:?}"
+        );
+
+        // Positive control: a *mutually* registered worktree does come back, so the
+        // assertion above is the back-link check firing rather than the whole feature
+        // being dead.
+        let (repo, wt) = write_registered_worktree(base.path(), "feature");
+        let canon_repo = std::fs::canonicalize(&repo).unwrap();
+        let canon_wt = std::fs::canonicalize(&wt).unwrap();
+        assert!(
+            worktrees_reachable_from(&canon_repo).contains(&canon_wt),
+            "a mutually registered worktree must still be reachable"
         );
     }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -19,37 +19,51 @@
 //!   (a relative path to the common dir).
 //! - The main worktree's `.git` *is* the common dir.
 //!
-//! **Trust flows outward from the allowed repo, never inward from the candidate.**
-//! We resolve the *allowed* tree's common dir (trusted: the operator allowed it),
-//! enumerate the worktrees that common dir itself vouches for, and admit a candidate
-//! only if it falls inside one. We never read the candidate's own `.git` to decide —
-//! that file is attacker-controllable, so a one-way "candidate points into us" pull
-//! would be spoofable (a hostile dir forging `gitdir:` to smuggle itself in). Letting
-//! only the trusted side vouch is exactly what git itself does, and it makes the
-//! spoof structurally impossible here: the candidate gets no say.
+//! **Both ends of the link must name each other, and neither end is trusted alone.**
+//! We resolve the *allowed* tree's common dir, enumerate the worktrees that common dir
+//! vouches for, and admit a candidate only if it falls inside one. We never read the
+//! candidate's own `.git` to decide — that file is attacker-controllable, so a one-way
+//! "candidate points into us" pull would be spoofable (a hostile dir forging `gitdir:`
+//! to smuggle itself in). And we do not take the allowed tree's own `.git` at its word
+//! either: it is content kaibo did not author, so the common dir it names must name the
+//! allowed tree back before any of its worktrees count. An earlier reading trusted that
+//! side because "the operator allowed it" — but allowing kaibo to *read* a directory is
+//! not the same grant as letting that directory *name other directories*.
+//!
+//! **The tree we were handed is the only tree that vouches.** [`common_git_dir`] reads
+//! `<tree>/.git` and no ancestor of it, so a tree that merely sits inside a repository
+//! reaches nothing: the enclosing repo's main worktree is by definition a *parent* of
+//! the allowed tree, and vouching for it would widen the boundary upward to every
+//! sibling the operator never named. Following worktrees reaches sideways, never up.
+//! [`worktrees_reachable_from`] is where both rules live; containment calls nothing else.
 
 use std::path::{Path, PathBuf};
 
-/// Resolve the canonicalized git *common* dir for `start` by reading git's link
-/// files only. Walks up to the nearest ancestor holding a `.git` entry, then:
-/// a `.git` directory is itself the common dir (main worktree); a `.git` *file*
-/// points at `<common>/worktrees/<name>`, whose `commondir` resolves to the common
-/// dir (linked worktree). `None` when `start` isn't inside a resolvable working tree.
-pub fn common_git_dir(start: &Path) -> Option<PathBuf> {
-    let mut dir = start;
-    loop {
-        let dotgit = dir.join(".git");
-        if dotgit.is_dir() {
-            // Main worktree (or a plain repo): `.git` is the common dir.
-            return std::fs::canonicalize(&dotgit).ok();
-        }
-        if dotgit.is_file() {
-            // Linked worktree: `.git` file → the per-worktree git dir → its commondir.
-            let gitdir = read_gitdir_pointer(&dotgit)?;
-            return resolve_commondir(&gitdir);
-        }
-        dir = dir.parent()?;
+/// Resolve the canonicalized git *common* dir for a worktree root, by reading git's
+/// link files only. `worktree_root` must hold the `.git` entry itself: a `.git`
+/// directory *is* the common dir (main worktree); a `.git` *file* points at
+/// `<common>/worktrees/<name>`, whose `commondir` resolves to the common dir (linked
+/// worktree). `None` for anything else — including a subdirectory of a repo.
+///
+/// **No ancestor walk, and that is the whole safety property.** Resolving a repo
+/// *above* the given tree inverts the trust direction this module rests on: the
+/// operator allowed one directory, and the enclosing repo's main worktree is by
+/// definition a *parent* of it, so vouching for that repo hands out every sibling the
+/// operator never named. A root under a home with dotfiles in git would have admitted
+/// the entire home directory. The tree kaibo was given is the only tree that gets to
+/// vouch, so it has to be the one holding `.git`.
+pub fn common_git_dir(worktree_root: &Path) -> Option<PathBuf> {
+    let dotgit = worktree_root.join(".git");
+    if dotgit.is_dir() {
+        // Main worktree (or a plain repo): `.git` is the common dir.
+        return std::fs::canonicalize(&dotgit).ok();
     }
+    if dotgit.is_file() {
+        // Linked worktree: `.git` file → the per-worktree git dir → its commondir.
+        let gitdir = read_gitdir_pointer(&dotgit)?;
+        return resolve_commondir(&gitdir);
+    }
+    None
 }
 
 /// The canonicalized working-tree roots a common git dir vouches for: the main
@@ -134,6 +148,41 @@ fn resolve_commondir(gitdir: &Path) -> Option<PathBuf> {
     }
 }
 
+/// The working trees an allowed tree may reach beyond itself: the worktrees its own
+/// common git dir vouches for, **and only when that common dir vouches for the allowed
+/// tree back**. Empty when `tree` is not a worktree root, when the handshake fails, or
+/// when there is nothing extra to reach. This is the one entry point containment uses;
+/// [`common_git_dir`] and [`vouched_worktrees`] are its halves.
+///
+/// **The handshake is the trust, in both directions.** `tree/.git` is content kaibo did
+/// not author — a repository cloned to review carries whatever its author put there —
+/// so a `.git` *file* naming an arbitrary git dir can aim `commondir` at any directory
+/// on the host, and vouching for that directory's worktrees would hand out a tree the
+/// operator never named. Allowing kaibo to *read* a directory is not the same grant as
+/// letting that directory *name other directories*. So the common dir must list `tree`
+/// itself among its worktree roots: a forged pointer reaches a common dir that has never
+/// heard of `tree`, and the reach collapses to nothing. This is the same two-way check
+/// the candidate side already got, applied to the side the reach starts from.
+///
+/// A vouched tree that strictly *contains* `tree` is dropped as well — a genuine but
+/// unusual layout (`git worktree add` inside the main worktree) would otherwise widen
+/// the boundary upward to the parent, which is the one thing following worktrees
+/// promises not to do. Reach that tree with `--allow-path`.
+pub fn worktrees_reachable_from(tree: &Path) -> Vec<PathBuf> {
+    let Some(common) = common_git_dir(tree) else {
+        return Vec::new();
+    };
+    let vouched = vouched_worktrees(&common);
+    // The handshake: this common dir must name `tree` as one of its own worktree roots.
+    if !vouched.iter().any(|wt| wt == tree) {
+        return Vec::new();
+    }
+    vouched
+        .into_iter()
+        .filter(|wt| wt == tree || !tree.starts_with(wt))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     //! Pure filesystem tests: hand-craft git's link-file layout with no `git`
@@ -197,6 +246,38 @@ mod tests {
             from_main,
             std::fs::canonicalize(repo.join(".git")).unwrap(),
             "the common dir must be the main worktree's own `.git`"
+        );
+    }
+
+    /// A subdirectory of a repo resolves *nothing*. The helper reads the tree it was
+    /// handed and no ancestor of it — so an allowed tree that merely sits inside
+    /// someone's repository can never make that repository vouch for its own siblings.
+    /// The walk this replaced admitted every sibling of the enclosing repo, and a root
+    /// under a home with dotfiles in git admitted the whole home directory
+    /// (`tests/containment.rs::a_repo_above_the_allowed_tree_does_not_widen_the_boundary`
+    /// is the end-to-end half).
+    #[test]
+    fn a_subdirectory_of_a_repo_resolves_no_common_dir() {
+        let base = tempdir().unwrap();
+        let (repo, _wt) = write_registered_worktree(base.path(), "feature");
+        let sub = repo.join("src").join("deep");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        // Positive control: the repo root itself still resolves, so a `None` below
+        // means the walk stopped, not that the fixture is unreadable.
+        assert!(
+            common_git_dir(&repo).is_some(),
+            "the repo root must still resolve its own common dir"
+        );
+        assert_eq!(
+            common_git_dir(&sub),
+            None,
+            "a subdirectory holds no `.git`, so it vouches for nothing"
+        );
+        assert_eq!(
+            common_git_dir(base.path()),
+            None,
+            "the directory *containing* the repo vouches for nothing either"
         );
     }
 

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -802,6 +802,62 @@ async fn spoofed_dotgit_pointing_into_allowed_repo_is_rejected() {
     );
 }
 
+/// The mirror of the spoof above, on the side the reach *starts* from. A `.git` file
+/// inside the allowed tree is content kaibo did not author — a repository cloned to
+/// review carries whatever its author put there — so it can aim `commondir` at any
+/// directory on the host. Following that pointer would vouch for a tree the operator
+/// never named, turning "read this repo" into "read that one". The common dir must
+/// name the allowed tree back, and a fabricated one has never heard of it.
+///
+/// No `require_git!`: the layout is hand-written precisely because git would never
+/// write it.
+#[tokio::test]
+async fn a_forged_dotgit_in_the_allowed_tree_cannot_aim_the_vouch() {
+    let base = tempdir().unwrap();
+    // The allowed tree — a plain directory whose `.git` is a file we control.
+    let project = base.path().join("project");
+    fs::create_dir(&project).unwrap();
+    // A fabricated per-worktree git dir, registered nowhere.
+    let fake = base.path().join("fake-gitdir");
+    fs::create_dir_all(&fake).unwrap();
+    // The tree the operator never named.
+    let victim = base.path().join("victim");
+    fs::create_dir_all(victim.join(".git")).unwrap();
+    fs::write(victim.join("secret.txt"), "sensitive\n").unwrap();
+    fs::write(
+        project.join(".git"),
+        format!("gitdir: {}\n", fake.display()),
+    )
+    .unwrap();
+    fs::write(
+        fake.join("commondir"),
+        format!("{}\n", victim.join(".git").display()),
+    )
+    .unwrap();
+
+    let handler = handler_with_allowed(Some(&project), &[]);
+
+    let err = try_run(&handler, &victim.to_string_lossy(), "cat secret.txt")
+        .await
+        .expect_err("a forged .git in the allowed tree must not aim the vouch");
+    assert!(
+        err.to_lowercase().contains("allowed"),
+        "rejection must name the boundary, got: {err}"
+    );
+
+    // Positive control: the forged pointer costs the operator nothing they had. The
+    // allowed tree itself still reads, so the refusal above is the boundary holding,
+    // not the handler failing to build.
+    fs::write(project.join("own.txt"), "mine\n").unwrap();
+    let inside = try_run(&handler, &project.to_string_lossy(), "cat own.txt")
+        .await
+        .expect("the allowed tree itself must still read");
+    assert!(
+        inside.contains("mine"),
+        "kaibo must still read the project it is pointed at, got: {inside}"
+    );
+}
+
 /// `follow_worktrees = false` keeps the boundary strictly static: a genuine linked
 /// worktree of an allowed repo is rejected like any other outside path.
 #[tokio::test]
@@ -866,6 +922,41 @@ async fn sibling_reachable_when_rooted_at_linked_worktree() {
     assert!(
         out.contains("main worktree"),
         "should read the main worktree's file, got: {out}"
+    );
+}
+
+/// A repo *above* the allowed tree must not widen the boundary. Rooted at a plain
+/// directory that happens to sit inside someone's repository — a project under a
+/// dotfiles `$HOME/.git` is the everyday shape — the ancestor walk finds that repo's
+/// common dir, whose main worktree is the repo root, and the repo root *contains* the
+/// allowed tree. Vouching for it hands the caller every sibling the operator never
+/// named. Follow may reach sideways to a worktree; never upward to the repo enclosing
+/// the tree it was given.
+#[tokio::test]
+async fn a_repo_above_the_allowed_tree_does_not_widen_the_boundary() {
+    require_git!("a_repo_above_the_allowed_tree_does_not_widen_the_boundary");
+    let base = tempdir().unwrap();
+    // `base` is the enclosing repository — stand-in for a home with dotfiles in git.
+    git(base.path(), &["init", "-q"]);
+    fs::write(base.path().join("README.md"), "the enclosing repo\n").unwrap();
+    git(base.path(), &["add", "."]);
+    git(base.path(), &["commit", "-q", "-m", "seed"]);
+    // The allowed tree: a plain subdirectory, not a repo of its own.
+    let project = base.path().join("project");
+    fs::create_dir(&project).unwrap();
+    // A sibling the operator never named, holding what must stay unreadable.
+    let private = base.path().join("private");
+    fs::create_dir(&private).unwrap();
+    fs::write(private.join("secret.txt"), "sensitive\n").unwrap();
+
+    let handler = handler_with_allowed(Some(&project), &[]);
+
+    let err = try_run(&handler, &private.to_string_lossy(), "cat secret.txt")
+        .await
+        .expect_err("a sibling of the allowed tree must stay outside the boundary");
+    assert!(
+        err.to_lowercase().contains("allowed"),
+        "rejection must name the boundary, got: {err}"
     );
 }
 

--- a/tests/containment.rs
+++ b/tests/containment.rs
@@ -858,6 +858,60 @@ async fn a_forged_dotgit_in_the_allowed_tree_cannot_aim_the_vouch() {
     );
 }
 
+/// The third door, and the one an attacker actually walks through. When the allowed
+/// tree is a *main* worktree its `.git` is a real directory **inside the tree** — the
+/// everyday shape of a repository someone cloned to review — so its whole contents,
+/// registration files included, are authored by whoever wrote the repo. A single
+/// `.git/worktrees/<name>/gitdir` file naming any directory on the host makes that
+/// directory a vouched worktree root.
+///
+/// The `tree`-side handshake cannot see this: the main worktree entry is `tree` itself
+/// by construction, so it is satisfied for free and says nothing about the *other*
+/// entries alongside it. Each vouch has to be mutual on its own — the worktree git
+/// itself registers holds a `.git` pointing back at the registration, and a directory
+/// that was merely named has no such pointer.
+///
+/// No `require_git!`: git would never write this registration.
+#[tokio::test]
+async fn a_registration_naming_a_host_directory_does_not_vouch_for_it() {
+    let base = tempdir().unwrap();
+    // The allowed tree: a main worktree, `.git` a real directory we author.
+    let project = base.path().join("project");
+    let dotgit = project.join(".git");
+    fs::create_dir_all(dotgit.join("worktrees").join("evil")).unwrap();
+    fs::write(project.join("own.txt"), "mine\n").unwrap();
+    // The tree the operator never named — stands in for any directory on the host.
+    let victim = base.path().join("victim");
+    fs::create_dir_all(&victim).unwrap();
+    fs::write(victim.join("secret.txt"), "sensitive\n").unwrap();
+    // One registration file, naming the victim. Nothing else is forged.
+    fs::write(
+        dotgit.join("worktrees").join("evil").join("gitdir"),
+        format!("{}\n", victim.join(".git").display()),
+    )
+    .unwrap();
+
+    let handler = handler_with_allowed(Some(&project), &[]);
+
+    let err = try_run(&handler, &victim.to_string_lossy(), "cat secret.txt")
+        .await
+        .expect_err("a directory a registration merely names must not be vouched for");
+    assert!(
+        err.to_lowercase().contains("allowed"),
+        "rejection must name the boundary, got: {err}"
+    );
+
+    // Positive control: the repo the operator did name still reads, so the refusal
+    // above is the boundary holding rather than the handler failing to build.
+    let inside = try_run(&handler, &project.to_string_lossy(), "cat own.txt")
+        .await
+        .expect("the allowed tree itself must still read");
+    assert!(
+        inside.contains("mine"),
+        "kaibo must still read the project it is pointed at, got: {inside}"
+    );
+}
+
 /// `follow_worktrees = false` keeps the boundary strictly static: a genuine linked
 /// worktree of an allowed repo is rejected like any other outside path.
 #[tokio::test]


### PR DESCRIPTION
Amy asked what else we could get into the next release, picked the attach-containment flake off the tracker as the P1, and then said of the fix shape: **"No ancestor walk"**. When the fix landed she added: *"we should also scan for similar classes of error before we're done"* — that scan found a second hole of the same class, fixed here too.

The tracker had this filed since 2026-08-14 as *"either a real admission race (a containment hole) or a harness race"*, intermittent and never pinned. It is a containment hole. The tests were right.

## What was wrong

`common_git_dir` walked up from the allowed tree to the nearest ancestor holding a `.git`, with no boundary — `dir = dir.parent()?` straight to `/`. `vouched_worktrees` then vouches for the parent of that `.git` as the main worktree. That parent *contains* the allowed tree, so every sibling of the enclosing repo was admitted.

Rooted at a plain directory inside a repository, `cat secret.txt` on a sibling the operator never named returned its contents:

```
a sibling of the allowed tree must stay outside the boundary:
  "exit: 0\n--- stdout ---\nsensitive\n"
```

The common case is safe — an MCP client sets cwd to a project root, that root *is* a repo, so `.git` is found at the tree itself and the vouch is correct. The escape needs the allowed tree to sit under a repo without being one: `--root` on a monorepo package, or any root under a home with dotfiles in git, which admits the whole home directory. `follow_worktrees` is on by default, so it needs no configuration to reach. The worst reading is that `--root` is how an operator *narrows* scope, and we silently un-narrowed it.

`docs/config.md` is embedded in the binary and served as `kaibo://config/guide`, and it promised the opposite in as many words:

> This is narrower than widening to the parent: `--allow-path ~/src` would grant read of everything under it, while follow admits exactly the worktrees of an already-allowed repo and nothing else.

It is now true as written.

## The class scan, and what it found

The class is a boundary check that resolves *outward* from the tree it was handed. The three other path-containment compares (`context.rs:75`, `view_image.rs:118`, `sweep_attach.rs:374`) are sound — canonicalize first, then component-wise `Path::starts_with` against a canonical root, and none of them touch the worktree-follow path. The ancestor walks in `cas.rs` and `store.rs` run the other direction, resolving a not-yet-existing path to make its refusal check stricter.

But the same one-way trust had an entry side. A `.git` **file** inside the allowed tree can aim `commondir` at any directory on the host. The module doc called that file trusted because "the operator allowed it" — which conflates permission to *read* a directory with authority to *name other directories*. A repository cloned to review is precisely where that content comes from. Probed before fixing:

```
PROBE RESULT: Ok("exit: 0\n--- stdout ---\nsensitive\n")
```

## The third hole, found by the review — and the one that matters

I put the branch through a cross-family pass (cast `crusoe`, GLM-5.2 synth over a Deepseek-V4-Flash explorer), asking whether the boundary was *actually* closed rather than asking it to check my description. It found a hole neither of the fixes above touches, and it predates them. Its citations were verified against the source before I acted on it, then the escape was reproduced.

`vouched_worktrees` read `<common>/worktrees/<name>/gitdir` as a **one-way** vouch: whatever absolute path that file names, its parent became a worktree root. When the allowed tree is a *main* worktree — `.git` a real directory inside the tree — that common dir is **inside the allowed tree**, so in any repository kaibo did not author every registration file under it is attacker-authored.

That is the everyday case, not an exotic one. Clone a repo to review, point kaibo at it, and one file — `.git/worktrees/evil/gitdir` containing `/etc/.git` — makes `/etc` a vouched worktree root. `~/.ssh` the same way. Anything that is not an ancestor of the tree, since ancestors are the only thing the filter above drops.

```
test a_registration_naming_a_host_directory_does_not_vouch_for_it ... FAILED
```

**The `tree`-side handshake cannot catch this**, which is the part worth understanding: for a main worktree the common dir *is* `<tree>/.git`, so `tree` is a vouched root by construction. The handshake passes for free and says nothing about the entries sitting beside it.

So each registration now earns its place separately, by naming its registration back the way git writes it. An attacker cannot forge that half — writing inside the target directory is the access being sought.

## The decision: one entry point, and every link named from both ends

`worktrees_reachable_from` now holds both rules, and containment plus the `kaibo://config` render call nothing else — so neither rule can be applied at one call site and forgotten at the other.

1. **The tree we were handed is the only tree that vouches.** `common_git_dir` reads `<tree>/.git` and no ancestor. A tree that merely sits inside a repository reaches nothing.
2. **The common dir must name that tree back** as one of its own worktree roots. A forged pointer reaches a common dir that has never heard of the tree, and the reach collapses to nothing. This is the same two-way check the *candidate* side already had, applied to the side the reach starts from.
3. **Every registered worktree must name its registration back.** Rule 2 passes for free whenever the common dir lives inside the allowed tree, so the mutual check has to run per entry, not once at the top.
4. A vouched tree that strictly contains the allowed tree is dropped — a genuine but unusual layout (`git worktree add` inside the main worktree) would otherwise widen upward, which is the one thing following worktrees promises not to do. Reach it with `--allow-path`.

Both intended shapes still work, pinned by the existing tests: rooted at a repo (`linked_worktree_of_allowed_repo_is_admitted`) and rooted at a linked worktree (`sibling_reachable_when_rooted_at_linked_worktree`).

The cost, stated plainly: `--root` on a subdirectory of a repo no longer follows that repo's worktrees. That is the narrowing the operator asked for by naming a subdirectory.

## Tests

Five, each run against the pre-fix behavior and failing there — the old code was reintroduced by hand to check:

```
test worktree::tests::a_subdirectory_of_a_repo_resolves_no_common_dir ... FAILED
test worktree::tests::a_registration_alone_does_not_vouch_for_the_directory_it_names ... FAILED
test a_repo_above_the_allowed_tree_does_not_widen_the_boundary ... FAILED
test a_forged_dotgit_in_the_allowed_tree_cannot_aim_the_vouch ... FAILED
test a_registration_naming_a_host_directory_does_not_vouch_for_it ... FAILED
```

**The teeth check caught itself first, and that is worth recording.** My first attempt at proving the back-link tests had teeth removed only the `back != registration` comparison — and both tests stayed green. The guard that actually fires on this shape is the back-link *read*, which fails on a nonexistent `<wt>/.git`. Re-run against the real one-way code, both fail. A check that reported clean while examining nothing, exactly the failure mode we keep a rule about.

The two real-`git` positive tests (`linked_worktree_of_allowed_repo_is_admitted`, `sibling_reachable_when_rooted_at_linked_worktree`) still pass, which is what proves the mutual check accepts the layouts git actually writes.

The forgery test carries a positive control — after the refusal it reads a file inside the allowed tree — so a refusal produced by a broken handler rather than by the boundary would not read as a pass. The unit test has one too, asserting the repo root still resolves so its `None` means the walk stopped rather than the fixture being unreadable.

`a_forged_dotgit_in_the_allowed_tree_cannot_aim_the_vouch` deliberately skips `require_git!`: the layout is hand-written precisely because git would never write it.

Suite: **1339 passed / 0 failed / 23 ignored across 40 suites**, exit code captured directly rather than through a pipeline.

## Disclosure

Amy's call: *"I doubt this is a problem for users in the wild but we'll fix it with haste"* — changelog only, worded as a possible security issue, no separate advisory. The `Security` section says it shipped in every release since 0.2.0.

That call was made when two holes were known, both needing an unusual root. The third needs only the normal usage — a cloned repo and a `--root` at it — so it may be worth revisiting whether the changelog alone is the right disclosure.

## Residual

The flake this started from is explained but not proven for the specific 2026-08-14 incident. The two `tests/attach.rs` teeth failed **as a pair** while admitting a `/tmp/.tmp…` path, which is exactly what a transient `/tmp/.git` produces through the walk — on a box running many concurrent agent sessions. Same mechanism, and the tests were reporting a real hole either way. Worth deleting the tracker entry when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
