### PR TITLE
Bump kaish-kernel to 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ record. Each later release appends a new section at the top.
   worktree must name its registration back, so one file in a repo you cloned to review
   cannot make any directory on the host readable.
 
+### Fixed
+
+- **kaish 0.17.2** — ordinary shell a model types now parses: `cat .git/HEAD`, `echo 123.txt`,
+  `HEAD:src/main.rs`, `p=~/x`, and `ls 1.0*` were all parse errors.
+- **Adjacent for-loop items are refused instead of silently iterating twice** — `for x in a"b" c`
+  ran the body three times.
+
 ### Changed
 
 - **A tool this server does not serve now refuses in kaibo's words** — naming the flag, the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-glob"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93656ec4bb59fa7c6cba023bfe1c3acdea85df527fee974de9aba753887c20ff"
+checksum = "6a8f0120878d1b18b3608cb0eacfcb55db97fd6b7a8374ee1fd44b507780985f"
 dependencies = [
  "async-trait",
  "ignore",
@@ -1811,18 +1811,18 @@ dependencies = [
 
 [[package]]
 name = "kaish-help"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16123dd474f38c16fcd0a7b8138617ba39b94523400dc2bf8b1228ea4b4ec9ab"
+checksum = "1181e0536c6114d2a3395e089aec38f2526ff25bbda16224f3b995e4815dfa5b"
 dependencies = [
  "kaish-types",
 ]
 
 [[package]]
 name = "kaish-kernel"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559a21f7191f6cd73d8e87c7bb366a333f25976e0fab45db9fe445e5acc67c92"
+checksum = "198f122a3f1238e1bdad93f7893360f6968e8895c77aacc490e7a38536688dd8"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-tool-api"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89aaa458905071760eecc648f21e8e63a0cd779e2f7a5c6e4fadc9d9edd7da3f"
+checksum = "9a5bc69b72b8673b23e88ef1cfd0c10eec1c64f62fcea8c3a2fcebc721316924"
 dependencies = [
  "async-trait",
  "clap",
@@ -1882,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-types"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12472b339a94b2f3579f71a472cdeac6cc236a408c8cd9be69f00aa01ba85a1d"
+checksum = "093211624f8fc7dd646c1e4240ad2f77a092c2208e304a7a096c2c4e245d1cc1"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "kaish-vfs"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444a42b9505034dc24cea0ba8724c4cc7e274900bff15c916780b4cd74377a2b"
+checksum = "8fc0e3aa081885961267f10b36b19e06611b8560ec7c57b3f8bf84c64d3391e0"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # `os-integration` (trash) OFF — so those builtins are never compiled in. kaibo's
 # read-only safety is thus structural (the dangerous surface doesn't exist),
 # backed by the runtime read-only mount; see src/sandbox.rs.
-kaish-kernel = { version = "0.17.1", default-features = false, features = ["localfs"] }
+kaish-kernel = { version = "0.17.2", default-features = false, features = ["localfs"] }
 # `time` is used by the deferred `generate` job's poll cadence (sleep + Instant) —
 # named here rather than inherited from a transitive enabler.
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }


### PR DESCRIPTION
Five lexer/parser fixes from kaish 0.17.2, all of them refusals a model earned by typing ordinary shell. `cargo build` was green with no source change on kaibo's side — which is exactly why the rule in AGENTS.md is that a green build is not the check.

## Probed by hand, in the shell, against both pins

| script | 0.17.1 | 0.17.2 |
|---|---|---|
| `cat .git/HEAD` | parse error, "adjacent words … not joined" | `ref: refs/heads/main` |
| `echo 123.txt 1.2.3 true:foo a+b` | "float must have trailing digit" | `123.txt 1.2.3 true:foo a+b` |
| `echo HEAD:src/main.rs` | parse error | `HEAD:src/main.rs` |
| `p=~/x; echo "$p"` | "found `=~` expected …" | `~/x` |
| `ls 1.0*` | parse error | `no matches: 1.0*` |
| `for x in a"b" c; …` | **iterated three times** (`a`, `b`, `c`) | refused before the body runs |

The for-loop one is a correctness fix, not a refusal, and it's the reason to take this bump promptly: `for x in a"b" c` silently ran the body once more than the script says.

## The composed contract changed this time

Unlike the 0.17.1 bump, the contract is **not** byte-identical. `kaish-help` ships new cheatsheet text for its own fixes — literal paths, literal words, the for-loop rule — and that reaches every preamble and the `run_kaish` tool definition through `kaish_syntax_core`.

Diffed whole across both pins over the real MCP surface (every `kaibo://` resource and every tool description, dumped over stdio JSON-RPC): four changed blocks, all kaish-authored. No kaibo-authored text moved. All eleven `help` surfaces unchanged.

Grepped kaibo's own prose for every idiom these fixes correct — a kaish idiom is never in one file. Nothing kaibo says is now false: the sandbox addendum teaches `cat -n`, `grep -rn`, and quoted `sed` ranges, all still correct on every pin kaibo has run, and it makes no claim about token pasting or quoting numeric words.

## Gates

- Suite: **1341 passed, 0 failed**.
- `kaish-vfs` bumped 0.17.1 → 0.17.2 alongside the kernel, so by the AGENTS.md rule this **does** re-arm `docs/sandbox-probes.md`. The 0.17.2 changes are lexer/parser only, so the containment battery is the part with something to find — flagging for the release decision rather than assuming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)