### PR TITLE
The read boundary says when it fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ record. Each later release appends a new section at the top.
   worktree must name its registration back, so one file in a repo you cloned to review
   cannot make any directory on the host readable.
 
+### Added
+
+- **The read boundary now says when it refuses a path** — a `warn` naming the path and the
+  allowed set, from every surface that checks containment. Rides the `logs` signal.
+- **A refused `run_kaish` call still closes a `run_kaish` span**, tagged
+  `outcome = "refused"` — a boundary that fired no longer looks like a call that never
+  arrived.
+
 ### Changed
 
 - **A tool this server does not serve now refuses in kaibo's words** — naming the flag, the

--- a/src/server/containment.rs
+++ b/src/server/containment.rs
@@ -311,3 +311,161 @@ impl super::Resolver {
         Ok(out)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::config::Config;
+    use crate::server::Resolver;
+    use crate::test_support::{capture_tracing, CapturedEvent};
+    use std::sync::Arc;
+
+    /// A resolver whose whole allowed set is one temp directory.
+    fn resolver_rooted_at(root: &std::path::Path) -> Resolver {
+        let mut config = Config::builtin();
+        config.root = Some(root.to_path_buf());
+        config.infer_cwd = false;
+        Resolver::from_config(Arc::new(config)).expect("resolver builds")
+    }
+
+    /// The one event a containment refusal must emit, or a description of what was
+    /// emitted instead — the assertion message is what a reader debugs from.
+    fn refusal_event(events: &[CapturedEvent]) -> CapturedEvent {
+        events
+            .iter()
+            .find(|e| e.has_field("outcome", "refused"))
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "no `outcome = refused` event; captured {} event(s): {:?}",
+                    events.len(),
+                    events
+                        .iter()
+                        .map(|e| (e.level, &e.message, &e.fields))
+                        .collect::<Vec<_>>()
+                )
+            })
+    }
+
+    /// The boundary firing is the most interesting thing kaibo does, and until now it
+    /// left no trace at all: `resolve_root` returns the refusal to the caller and the
+    /// server records nothing, so an operator watching a fleet cannot tell a boundary
+    /// that never fired from one that fired a hundred times.
+    ///
+    /// The event carries `outcome = "refused"` as a field — that name is already on
+    /// [`SAFE_ATTRIBUTES`](crate::otel_filter::SAFE_ATTRIBUTES), so the *record that a
+    /// refusal happened* exports with no content policy change — and names the path in
+    /// the message body, which follows kaibo's existing rule for a path: content, and
+    /// so redacted from traces unless the operator opts in.
+    #[test]
+    fn a_refused_root_says_so() {
+        let allowed = tempfile::tempdir().expect("temp allowed tree");
+        let outside = tempfile::tempdir().expect("temp outside tree");
+        let resolver = resolver_rooted_at(allowed.path());
+        let asked = outside.path().display().to_string();
+
+        let captured = capture_tracing(async {
+            let refusal = resolver.resolve_root(Some(asked.clone()));
+            assert!(
+                refusal.is_err(),
+                "guard: the path is outside the allowed set"
+            );
+        });
+
+        let event = refusal_event(&captured.events());
+        assert_eq!(
+            event.level,
+            tracing::Level::WARN,
+            "a boundary refusal is a warning, not an info line: {event:?}"
+        );
+        assert!(
+            event.message.contains(&asked),
+            "the message names the path that was refused: {}",
+            event.message
+        );
+        assert!(
+            !event.fields.values().any(|v| v.contains(&asked)),
+            "the path stays in the message body, out of the always-exported fields: {:?}",
+            event.fields
+        );
+    }
+
+    /// The same funnel, reached from the attachment surface. `resolve_attachments` and
+    /// `resolve_root` share `containment_error` precisely so the two boundaries cannot
+    /// drift; this pins that the telemetry cannot drift either.
+    #[test]
+    fn a_refused_attachment_says_so() {
+        let allowed = tempfile::tempdir().expect("temp allowed tree");
+        let outside = tempfile::tempdir().expect("temp outside tree");
+        let file = outside.path().join("secret.txt");
+        std::fs::write(&file, b"outside the boundary").expect("fixture file");
+        let resolver = resolver_rooted_at(allowed.path());
+        let asked = file.display().to_string();
+
+        let captured = capture_tracing(async {
+            let refusal = resolver
+                .resolve_attachments(std::slice::from_ref(&asked))
+                .await;
+            assert!(
+                refusal.is_err(),
+                "guard: the file is outside the allowed set"
+            );
+        });
+
+        let event = refusal_event(&captured.events());
+        assert!(
+            event.message.contains(&asked),
+            "the message names the attachment that was refused: {}",
+            event.message
+        );
+    }
+
+    /// And from the single-file surface `view_image` reads through.
+    #[test]
+    fn a_refused_file_read_says_so() {
+        let allowed = tempfile::tempdir().expect("temp allowed tree");
+        let outside = tempfile::tempdir().expect("temp outside tree");
+        let file = outside.path().join("secret.png");
+        std::fs::write(&file, b"outside the boundary").expect("fixture file");
+        let resolver = resolver_rooted_at(allowed.path());
+        let asked = file.display().to_string();
+
+        let captured = capture_tracing(async {
+            let refusal = resolver.read_contained_file(&asked, 1 << 20).await;
+            assert!(
+                refusal.is_err(),
+                "guard: the file is outside the allowed set"
+            );
+        });
+
+        let event = refusal_event(&captured.events());
+        assert!(
+            event.message.contains(&asked),
+            "the message names the file that was refused: {}",
+            event.message
+        );
+    }
+
+    /// A path *inside* the boundary must stay quiet. The warn is a signal an operator
+    /// can alert on, which it stops being the moment an ordinary call emits it.
+    #[test]
+    fn an_allowed_root_emits_no_refusal() {
+        let allowed = tempfile::tempdir().expect("temp allowed tree");
+        let resolver = resolver_rooted_at(allowed.path());
+        let asked = allowed.path().display().to_string();
+
+        let captured = capture_tracing(async {
+            resolver
+                .resolve_root(Some(asked))
+                .expect("guard: the path is inside the allowed set");
+        });
+
+        assert!(
+            !captured
+                .events()
+                .iter()
+                .any(|e| e.has_field("outcome", "refused")),
+            "an allowed path emits no refusal: {:?}",
+            captured.events()
+        );
+    }
+}

--- a/src/server/containment.rs
+++ b/src/server/containment.rs
@@ -88,33 +88,6 @@ impl super::Resolver {
         self.containing_tree(canon).is_some()
     }
 
-    /// Resolve caller-named attachment paths into [`Attachment`](crate::attach::Attachment)s,
-    /// read and encoded server-side so the bytes never transit the calling agent's
-    /// context. Each path obeys the *same* boundary as a session root — canonicalize
-    /// (symlinks + `..` resolved), require a regular file, then the shared
-    /// [`containing_tree`](Self::containing_tree) check (allowed set + followed worktrees)
-    /// — so attachments can't read outside the workspace any more than `run_kaish` can.
-    ///
-    /// Failures are loud and per-path: a missing file, a directory, an over-cap or
-    /// non-text/non-image file is a clear `invalid_params`, never a silent skip — an
-    /// attachment the caller named but we dropped would be a corrupt answer. An absolute
-    /// per-file size ceiling is enforced *before* reading (via the file's metadata) so a
-    /// giant file is refused without first slurping it into memory; a batch-level count cap
-    /// and cumulative-byte budget ([`check_attachment_bounds`](crate::attach::check_attachment_bounds))
-    /// bound the *whole call* the same way — a stray thousand-file glob, or many
-    /// individually-legal files summing to an OOM, is refused before the offending read.
-    ///
-    /// **The read goes through the read-only kaish VFS, not `std::fs::read`** — the same
-    /// mechanism `view_image` uses. The canonicalize + containment check above is the
-    /// *friendly early error*; the read itself is mounted on a [`KaishWorker`] rooted at
-    /// the attachment's containing tree, whose VFS re-resolves at read time and refuses to
-    /// follow a symlink out of that tree (proved by `tests/containment.rs`'s
-    /// `mount_layer_symlink_*` battery). That closes the check-then-open TOCTOU window the
-    /// old `std::fs::read` left open — a path swapped for an out-of-tree symlink after the
-    /// check is rejected at the mount layer regardless of timing, structurally rather than
-    /// by racing a re-check. One worker is spawned per *distinct* containing tree and
-    /// reused across attachments under it, so the common case (files under one project
-    /// root) builds a single worker.
     /// Read one caller-named file's bytes, contained.
     ///
     /// The single-file sibling of [`resolve_attachments`](Self::resolve_attachments),
@@ -198,6 +171,33 @@ impl super::Resolver {
         Ok(bytes)
     }
 
+    /// Resolve caller-named attachment paths into [`Attachment`](crate::attach::Attachment)s,
+    /// read and encoded server-side so the bytes never transit the calling agent's
+    /// context. Each path obeys the *same* boundary as a session root — canonicalize
+    /// (symlinks + `..` resolved), require a regular file, then the shared
+    /// [`containing_tree`](Self::containing_tree) check (allowed set + followed worktrees)
+    /// — so attachments can't read outside the workspace any more than `run_kaish` can.
+    ///
+    /// Failures are loud and per-path: a missing file, a directory, an over-cap or
+    /// non-text/non-image file is a clear `invalid_params`, never a silent skip — an
+    /// attachment the caller named but we dropped would be a corrupt answer. An absolute
+    /// per-file size ceiling is enforced *before* reading (via the file's metadata) so a
+    /// giant file is refused without first slurping it into memory; a batch-level count cap
+    /// and cumulative-byte budget ([`check_attachment_bounds`](crate::attach::check_attachment_bounds))
+    /// bound the *whole call* the same way — a stray thousand-file glob, or many
+    /// individually-legal files summing to an OOM, is refused before the offending read.
+    ///
+    /// **The read goes through the read-only kaish VFS, not `std::fs::read`** — the same
+    /// mechanism `view_image` uses. The canonicalize + containment check above is the
+    /// *friendly early error*; the read itself is mounted on a [`KaishWorker`] rooted at
+    /// the attachment's containing tree, whose VFS re-resolves at read time and refuses to
+    /// follow a symlink out of that tree (proved by `tests/containment.rs`'s
+    /// `mount_layer_symlink_*` battery). That closes the check-then-open TOCTOU window the
+    /// old `std::fs::read` left open — a path swapped for an out-of-tree symlink after the
+    /// check is rejected at the mount layer regardless of timing, structurally rather than
+    /// by racing a re-check. One worker is spawned per *distinct* containing tree and
+    /// reused across attachments under it, so the common case (files under one project
+    /// root) builds a single worker.
     pub async fn resolve_attachments(
         &self,
         paths: &[String],

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2639,27 +2639,44 @@ impl KaiboHandler {
         &self,
         Parameters(input): Parameters<RunKaishInput>,
     ) -> Result<CallToolResult, McpError> {
-        let root = self.resolve_root(input.path)?;
+        // The direct-shell tool gets its own trace (no model loop under it). The span
+        // brackets the WHOLE call, containment check included, so every way the call
+        // can end closes a span — `tool_span.rs` settled the same question for the
+        // inner tools, and a refused call producing no span at all made the boundary
+        // firing indistinguishable from the call never arriving. The kaish worker is
+        // `!Send` on its own thread; this span never crosses that boundary, it only
+        // wraps the `.await` from the caller side.
+        let span = tracing::info_span!("run_kaish", outcome = tracing::field::Empty);
+        async move {
+            let root = self.resolve_root(input.path).inspect_err(|_| {
+                // A refusal is an outcome, not an absence. `resolve_root` already
+                // logged *what* it refused (see `containment_error`); this records
+                // *which call* it was, on the span the caller can join to.
+                tracing::Span::current().record("outcome", "refused");
+            })?;
 
-        // A fresh worker (and kernel) per call: stateless, starts at root, and the
-        // !Send kernel stays on its own thread so this future stays Send. Applies the
-        // configured sandbox limits (timeout, output cap, disabled builtins).
-        let worker = KaishWorker::spawn_with(&root, self.config.sandbox.clone())
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
-        // The direct-shell tool gets its own trace (no model loop under it). The kaish
-        // worker is `!Send` on its own thread, but this span wraps the async `.await`
-        // here, so the script's wall-clock is captured from the caller side — no span
-        // crosses the thread boundary.
-        let span = tracing::info_span!("run_kaish");
-        let out = worker
-            .run(input.script)
-            .instrument(span)
-            .await
-            .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+            // A fresh worker (and kernel) per call: stateless, starts at root, and the
+            // !Send kernel stays on its own thread so this future stays Send. Applies the
+            // configured sandbox limits (timeout, output cap, disabled builtins).
+            let worker =
+                KaishWorker::spawn_with(&root, self.config.sandbox.clone()).map_err(|e| {
+                    tracing::Span::current().record("outcome", "error");
+                    McpError::internal_error(format!("{e:#}"), None)
+                })?;
+            let out = worker.run(input.script).await.map_err(|e| {
+                tracing::Span::current().record("outcome", "error");
+                McpError::internal_error(format!("{e:#}"), None)
+            })?;
 
-        Ok(CallToolResult::success(vec![ContentBlock::text(
-            format_output(&out),
-        )]))
+            // A non-zero *script* exit is ordinary output, not a tool failure — the
+            // same reading `tool_span.rs` takes — so the shell running at all is `ok`.
+            tracing::Span::current().record("outcome", "ok");
+            Ok(CallToolResult::success(vec![ContentBlock::text(
+                format_output(&out),
+            )]))
+        }
+        .instrument(span)
+        .await
     }
 
     #[tool(
@@ -5038,6 +5055,83 @@ mod tests {
     use rmcp::model::{ContentBlock, NumberOrString};
     use rmcp::ServerHandler;
     use serde_json::json;
+
+    /// A `run_kaish` call refused at the boundary must still close a `run_kaish` span,
+    /// tagged `outcome = "refused"`.
+    ///
+    /// Before this, the span was built *after* `resolve_root`, so a refused call was the
+    /// one outcome of the tool that produced no span at all — the boundary firing looked
+    /// exactly like the call never happening. `tool_span.rs` already settled the same
+    /// question for the inner tools ("a malformed-args refusal is reported as
+    /// `outcome = error` rather than never appearing — the honest reading of *did this
+    /// call work*"); this is the MCP surface catching up to it.
+    #[test]
+    fn a_refused_run_kaish_still_closes_a_span() {
+        use crate::test_support::capture_tracing;
+        let allowed = tempfile::tempdir().expect("temp allowed tree");
+        let outside = tempfile::tempdir().expect("temp outside tree");
+        let mut config = crate::config::Config::builtin();
+        config.root = Some(allowed.path().to_path_buf());
+        config.infer_cwd = false;
+        let handler = KaiboHandler::new(config).expect("handler builds");
+        let asked = outside.path().display().to_string();
+
+        let captured = capture_tracing(async {
+            let refusal = handler
+                .run_kaish(Parameters(RunKaishInput {
+                    script: "pwd".to_string(),
+                    path: Some(asked),
+                }))
+                .await;
+            assert!(
+                refusal.is_err(),
+                "guard: the path is outside the allowed set"
+            );
+        });
+
+        let spans = captured.spans();
+        let span = spans
+            .iter()
+            .find(|s| s.name == "run_kaish")
+            .unwrap_or_else(|| {
+                panic!("a refused call still opens a `run_kaish` span; saw {spans:?}")
+            });
+        assert_eq!(
+            span.outcome.as_deref(),
+            Some("refused"),
+            "the span says how the call ended: {span:?}"
+        );
+    }
+
+    /// The other half of the same field: a call that runs closes `outcome = "ok"`, so
+    /// the refusal above is a distinguishable value rather than the only one ever set.
+    #[test]
+    fn a_served_run_kaish_closes_ok() {
+        use crate::test_support::capture_tracing;
+        let allowed = tempfile::tempdir().expect("temp allowed tree");
+        let mut config = crate::config::Config::builtin();
+        config.root = Some(allowed.path().to_path_buf());
+        config.infer_cwd = false;
+        let handler = KaiboHandler::new(config).expect("handler builds");
+        let asked = allowed.path().display().to_string();
+
+        let captured = capture_tracing(async {
+            handler
+                .run_kaish(Parameters(RunKaishInput {
+                    script: "pwd".to_string(),
+                    path: Some(asked),
+                }))
+                .await
+                .expect("guard: the path is inside the allowed set");
+        });
+
+        let spans = captured.spans();
+        let span = spans
+            .iter()
+            .find(|s| s.name == "run_kaish")
+            .unwrap_or_else(|| panic!("a served call opens a `run_kaish` span; saw {spans:?}"));
+        assert_eq!(span.outcome.as_deref(), Some("ok"), "{span:?}");
+    }
 
     /// deliberate-direct's wall-clock backstop tracks its synth backend's own
     /// `request_timeout` (+ margin), NOT the interactive `call_deadline`. This is the

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2648,25 +2648,31 @@ impl KaiboHandler {
         // wraps the `.await` from the caller side.
         let span = tracing::info_span!("run_kaish", outcome = tracing::field::Empty);
         async move {
-            let root = self.resolve_root(input.path).inspect_err(|_| {
-                // A refusal is an outcome, not an absence. `resolve_root` already
-                // logged *what* it refused (see `containment_error`); this records
-                // *which call* it was, on the span the caller can join to.
-                tracing::Span::current().record("outcome", "refused");
-            })?;
+            // The outcome starts at the failure value and is refined as the call gets
+            // further. Written this way, rather than on each error arm, because the one
+            // value that is not this handler's to assign is `refused`: only the
+            // containment check knows the boundary fired, and it records that itself
+            // (see `Resolver::containment_error`) from inside the `resolve_root` below —
+            // after this line, and before any arm here could overwrite it. So each
+            // writer sets the field when it knows, in the order it knows.
+            //
+            // `resolve_root` refuses three other ways — no default root, a path that
+            // does not resolve, a path that is not a directory — and those are caller
+            // mistakes, not the boundary firing. They stay `error`, the same reading
+            // `tool_span.rs` gives a malformed-args refusal, so an operator alerting on
+            // `outcome = refused` counts boundary hits and not typos.
+            tracing::Span::current().record("outcome", "error");
+            let root = self.resolve_root(input.path)?;
 
             // A fresh worker (and kernel) per call: stateless, starts at root, and the
             // !Send kernel stays on its own thread so this future stays Send. Applies the
             // configured sandbox limits (timeout, output cap, disabled builtins).
-            let worker =
-                KaishWorker::spawn_with(&root, self.config.sandbox.clone()).map_err(|e| {
-                    tracing::Span::current().record("outcome", "error");
-                    McpError::internal_error(format!("{e:#}"), None)
-                })?;
-            let out = worker.run(input.script).await.map_err(|e| {
-                tracing::Span::current().record("outcome", "error");
-                McpError::internal_error(format!("{e:#}"), None)
-            })?;
+            let worker = KaishWorker::spawn_with(&root, self.config.sandbox.clone())
+                .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
+            let out = worker
+                .run(input.script)
+                .await
+                .map_err(|e| McpError::internal_error(format!("{e:#}"), None))?;
 
             // A non-zero *script* exit is ordinary output, not a tool failure — the
             // same reading `tool_span.rs` takes — so the shell running at all is `ok`.
@@ -5100,6 +5106,55 @@ mod tests {
             span.outcome.as_deref(),
             Some("refused"),
             "the span says how the call ended: {span:?}"
+        );
+    }
+
+    /// A path that simply does not exist is a caller mistake, not the boundary firing,
+    /// and must NOT read as `refused` — an operator alerting on that value is counting
+    /// boundary hits, and a typo landing in the same bucket makes the number useless.
+    ///
+    /// `resolve_root` refuses four ways and only one of them is the boundary. Caught by
+    /// the cross-family review of this change (cast `crusoe`): the first cut recorded
+    /// `refused` on every `resolve_root` error, so the span and the warn could disagree
+    /// — the span said the boundary fired while the logs, which only
+    /// `containment_error` writes, said nothing at all.
+    #[test]
+    fn a_nonexistent_path_is_an_error_not_a_refusal() {
+        use crate::test_support::capture_tracing;
+        let allowed = tempfile::tempdir().expect("temp allowed tree");
+        let mut config = crate::config::Config::builtin();
+        config.root = Some(allowed.path().to_path_buf());
+        config.infer_cwd = false;
+        let handler = KaiboHandler::new(config).expect("handler builds");
+        let asked = allowed.path().join("no-such-dir").display().to_string();
+
+        let captured = capture_tracing(async {
+            let refusal = handler
+                .run_kaish(Parameters(RunKaishInput {
+                    script: "pwd".to_string(),
+                    path: Some(asked),
+                }))
+                .await;
+            assert!(refusal.is_err(), "guard: the path does not exist");
+        });
+
+        let spans = captured.spans();
+        let span = spans
+            .iter()
+            .find(|s| s.name == "run_kaish")
+            .unwrap_or_else(|| panic!("the call still opens a span; saw {spans:?}"));
+        assert_eq!(
+            span.outcome.as_deref(),
+            Some("error"),
+            "a path that does not resolve is an error, not the boundary firing: {span:?}"
+        );
+        assert!(
+            !captured
+                .events()
+                .iter()
+                .any(|e| e.has_field("outcome", "refused")),
+            "and it logs no refusal: {:?}",
+            captured.events()
         );
     }
 

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -256,13 +256,45 @@ impl Resolver {
     }
 
     /// The shared "outside the allowed set" rejection, naming the boundary and the
-    /// three widening knobs.
+    /// three widening knobs — and the one place kaibo records that its boundary fired.
+    ///
+    /// Read-only containment is the product, so the boundary refusing a path is the
+    /// most interesting thing kaibo does, and an operator watching a fleet needs to
+    /// tell a boundary that never fired from one that fired a hundred times. Every
+    /// refusal funnels here — `resolve_root`, `resolve_attachments`, and
+    /// `read_contained_file` all call it — so one `warn` covers the whole class, from
+    /// the MCP tools and the CLI subcommands alike, and a fourth surface added later
+    /// is reported the moment it uses the shared check.
+    ///
+    /// The split between the field and the message is kaibo's existing export policy,
+    /// not a new one. `outcome` is on
+    /// [`SAFE_ATTRIBUTES`](crate::otel_filter::SAFE_ATTRIBUTES), so *that a refusal
+    /// happened* always exports; the paths live in the message body, which
+    /// [`CONTENT_ATTRIBUTES`](crate::otel_filter::CONTENT_ATTRIBUTES) holds back from
+    /// traces unless the operator opts in. A caller-named path is content by the same
+    /// rule that keeps `gen_ai.tool.arguments` off the safe list. The logs signal
+    /// carries the line whole, which is what it is for: what kaibo says about itself.
     pub(super) fn containment_error(&self, raw: &Path, canon: &Path) -> McpError {
         let trees: Vec<String> = self
             .allowed_set
             .iter()
             .map(|p| p.display().to_string())
             .collect();
+        // Name the resolution only when it changed something. A caller usually passes
+        // an already-canonical path, and "refused /etc: it resolves to /etc" reads as
+        // noise in the line an operator sees most often; a `..` or a symlink that
+        // landed somewhere else is exactly what they need spelled out.
+        let resolution = if raw == canon {
+            String::new()
+        } else {
+            format!(", which resolves to {}", canon.display())
+        };
+        tracing::warn!(
+            outcome = "refused",
+            "read boundary refused {}{resolution} — outside the allowed set [{}]",
+            raw.display(),
+            trees.join(", "),
+        );
         McpError::invalid_params(
             format!(
                 "path {} resolves to {}, which is outside the allowed set [{}]. \

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -256,7 +256,7 @@ impl Resolver {
     }
 
     /// The shared "outside the allowed set" rejection, naming the boundary and the
-    /// three widening knobs — and the one place kaibo records that its boundary fired.
+    /// three widening knobs — and the one place kaibo logs that its boundary fired.
     ///
     /// Read-only containment is the product, so the boundary refusing a path is the
     /// most interesting thing kaibo does, and an operator watching a fleet needs to
@@ -265,6 +265,13 @@ impl Resolver {
     /// `read_contained_file` all call it — so one `warn` covers the whole class, from
     /// the MCP tools and the CLI subcommands alike, and a fourth surface added later
     /// is reported the moment it uses the shared check.
+    ///
+    /// *This* boundary, precisely: the allowed set. A consult attachment refused for
+    /// resolving outside the **session root** ([`resolve_consult_attachments`](Self::resolve_consult_attachments)) is a different
+    /// class — the file is inside the allowed set, and the refusal is about which
+    /// project this call mounts — so it stays quiet here. An operator alerting on this
+    /// warn is asking "did the read boundary fire", not "did a caller name the wrong
+    /// project".
     ///
     /// The split between the field and the message is kaibo's existing export policy,
     /// not a new one. `outcome` is on
@@ -289,6 +296,12 @@ impl Resolver {
         } else {
             format!(", which resolves to {}", canon.display())
         };
+        // Refine the enclosing call's span too, for a handler built to receive it —
+        // `run_kaish` declares an `outcome` field and opens its span before this check.
+        // `Span::record` is a no-op for a field the current span never declared, so
+        // this reaches exactly those spans and no others, and it costs nothing when
+        // there is no span at all (the four handlers that resolve before they have one).
+        tracing::Span::current().record("outcome", "refused");
         tracing::warn!(
             outcome = "refused",
             "read boundary refused {}{resolution} — outside the allowed set [{}]",

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -21,11 +21,13 @@
 //! and had nowhere to report.
 //!
 //! The read boundary refusing a path is the third, and the one where the asymmetry
-//! bites hardest: a refusal happens *before* a handler has a phase to open a span
-//! around, so for four of the five MCP tools the logs signal is the only road it
-//! travels. `run_kaish` is the exception — its span brackets the whole call, so a
-//! refused shell call closes a `run_kaish` span with `outcome = "refused"` and
-//! reaches traces too. See `server/resolver.rs::containment_error`.
+//! bites hardest: a refusal usually happens *before* the handler has a phase to open
+//! a span around, so the logs signal is the only road it travels. That covers four of
+//! the five tools that resolve a root (`consult`, `consult_submit`, `explore`,
+//! `deliberate`) and every attachment refusal besides. `run_kaish` is the exception —
+//! its span brackets the whole call, so a refused shell call closes a `run_kaish` span
+//! with `outcome = "refused"` and reaches traces too. See
+//! `server/resolver.rs::containment_error`.
 //!
 //! **Metrics carry what neither of those makes cheap to aggregate** — and, more to the
 //! point, what neither of them can do *safely by construction*. Traces are made safe by

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -5,8 +5,8 @@
 //! span per turn (carrying `gen_ai.request.model` and every `gen_ai.usage.*` token
 //! field), and a `tool` span per tool call. Our `run_kaish` and delegated
 //! `explore′` sweeps are rig tools, so they show up as tool spans for free; the
-//! `#[instrument]`s on the four MCP handlers and on `run_phase` (see `server.rs` /
-//! `consult.rs`) just give that tree named kaibo parents. This module's whole job
+//! spans the MCP handlers open around each phase and on `run_phase` (see `server.rs`
+//! / `consult.rs`) just give that tree named kaibo parents. This module's whole job
 //! is to *export* it: stand up the OTLP/HTTP exporters and hand `main`'s subscriber
 //! registry the layers that feed them.
 //!
@@ -19,6 +19,13 @@
 //! phase returns an empty answer and is forced into a write-up turn. Both classes
 //! were tracked as "incidence unmeasured" precisely because the instrument existed
 //! and had nowhere to report.
+//!
+//! The read boundary refusing a path is the third, and the one where the asymmetry
+//! bites hardest: a refusal happens *before* a handler has a phase to open a span
+//! around, so for four of the five MCP tools the logs signal is the only road it
+//! travels. `run_kaish` is the exception — its span brackets the whole call, so a
+//! refused shell call closes a `run_kaish` span with `outcome = "refused"` and
+//! reaches traces too. See `server/resolver.rs::containment_error`.
 //!
 //! **Metrics carry what neither of those makes cheap to aggregate** — and, more to the
 //! point, what neither of them can do *safely by construction*. Traces are made safe by

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -774,6 +774,12 @@ where
 /// Wraps [`serialized_capture`], so it inherits both the serial guard and the
 /// keepalive dispatcher that keep callsite interest from being poisoned by a
 /// no-subscriber test elsewhere in this binary.
+///
+/// The subscriber is installed as **this thread's** default, so a body that emits
+/// from another thread — a `tokio::spawn`, or kaish's own kernel thread — records
+/// nothing here, silently. Every current caller emits on the calling thread. A future
+/// one that spawns needs a globally-installed subscriber instead, which this binary's
+/// other tests cannot share.
 pub fn capture_tracing<F: std::future::Future>(body: F) -> Captured {
     use tracing_subscriber::layer::SubscriberExt;
     let captured = Captured::default();

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -612,3 +612,177 @@ pub fn serialized_capture<F: std::future::Future>(body: F) {
         .unwrap()
         .block_on(body);
 }
+
+// --- Event + outcome capture --------------------------------------------------
+//
+// The span-capture harness above answers "what fields did this span carry". This
+// pair answers the two questions the containment-telemetry tests ask instead: did
+// kaibo *say* something happened (an event), and did the span that wrapped the call
+// record how it ended (`outcome`). Both ride the same [`serialized_capture`] guard —
+// they mutate the same process-global tracing state.
+
+/// One `tracing` event as captured: its level, its rendered message, and the
+/// string-valued fields it carried.
+///
+/// The message and the fields are kept apart on purpose. kaibo's export policy
+/// treats them differently — `message` is a content attribute
+/// ([`crate::otel_filter::CONTENT_ATTRIBUTES`]) and drops unless the operator opts
+/// in, while a field on [`SAFE_ATTRIBUTES`](crate::otel_filter::SAFE_ATTRIBUTES)
+/// always exports — so a test that cares which half a value landed in has to see
+/// them separately.
+#[derive(Clone, Debug)]
+pub struct CapturedEvent {
+    pub level: tracing::Level,
+    pub message: String,
+    pub fields: std::collections::BTreeMap<String, String>,
+}
+
+impl CapturedEvent {
+    /// Does this event carry `field = value`?
+    pub fn has_field(&self, field: &str, value: &str) -> bool {
+        self.fields.get(field).map(String::as_str) == Some(value)
+    }
+}
+
+/// One closed span as captured: its name and whatever `outcome` it ended with.
+#[derive(Clone, Debug)]
+pub struct CapturedOutcome {
+    pub name: String,
+    pub outcome: Option<String>,
+}
+
+/// Everything one capture run saw, in emission order.
+#[derive(Clone, Default)]
+pub struct Captured {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+    spans: Arc<Mutex<Vec<CapturedOutcome>>>,
+}
+
+impl Captured {
+    /// The events emitted during the run.
+    pub fn events(&self) -> Vec<CapturedEvent> {
+        self.events
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// The spans that closed during the run.
+    pub fn spans(&self) -> Vec<CapturedOutcome> {
+        self.spans.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+}
+
+/// Collects a `tracing` record's fields, keeping `message` apart from the rest.
+#[derive(Default)]
+struct FieldGrab {
+    message: String,
+    fields: std::collections::BTreeMap<String, String>,
+}
+
+impl FieldGrab {
+    fn put(&mut self, name: &str, value: String) {
+        if name == "message" {
+            self.message = value;
+        } else {
+            self.fields.insert(name.to_string(), value);
+        }
+    }
+}
+
+impl tracing::field::Visit for FieldGrab {
+    fn record_str(&mut self, f: &tracing::field::Field, v: &str) {
+        self.put(f.name(), v.to_string());
+    }
+    fn record_i64(&mut self, f: &tracing::field::Field, v: i64) {
+        self.put(f.name(), v.to_string());
+    }
+    fn record_bool(&mut self, f: &tracing::field::Field, v: bool) {
+        self.put(f.name(), v.to_string());
+    }
+    // `%value` and the event body both arrive here; `Debug` on a `&str` quotes it,
+    // so trim the quotes to compare against what the call site wrote.
+    fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+        self.put(f.name(), format!("{v:?}").trim_matches('"').to_string());
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for Captured
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut g = FieldGrab::default();
+        event.record(&mut g);
+        self.events
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(CapturedEvent {
+                level: *event.metadata().level(),
+                message: g.message,
+                fields: g.fields,
+            });
+    }
+
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut g = FieldGrab::default();
+        attrs.record(&mut g);
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(g);
+        }
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            if let Some(g) = span.extensions_mut().get_mut::<FieldGrab>() {
+                values.record(g);
+            }
+        }
+    }
+
+    fn on_close(&self, id: tracing::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        let outcome = span
+            .extensions()
+            .get::<FieldGrab>()
+            .and_then(|g| g.fields.get("outcome").cloned());
+        let name = span.name().to_string();
+        self.spans
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(CapturedOutcome { name, outcome });
+    }
+}
+
+/// Run `body` with a capturing subscriber installed as this thread's default, and
+/// hand back everything it recorded.
+///
+/// Wraps [`serialized_capture`], so it inherits both the serial guard and the
+/// keepalive dispatcher that keep callsite interest from being poisoned by a
+/// no-subscriber test elsewhere in this binary.
+pub fn capture_tracing<F: std::future::Future>(body: F) -> Captured {
+    use tracing_subscriber::layer::SubscriberExt;
+    let captured = Captured::default();
+    let sink = captured.clone();
+    serialized_capture(async move {
+        let subscriber = tracing_subscriber::registry().with(sink);
+        let guard = tracing::subscriber::set_default(subscriber);
+        body.await;
+        drop(guard);
+    });
+    captured
+}


### PR DESCRIPTION
Two `run_kaish` calls through MCP yesterday — one served, one refused at the boundary — produced exactly **one** span and **zero** log lines about the path outside the allowed set. kaibo logged 329 info + 12 warn that day and none of them was the refusal.

For a product whose whole claim is read-only containment, the boundary firing is the most interesting event there is, and it left no trace at all. An operator watching a fleet could not tell a boundary that never fired from one that fired a hundred times — and #184 shipped three fixes to exactly that boundary with no way to see it exercised in the field.

Observability, not correctness. Nothing here changes what kaibo refuses.

## The funnel

Every containment refusal already routes through one function, `Resolver::containment_error`. `resolve_root`, `resolve_attachments`, and `read_contained_file` all call it, and they are reached from five MCP tools and four CLI subcommands. One `warn` there covers the whole class, and a fourth surface added later is reported the moment it uses the shared check.

## Where the path goes, and why

The split between the field and the message is kaibo's **existing** export policy, not a new one:

- `outcome = "refused"` is a field, and `outcome` is already on `SAFE_ATTRIBUTES` — so *that a refusal happened* always exports, with no allowlist change.
- The paths live in the **message body**, which `CONTENT_ATTRIBUTES` holds back from traces unless the operator sets `capture_content`.

A caller-named path is content by the same rule that keeps `gen_ai.tool.arguments` off the safe list — the comment there says "which names paths" in as many words. The alternative was adding a path to `SAFE_ATTRIBUTES`; Amy chose this one, because it needs no new policy. The logs signal carries the line whole, which is what that signal is for.

## `run_kaish` opens its span before the check

It used to build the span *after* `resolve_root`, so a refused call was the one outcome of the tool that produced no span at all. `tool_span.rs` had already settled the same question for the inner tools — a malformed-args refusal is reported as `outcome = error` rather than never appearing, "the honest reading of *did this call work*" — and this is the MCP surface catching up. The span now brackets the whole call, so its duration includes the check and the worker spawn; nothing asserted the old bracket.

## The review found a real bug in the first cut

A cross-family pass (kaibo cast `crusoe` — explorer DeepSeek-V4-Flash, synth GLM-5.3) caught that the first cut recorded `outcome = "refused"` on **every** `resolve_root` error. It refuses four ways — no default root, a path that does not resolve, a path that is not a directory, and the boundary — and only the last is the boundary firing. A typo'd path made the span claim a boundary hit the logs knew nothing about, so an operator alerting on `refused` would have been counting typos.

Fixed by putting each writer where the knowledge is: `containment_error` records `refused` itself; `Span::record` is a no-op for a field the current span never declared, so it reaches exactly the spans built to receive it. The handler pre-sets `error` and lets that refinement land after it — which also means a future early return closes `error` rather than closing with nothing.

Every citation in that review was verified against source before I acted on any of it. Three prose corrections came from the same pass, and one drive-by: `resolve_attachments`' doc comment was sitting on `read_contained_file`, fused ahead of that function's own doc, leaving `resolve_attachments` undocumented.

## What still doesn't reach traces

The other four handlers refuse before they have a phase to open a span around, so for them the logs signal is the only road. That's named in `telemetry.rs`'s module doc rather than left for the next reader to rediscover; giving them handler-level spans is a larger change than this one. The sibling refusal for an attachment outside the *session root* stays quiet on purpose — that file is inside the allowed set, and the refusal is about which project the call mounts, not about the boundary.

## Tests

Seven, all run against the pre-fix code and failing there: three refusal surfaces (zero events captured), the `run_kaish` pair (no span, no outcome field), and the vocabulary test that reproduces the reviewed bug. Two negative controls, both sabotage-checked rather than assumed:

- *an allowed path stays quiet* — moved the warn to fire on every resolve, went red.
- *a nonexistent path reads `error`* — restored the first cut's recording, went red.

New reusable capture helpers in `test_support.rs`, riding the existing `serialized_capture` guard so they inherit the callsite-interest protection that module already documents.

Suite: **1348 passed, 0 failed**. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)