### PR TITLE
Absorb the writing-style rules; one word for a survey

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,11 +240,12 @@ Every prompt, preamble, tool description, help line, and error string is text so
 reads. When we touch one, we **re-read the whole block and judge it whole** — not the diff
 by itself.
 
-**kaibo adopts kaish's `docs/style.md`** — that guide names kaibo as an adopter, and it is
-the source for *how* our prose reads: a small vocabulary, one word per concept, exact
-numbers, the constraint stated before any qualifier, and one clause of reason after a rule.
-Read it before you write help text or operator docs. It sorts files by *weight* — how
-strictly its rules apply to that file — and kaibo's files sort like this.
+The rules for *how* our prose reads are below, absorbed from kaish's writing-style
+guidance so they stand on their own here. kaish keeps a small, predictable subset of `sh`
+so existing shell skill transfers; we keep a small, predictable subset of English for the
+same reason. That subset serves both readers we have: a person configuring kaibo, and the
+model that reads the same words. Files sort by *weight* — how strictly these rules apply
+to that file — and kaibo's files sort like this.
 
 | Weight | kaibo files |
 |---|---|
@@ -285,8 +286,6 @@ settle from the guide alone (2026-08-07, `src/cli.rs`).
   for the shape.** The CLI caller is a person or an agent with file access; both can act on
   a key name, and neither can act on "configure it properly". Name `kaibo configure` only
   when the fix is multi-step setup rather than one key.
-- **`family` is a kaibo term** — a model lineage from one vendor, as in "a model outside
-  your own family". About forty uses, one sense. Use it; do not paraphrase it.
 
 Three audiences are optimized differently:
 
@@ -312,12 +311,10 @@ Three audiences are optimized differently:
   of thousands to millions of tokens. Here verbosity is *licensed where it shapes
   behavior*: say it a few ways, frame positively, be explicit (see **Driving the
   models**). Verbose to install behavior, never verbose by default — plain is not terse:
-  keep the repetition that installs an obligation, drop the decoration around it. Why
-  "Subset, not slang" binds hardest here: most of our synths are not English-first
-  (DeepSeek, GLM, Qwen, Kimi) and the small local models already fixate on odd phrasing,
-  so figurative English is a comprehension tax charged to exactly the models we most need
-  to work well. `built_in_preambles_are_written_without_em_dash_clause_chains` holds the
-  mechanical half.
+  keep the repetition that installs an obligation, drop the decoration around it.
+  **Vocabulary choices** binds hardest on this audience, for the reason stated there.
+  `built_in_preambles_are_written_without_em_dash_clause_chains` holds the mechanical
+  half.
 - **Operator-facing docs** — `docs/config.example.toml`, `docs/config.md`, `README.md`.
   The first two are **embedded in the binary** (`include_str!`) and served as
   `kaibo://config/example` and `kaibo://config/guide`, so a model reads them as often as
@@ -329,6 +326,82 @@ Three audiences are optimized differently:
   a pointer for the rest); the **guide** explains semantics and interactions. Detail that
   isn't a knob belongs in the guide — the template is read start to finish by whoever is
   configuring kaibo, so every line there is a line they pay for.
+
+### Vocabulary choices
+
+Keep the vocabulary small. This limits the number of *distinct words*, not the length of
+the text — a familiar word may need a longer sentence, and that trade is the right one.
+Our synths are mostly not English-first (DeepSeek, GLM, Qwen, Kimi) and the small local
+models fixate on odd phrasing, so a figure of speech is a comprehension tax charged to
+exactly the models we most need to work well.
+
+Use plain words instead of figures of speech. The intended meaning must be available from
+the words themselves, in second-language and partial-context reading.
+
+Use American spelling to match the corpus: `modeled`, not `modelled`.
+
+### One term, one meaning
+
+Pick one word for each concept and keep it. Do not vary a word for style. When a term
+carries a behavioral guarantee, its definition belongs in the Terms table below.
+
+A term may differ between published and internal text, but only deliberately and only one
+way each: `survey` is what published text calls one explorer investigation pass, and
+`sweep` is what the code calls it. Both are in the table so the split is recorded rather
+than rediscovered.
+
+`surface` can hide the thing it names. In published text, name the tool schema, the error
+message, the help topic, or the config key.
+
+Cross-references take one form per target: `kaibo://config` for a resource, `docs/config.md`
+for the guide. Link instead of re-explaining.
+
+### Provide specific values
+
+Give the exit code, the size, the flag, the default, and the condition whenever it is
+practical. This saves a round trip and gives a model a clear observation to update on.
+
+> Before: An oversize attachment is refused.
+>
+> After: An attachment over 5 MB is refused from its metadata, before a byte is read.
+
+State the default and the condition too: "off by default", "applies to the `explorer` slot
+only", "`0` removes the tool entirely".
+
+### The example is the rule
+
+Show the correct example before explaining it, and make the example carry the rule by
+itself — a reader who sees only the example must still get it right.
+
+> Before: **Read whole files.** `cat -n FILE` numbers every line, which is what makes a
+> `file:line` citation exact.
+>
+> After: `cat -n src/auth.rs` — the whole file, numbered. Lead with line numbers so every
+> claim cites `file:line`.
+
+Avoid an incorrect example. When one is necessary, put the correct form first and mark the
+error next to it.
+
+### Terms
+
+The terms that carry a stable definition. **This table is the source.** It grows when a
+collision appears in real prose, not in advance.
+
+| Term | Part of speech | Meaning |
+|---|---|---|
+| backend | noun | A named connection to one provider: a wire protocol, a base URL, and a key source. Two backends may share a protocol. |
+| cast | noun | A model team. Maps each role to a `"backend/model-id"`, freely cross-backend. A call picks one with `cast`. |
+| slot | noun | One role within a cast — `explorer`, `synth`, `vision`, `image` — and the model bound to it. |
+| arm | noun | A resolved slot: a built client plus the request shape for that model. The one live construction point is `Arm::from_slot`. |
+| lane | noun | How a synth is driven: `interactive`, `batch` (a provider's offline queue), or `direct` (a big local model kaibo runs itself). |
+| phase | noun | One model, one preamble, one injected toolset, run as a bounded tool loop. `run_phase` is the primitive. |
+| survey | noun | One explorer investigation pass, ending in a cited report. `explore` runs one; `consult` delegates one. **The published name** — `sweep` is the same thing in code. |
+| sweep | noun | The internal name for a survey. Used in code, comments, and module names; never in published text. |
+| dossier | noun | The cited evidence an offline synth reasons over in `deliberate`, gathered by an explorer beforehand. |
+| family | noun | A model lineage from one vendor, as in "a model outside your own family". About forty uses, one sense. Use it; do not paraphrase it. |
+| allowed set | noun | The canonicalized trees a call's path must resolve into — `--root`, each `--allow-path`, and any followed worktree. The read boundary. |
+| published | adjective | Text kaibo sends to a model: a tool `description`, a schema param doc, a clap arg doc, a help topic, an error string. Everything else is internal. |
+
 
 ## Driving the models
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,8 +395,8 @@ collision appears in real prose, not in advance.
 | arm | noun | A resolved slot: a built client plus the request shape for that model. The one live construction point is `Arm::from_slot`. |
 | lane | noun | How a synth is driven: `interactive`, `batch` (a provider's offline queue), or `direct` (a big local model kaibo runs itself). |
 | phase | noun | One model, one preamble, one injected toolset, run as a bounded tool loop. `run_phase` is the primitive. |
-| survey | noun | One explorer investigation pass, ending in a cited report. `explore` runs one; `consult` delegates one. **The published name** — `sweep` is the same thing in code. |
-| sweep | noun | The internal name for a survey. Used in code, comments, and module names; never in published text. |
+| survey | noun | One explorer investigation pass, ending in a cited report. `explore` runs one; `consult` delegates one; `deliberate` builds a dossier from one. **The published name.** |
+| sweep | noun | The same thing in code — module names, identifiers, comments. Not published. Retiring from published prose, not yet finished; `docs/` is converted, the tool descriptions and CLI help are not. As a plain verb ("omit `backend` to sweep every configured backend") it is ordinary English and stays. |
 | dossier | noun | The cited evidence an offline synth reasons over in `deliberate`, gathered by an explorer beforehand. |
 | family | noun | A model lineage from one vendor, as in "a model outside your own family". About forty uses, one sense. Use it; do not paraphrase it. |
 | allowed set | noun | The canonicalized trees a call's path must resolve into — `--root`, each `--allow-path`, and any followed worktree. The read boundary. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,7 +396,7 @@ collision appears in real prose, not in advance.
 | lane | noun | How a synth is driven: `interactive`, `batch` (a provider's offline queue), or `direct` (a big local model kaibo runs itself). |
 | phase | noun | One model, one preamble, one injected toolset, run as a bounded tool loop. `run_phase` is the primitive. |
 | survey | noun | One explorer investigation pass, ending in a cited report. `explore` runs one; `consult` delegates one; `deliberate` builds a dossier from one. **The published name.** |
-| sweep | noun | The same thing in code — module names, identifiers, comments. Not published. Retiring from published prose, not yet finished; `docs/` is converted, the tool descriptions and CLI help are not. As a plain verb ("omit `backend` to sweep every configured backend") it is ordinary English and stays. |
+| sweep | noun | The same thing in code — module names, identifiers, comments. Not published. Retiring from published prose, not yet finished; `docs/` is converted, the preambles, tool descriptions, and CLI help are not. As a plain verb ("omit `backend` to sweep every configured backend") it is ordinary English and stays. |
 | dossier | noun | The cited evidence an offline synth reasons over in `deliberate`, gathered by an explorer beforehand. |
 | family | noun | A model lineage from one vendor, as in "a model outside your own family". About forty uses, one sense. Use it; do not paraphrase it. |
 | allowed set | noun | The canonicalized trees a call's path must resolve into — `--root`, each `--allow-path`, and any followed worktree. The read boundary. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ record. Each later release appends a new section at the top.
 
 ### Changed
 
+- **The docs call an explorer's investigation pass a `survey`**, matching what `explore`'s
+  own description has always said; `sweep` was a second word for the same thing.
 - **A tool this server does not serve now refuses in kaibo's words** — naming the flag, the
   cast shape it wants, or the absent job producer, plus the tools that are live. A
   misspelled name still reads as `tool not found`.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ two-model team you picked, from whatever family you like.
 
 From there kaibo runs its own agents. The **synth** is the synthesis agent: it owns
 the investigation, and it decides how to work. It reads spans through the read-only shell
-itself, and it can hand a broad sweep to the **explorer** — a cheaper, faster model that
+itself, and it can hand a broad survey to the **explorer** — a cheaper, faster model that
 searches the repo and reports back what it found. Delegating is a tool call, and it's the
 synth's call whether to make one. Then the synth checks what matters, fills the gaps, and
 writes the answer.
@@ -293,7 +293,7 @@ A **direct** cast has no handle to give — the job would be this process — so
 the long local completion in the foreground and prints the answer, saying on stderr
 that it is waiting. Either way kaibo keeps the dossier and names its digest; pass that
 back as `--dossier` to put the same evidence in front of a second cast with no explorer
-sweep at all, across front doors:
+survey at all, across front doors:
 
 ```sh
 kaibo deliberate "second opinion, same evidence" --cast fable --dossier kaibo://cas/<digest>
@@ -511,7 +511,7 @@ data path the model can't steer. See "Media CAS" in [`docs/config.md`](docs/conf
 
 ## Backends, Roles, and Casts
 
-Short version: a **cast** is just a named team — a cheap explorer that sweeps plus a
+Short version: a **cast** is just a named team — a cheap explorer that surveys plus a
 strong synth that answers — and a call picks its team with the `cast` argument.
 Everything below is how you wire your own.
 
@@ -527,7 +527,7 @@ config has three concepts for configuring models:
   Secrets never live in the TOML — only the *name* of an env var or the path to a key
   file. `openrouter` is a keyed gateway with a fixed endpoint — one key reaching every
   major model family, reasoning on by default via its unified `effort` param.
-- **role** — a *job* a model does: `explorer` (fast sweeps), `synth` (the voice that
+- **role** — a *job* a model does: `explorer` (fast surveys), `synth` (the voice that
   answers), and `image` (the media member behind `generate`). A reasoning slot that
   reads images carries a `vision` pin (see [`docs/casts.md`](docs/casts.md)).
 - **cast** — a *composition*: a named team assigning models to roles. The `cast` call
@@ -549,10 +549,10 @@ base_url = "http://localhost:8080/v1"
 key_optional = true
 
 # A cast that mixes model families — a different lineage per role, named as one team.
-# (kaibo calls this a "chimera": local Qwen does the sweeping, hosted GPT writes
+# (kaibo calls this a "chimera": local Qwen does the surveying, hosted GPT writes
 # the answer. Two families, not two flavors of one.)
 [casts.mixed]
-explorer = "llama/qwen2.5-coder-7b"       # cheap, local sweeps — Qwen family
+explorer = "llama/qwen2.5-coder-7b"       # cheap, local surveys — Qwen family
 synth    = { backend = "gpt", id = "gpt-5.6-sol", vision = true, effort = "high" }
 ```
 
@@ -649,7 +649,7 @@ note kaibo asks OpenRouter for no-collection routing by default
 
 **How long does a consult take?** It's a multi-step investigation, not a single API
 call — a deep one can run a few minutes, more with thinking on and a large repo to
-sweep. kaibo emits MCP progress notifications as the explorer and synth work, so a
+survey. kaibo emits MCP progress notifications as the explorer and synth work, so a
 client that surfaces them shows live progress; whether you actually see those beats is
 up to your agent's UI, which kaibo can't control. If you'd rather not block on it,
 `consult_submit` starts the same investigation in the background and `job_get` picks
@@ -703,7 +703,7 @@ without thinking about it; a frontier Anthropic or OpenAI cast adds up a good de
 faster, especially with thinking on. Check your provider's current rates — they move,
 and kaibo won't guess at them for you. What kaibo does do is spend as little as the
 work allows: a family-mixing cast (cheap local explorer + hosted synth) keeps the
-broad, token-heavy sweeping off the expensive model and pays it only for the answer,
+broad, token-heavy surveying off the expensive model and pays it only for the answer,
 and the agent conversations are set up to cache well on most providers. For the
 strongest models, `batch_submit` rides the provider's discounted batch lane.
 

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -14,7 +14,7 @@ floor up. Two symptoms surfaced it:
 
 1. **A profile is one `kind`, so a team is locked to one family.** Roles bind to
    a profile, and a profile is a single connection — so a *chimera* (a deepseek
-   explorer feeding a claude synth: cheap local sweeps, a hosted answer) had no
+   explorer feeding a claude synth: cheap local surveys, a hosted answer) had no
    spelling at all. One composed team, two families, one name — the fused profile
    can't say it.
 2. **The vocabulary confused its only user.** "Profile" meant *connection* in
@@ -69,7 +69,7 @@ api_key_env = "OPENAI_API_KEY"
 # --- casts: role → "backend/model". `cast = "chimera"` selects the whole thing. ---
 
 [casts.chimera]
-explorer = "deepseek/deepseek-v4-flash"     # cheap fast sweeps — local/cheap family
+explorer = "deepseek/deepseek-v4-flash"     # cheap fast surveys — local/cheap family
 synth    = "claude/claude-sonnet-4-6"       # the voice that answers — hosted family
 
 [casts.local-only]                          # privacy posture: nothing leaves the box
@@ -130,16 +130,16 @@ tier looks tempting — two considerations before pinning one:
 
 - **Confabulation risk is why we usually want smarter models.** Under a
   restricted toolset a small or flash-tier model may confabulate — calling a
-  tool that is not in its set, for example — and a sweep re-run without
+  tool that is not in its set, for example — and a survey re-run without
   corrective feedback tends to repeat the confabulation. Thinking depth is not
   the lever here: kaibo already enables thinking at high effort by default on
   every wire that supports it, so the reliable lever is model capability.
-  Prefer a pro-tier explorer for a long sweep that must complete (a
-  `deliberate` dossier build); a flash tier fits interactive sweeps, where the
+  Prefer a pro-tier explorer for a long survey that must complete (a
+  `deliberate` dossier build); a flash tier fits interactive surveys, where the
   consult driver absorbs a failed delegation and answers from its own reads.
 - **Match the explorer to its provider's rate ceiling, not its synth's
-  family.** A sweep with whole-file attachments can request 100k+ tokens per
-  minute; against a tight org TPM ceiling the sweep rate-limits, and a retry
+  family.** A survey with whole-file attachments can request 100k+ tokens per
+  minute; against a tight org TPM ceiling the survey rate-limits, and a retry
   self-starves the next window. The per-call `explorer_backend` /
   `explorer_model` overrides pair any synth with an explorer on a roomier
   provider — family-match buys the synth's answer nothing, and that freedom is
@@ -163,7 +163,7 @@ server.rs: resolve_cast("chimera")
 
 consult(question, root, arms, cfg, session)
 └─ run_phase(synth_arm): loop over {run_kaish, explore′, view_image…}
-     └─ explore′ delegates each sweep to run_phase(explorer_arm)
+     └─ explore′ delegates each survey to run_phase(explorer_arm)
         — different client, different wire protocol, same loop primitive
 ```
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -111,8 +111,8 @@ generate       = true      # ...and needs a cast with an `image` slot AND [cas] 
 # overridden per slot (table form, below); request_timeout_secs per backend.
 # ---------------------------------------------------------------------------
 [defaults]
-explorer_max_turns = 100     # bounds each cheap explore′ sweep — set here only, no per-call arg
-synth_max_turns    = 200     # bounds the consult driver loop (sweeps AND span reads)
+explorer_max_turns = 100     # bounds each cheap explore′ survey — set here only, no per-call arg
+synth_max_turns    = 200     # bounds the consult driver loop (surveys AND span reads)
 max_tokens         = 16384   # output headroom; MUST sit well above thinking_budget
 thinking_budget    = 8192    # reasoning budget where the provider exposes a toggle
 
@@ -190,8 +190,8 @@ job_capacity     = 64        # max async-consult jobs held in memory, running pl
 # never dropped. 0 inlines nothing — the escape hatch for a small-context local cast.
 inline_attach_budget = 262144   # 256 KiB
 
-# Files ONE explorer sweep may route with its attach tool (the bytes ride alongside
-# the sweep's report, never through the explorer's context). 0 disables the tool.
+# Files ONE explorer survey may route with its attach tool (the bytes ride alongside
+# the survey's report, never through the explorer's context). 0 disables the tool.
 max_attachments = 32
 
 # ---------------------------------------------------------------------------
@@ -574,7 +574,7 @@ api_key_cmd = ["op", "read", "op://Vault/Kaibo/Deepseek-key"]
 #     `local-only` below) — that single lineage already augments your own agent's. ---
 
 [casts.chimera]
-explorer = "deepseek/deepseek-v4-flash"     # cheap fast sweeps — DeepSeek family
+explorer = "deepseek/deepseek-v4-flash"     # cheap fast surveys — DeepSeek family
 synth    = "claude/claude-sonnet-4-6"       # the voice that answers — Claude family
 
 # --- Privacy posture: nothing leaves the box. `gemma` is the built-in alias for
@@ -763,7 +763,7 @@ synth    = "gemini/gemini-pro-latest"        # batch-capable synth; Pro is more 
 # kaibo-facing shape is identical to the others. It needs the HOSTED backend: the Batch API
 # is OpenAI Platform's, so `lane = "batch"` on a local OpenAI-compatible server is a load
 # error naming the fix. Pairing an interactive explorer with the offline synth is what makes
-# a cast `deliberate`-capable — Luna sweeps the repo live and builds the cited dossier, Sol
+# a cast `deliberate`-capable — Luna surveys the repo live and builds the cited dossier, Sol
 # reasons over it offline at max effort.
 [casts.gpt-batch]
 synth    = { backend = "gpt", id = "gpt-5.6-sol", lane = "batch" }
@@ -848,7 +848,7 @@ synth    = { backend = "gemma", id = "Big-Local-70B-GGUF", lane = "direct" }
 # (a calling agent can't inject a prompt). An empty value is a loud load error.
 # Precedence per phase: slot `preamble` (per-model, above) > [prompts].<phase> >
 # built-in. The synth slot feeds both `consult` and `oneshot`, but each keeps
-# its own key, so they can diverge. Phases: `explorer` (the nested explore′ sweep),
+# its own key, so they can diverge. Phases: `explorer` (the nested explore′ survey),
 # `consult` (the driver), `oneshot` (the thin toolless answer), `batch` (the offline
 # max-thinking answer).
 # ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -282,7 +282,7 @@ A role table. Each slot takes one of two forms:
 
 ```toml
 [casts.chimera]
-explorer = "deepseek/deepseek-v4-flash"     # cheap fast sweeps
+explorer = "deepseek/deepseek-v4-flash"     # cheap fast surveys
 synth    = "claude/claude-sonnet-4-6"       # the model that answers
 
 # table form: id + capability pins + per-slot tunables
@@ -503,11 +503,11 @@ Inlined bytes ride every turn of the driver loop, so this bounds resident prompt
 not just one request. The toolless tools (`oneshot`, `batch_submit`) are unaffected;
 with no shell to fall back on, they keep their own per-file and per-call caps.
 
-**`max_attachments`.** Cap on how many files one explorer sweep may route with its
-`attach` tool. The routed bytes ride alongside the sweep's report to whoever reads it —
+**`max_attachments`.** Cap on how many files one explorer survey may route with its
+`attach` tool. The routed bytes ride alongside the survey's report to whoever reads it —
 the `consult` driver, or `deliberate`'s offline synth — without entering the explorer's
 own context. Distinct from `inline_attach_budget`, which bounds inlining the *caller's*
-attachments into the driver prompt: this bounds a sweep's own routing, and it is a
+attachments into the driver prompt: this bounds a survey's own routing, and it is a
 behavioral guard rather than a memory one (the per-file and cumulative byte caps in
 `attach.rs` bound the worst case). `0` disables the tool. Also settable via
 `KAIBO_MAX_ATTACHMENTS` and `--max-attachments`.
@@ -617,7 +617,7 @@ base_url = "http://localhost:8080/v1"
 key_optional = true
 
 [casts.mixed]
-explorer = "llama/qwen2.5-coder-7b"     # sweeps stay local and free
+explorer = "llama/qwen2.5-coder-7b"     # surveys stay local and free
 synth    = { backend = "gpt", id = "gpt-5.6-sol", vision = true, effort = "high" }
 ```
 
@@ -960,7 +960,7 @@ kaibo emits six instruments, all histograms, all named by the conventions:
 | `gen_ai.execute_tool.duration` | How long one `run_kaish` / `explore′` / `view_image` took |
 
 The agent metrics carry `gen_ai.agent.name` — `synth` or `explorer` — and that label is
-what makes them worth reading. A delegated sweep is its own invocation, so its twenty
+what makes them worth reading. A delegated survey is its own invocation, so its twenty
 turns are counted against `explorer`, and the driver's `tool_calls` counts only the
 delegation it made. Reading `gen_ai.invoke_agent.tool_calls` for `synth` therefore
 answers the delegation question directly, where before it took trace archaeology.
@@ -1065,7 +1065,7 @@ artifact-producing tool writes into. Three produce today:
 
 `deliberate` needs no key of its own — kaibo writes the dossier, not a model. Each
 deliberation names its dossier's `kaibo://cas/<digest>`; pass that digest back as the
-`dossier` argument to run a second synth over the same evidence with no explorer sweep.
+`dossier` argument to run a second synth over the same evidence with no explorer survey.
 Size the store for dossiers: they are the bulkiest objects most installs hold, and they
 accumulate on every deliberation. A refused write (a full `max_bytes`, an I/O error) is
 logged and the deliberation proceeds — you lose the record, never the answer.
@@ -1264,7 +1264,7 @@ digest and nothing else: it never reports whether the content was already in the
 because that answer would let one project's model team probe another's artifacts. Refusals
 are sanitized for the same reason — the model is told what to do next, never the store's
 path or how full it is. Only the `consult` driver loop gets the tool; delegated explorer
-sweeps never do.
+surveys never do.
 
 **Where the digests are written down.** The answer's footer names every artifact this call
 saved, with its mime, size, label, and (in disk mode) its path. A consult that saved and
@@ -1331,7 +1331,7 @@ This is the distinction from `[server] allow_paths` below. `allow_paths` widens 
 *model* can explore; `[context]` injects fixed operator text the model never navigates to.
 
 **Where it lands.** Every codebase-reading phase: the `consult` driver and its nested
-`explore′` sweep, standalone `explore`, and `deliberate`'s dossier explorer. The cheap
+`explore′` survey, standalone `explore`, and `deliberate`'s dossier explorer. The cheap
 explorer therefore orients on the same guidance while it searches, not only at answer
 time. The toolless `oneshot` and the offline batch synth read no project and get none.
 
@@ -1357,7 +1357,7 @@ Prefer architectural answers; name the file:line that carries each claim.
 
 | key | replaces | runs in |
 |---|---|---|
-| `explorer` | `report_preamble` | the nested `explore′` sweep inside `consult` |
+| `explorer` | `report_preamble` | the nested `explore′` survey inside `consult` |
 | `consult` | `consult_preamble` | the `consult` driver |
 | `oneshot` | `oneshot_preamble` | the thin, toolless `oneshot` |
 | `batch` | `batch_preamble` | the offline, max-thinking `batch_submit` |
@@ -1459,7 +1459,7 @@ directory. Names are traded for structure, and the model recovers them with `glo
 `full_list_max_files = 0` is a load error, since it would refuse every repo; disable the
 block instead. `tree_max_depth = 0` is a load error, since it would render an empty map.
 
-**Scope.** The exploring phases: the `consult` driver and its nested `explore′` sweep,
+**Scope.** The exploring phases: the `consult` driver and its nested `explore′` survey,
 standalone `explore`, and `deliberate`'s dossier explorer. The toolless `oneshot` reads no
 project and gets no map. Like `[context]`, the block re-sends each turn, which the size
 gate keeps bounded. Whether it erases discovery

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -10,7 +10,7 @@ The branch is `rate-limits`; the worktree is `~/src/wt/kaibo-rate-limits`.
   200000` on three attached files, kaibo neither backed off nor retried, and the
   whole investigation was lost before the synth ran.
 - kaibo sends bursts by construction: rig runs a turn's tool calls with
-  `buffer_unordered`, and a consult can fan out sweeps.
+  `buffer_unordered`, and a consult can fan out surveys.
 - Non-goal, stated so nobody reaches for this plan to fix it: the 2026-08 OpenAI
   batch `validating` failure ("Cannot find file …") is provider-side, reproduced
   with plain curl and reported by many others since 2026-08-19. Retry at kaibo's

--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -37,7 +37,7 @@ Battery E). The probes are the *empirical* check on top of the *structural* guar
 
 `run_kaish` drives the read-only kaish kernel **directly** — no model, so **zero
 classifier exposure** — and it is the *exact* `KaishWorker`/VFS that `consult` (its
-driver and nested `explore′` sweep) injects. Hammering it directly therefore covers the
+driver and nested `explore′` survey) injects. Hammering it directly therefore covers the
 model-driven tools too: a model can only emit kaish, which hits the same walls.
 (`oneshot` reads no project — it has no shell at all.)
 


### PR DESCRIPTION
Two things, and the first explains the second.

## The style pointer has been dead since 2026-08-18

AGENTS.md said: *"kaibo adopts kaish's `docs/style.md` — that guide names kaibo as an adopter… Read it before you write help text or operator docs."*

Both halves are false. kaish deleted that file in `e22b0be3` ("rearrange files and remove docs/style.md") and folded its content into its own AGENTS.md § "Writing style", which no longer mentions kaibo. So for three weeks every reader told to go read it — a fresh session, a subagent with no kaish checkout, a person — has found nothing. Amy asked whether we'd ever absorbed it, after noticing #183's config prose read "very Claude-compact". This is very plausibly why.

Absorbed into AGENTS.md directly rather than a new `docs/style.md` (Amy's call): one file, always loaded, nothing to fetch. It costs resident context and the trade is deliberate.

**Only what kaibo didn't already have.** "Fast and informative failures" is covered by our error-strings paragraph, "Write for model context" by the three-audiences block, and kaish's "Published builtin text" is clap/ParamSchema-specific — we have our own published/internal rule. New:

- **Vocabulary choices** — small vocabulary, plain words over figures of speech, American spelling. Framed on the reason that actually binds here: our synths are mostly not English-first.
- **One term, one meaning** — including the rule for a term that differs between published and internal text.
- **Provide specific values** — the exit code, the size, the default, the condition.
- **The example is the rule** — show the correct example first; make it carry the rule alone.
- **A Terms table**, seeded with twelve kaibo terms that carry a guarantee: `backend`, `cast`, `slot`, `arm`, `lane`, `phase`, `survey`, `sweep`, `dossier`, `family`, `allowed set`, `published`. It grows when a collision appears in real prose, not in advance — shaped to receive later analysis rather than to be complete now.

Two deduplications, because one term, one meaning applies to the guide itself: the `family` ruling restated what the table now defines, and the three-audiences block argued the non-English-first case in full — it now points at Vocabulary choices, where that argument lives once.

## `sweep` and `survey` were two words for one thing

`explore`'s tool description and CLI help say **survey**. The operator docs said **sweep**, 26 times, never defined. A calling agent reads the first and an operator reads the second, so the split was invisible from either seat.

`survey` wins in published text because it is already resident — it is in the front-door `explore` description every calling agent pays for each session. `sweep` stays the internal name in code (~450 uses, its own module). Converted 26 sites across `README.md`, `config.example.toml`, `config.md`, `casts.md`, `rate-limits.md`, `sandbox-probes.md`.

**The verb sense is deliberately untouched**, which is why this was done by hand rather than with `sed`. "Omit `backend` to sweep every configured backend" is ordinary English for iterating over all of something, not kaibo's noun — three sites keep it.

**Not converted:** ~25 occurrences in tool descriptions and clap doc comments in `server.rs`/`cli.rs`. They sit under the 2048-character resident budget and are the text the coming prompt work will most likely rewrite, so renaming them now would collide for no benefit. The Terms table states that the retirement is in progress rather than implying it's finished.

Suite: **1341 passed, 0 failed**.

Overlaps #183 in `docs/config.example.toml` and `docs/config.md` — both sides now say `survey`, so the conflict is trivial whichever merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)