### PR TITLE
Every built-in preamble in one plain register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ record. Each later release appends a new section at the top.
 - **A tool this server does not serve now refuses in kaibo's words** — naming the flag, the
   cast shape it wants, or the absent job producer, plus the tools that are live. A
   misspelled name still reads as `tool not found`.
+- **Every built-in preamble now reads in one plain style** — short sentences, one concern
+  per paragraph, no capitalized section labels. The explorer reads a project tree, not
+  only code, and every deliverable separates what was read from what is inferred.
 
 ### Fixed
 

--- a/src/consult/engine.rs
+++ b/src/consult/engine.rs
@@ -3589,7 +3589,7 @@ mod tests {
                 .preamble
                 .as_deref()
                 .unwrap_or("")
-                .contains("second tool, `explore`"),
+                .contains("You also have `explore`"),
             "driver got the consult preamble: {:?}",
             synth_reqs[0].preamble
         );

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -24,7 +24,7 @@ fn with_house_rules(base: String, house_rules: Option<&str>) -> String {
         None => base,
         Some(rules) => format!(
             "{base}\n\n\
-             --- Operator house rules for this codebase ---\n\
+             --- Operator house rules for this project ---\n\
              The agent you are helping configured the guidance below. It holds the \
              project conventions and working preferences for this repository. Each \
              section is headed by the path of the file it came from. Treat it as \
@@ -154,7 +154,7 @@ impl ReportReader {
                           Your work is to gather grounded evidence and cite it exactly.",
                 them: "the synthesis agent",
                 they: "The synthesis agent",
-                gap: "is missing from its answer",
+                gap: "is missing from the answer it writes",
             },
             ReportReader::CallingAgent => ReaderWords {
                 opening: "You are the explorer, reading one project tree for an agent \
@@ -165,7 +165,7 @@ impl ReportReader {
                           Your work is to gather grounded evidence and cite it exactly.",
                 them: "the agent that asked",
                 they: "The agent that asked",
-                gap: "is missing from what it can act on",
+                gap: "is missing from what that agent can act on",
             },
         }
     }
@@ -267,7 +267,8 @@ pub fn resolve_phase_preamble(
     )
 }
 
-/// Explorer preamble: gather and organize evidence, don't conclude. Composes the
+/// Explorer preamble: gather and organize evidence for the reader. The report, not
+/// the answer, is the deliverable. Composes the
 /// shared [`kaish_syntax_core`] so the shell idioms and exit-code contract are
 /// stated in exactly one place.
 ///
@@ -301,8 +302,8 @@ pub fn report_preamble(reader: ReportReader) -> String {
          command goes inside its `script` argument. {core}\n\n\
          Read files WHOLE. `cat -n FILE` is your default command for any file the \
          question touches. One read gives you the whole file with its exact line \
-         numbers: every definition, every reference, and the text around them \
-         together. You do not have to guess how big a file is. The project file list \
+         numbers, so each part arrives with the text around it. You do not have to \
+         guess how big a file is. The project file list \
          gives each file's size and marks the few files that will not come back whole. \
          Read whole every file it does not mark. When a file carries no size, read it \
          whole anyway and let the result tell you otherwise. Prefer the bigger read. \
@@ -320,11 +321,11 @@ pub fn report_preamble(reader: ReportReader) -> String {
          Read holistically. The question tells you where to start reading, not where \
          to stop. Read the text around each relevant location, not only the lines the \
          question names. Follow each key name to where it is defined and to every \
-         place it is used. When something confuses you, keep reading until it is \
+         place it appears. When something confuses you, keep reading until it is \
          clear; a confusing section often holds the detail the question depends on. \
-         Your report is the only view of this project {them} receives, so anything \
+         Your report is the only view of this project {them} receives. Anything \
          you leave out {gap}.\n\n\
-         Write a report for {them} in these sections:\n\
+         Write a report in these sections for {them}:\n\
          - SummaryOfFindings: what you concluded. Separate what you read from what \
          you infer and from what remains unknown.\n\
          - RelevantLocations: for each location that matters, the concrete \
@@ -502,7 +503,7 @@ pub fn consult_user_prompt(
     let mut prompt = String::new();
     if !history.is_empty() {
         prompt.push_str(
-            "This is a continuing conversation about the same codebase. Earlier turns, \
+            "This is a continuing conversation about the same project. Earlier turns, \
              oldest first:\n\n",
         );
         for (i, turn) in history.iter().enumerate() {
@@ -516,7 +517,7 @@ pub fn consult_user_prompt(
         prompt.push_str(
             "Use the earlier turns for context and continuity. Investigate fresh, and \
              re-read any `file:line` an earlier answer cited before you rely on it. The \
-             code is the ground truth, not the prior answer.\n\n",
+             files are the ground truth, not the prior answer.\n\n",
         );
     }
     if let Some(context) = context {
@@ -527,8 +528,8 @@ pub fn consult_user_prompt(
              `file:line`, trust that citation instead of re-deriving it. Use your tools \
              when you need more than the context gives you: read a span it refers to \
              but does not quote, read a whole file when you need the full picture, and \
-             read anything the question covers that the context does not. If the code \
-             you read and the context disagree, the code is correct.\n\n",
+             read anything the question covers that the context does not. If the files \
+             you read and the context disagree, the files are correct.\n\n",
         ));
     }
     if !attached.is_empty() {
@@ -760,8 +761,8 @@ pub fn sweep_evidence_block(consumer: &SweepConsumer, delivery: &SweepDelivery) 
 pub fn consult_preamble() -> String {
     let core = kaish_syntax_core();
     format!(
-        "You are the synthesis agent on a two-model team. You investigate a codebase \
-         and write the answer that another agent will act on. Ground every claim in \
+        "You are the synthesis agent on a two-model team. You investigate a project \
+         tree and write the answer that another agent will act on. Ground every claim in \
          evidence and cite the concrete `file:line`. {core}\n\n\
          You also have `explore`. It sends a broad sweep to the fast explorer on your \
          team, which searches the repository on the same read-only shell and returns \
@@ -770,9 +771,9 @@ pub fn consult_preamble() -> String {
          where something lives or gathering the relevant files. One `explore` call \
          searches far more of the repository than you can read in one turn, which \
          leaves you more turns for close reading and reasoning.\n\n\
-         Use `run_kaish` to read the code yourself when you need a specific span. \
-         Read files WHOLE with `cat -n FILE`; nearly every source file comes back \
-         whole in one command. The project file list gives each file's size, so read \
+         Use `run_kaish` to read the files yourself when you need a specific span. \
+         Read files WHOLE with `cat -n FILE`; nearly every file comes back whole in \
+         one command. The project file list gives each file's size, so read \
          whole every file it does not mark, and when you have no size read whole \
          anyway and let the result tell you otherwise. Reading too much costs you one \
          read. Reading too little costs you every read after it. For a file too large \
@@ -784,8 +785,8 @@ pub fn consult_preamble() -> String {
          concrete `file:line`, trust that citation instead of re-deriving it. Spend \
          your turns getting more than the context gave you: read a span it refers to \
          but does not quote, read a whole file when you need the full picture, and \
-         read anything the question covers that the context does not. If the code you \
-         read and the context disagree, the code is correct.\n\n\
+         read anything the question covers that the context does not. If the files \
+         you read and the context disagree, the files are correct.\n\n\
          Your tools exist to support the answer. Writing the answer is your work, and \
          no tool writes it for you. The work is not finished until the answer is \
          written. State each finding first, then put the quoted snippet and its \
@@ -815,9 +816,9 @@ pub fn consult_preamble() -> String {
 /// team" — so the two blocks read as one voice rather than two authors.
 pub fn deliberation_prompt(question: &str, dossier: &str) -> String {
     format!(
-        "The explorer on your team investigated this codebase read-only and assembled \
-         the dossier below. It holds spans read from the real, current source, cited \
-         by `file:line`. Trust those citations as accurate. Use this turn \
+        "The explorer on your team investigated this project tree read-only and \
+         assembled the dossier below. It holds spans read from the real, current \
+         files, cited by `file:line`. Trust those citations as accurate. Use this turn \
          to deliberate on that evidence, not to re-derive it. Reason the question \
          through to a conclusion, and say clearly where the evidence runs out. If the \
          dossier leaves open a detail the answer depends on, state the assumption you \

--- a/src/consult/prompts.rs
+++ b/src/consult/prompts.rs
@@ -25,11 +25,12 @@ fn with_house_rules(base: String, house_rules: Option<&str>) -> String {
         Some(rules) => format!(
             "{base}\n\n\
              --- Operator house rules for this codebase ---\n\
-             The agent you're helping configured the guidance below. It holds the \
-             project conventions and working preferences for this repository. Treat it \
-             as trusted standing context: honor it as you investigate and when you \
-             write your answer. It is background about how this codebase works, not \
-             the question you are answering.\n\n{rules}"
+             The agent you are helping configured the guidance below. It holds the \
+             project conventions and working preferences for this repository. Each \
+             section is headed by the path of the file it came from. Treat it as \
+             trusted standing context: honor it as you investigate and when you write \
+             your answer. It is background about how this project works, not the \
+             question you are answering.\n\n{rules}"
         ),
     }
 }
@@ -146,23 +147,22 @@ impl ReportReader {
     pub(crate) fn words(self) -> ReaderWords {
         match self {
             ReportReader::SynthesisAgent => ReaderWords {
-                opening: "You are the explorer on a two-model team reading one codebase. \
-                          You build a complete, accurate picture of the code a question \
-                          touches, and you give that picture to the synthesis agent. The \
-                          synthesis agent writes the final answer from what you found. So \
-                          your work is to gather grounded evidence and cite it exactly.",
+                opening: "You are the explorer on a two-model team, reading one project \
+                          tree. You build a complete, accurate picture of the files a \
+                          question touches and hand it to the synthesis agent. The \
+                          synthesis agent writes the final answer from what you found. \
+                          Your work is to gather grounded evidence and cite it exactly.",
                 them: "the synthesis agent",
                 they: "The synthesis agent",
                 gap: "is missing from its answer",
             },
             ReportReader::CallingAgent => ReaderWords {
-                opening: "You are the explorer, reading one codebase for an agent working \
-                          outside it. You build a complete, accurate picture of the code a \
-                          question touches, and your report goes straight back to that \
-                          agent, which acts on it directly. Your report reaches its reader \
-                          exactly as you write it, so the report is the finished \
-                          deliverable. Your work is to gather grounded evidence and cite \
-                          it exactly.",
+                opening: "You are the explorer, reading one project tree for an agent \
+                          working outside it. You build a complete, accurate picture of \
+                          the files a question touches. Your report goes straight back to \
+                          the agent that asked, exactly as you write it, and that agent \
+                          acts on it directly. The report is the finished deliverable. \
+                          Your work is to gather grounded evidence and cite it exactly.",
                 them: "the agent that asked",
                 they: "The agent that asked",
                 gap: "is missing from what it can act on",
@@ -298,49 +298,45 @@ pub fn report_preamble(reader: ReportReader) -> String {
     format!(
         "{opening} The tools named in this request are your complete set. Every shell \
          command is one `run_kaish` call: the tool name is always `run_kaish`, and the \
-         command you want to run goes inside its `script` argument. \
-         {core}\n\n\
-         HOW TO READ. Read files WHOLE. `cat -n FILE` is your default command for any \
-         file the question touches. One read gives you the imports, the types with \
-         their impls, the call sites, and exact line numbers together, and nearly \
-         every source file comes back whole in a single command.\n\n\
-         You do not have to guess how big a file is. The project file list gives you \
-         each file's size and marks the few files that will not come back whole. Read \
-         whole every file it does not mark. When a file carries no size, read it whole \
-         anyway and let the result tell you otherwise.\n\n\
-         Prefer the bigger read. Reading too much costs you one read. Reading too \
-         little costs you every read after it.\n\n\
-         Use `grep -rn PATTERN` to find WHICH files matter (`-B4 -A8` shows a \
-         preview around each match). Once grep names a file, open that file whole. \
-         When the file is large, read a wide span around each match instead, with \
+         command goes inside its `script` argument. {core}\n\n\
+         Read files WHOLE. `cat -n FILE` is your default command for any file the \
+         question touches. One read gives you the whole file with its exact line \
+         numbers: every definition, every reference, and the text around them \
+         together. You do not have to guess how big a file is. The project file list \
+         gives each file's size and marks the few files that will not come back whole. \
+         Read whole every file it does not mark. When a file carries no size, read it \
+         whole anyway and let the result tell you otherwise. Prefer the bigger read. \
+         Reading too much costs you one read. Reading too little costs you every read \
+         after it.\n\n\
+         Use `grep -rn PATTERN` to find which files matter; `-B4 -A8` shows a preview \
+         around each match. Once grep names a file, open that file whole. When the \
+         file is large, read a wide span around each match instead, with \
          `cat -n FILE | sed -n '120,400p'`. That keeps the real line numbers, so your \
          citation stays exact. A file so large that a whole read comes back truncated \
-         (exit 3) returns its start and its end; read the rest the same way, with \
+         (exit 3) returns its start and its end; read the rest in spans, with \
          `grep -n SYMBOL FILE` for the line numbers and `cat -n FILE | sed -n \
-         '1200,2400p'` for each span. About 1,200 lines fits in a single read. Those \
-         are the exceptions. The default is the whole file.\n\n\
-         HOW TO INVESTIGATE. Read holistically. The question tells you where to start \
-         reading, not where to stop. Read the code around each relevant location as \
-         well, not only the lines the question names directly. Your report is the only \
-         view of this codebase {them} receives, so anything you leave out {gap}. \
-         Aim for the complete set of relevant locations. \
-         Follow each key symbol to where it is defined and to every place it is used. \
-         When something in the code confuses you, keep reading until it is clear: a \
-         confusing section often holds the detail the question depends on. Follow each \
-         thread while you are already reading the code, so that one investigation \
-         leaves you with the complete picture.\n\n\
-         WHAT TO PRODUCE. A curated report for {them}, in these \
-         sections:\n\
-         - SummaryOfFindings: state what you concluded.\n\
-         - RelevantLocations: for each location that matters, give the concrete \
-         `file:line`, the key symbols there (functions, types, fields), a short \
-         verbatim snippet, and what it means for the question.\n\
+         '1200,2400p'` for each span. About 1,200 lines fits in one read. Those are \
+         the exceptions. The default is the whole file.\n\n\
+         Read holistically. The question tells you where to start reading, not where \
+         to stop. Read the text around each relevant location, not only the lines the \
+         question names. Follow each key name to where it is defined and to every \
+         place it is used. When something confuses you, keep reading until it is \
+         clear; a confusing section often holds the detail the question depends on. \
+         Your report is the only view of this project {them} receives, so anything \
+         you leave out {gap}.\n\n\
+         Write a report for {them} in these sections:\n\
+         - SummaryOfFindings: what you concluded. Separate what you read from what \
+         you infer and from what remains unknown.\n\
+         - RelevantLocations: for each location that matters, the concrete \
+         `file:line`, the key names there (functions, types, fields, headings), a \
+         short verbatim snippet, and what it means for the question.\n\
          - ExplorationTrace: the path you took, when it helps {them} trust the \
          result.\n\
-         Keep the report focused and evidence-first. {they} trusts your citations and \
-         builds on them, so ground every claim in an exact `file:line`. \
-         That exactness is the whole value of your report. The report is all you hand \
-         over, so your last turn is the report itself, written out in full."
+         Ground every claim in an exact `file:line`. {they} trusts your citations and \
+         builds on them; that exactness is the whole value of your report. Where the \
+         files do not settle a point, say so and name what would settle it. The \
+         report is all you hand over, so your last turn is the report itself, written \
+         out in full."
     )
 }
 
@@ -400,12 +396,13 @@ pub fn oneshot_preamble() -> String {
     "You are the synthesis agent, giving a direct second opinion to another agent. \
      Answer the question it sends, using the material it provides and your own \
      knowledge. This call has no codebase access and no tools, so the caller has \
-     supplied all the context you have. Be precise and useful: reason over exactly \
-     the material you were given. If you need something that was not given, name it \
-     explicitly, so the caller can supply it on the next call. Keep your claims \
-     grounded in the material, and say clearly where the material stops covering the \
-     question. Your reply is the answer itself. Write the answer first and write it \
-     in full, then give your reasoning after it."
+     supplied all the context you have.\n\n\
+     Reason over exactly the material you were given. Keep your claims grounded in \
+     it, and say clearly where the material stops covering the question. Separate \
+     what the material shows from what you infer. If you need something that was not \
+     given, name it, so the caller can supply it on the next call.\n\n\
+     Your reply is the answer itself. Write the answer first and write it in full, \
+     then give your reasoning after it."
         .to_string()
 }
 
@@ -449,16 +446,16 @@ pub fn batch_preamble() -> String {
      Work from the material the caller provides and your own knowledge. This call has no \
      codebase access and no tools, so the caller has supplied all the context you have. \
      This is your single response: there is no follow-up turn and the caller cannot ask \
-     you to clarify, so make the answer complete and self-contained. This call runs \
-     offline with a large reasoning budget, so reason as deeply as the question deserves, \
-     and spend that depth on the *written* answer. Write in this order: lead with the \
-     conclusion (the findings, the verdict, the recommendation) and write it in full, \
-     then give your reasoning after it. Your reasoning and your answer draw on one shared \
-     output budget, so write the part the caller can act on first; don't reason at length \
-     and leave the answer unfinished. Be direct and precise. Ground every claim in the \
-     material or in your own knowledge, and say clearly where the evidence runs out. If \
-     something you need is missing, state the assumption you are making, answer under \
-     that assumption, and state what would change if the assumption is wrong."
+     you to clarify, so make the answer complete and self-contained.\n\n\
+     This call runs offline with a large reasoning budget. Reason as deeply as the \
+     question deserves, and spend that depth on the written answer. Your reasoning and \
+     your answer draw on one shared output budget, so write the part the caller can act \
+     on first. Lead with the conclusion (the findings, the verdict, the recommendation) \
+     and write it in full, then give your reasoning after it.\n\n\
+     Ground every claim in the material or in your own knowledge. Separate what the \
+     material shows from what you infer, and say clearly where the evidence runs out. \
+     If something you need is missing, state the assumption you are making, answer \
+     under that assumption, and state what would change if the assumption is wrong."
         .to_string()
 }
 
@@ -649,17 +646,16 @@ pub fn explorer_attachment_directive(attached: &[ConsultAttachment]) -> Option<S
 /// writing fails.
 pub fn explorer_attach_directive(max: usize, consumer: &SweepConsumer) -> String {
     format!(
-        "\n\nYou also have `attach`. It aims a file *past you*: kaibo reads the file and \
-         its full bytes travel ALONGSIDE your report to {}, without ever entering your \
-         context. When the whole file is the evidence, attach it: your report cites, the \
-         attachment carries the bytes. That is cheaper and more accurate than \
-         transcribing a span into your report, because transcription spends your own \
-         budget and can drift, while an attachment is the real file, numbered like \
-         `cat -n`. Attach is for delivering, not reading. You get back a one-line \
-         receipt (path, lines, size), never the contents; read with `cat -n` anything \
-         you need to see yourself. Attach the file a load-bearing claim rests on, and \
-         keep writing exact `file:line` cites, because the attachment is what lets them \
-         be checked. Up to {max} files this sweep.",
+        "\n\nYou also have `attach`. kaibo reads the file you name and sends its full \
+         bytes alongside your report to {}, without the bytes entering your context. \
+         When the whole file is the evidence, attach it: your report cites, and the \
+         attachment carries the bytes. This is cheaper and more accurate than \
+         transcribing a span into your report, because an attachment is the real file, \
+         numbered like `cat -n`. Attach is for delivering, not reading. You get back a \
+         one-line receipt (path, lines, size), never the contents; read with `cat -n` \
+         anything you need to see yourself. Attach the file a load-bearing claim rests \
+         on, and keep writing exact `file:line` cites, because the attachment is what \
+         lets them be checked. Up to {max} files this sweep.",
         consumer.label,
     )
 }
@@ -767,39 +763,38 @@ pub fn consult_preamble() -> String {
         "You are the synthesis agent on a two-model team. You investigate a codebase \
          and write the answer that another agent will act on. Ground every claim in \
          evidence and cite the concrete `file:line`. {core}\n\n\
-         You also have a second tool, `explore`. It sends a broad sweep to the fast \
-         explorer on your team, which searches the repository on the same read-only \
-         shell and returns a curated report: RelevantLocations carrying `file:line`, \
-         key symbols, and snippets. Delegate a sweep when a question needs breadth, \
-         such as finding where something lives or gathering the relevant files. The \
-         explorer is fast and cheap, and one `explore` call searches far more of the \
-         repository than you could read in one turn, which leaves you more turns for \
-         reading the most important code closely and for reasoning. Use `run_kaish` \
-         to read the code yourself when you need a specific span. When you read \
-         directly, read files WHOLE with `cat -n FILE`, because nearly every source \
-         file comes back whole in a single command. The project file list gives you \
-         each file's size, so read whole every file it does not mark, and when you \
-         have no size read whole anyway and let the result tell you otherwise. \
-         Reading too much costs you one read. Reading too little costs you every read \
-         after it. For a file too large to come back whole, run `grep -n SYMBOL FILE` \
-         to get the line numbers you need, then read a wide span around each one with \
-         `cat -n FILE | sed -n '1200,2400p'`.\n\n\
-         Your tools exist to support the answer. Writing the answer is your work, and \
-         no tool writes it for you. Every read you make is evidence for that answer, \
-         and the work is not finished until the answer is written. Write it in this \
-         order: state the finding first, then put the quoted snippet and its \
-         `file:line` underneath it, so the evidence supports the claim directly. Where \
-         the evidence settles the question, answer it fully. Where the evidence runs \
-         out, say so and name what would close the gap; naming the limit of your \
-         evidence is itself a grounded answer. When you have what the question needs, \
-         your next turn is that answer, written out in full.\n\n\
-         The caller may give you CONTEXT: a diff or change summary, a prior report, \
+         You also have `explore`. It sends a broad sweep to the fast explorer on your \
+         team, which searches the repository on the same read-only shell and returns \
+         a curated report: RelevantLocations with `file:line`, key symbols, and \
+         snippets. Delegate a sweep when a question needs breadth, such as finding \
+         where something lives or gathering the relevant files. One `explore` call \
+         searches far more of the repository than you can read in one turn, which \
+         leaves you more turns for close reading and reasoning.\n\n\
+         Use `run_kaish` to read the code yourself when you need a specific span. \
+         Read files WHOLE with `cat -n FILE`; nearly every source file comes back \
+         whole in one command. The project file list gives each file's size, so read \
+         whole every file it does not mark, and when you have no size read whole \
+         anyway and let the result tell you otherwise. Reading too much costs you one \
+         read. Reading too little costs you every read after it. For a file too large \
+         to come back whole, run `grep -n SYMBOL FILE` for the line numbers you need, \
+         then read a wide span around each one with `cat -n FILE | sed -n \
+         '1200,2400p'`.\n\n\
+         The caller may give you context: a diff or change summary, a prior report, \
          or pasted source. Treat it as trusted starting evidence. When it cites a \
          concrete `file:line`, trust that citation instead of re-deriving it. Spend \
-         your turns getting *more* than the context gave you: read a span it refers \
-         to but does not quote, read a whole file when you need the full picture, and \
+         your turns getting more than the context gave you: read a span it refers to \
+         but does not quote, read a whole file when you need the full picture, and \
          read anything the question covers that the context does not. If the code you \
-         read and the context disagree, the code is correct."
+         read and the context disagree, the code is correct.\n\n\
+         Your tools exist to support the answer. Writing the answer is your work, and \
+         no tool writes it for you. The work is not finished until the answer is \
+         written. State each finding first, then put the quoted snippet and its \
+         `file:line` under it, so the evidence supports the claim directly. Separate \
+         what you read from what you infer and from what remains unknown. Where the \
+         evidence settles the question, answer it fully. Where the evidence runs out, \
+         say so and name what would close the gap; naming the limit of your evidence \
+         is itself a grounded answer. When you have what the question needs, your \
+         next turn is that answer, written out in full."
     )
 }
 
@@ -820,9 +815,9 @@ pub fn consult_preamble() -> String {
 /// team" — so the two blocks read as one voice rather than two authors.
 pub fn deliberation_prompt(question: &str, dossier: &str) -> String {
     format!(
-        "The explorer on your team investigated this codebase READ-ONLY and assembled \
-         the dossier below. The dossier holds spans it read from the real, current \
-         source, cited by `file:line`. Trust those citations as accurate. Use this turn \
+        "The explorer on your team investigated this codebase read-only and assembled \
+         the dossier below. It holds spans read from the real, current source, cited \
+         by `file:line`. Trust those citations as accurate. Use this turn \
          to deliberate on that evidence, not to re-derive it. Reason the question \
          through to a conclusion, and say clearly where the evidence runs out. If the \
          dossier leaves open a detail the answer depends on, state the assumption you \
@@ -885,7 +880,7 @@ mod tests {
             "truncation stages into targeted wide spans: {p}"
         );
         assert!(
-            p.contains("WHICH files matter"),
+            p.contains("which files matter"),
             "grep framed as the locator: {p}"
         );
         // Identity, in the code's own vocabulary: this is the *explorer* half of the
@@ -1107,7 +1102,7 @@ mod tests {
             "the report must still name its reader, not go unaddressed: {p}"
         );
         assert!(
-            p.contains("the report is the finished deliverable"),
+            p.contains("The report is the finished deliverable."),
             "the explorer must know nothing downstream restates its work: {p}"
         );
         assert!(

--- a/tests/consult.rs
+++ b/tests/consult.rs
@@ -1050,7 +1050,7 @@ async fn mixed_cast_consult_routes_each_phase_to_its_own_client() {
         s[0].preamble
             .as_deref()
             .unwrap_or("")
-            .contains("second tool, `explore`"),
+            .contains("You also have `explore`"),
         "synth client got the consult preamble: {:?}",
         s[0].preamble
     );


### PR DESCRIPTION
Every built-in preamble in `src/consult/prompts.rs` now reads in one plain register: identity in one sentence, one concern per paragraph, plain imperative sentences, no capitalized section labels, and the deliverable obligation closing each prompt. The explorer used to assume source code (imports, impls, call sites, symbols). It now reads a project tree and the files a question touches, so a documentation-only repository is a normal target, and the consult driver, deliberation prompt, house-rules splice, and history framing use the same word for the same thing.

This is a restyle, not a rewrite. Every phrase the tests pin survives except two that moved with their sentences, and the whole-file rule keeps all four of its registers, because the test that holds them records the measurement behind the repetition.

One instruction is new in every prompt that produces a deliverable:

```text
Separate what you read from what you infer and from what remains unknown.
```

The house-rules splice now says each section is headed by the path of the file it came from; the headers were already there. The consult driver's context paragraph now precedes the answer paragraph, so the prompt ends on the obligation to write the answer, where a small model attends most. For the calling agent, the gap sentence is split so "it" sits next to its antecedent:

```text
Your report is the only view of this project the agent that asked receives.
Anything you leave out is missing from what that agent can act on.
```

Left for a later pass: the explorer's reading guidance still repeats the kaish sandbox addendum.

Stacks on #183, which must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
