### PR TITLE
The built-in deepseek cast dialed a model DeepSeek retired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ record. Each later release appends a new section at the top.
 
 ### Fixed
 
+- **The built-in `deepseek` cast now names a model DeepSeek serves** — it dialed
+  `deepseek-v4-flash`, which the provider retired, so the shipped default failed at
+  request time. Both roles run `deepseek-flash`, the undated id.
 - **kaish 0.17.2** — ordinary shell a model types now parses: `cat .git/HEAD`, `echo 123.txt`,
   `HEAD:src/main.rs`, `p=~/x`, and `ls 1.0*` were all parse errors.
 - **Adjacent for-loop items are refused instead of silently iterating twice** — `for x in a"b" c`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ of your context:
 > record, even Debug noise, briefly wakes the parked loop. An optimization concern,
 > not a correctness one. *[abridged]*
 >
-> ——— kaibo · cast `deepseek` · explorer `deepseek-v4-flash` · synth `deepseek-v4-pro`
+> ——— kaibo · cast `deepseek` · explorer `deepseek-flash` · synth `deepseek-flash`
 
 That's a real consult against this repo, and it ran about four minutes. The
 full answer also surfaced a benign spurious-wakeup path and an optimization
@@ -562,7 +562,7 @@ merges over them by name. The built-ins are:
 | cast | explorer | synth |
 |---|---|---|
 | `anthropic` *(default)* | `claude-haiku-4-5` | `claude-sonnet-4-6` |
-| `deepseek` | `deepseek-v4-flash` | `deepseek-v4-pro` |
+| `deepseek` | `deepseek-flash` | `deepseek-flash` |
 | `gemini` | `gemini-flash-lite-latest` | `gemini-3.5-flash` |
 | `openrouter` | `qwen/qwen3.6-flash` | `qwen/qwen3.7-max` |
 | `openai-local` | local Gemma (small) | local Gemma (large) |

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -69,7 +69,7 @@ api_key_env = "OPENAI_API_KEY"
 # --- casts: role → "backend/model". `cast = "chimera"` selects the whole thing. ---
 
 [casts.chimera]
-explorer = "deepseek/deepseek-v4-flash"     # cheap fast surveys — local/cheap family
+explorer = "deepseek/deepseek-flash"        # cheap fast surveys — local/cheap family
 synth    = "claude/claude-sonnet-4-6"       # the voice that answers — hosted family
 
 [casts.local-only]                          # privacy posture: nothing leaves the box
@@ -153,7 +153,7 @@ All the chimera-ness happens in one resolution step at the server boundary.
 ```
 server.rs: resolve_cast("chimera")
 │
-├─ explorer = "deepseek/deepseek-v4-flash"
+├─ explorer = "deepseek/deepseek-flash"
 │    └─ Arm { client: rig(deepseek backend, lazy key), model,
 │             params: ModelShape(DeepSeek, model) + explorer effort/temp,
 │             caps: vision=false }

--- a/docs/casts.md
+++ b/docs/casts.md
@@ -69,7 +69,7 @@ api_key_env = "OPENAI_API_KEY"
 # --- casts: role → "backend/model". `cast = "chimera"` selects the whole thing. ---
 
 [casts.chimera]
-explorer = "deepseek/deepseek-flash"        # cheap fast surveys — local/cheap family
+explorer = "deepseek/deepseek-flash"        # reads the tree and cites — DeepSeek family
 synth    = "claude/claude-sonnet-4-6"       # the voice that answers — hosted family
 
 [casts.local-only]                          # privacy posture: nothing leaves the box

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -574,7 +574,7 @@ api_key_cmd = ["op", "read", "op://Vault/Kaibo/Deepseek-key"]
 #     `local-only` below) — that single lineage already augments your own agent's. ---
 
 [casts.chimera]
-explorer = "deepseek/deepseek-v4-flash"     # cheap fast surveys — DeepSeek family
+explorer = "deepseek/deepseek-flash"        # cheap fast surveys — DeepSeek family
 synth    = "claude/claude-sonnet-4-6"       # the voice that answers — Claude family
 
 # --- Privacy posture: nothing leaves the box. `gemma` is the built-in alias for
@@ -609,8 +609,8 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 # kind = "stability"              # key: STABILITY_API_KEY / ~/.stability-key.txt
 
 # [casts.artist]
-# explorer = "deepseek/deepseek-v4-flash"
-# synth    = "deepseek/deepseek-v4-pro"
+# explorer = "deepseek/deepseek-flash"
+# synth    = "deepseek/deepseek-flash"
 # image    = "sd/core"            # core | ultra | an sd3.5 variant (e.g. sd3.5-large)
 
 # --- The openai-images kind covers two shapes with one wire. Hosted OpenAI: no
@@ -694,7 +694,7 @@ synth    = { backend = "llama", id = "qwen2.5-vl-32b", vision = true }
 
 [casts.deep-dive]
 aliases  = ["deep"]                          # casts (and backends) take aliases
-explorer = { backend = "deepseek", id = "deepseek-v4-flash", temperature = 0.0, thinking_budget = 4096, thinking_style = "auto" }
+explorer = { backend = "deepseek", id = "deepseek-flash", temperature = 0.0, thinking_budget = 4096, thinking_style = "auto" }
 synth    = { backend = "claude", id = "claude-opus-4-8", effort = "max", max_tokens = 32768 }
 
 # --- The built-in `openrouter` backend already has a key source, so a custom cast on

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -567,14 +567,14 @@ api_key_cmd = ["op", "read", "op://Vault/Kaibo/Deepseek-key"]
 # ---------------------------------------------------------------------------
 
 # --- Advanced — a chimera: mix model FAMILIES across roles, a different lineage per
-#     job, named as one team (`cast = "chimera"`). A cheap DeepSeek explorer + a strong
-#     Claude synth give you mistakes that don't line up. It's the power-user option and
+#     job, named as one team (`cast = "chimera"`). A DeepSeek explorer and a Claude
+#     synth give you mistakes that don't line up. It's the power-user option and
 #     wants a key per family. The common case is simpler: ONE outside family, explorer
 #     and synth both within it (the built-in `deepseek`/`gemini`/`anthropic` casts, or
 #     `local-only` below) — that single lineage already augments your own agent's. ---
 
 [casts.chimera]
-explorer = "deepseek/deepseek-flash"        # cheap fast surveys — DeepSeek family
+explorer = "deepseek/deepseek-flash"        # reads the tree and cites — DeepSeek family
 synth    = "claude/claude-sonnet-4-6"       # the voice that answers — Claude family
 
 # --- Privacy posture: nothing leaves the box. `gemma` is the built-in alias for

--- a/docs/config.md
+++ b/docs/config.md
@@ -282,7 +282,7 @@ A role table. Each slot takes one of two forms:
 
 ```toml
 [casts.chimera]
-explorer = "deepseek/deepseek-v4-flash"     # cheap fast surveys
+explorer = "deepseek/deepseek-flash"        # cheap fast surveys
 synth    = "claude/claude-sonnet-4-6"       # the model that answers
 
 # table form: id + capability pins + per-slot tunables
@@ -536,7 +536,7 @@ not OpenAI Platform's own but should still take the Responses shape; see
 | cast | explorer | synth | synth lane |
 |---|---|---|---|
 | `anthropic` | `anthropic/claude-haiku-4-5` | `anthropic/claude-sonnet-4-6` | |
-| `deepseek` | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` | |
+| `deepseek` | `deepseek/deepseek-flash` | `deepseek/deepseek-flash` | |
 | `gemini` | `gemini/gemini-flash-lite-latest` | `gemini/gemini-3.5-flash` | |
 | `openrouter` | `openrouter/qwen/qwen3.6-flash` | `openrouter/qwen/qwen3.7-max` | |
 | `openai-local` | `openai-local/Gemma-4-E4B-it-GGUF` | `openai-local/Gemma-4-26B-A4B-it-GGUF` | |

--- a/docs/config.md
+++ b/docs/config.md
@@ -282,7 +282,7 @@ A role table. Each slot takes one of two forms:
 
 ```toml
 [casts.chimera]
-explorer = "deepseek/deepseek-flash"        # cheap fast surveys
+explorer = "deepseek/deepseek-flash"        # reads the tree and cites
 synth    = "claude/claude-sonnet-4-6"       # the model that answers
 
 # table form: id + capability pins + per-slot tunables

--- a/src/config.rs
+++ b/src/config.rs
@@ -2498,7 +2498,11 @@ pub fn default_models(kind: ProviderKind) -> (&'static str, &'static str) {
     };
     match wire {
         credentials::WireKind::Anthropic => ("claude-haiku-4-5", "claude-sonnet-4-6"),
-        credentials::WireKind::DeepSeek => ("deepseek-v4-flash", "deepseek-v4-pro"),
+        // DeepSeek serves `deepseek-flash` and `deepseek-v4-pro`; `deepseek-v4-flash`
+        // was retired under us and the built-in dialed it until 2026-09-10. The
+        // undated id is the rot-resistant one — it tracks each new flash generation —
+        // and DeepSeek is folding pro into flash, so both roles name it.
+        credentials::WireKind::DeepSeek => ("deepseek-flash", "deepseek-flash"),
         credentials::WireKind::Gemini => ("gemini-flash-lite-latest", "gemini-3.5-flash"),
         // OpenRouter's job here is a family we *can't* reach directly (we key
         // DeepSeek, Gemini, and Anthropic on their own backends), so the gateway

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,8 +1,14 @@
-//! ProviderKind credentials, from key-files with an env-var override.
+//! ProviderKind credentials: the pure resolution primitives, and the names a
+//! provider's key conventionally goes by.
 //!
-//! Long-term kaibo will take credentials from both files and env. For now the
-//! source of truth is a per-provider dotfile in `$HOME`; if the matching env var
-//! is set it wins (handy for CI / one-off overrides).
+//! **kaibo seeds no key.** A running kaibo resolves a key only from what a backend
+//! declares in `config.toml` — `api_key_env`, `api_key_file`, or `api_key_cmd` — so a
+//! built-in backend with no declared source has no key and every cast built on it is
+//! dropped at startup. The env vars and dotfiles below are *conventional names*, the
+//! values an operator points those fields at, and [`ProviderKind::env_var`] is what
+//! names one in the "declare `api_key_env`" hint a refusal carries. Nothing here reads
+//! them on kaibo's behalf; [`load`] does, and it exists for the `#[ignore]`d live
+//! probes, which need a key before there is a server to ask.
 //!
 //! - Anthropic:  `ANTHROPIC_API_KEY`  / `~/.anthropic-key.txt`
 //! - DeepSeek:   `DEEPSEEK_API_KEY`   / `~/.deepseek-key`
@@ -611,8 +617,10 @@ fn read_capped(mut r: impl Read, cap: usize) -> Vec<u8> {
 }
 
 /// Load a *keyed* `provider`'s key from the real environment and `$HOME` (env var
-/// over dotfile). The opt-in live-probe tests use it to gate on whether a real key
-/// is present. The key-optional (`Openai`) provider is refused: its key may
+/// over dotfile). **Test infrastructure, not a product path**: its one caller is
+/// `live_key` in `tests/consult.rs`, the fallback an `#[ignore]`d live probe uses when
+/// the operator's config declares no backend of that kind. A running kaibo never
+/// reaches it — `Backend::resolve_key` reads declared sources only. The key-optional (`Openai`) provider is refused: its key may
 /// legitimately be absent, so it has no single "the key" to load — resolve it through
 /// the backend (`Backend::resolve_key`), which falls back to a placeholder.
 pub fn load(provider: ProviderKind) -> Result<String> {

--- a/src/server/config_resource.rs
+++ b/src/server/config_resource.rs
@@ -1502,7 +1502,7 @@ mod tests {
             "anthropic slot carries resolved vision=true:\n{anthropic_synth}"
         );
         let deepseek_synth = body
-            .find("deepseek/deepseek-v4-pro")
+            .find("deepseek/deepseek-flash")
             .map(|i| &body[i..i + 120])
             .unwrap();
         assert!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9685,6 +9685,33 @@ enabled = false
         }
     }
 
+    /// The guide names the models every built-in cast dials, so a default that drifts
+    /// leaves the document promising an operator a model kaibo will not ask for. That is
+    /// how `deepseek-v4-flash` outlived DeepSeek retiring it: the registry and four
+    /// documents each carried the id and nothing tied them together. Now the registry is
+    /// the source and the guide has to keep up.
+    #[test]
+    fn the_guide_names_the_models_every_built_in_cast_dials() {
+        use crate::credentials::ProviderKind;
+        for kind in [
+            ProviderKind::Anthropic,
+            ProviderKind::DeepSeek,
+            ProviderKind::Gemini,
+            ProviderKind::OpenRouter,
+            ProviderKind::Openai,
+        ] {
+            let backend = kind.builtin_name();
+            let (explorer, synth) = crate::config::default_models(kind);
+            for id in [explorer, synth] {
+                assert!(
+                    CONFIG_GUIDE_MD.contains(&format!("`{backend}/{id}`")),
+                    "docs/config.md never names `{backend}/{id}`, which the built-in \
+                     `{backend}` cast dials — the guide and the registry have drifted"
+                );
+            }
+        }
+    }
+
     // --- kaibo://config resource tests ---------------------------------------
 
     /// The config resource must appear in the listing with the correct URI and a


### PR DESCRIPTION
Setting the DeepSeek backend up on this box surfaced a shipped default that cannot work. The provider's catalog serves `deepseek-flash` and `deepseek-v4-pro`. There is no `deepseek-v4-flash` — and that is what `default_models` seeds the built-in `deepseek` cast with. Install kaibo, declare a DeepSeek key, ask for `cast="deepseek"`, and the call fails at request time on a default we ship.

Both roles now name `deepseek-flash`. The undated id is the rot-resistant one — it tracks each new flash generation rather than pinning a version the provider will retire under us — and DeepSeek is folding v4-pro into flash, so the two-tier split has nothing left to split.

The same dead id was in four documents: `docs/config.md` twice (including the built-in registry table), `docs/config.example.toml` three times (one of them the annotated slot example an operator copies), `docs/casts.md`, and `README.md` (the built-in table and a sample provenance footer). Two of those are `include_str!`'d and served as `kaibo://config/guide` and `kaibo://config/example`, so an operator *or a model* reading them was being taught a config that cannot work.

**Why it drifted: nothing tied the registry to the documents.** `the_guide_names_the_models_every_built_in_cast_dials` now does — for every built-in cast, the embedded guide must name both models it dials. Run against the old pair it fails and names the id, which is the check that would have caught this the day DeepSeek changed the catalog.

## A correction inside this PR

I first reported `credentials::load()` as dead code and was going to delete it with `key_file()` and `key_file_name()`. **It is not dead** — `live_key` in `tests/consult.rs:1791` calls it as the fallback an `#[ignore]`d live probe uses when the operator's config declares no backend of that kind. My grep covered `src/` only and the caller is a bare `load(kind)` in `tests/`.

What *is* wrong there is prose, and it is what misled me: `credentials.rs` opened by saying a per-provider dotfile in `$HOME` is the source of truth with the env var winning over it. That describes seeding kaibo removed. The same module doc says so correctly four paragraphs down, and `docs/config.md` has documented the removal all along — the docs were right, the module doc contradicted itself. It now leads with what is true (kaibo resolves declared sources only, and these names are what an operator points `api_key_file`/`api_key_env` at) and scopes `load()` as live-probe infrastructure.

Suite 1363/0, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)