### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,68 +15,56 @@ record. Each later release appends a new section at the top.
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-09-10
+
 ### Security
 
 - **Following git worktrees could widen the read boundary past the tree you named** —
   possible exposure of files outside the workspace on every release since `0.2.0`.
-- **An allowed tree now reaches worktrees only when it holds `.git` itself**; kaibo reads
-  no ancestor of it, so a `--root` inside a larger repo no longer reaches that repo.
-- **A forged `.git` in the allowed tree can no longer aim the reach** — the common dir must
-  name that tree back, so a cloned repo cannot point kaibo at a directory you never named.
-- **A git worktree registration alone no longer vouches for the directory it names** — the
-  worktree must name its registration back, so one file in a repo you cloned to review
-  cannot make any directory on the host readable.
+- **An allowed tree reaches worktrees only when it holds `.git` itself** — no ancestor
+  walk, so a `--root` inside a larger repo no longer reaches that repo.
+- **A forged `.git` can no longer aim the reach** — the common dir must name the tree back.
+- **A registration alone no longer vouches for the directory it names** — the worktree
+  must name its registration back.
 - **A worktree link vouches only in the shape git writes it** — the registration must be a
-  direct child of the repo's `worktrees` directory and must name `<worktree>/.git`, which
-  must live in the directory it vouches for. A mutually-naming pair of ordinary files no
-  longer admits a directory.
+  direct child of `worktrees` and must name `<worktree>/.git`, living where it vouches.
 
 ### Added
 
-- **The read boundary now says when it refuses a path** — a `warn` naming the path and the
-  allowed set, from every surface that checks containment. Rides the `logs` signal.
-- **A refused `run_kaish` call still closes a `run_kaish` span**, tagged
-  `outcome = "refused"` — a boundary that fired no longer looks like a call that never
-  arrived.
+- **The read boundary says when it refuses a path** — a `warn` naming the path and the
+  allowed set, from every surface that checks containment.
+- **A refused `run_kaish` call still closes its span**, tagged `outcome = "refused"`.
 
 ### Changed
 
-- **A composed preamble still ends on the work it asks for** — the project file map and
-  operator house rules splice in after a prompt's closing line, so the obligation is
-  restated last. An operator override keeps its own last word.
-- **A session's earlier turns are trusted evidence** — the history framing asks for what
-  the new question reaches instead of a re-read of every citation an earlier answer made.
-- **`deliberate` closes on the answer after the dossier**, and every prompt that hands
-  work to someone else asks for the same separation of what was read, inferred, and left
-  unknown, in the same words.
-- **The explorer's attach directive names its reader `the synthesis agent`** — `the
-  consult driver` was a second name for the model the preamble already named.
-- **The docs call an explorer's investigation pass a `survey`**, matching what `explore`'s
-  own description has always said; `sweep` was a second word for the same thing.
-- **A tool this server does not serve now refuses in kaibo's words** — naming the flag, the
-  cast shape it wants, or the absent job producer, plus the tools that are live. A
-  misspelled name still reads as `tool not found`.
-- **Every built-in preamble now reads in one plain style** — short sentences, one concern
-  per paragraph, no capitalized section labels. The explorer reads a project tree, not
-  only code, and every deliverable separates what was read from what is inferred.
+- **A composed preamble still ends on the work it asks for** — the file map and house
+  rules splice in after the closing line, so the obligation is restated last.
+- **A session's earlier turns are trusted evidence**, not spans to re-read.
+- **`deliberate` closes on the answer after the dossier.**
+- **Every prompt that hands work on asks for the same separation** of what was read,
+  inferred, and left unknown, in the same words.
+- **Every built-in preamble reads in one plain style** — short sentences, one concern per
+  paragraph. The explorer reads a project tree, not only code.
+- **The docs call an explorer's investigation pass a `survey`** — `sweep` was a second
+  word for the same thing, and the attach directive's reader is `the synthesis agent`.
+- **A tool this server does not serve refuses in kaibo's words**, naming the knob and the
+  tools that are live. A misspelled name still reads as `tool not found`.
 
 ### Fixed
 
-- **The built-in `deepseek` cast now names a model DeepSeek serves** — it dialed
-  `deepseek-v4-flash`, which the provider retired, so the shipped default failed at
-  request time. Both roles run `deepseek-flash`, the undated id.
-- **kaish 0.17.2** — ordinary shell a model types now parses: `cat .git/HEAD`, `echo 123.txt`,
-  `HEAD:src/main.rs`, `p=~/x`, and `ls 1.0*` were all parse errors.
-- **Adjacent for-loop items are refused instead of silently iterating twice** — `for x in a"b" c`
+- **The built-in `deepseek` cast names a model DeepSeek serves** — it dialed
+  `deepseek-v4-flash`, retired by the provider, so the shipped default failed on use.
+- **kaish 0.17.2** — shell a model types now parses: `cat .git/HEAD`, `echo 123.txt`,
+  `HEAD:src/main.rs`, `p=~/x`, `ls 1.0*`.
+- **Adjacent for-loop items are refused, not silently iterated twice** — `for x in a"b" c`
   ran the body three times.
-- **`explore` no longer tells its explorer that a synthesis agent will write the answer** —
-  on a standalone `explore` there is none, and the report is the deliverable.
+- **`explore` no longer promises its explorer a synthesis agent** — standalone, the report
+  is the deliverable.
 
 ### Removed
 
 - **`explorer_max_turns` / `synth_max_turns` are no longer tool arguments or CLI flags** —
-  the turn budget is the server's, set in `[defaults]` or `KAIBO_*_MAX_TURNS`, so two
-  calls to one server stay comparable. A call still passing one is refused by name.
+  the turn budget is the server's, so two calls to one server stay comparable.
 
 ## [0.4.0] — 2026-09-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "kaibo"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kaibo"
 description = "kaibo — a two-phase MCP consult agent that explores a read-only filesystem through kaish builtins"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/docs/sandbox-probes.md
+++ b/docs/sandbox-probes.md
@@ -518,35 +518,50 @@ detail is in git, and anything durable a run found has been promoted into the ba
 belongs to rather than left here to be re-read — that promotion is the point of the
 compression, not a side effect of it.
 
-- **2026-09-02** — **Full A–G**, branch `kaish-0.17.1`, run because the `kaish-kernel`
-  0.17.0 → 0.17.1 patch touches the VFS and so trips the trigger. **All clear.** Every
-  battery was run against **both** pins and diffed; A, B, D, E, F and G came back
-  byte-identical, so the two changes below are the whole delta a model can see.
-  - **The release blocker is fixed:** `readlink -f` and `realpath` resolve an in-tree
-    path (exit 0) and refuse an escape by name, where 0.17.0 failed on every operand
-    with `No such file or directory: /tmp`. G3 re-run on the new canonicalize path —
-    existing, missing, and unreadable targets still refuse byte-identically.
-  - **The one new observable, accepted:** the directories *above* the mount list again,
-    each naming only the next component down to the project. Battery C's `/home` note
-    is corrected in place. Synthesis, not host reads — counted it: `ls /tmp` returns one
-    entry where the host holds 3575, and `stat`/`realpath` cannot tell a real host file
-    beside the chain from one that was never created. Adjacent secrets, siblings, and
-    the state db and media CAS all stay invisible (E2/F2 re-run).
-  - **The probe caught itself once:** E1 run without `--root` created a state db, because
-    the fixture was then outside every allowed tree and the guard correctly did not fire.
-    The §0 question — would this read differently if the probe were broken? — is what
-    found it.
-  - **Battery H is new**, written from its own first run against a scratch store: the CAS
-    write path had containment (F) but nothing measured its *shape*. All clear — a stored
-    object's name equals `sha256sum` of its input, a repeat write leaves inode and mtime
-    untouched, a refusal stores nothing, and a fresh object stays invisible to kaish.
-    Writing it found one missing test, now added: `write_cas` had no case for a symlink
-    inside the tree pointing out, the leg `read_contained_file`'s own doc calls the one
-    worth not skipping.
-  - Suites: containment 25 (one new), full `cargo test` 1147 passed. The lone failure is
-    the known `tests/credentials.rs` ETXTBSY exec race under parallelism; green serially,
-    reproduces on unmodified code.
-  - §7 not re-run; deferred to the v0.4.0 pre-release check.
+- **2026-09-10** — **Full A–H**, main `31fdc09`, the 0.5.0 pre-release pass. Run because
+  two triggers fired at once: `kaish-vfs` moved with the 0.17.2 bump (#187), and #191
+  changed containment itself — the worktree vouch now demands git's own shape. **All
+  clear.**
+  - **A** ten writes refused, nine naming `permission denied: filesystem is read-only`
+    and the cross-mount `ln -s` naming the mount rule; host tree clean afterwards.
+    **B** eleven host commands, all 127. **C** every out-of-root read `not found`,
+    including `~/.deepseek-key`, which holds a real key this session — absence would have
+    passed vacuously, so the file existing is what makes the result mean something.
+    `env` carries only kernel-owned `PIPESTATUS`/`PWD`; every provider key, `$HOME` and
+    `$PATH` expand empty. Counted the prefix: `ls /home/atobey` returns 1 entry where the
+    host holds 74, and `/tmp` (631 on the host) is not found at all. **D** all five
+    `path` rows as documented; the `..` row canonicalizes to `/etc` and is refused by
+    *containment*, message naming the allowed set. **E/F** store and CAS both refuse a
+    path inside the project before touching disk, and neither is readable or enumerable
+    from kaish — nor is `~/.local` itself. `no_write_path` green, count exact. **G**
+    target string readable, no bytes cross, and the three refusals stay byte-identical
+    across exists / missing / unreadable. **H** object names equal `sha256sum` of their
+    input, a repeat write leaves inode and mtime untouched to the nanosecond, a refused
+    write stores nothing, and a fresh object stays invisible to kaish.
+  - **The F3 this file asked for is now covered, and it split in two.** `write_cas` —
+    the model-reachable deposit — refuses a source outside the allowed set and stores an
+    in-tree one, with the positive control run so the refusal is not vacuous. The CLI
+    `kaibo cas write` does **not** refuse an outside source, and that is correct rather
+    than a finding: the CLI caller is the operator, who can already read the file. H1's
+    note reads as if one rule covers both surfaces; it covers the tool. Probe the tool.
+  - **The probe caught itself again**, the way §0 says it will. The Battery H fixture put
+    `--state-db` inside the tree it passed as `--root`, so E1 fired, persistence went
+    off, the CAS fell to memory, and `cas write` refused — three batteries' worth of
+    correct behavior reading, at a glance, like a broken store. Both stores have to sit
+    outside the allowed tree for H to measure anything.
+  - **Two message drifts, neither a hole.** `kill 1` now answers `signalling a PID
+    requires the subprocess capability` (exit 1), not the "not supported on this
+    platform" stub this file records. And `grep` following an escaping symlink refuses
+    with exit 1 and *no* stderr line, where every other verb in G2 names the reason —
+    worth knowing before someone reads the silence as success.
+  - Gates beside the batteries: `cargo tree -i` absent for aws-lc-rs / aws-lc-sys /
+    mimalloc / openssl-sys with a printing negative control (`kaish-kernel v0.17.2`);
+    musl binary `statically linked` / `not a dynamic executable` and runs; suite 1363/0.
+
+- **2026-09-02** — Full A–G, branch `kaish-0.17.1`, run against both pins and diffed. All
+  clear. `readlink -f`/`realpath` fixed; the directories above the mount list again, each
+  naming only the next component down. **Battery H is new** — the CAS write path had
+  containment but nothing measured its shape.
 
 - **2026-09-01** — Full A–G, branch `kaish-0.17`, for the 0.14.1 → 0.17.0 bump. All
   clear. Three pass criteria here were false against 0.17 and were corrected in place;


### PR DESCRIPTION
Version `0.4.0` → `0.5.0`, a fresh empty unreleased section, and `docs/sandbox-probes.md` stamped with the run that gates this release.

**Minor, not patch**, for two reasons. #182 removed `explorer_max_turns`/`synth_max_turns` as tool arguments and CLI flags — a caller-facing break. And the read boundary changed four times: three worktree-follow escapes closed in #184, then #191 requiring git's own *shape* after a kaibo deliberation argued that mutual agreement between two files is not provenance.

The changelog section was shortened before retitling, per the rule that entries get shorter over time — 70 lines to 52, no bullet dropped. The four bullets that each narrowed the same worktree rule now say what they narrow in one line apiece.

## Gates

| gate | result |
|---|---|
| `cargo tree -i` aws-lc-rs / aws-lc-sys / mimalloc / openssl-sys | absent, negative control prints `kaish-kernel v0.17.2` |
| musl build | `statically linked`, `not a dynamic executable`, runs |
| suite | 1363 passed, 0 failed |
| sandbox battery A–H | all clear |

## The battery

Run because two triggers fired at once: `kaish-vfs` moved with the 0.17.2 bump (#187), and #191 changed containment itself.

Highlights worth reading rather than trusting: every out-of-root read came back `not found` including `~/.deepseek-key`, which holds a real key this session — absence would have passed vacuously, so the file existing is what makes the result mean anything. The prefix listing was *counted*: `ls /home/atobey` returns 1 entry where the host holds 74. Battery D's `..` row canonicalizes to `/etc` and is refused by containment with the message naming the allowed set, not by a resolution failure. G3's three refusals stay byte-identical across exists / missing / unreadable, so a hostile repo gets no existence oracle.

**The F3 this runbook has asked for since 2026-08-13 is now covered, and it split in two.** `write_cas` — the model-reachable deposit — refuses a source outside the allowed set, with the positive control run so the refusal is not vacuous. The CLI `kaibo cas write` does *not* refuse an outside source, and that is correct rather than a finding: the CLI caller is the operator, who can already read the file. H1's note reads as though one rule covers both surfaces; it covers the tool.

**The probe caught itself again**, which is what §0 exists for. The Battery H fixture put `--state-db` inside the tree it passed as `--root`, so E1 fired, persistence went off, the CAS fell back to memory and `cas write` refused — three batteries' worth of correct behavior reading, at a glance, like a broken store.

Two message drifts recorded, neither a hole: `kill 1` now answers `signalling a PID requires the subprocess capability`, and `grep` following an escaping symlink refuses with exit 1 and *no* stderr line, where every other verb in G2 names the reason — worth knowing before someone reads that silence as success.

## After merge

Tag `v0.5.0` to fire the release matrix, then verify a downloaded asset the way a user would (`gh attestation verify`, `cosign verify-blob`) and run `scripts/bump-tap.sh v0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)